### PR TITLE
Say it in four more tools, where the same reader is carried

### DIFF
--- a/locales/ar/tools/crop-video.html
+++ b/locales/ar/tools/crop-video.html
@@ -151,6 +151,35 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">ينتهي الملف في منتصف إطار.</span>
+    <span data-phrase="read.avcshort">سجل إعداد H.264 أقصر مما ينبغي.</span>
+    <span data-phrase="read.hevcshort">سجل إعداد HEVC أقصر مما ينبغي.</span>
+    <span data-phrase="read.av1short">سجل إعداد AV1 أقصر مما ينبغي.</span>
+    <span data-phrase="read.compactsizes">أحجام العيّنات في جدول مضغوط لا يفكّه هذا القارئ.</span>
+    <span data-phrase="read.sampletables">جداول العيّنات ناقصة.</span>
+    <span data-phrase="read.chunktable">جدول الكتل فارغ.</span>
+    <span data-phrase="read.nosamples">لا عيّنات في هذا المسار.</span>
+    <span data-phrase="read.nostbl">ينقص مسارَ الفيديو جداولُ عيّناته.</span>
+    <span data-phrase="read.nostsd">لا وصف للعيّنات في مسار الفيديو.</span>
+    <span data-phrase="read.emptystsd">وصف عيّنات الفيديو فارغ.</span>
+    <span data-phrase="read.encrypted">مسار الفيديو مشفَّر.</span>
+    <span data-phrase="read.unknowncodec">الفيديو مخزَّن بصيغة &laquo;{type}&raquo;، وهي صيغة لا يعرفها هذا القارئ.</span>
+    <span data-phrase="read.noconfig">مسار &laquo;{type}&raquo; لا يحمل معه أي إعداد لفاكّ الترميز.</span>
+    <span data-phrase="read.notmp4">هذا ليس ملف MP4 ولا MOV.</span>
+    <span data-phrase="read.nomoov">لا ترويسة فيلم في هذا الملف.</span>
+    <span data-phrase="read.novideo">لا مسار فيديو في هذا الملف يستطيع هذا القارئ استعماله.</span>
+    <span data-phrase="read.notimescale">لا مقياس زمني لمسار الفيديو.</span>
+    <span data-phrase="read.nofragments">شظايا هذا الملف لا تحمل أي إطار لمسار الفيديو الذي فيه.</span>
+    <span data-phrase="read.unreadable">لم يمكن قراءة الملف بوصفه MP4.</span>
+    <span data-phrase="read.notplayed">هذه الصيغة ليست مما يشغّله هذا المتصفّح.</span>
+    <span data-phrase="read.layout">بنية هذا الملف ليست مما يفهمه القارئ هنا.</span>
+    <span data-phrase="read.nodecoder">لا يفكّ هذا المتصفّح ترميز {codec} مباشرةً.</span>
+    <span data-phrase="read.nowebcodecs">لا WebCodecs في هذا المتصفّح، فلا سبيل إلى فكّ ترميز الإطارات إطاراً إطاراً.</span>
+    <span data-phrase="read.turned">هذا الملف مخزَّن مُداراً، والقارئ هنا ومشغّل المتصفّح لا يتفقان على مقدار الإدارة.</span>
+    <span data-phrase="open.failed">لا يستطيع هذا المتصفّح فتح هذا الملف. {reason}</span>
+    <span data-phrase="open.norecord">لا يستطيع هذا المتصفّح تسجيل الفيديو، فلا يستطيع قصّ أطراف هذا الملف.</span>
+    <span data-phrase="path.record">{reason} ولذلك تُقصّ أطراف هذا بتشغيله وتسجيل ما يخرج منه: وهذا يستغرق من الوقت مثل
+      طول الفيديو، ويُعاد ترميز الصوت بدل نسخه.</span>
     <span data-phrase="net.clean">مقطعك لم يذهب إلى أي مكان. {total} ملفاً
       حُمِّلت. {platform}</span>
     <span data-phrase="net.dirty">اتصل شيءٌ بـ {hosts}، وهو ما لا تفعله هذه

--- a/locales/ar/tools/grab-frame.html
+++ b/locales/ar/tools/grab-frame.html
@@ -137,6 +137,37 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">ينتهي الملف في منتصف إطار.</span>
+    <span data-phrase="read.avcshort">سجل إعداد H.264 أقصر مما ينبغي.</span>
+    <span data-phrase="read.hevcshort">سجل إعداد HEVC أقصر مما ينبغي.</span>
+    <span data-phrase="read.av1short">سجل إعداد AV1 أقصر مما ينبغي.</span>
+    <span data-phrase="read.compactsizes">أحجام العيّنات في جدول مضغوط لا يفكّه هذا القارئ.</span>
+    <span data-phrase="read.sampletables">جداول العيّنات ناقصة.</span>
+    <span data-phrase="read.chunktable">جدول الكتل فارغ.</span>
+    <span data-phrase="read.nosamples">لا عيّنات في هذا المسار.</span>
+    <span data-phrase="read.nostbl">ينقص مسارَ الفيديو جداولُ عيّناته.</span>
+    <span data-phrase="read.nostsd">لا وصف للعيّنات في مسار الفيديو.</span>
+    <span data-phrase="read.emptystsd">وصف عيّنات الفيديو فارغ.</span>
+    <span data-phrase="read.encrypted">مسار الفيديو مشفَّر.</span>
+    <span data-phrase="read.unknowncodec">الفيديو مخزَّن بصيغة &laquo;{type}&raquo;، وهي صيغة لا يعرفها هذا القارئ.</span>
+    <span data-phrase="read.noconfig">مسار &laquo;{type}&raquo; لا يحمل معه أي إعداد لفاكّ الترميز.</span>
+    <span data-phrase="read.notmp4">هذا ليس ملف MP4 ولا MOV.</span>
+    <span data-phrase="read.nomoov">لا ترويسة فيلم في هذا الملف.</span>
+    <span data-phrase="read.novideo">لا مسار فيديو في هذا الملف يستطيع هذا القارئ استعماله.</span>
+    <span data-phrase="read.notimescale">لا مقياس زمني لمسار الفيديو.</span>
+    <span data-phrase="read.nofragments">شظايا هذا الملف لا تحمل أي إطار لمسار الفيديو الذي فيه.</span>
+    <span data-phrase="read.unreadable">لم يمكن قراءة الملف بوصفه MP4.</span>
+    <span data-phrase="read.notplayed">هذه الصيغة ليست مما يشغّله هذا المتصفّح.</span>
+    <span data-phrase="read.layout">بنية هذا الملف ليست مما يفهمه القارئ هنا.</span>
+    <span data-phrase="read.nodecoder">لا يفكّ هذا المتصفّح ترميز {codec} مباشرةً.</span>
+    <span data-phrase="read.nowebcodecs">لا WebCodecs في هذا المتصفّح، فلا سبيل إلى فكّ ترميز الإطارات إطاراً إطاراً.</span>
+    <span data-phrase="read.turned">هذا الملف مخزَّن مُداراً، والقارئ هنا ومشغّل المتصفّح لا يتفقان على مقدار الإدارة.</span>
+    <span data-phrase="open.failed">لا يستطيع هذا المتصفّح فتح هذا الملف. {reason}</span>
+    <span data-phrase="path.player">{reason} ولذلك يقرأ مشغّل المتصفّح هذا الملف بدل قراءته إطاراً إطاراً: تُحفظ الصورة
+      بحجم الفيديو الكامل كما كانت، غير أن الإطار الذي تقع عليه يختاره المشغّل، والخطوة
+      الواحدة تتقدّم إطاراً تقريباً لا إطاراً بالضبط.</span>
+    <span data-phrase="path.nopreview">لا يشغّل هذا المتصفّح هذا الملف، فليس هنا ما يُضغط لتشغيله. أما فكّ الترميز
+      فيستطيعه، ومنه تأتي الصور الثابتة؛ تنقّل في الفيديو بالمِزلاق وبمفاتيح الأسهم.</span>
     <span data-phrase="net.clean">مقطعك لم يذهب إلى أي مكان. {total} ملفاً
       حُمِّلت. {platform}</span>
     <span data-phrase="net.dirty">اتصل شيءٌ بـ {hosts}، وهو ما لا تفعله هذه

--- a/locales/ar/tools/timelapse-video.html
+++ b/locales/ar/tools/timelapse-video.html
@@ -157,6 +157,36 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">ينتهي الملف في منتصف إطار.</span>
+    <span data-phrase="read.avcshort">سجل إعداد H.264 أقصر مما ينبغي.</span>
+    <span data-phrase="read.hevcshort">سجل إعداد HEVC أقصر مما ينبغي.</span>
+    <span data-phrase="read.av1short">سجل إعداد AV1 أقصر مما ينبغي.</span>
+    <span data-phrase="read.compactsizes">أحجام العيّنات في جدول مضغوط لا يفكّه هذا القارئ.</span>
+    <span data-phrase="read.sampletables">جداول العيّنات ناقصة.</span>
+    <span data-phrase="read.chunktable">جدول الكتل فارغ.</span>
+    <span data-phrase="read.nosamples">لا عيّنات في هذا المسار.</span>
+    <span data-phrase="read.nostbl">ينقص مسارَ الفيديو جداولُ عيّناته.</span>
+    <span data-phrase="read.nostsd">لا وصف للعيّنات في مسار الفيديو.</span>
+    <span data-phrase="read.emptystsd">وصف عيّنات الفيديو فارغ.</span>
+    <span data-phrase="read.encrypted">مسار الفيديو مشفَّر.</span>
+    <span data-phrase="read.unknowncodec">الفيديو مخزَّن بصيغة &laquo;{type}&raquo;، وهي صيغة لا يعرفها هذا القارئ.</span>
+    <span data-phrase="read.noconfig">مسار &laquo;{type}&raquo; لا يحمل معه أي إعداد لفاكّ الترميز.</span>
+    <span data-phrase="read.notmp4">هذا ليس ملف MP4 ولا MOV.</span>
+    <span data-phrase="read.nomoov">لا ترويسة فيلم في هذا الملف.</span>
+    <span data-phrase="read.novideo">لا مسار فيديو في هذا الملف يستطيع هذا القارئ استعماله.</span>
+    <span data-phrase="read.notimescale">لا مقياس زمني لمسار الفيديو.</span>
+    <span data-phrase="read.nofragments">شظايا هذا الملف لا تحمل أي إطار لمسار الفيديو الذي فيه.</span>
+    <span data-phrase="read.unreadable">لم يمكن قراءة الملف بوصفه MP4.</span>
+    <span data-phrase="read.notplayed">هذه الصيغة ليست مما يشغّله هذا المتصفّح.</span>
+    <span data-phrase="read.layout">بنية هذا الملف ليست مما يفهمه القارئ هنا.</span>
+    <span data-phrase="read.nodecoder">لا يفكّ هذا المتصفّح ترميز {codec} مباشرةً.</span>
+    <span data-phrase="read.nowebcodecs">لا WebCodecs في هذا المتصفّح، فلا سبيل إلى فكّ ترميز الإطارات إطاراً إطاراً.</span>
+    <span data-phrase="open.failed">لا يستطيع هذا المتصفّح فتح هذا الملف. {reason}</span>
+    <span data-phrase="open.nodecode">فتح هذا المتصفّح الملف لكنه لا يستطيع فكّ ترميز الفيديو الذي فيه. وهذا في الغالب
+      Dolby Vision، أو HEVC على جهاز لا دعم عتادياً فيه له: تُقرأ الحاوية قراءةً سليمة ولا
+      تصل الصورة أبداً. حوّله أولاً إلى MP4 عادي (H.264)، عندها تقرأه هذه الأداة مباشرةً.</span>
+    <span data-phrase="path.seek">{reason} ولذلك يُقرأ هذا بنقل مشغّل المتصفّح إلى كل لحظة: وهذا يصلح مع كل صيغة
+      يشغّلها المتصفّح، وهو أبطأ قليلاً.</span>
     <span data-phrase="net.clean">مقطعك لم يذهب إلى أي مكان. {total} ملفاً
       حُمِّلت. {platform}</span>
     <span data-phrase="net.dirty">اتصل شيءٌ بـ {hosts}، وهو ما لا تفعله هذه

--- a/locales/ar/tools/video-to-gif.html
+++ b/locales/ar/tools/video-to-gif.html
@@ -172,6 +172,34 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">ينتهي الملف في منتصف إطار.</span>
+    <span data-phrase="read.avcshort">سجل إعداد H.264 أقصر مما ينبغي.</span>
+    <span data-phrase="read.hevcshort">سجل إعداد HEVC أقصر مما ينبغي.</span>
+    <span data-phrase="read.av1short">سجل إعداد AV1 أقصر مما ينبغي.</span>
+    <span data-phrase="read.compactsizes">أحجام العيّنات في جدول مضغوط لا يفكّه هذا القارئ.</span>
+    <span data-phrase="read.sampletables">جداول العيّنات ناقصة.</span>
+    <span data-phrase="read.chunktable">جدول الكتل فارغ.</span>
+    <span data-phrase="read.nosamples">لا عيّنات في هذا المسار.</span>
+    <span data-phrase="read.nostbl">ينقص مسارَ الفيديو جداولُ عيّناته.</span>
+    <span data-phrase="read.nostsd">لا وصف للعيّنات في مسار الفيديو.</span>
+    <span data-phrase="read.emptystsd">وصف عيّنات الفيديو فارغ.</span>
+    <span data-phrase="read.encrypted">مسار الفيديو مشفَّر.</span>
+    <span data-phrase="read.unknowncodec">الفيديو مخزَّن بصيغة &laquo;{type}&raquo;، وهي صيغة لا يعرفها هذا القارئ.</span>
+    <span data-phrase="read.noconfig">مسار &laquo;{type}&raquo; لا يحمل معه أي إعداد لفاكّ الترميز.</span>
+    <span data-phrase="read.notmp4">هذا ليس ملف MP4 ولا MOV.</span>
+    <span data-phrase="read.nomoov">لا ترويسة فيلم في هذا الملف.</span>
+    <span data-phrase="read.novideo">لا مسار فيديو في هذا الملف يستطيع هذا القارئ استعماله.</span>
+    <span data-phrase="read.notimescale">لا مقياس زمني لمسار الفيديو.</span>
+    <span data-phrase="read.nofragments">شظايا هذا الملف لا تحمل أي إطار لمسار الفيديو الذي فيه.</span>
+    <span data-phrase="read.unreadable">لم يمكن قراءة الملف بوصفه MP4.</span>
+    <span data-phrase="read.notplayed">هذه الصيغة ليست مما يشغّله هذا المتصفّح.</span>
+    <span data-phrase="read.layout">بنية هذا الملف ليست مما يفهمه القارئ هنا.</span>
+    <span data-phrase="read.nodecoder">لا يفكّ هذا المتصفّح ترميز {codec} مباشرةً.</span>
+    <span data-phrase="read.nowebcodecs">لا WebCodecs في هذا المتصفّح، فلا سبيل إلى فكّ ترميز الإطارات إطاراً إطاراً.</span>
+    <span data-phrase="read.turned">هذا الملف مخزَّن مُداراً، والقارئ هنا ومشغّل المتصفّح لا يتفقان على مقدار الإدارة.</span>
+    <span data-phrase="open.failed">لا يستطيع هذا المتصفّح فتح هذا الملف. {reason}</span>
+    <span data-phrase="path.seek">{reason} ولذلك تُجمَع الإطارات بنقل المشغّل إلى كل لحظة. وهذا أبطأ، والمتصفّح هو
+      الذي يقرّر على أي إطار تقع كل نقلة، فقد يخرج المقطع السريع بإطار زائغ هنا أو هناك.</span>
     <span data-phrase="net.clean">مقطعك لم يذهب إلى أي مكان. {total} ملفاً
       حُمِّلت. {platform}</span>
     <span data-phrase="net.dirty">اتصل شيءٌ بـ {hosts}، وهو ما لا تفعله هذه

--- a/locales/de/tools/crop-video.html
+++ b/locales/de/tools/crop-video.html
@@ -152,6 +152,39 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">Die Datei endet mitten in einem Einzelbild.</span>
+    <span data-phrase="read.avcshort">Der H.264-Konfigurationsdatensatz ist zu kurz.</span>
+    <span data-phrase="read.hevcshort">Der HEVC-Konfigurationsdatensatz ist zu kurz.</span>
+    <span data-phrase="read.av1short">Der AV1-Konfigurationsdatensatz ist zu kurz.</span>
+    <span data-phrase="read.compactsizes">Die Sample-Größen stehen in einer kompakten Tabelle, die dieser Leser nicht
+      dekodiert.</span>
+    <span data-phrase="read.sampletables">Die Sample-Tabellen sind unvollständig.</span>
+    <span data-phrase="read.chunktable">Die Chunk-Tabelle ist leer.</span>
+    <span data-phrase="read.nosamples">Die Spur enthält keine Samples.</span>
+    <span data-phrase="read.nostbl">Der Videospur fehlen ihre Sample-Tabellen.</span>
+    <span data-phrase="read.nostsd">Die Videospur hat keine Sample-Beschreibung.</span>
+    <span data-phrase="read.emptystsd">Die Sample-Beschreibung des Videos ist leer.</span>
+    <span data-phrase="read.encrypted">Die Videospur ist verschlüsselt.</span>
+    <span data-phrase="read.unknowncodec">Das Video liegt als &bdquo;{type}&ldquo; vor, und das kennt dieser Leser nicht.</span>
+    <span data-phrase="read.noconfig">Die Spur &bdquo;{type}&ldquo; führt keine Dekoder-Konfiguration mit sich.</span>
+    <span data-phrase="read.notmp4">Das ist keine MP4- oder MOV-Datei.</span>
+    <span data-phrase="read.nomoov">Die Datei hat keinen Film-Header.</span>
+    <span data-phrase="read.novideo">Die Datei hat keine Videospur, mit der dieser Leser etwas anfangen kann.</span>
+    <span data-phrase="read.notimescale">Die Videospur hat keine Zeitskala.</span>
+    <span data-phrase="read.nofragments">Die Fragmente in dieser Datei enthalten keine Einzelbilder für ihre Videospur.</span>
+    <span data-phrase="read.unreadable">Die Datei ließ sich nicht als MP4 lesen.</span>
+    <span data-phrase="read.notplayed">Dieses Format spielt dieser Browser nicht ab.</span>
+    <span data-phrase="read.layout">Der Aufbau dieser Datei ist keiner, den der Leser hier versteht.</span>
+    <span data-phrase="read.nodecoder">Dieser Browser dekodiert {codec} nicht direkt.</span>
+    <span data-phrase="read.nowebcodecs">Dieser Browser hat kein WebCodecs, also lassen sich die Einzelbilder nicht eines
+      nach dem anderen dekodieren.</span>
+    <span data-phrase="read.turned">Diese Datei ist gedreht gespeichert, und der Leser hier und der Player des Browsers
+      sind sich über die Drehung nicht einig.</span>
+    <span data-phrase="open.failed">Dieser Browser kann diese Datei nicht öffnen. {reason}</span>
+    <span data-phrase="open.norecord">Dieser Browser kann kein Video aufnehmen und diese Datei deshalb nicht zuschneiden.</span>
+    <span data-phrase="path.record">{reason} Deshalb wird dieses hier zugeschnitten, indem es abgespielt und dabei
+      aufgenommen wird &mdash; das dauert so lange, wie das Video lang ist, und der Ton
+      wird neu kodiert statt kopiert.</span>
     <span data-phrase="net.clean">Ihr Video ist nirgendwohin gegangen. {total}
       Dateien geladen. {platform}</span>
     <span data-phrase="net.dirty">Etwas hat {hosts} kontaktiert, und das tut

--- a/locales/de/tools/grab-frame.html
+++ b/locales/de/tools/grab-frame.html
@@ -139,6 +139,42 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">Die Datei endet mitten in einem Einzelbild.</span>
+    <span data-phrase="read.avcshort">Der H.264-Konfigurationsdatensatz ist zu kurz.</span>
+    <span data-phrase="read.hevcshort">Der HEVC-Konfigurationsdatensatz ist zu kurz.</span>
+    <span data-phrase="read.av1short">Der AV1-Konfigurationsdatensatz ist zu kurz.</span>
+    <span data-phrase="read.compactsizes">Die Sample-Größen stehen in einer kompakten Tabelle, die dieser Leser nicht
+      dekodiert.</span>
+    <span data-phrase="read.sampletables">Die Sample-Tabellen sind unvollständig.</span>
+    <span data-phrase="read.chunktable">Die Chunk-Tabelle ist leer.</span>
+    <span data-phrase="read.nosamples">Die Spur enthält keine Samples.</span>
+    <span data-phrase="read.nostbl">Der Videospur fehlen ihre Sample-Tabellen.</span>
+    <span data-phrase="read.nostsd">Die Videospur hat keine Sample-Beschreibung.</span>
+    <span data-phrase="read.emptystsd">Die Sample-Beschreibung des Videos ist leer.</span>
+    <span data-phrase="read.encrypted">Die Videospur ist verschlüsselt.</span>
+    <span data-phrase="read.unknowncodec">Das Video liegt als &bdquo;{type}&ldquo; vor, und das kennt dieser Leser nicht.</span>
+    <span data-phrase="read.noconfig">Die Spur &bdquo;{type}&ldquo; führt keine Dekoder-Konfiguration mit sich.</span>
+    <span data-phrase="read.notmp4">Das ist keine MP4- oder MOV-Datei.</span>
+    <span data-phrase="read.nomoov">Die Datei hat keinen Film-Header.</span>
+    <span data-phrase="read.novideo">Die Datei hat keine Videospur, mit der dieser Leser etwas anfangen kann.</span>
+    <span data-phrase="read.notimescale">Die Videospur hat keine Zeitskala.</span>
+    <span data-phrase="read.nofragments">Die Fragmente in dieser Datei enthalten keine Einzelbilder für ihre Videospur.</span>
+    <span data-phrase="read.unreadable">Die Datei ließ sich nicht als MP4 lesen.</span>
+    <span data-phrase="read.notplayed">Dieses Format spielt dieser Browser nicht ab.</span>
+    <span data-phrase="read.layout">Der Aufbau dieser Datei ist keiner, den der Leser hier versteht.</span>
+    <span data-phrase="read.nodecoder">Dieser Browser dekodiert {codec} nicht direkt.</span>
+    <span data-phrase="read.nowebcodecs">Dieser Browser hat kein WebCodecs, also lassen sich die Einzelbilder nicht eines
+      nach dem anderen dekodieren.</span>
+    <span data-phrase="read.turned">Diese Datei ist gedreht gespeichert, und der Leser hier und der Player des Browsers
+      sind sich über die Drehung nicht einig.</span>
+    <span data-phrase="open.failed">Dieser Browser kann diese Datei nicht öffnen. {reason}</span>
+    <span data-phrase="path.player">{reason} Deshalb wird diese Datei vom Player des Browsers gelesen und nicht
+      Einzelbild für Einzelbild: Das Bild wird weiterhin in voller Größe des Videos
+      gespeichert, aber welches Einzelbild Sie treffen, entscheidet der Player, und ein
+      Schritt bewegt sich um ungefähr ein Bild statt um genau eines.</span>
+    <span data-phrase="path.nopreview">Dieser Browser spielt diese Datei nicht ab, es gibt hier also nichts zum Abspielen.
+      Dekodieren kann er sie aber, und daraus entstehen die Standbilder; bewegen Sie sich
+      mit dem Schieberegler und den Pfeiltasten durch das Video.</span>
     <span data-phrase="net.clean">Ihr Video ist nirgendwohin gegangen. {total}
       Dateien geladen. {platform}</span>
     <span data-phrase="net.dirty">Etwas hat {hosts} kontaktiert, und das tut

--- a/locales/de/tools/timelapse-video.html
+++ b/locales/de/tools/timelapse-video.html
@@ -159,6 +159,41 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">Die Datei endet mitten in einem Einzelbild.</span>
+    <span data-phrase="read.avcshort">Der H.264-Konfigurationsdatensatz ist zu kurz.</span>
+    <span data-phrase="read.hevcshort">Der HEVC-Konfigurationsdatensatz ist zu kurz.</span>
+    <span data-phrase="read.av1short">Der AV1-Konfigurationsdatensatz ist zu kurz.</span>
+    <span data-phrase="read.compactsizes">Die Sample-Größen stehen in einer kompakten Tabelle, die dieser Leser nicht
+      dekodiert.</span>
+    <span data-phrase="read.sampletables">Die Sample-Tabellen sind unvollständig.</span>
+    <span data-phrase="read.chunktable">Die Chunk-Tabelle ist leer.</span>
+    <span data-phrase="read.nosamples">Die Spur enthält keine Samples.</span>
+    <span data-phrase="read.nostbl">Der Videospur fehlen ihre Sample-Tabellen.</span>
+    <span data-phrase="read.nostsd">Die Videospur hat keine Sample-Beschreibung.</span>
+    <span data-phrase="read.emptystsd">Die Sample-Beschreibung des Videos ist leer.</span>
+    <span data-phrase="read.encrypted">Die Videospur ist verschlüsselt.</span>
+    <span data-phrase="read.unknowncodec">Das Video liegt als &bdquo;{type}&ldquo; vor, und das kennt dieser Leser nicht.</span>
+    <span data-phrase="read.noconfig">Die Spur &bdquo;{type}&ldquo; führt keine Dekoder-Konfiguration mit sich.</span>
+    <span data-phrase="read.notmp4">Das ist keine MP4- oder MOV-Datei.</span>
+    <span data-phrase="read.nomoov">Die Datei hat keinen Film-Header.</span>
+    <span data-phrase="read.novideo">Die Datei hat keine Videospur, mit der dieser Leser etwas anfangen kann.</span>
+    <span data-phrase="read.notimescale">Die Videospur hat keine Zeitskala.</span>
+    <span data-phrase="read.nofragments">Die Fragmente in dieser Datei enthalten keine Einzelbilder für ihre Videospur.</span>
+    <span data-phrase="read.unreadable">Die Datei ließ sich nicht als MP4 lesen.</span>
+    <span data-phrase="read.notplayed">Dieses Format spielt dieser Browser nicht ab.</span>
+    <span data-phrase="read.layout">Der Aufbau dieser Datei ist keiner, den der Leser hier versteht.</span>
+    <span data-phrase="read.nodecoder">Dieser Browser dekodiert {codec} nicht direkt.</span>
+    <span data-phrase="read.nowebcodecs">Dieser Browser hat kein WebCodecs, also lassen sich die Einzelbilder nicht eines
+      nach dem anderen dekodieren.</span>
+    <span data-phrase="open.failed">Dieser Browser kann diese Datei nicht öffnen. {reason}</span>
+    <span data-phrase="open.nodecode">Dieser Browser hat die Datei geöffnet, kann das Video darin aber nicht dekodieren.
+      Das ist meist Dolby Vision oder HEVC auf einem Rechner ohne Hardware-Unterstützung
+      dafür: Der Container liest sich einwandfrei, und das Bild kommt nie an. Wandeln Sie
+      die Datei zuerst in ein gewöhnliches MP4 (H.264) um, dann liest dieses Werkzeug sie
+      direkt.</span>
+    <span data-phrase="path.seek">{reason} Deshalb wird dieses hier gelesen, indem der Player des Browsers zu jedem
+      Zeitpunkt gesprungen wird &mdash; das funktioniert bei jedem Format, das der Browser
+      abspielt, und ist ein wenig langsamer.</span>
     <span data-phrase="net.clean">Ihr Video ist nirgendwohin gegangen. {total}
       Dateien geladen. {platform}</span>
     <span data-phrase="net.dirty">Etwas hat {hosts} kontaktiert, und das tut

--- a/locales/de/tools/video-to-gif.html
+++ b/locales/de/tools/video-to-gif.html
@@ -175,6 +175,39 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">Die Datei endet mitten in einem Einzelbild.</span>
+    <span data-phrase="read.avcshort">Der H.264-Konfigurationsdatensatz ist zu kurz.</span>
+    <span data-phrase="read.hevcshort">Der HEVC-Konfigurationsdatensatz ist zu kurz.</span>
+    <span data-phrase="read.av1short">Der AV1-Konfigurationsdatensatz ist zu kurz.</span>
+    <span data-phrase="read.compactsizes">Die Sample-Größen stehen in einer kompakten Tabelle, die dieser Leser nicht
+      dekodiert.</span>
+    <span data-phrase="read.sampletables">Die Sample-Tabellen sind unvollständig.</span>
+    <span data-phrase="read.chunktable">Die Chunk-Tabelle ist leer.</span>
+    <span data-phrase="read.nosamples">Die Spur enthält keine Samples.</span>
+    <span data-phrase="read.nostbl">Der Videospur fehlen ihre Sample-Tabellen.</span>
+    <span data-phrase="read.nostsd">Die Videospur hat keine Sample-Beschreibung.</span>
+    <span data-phrase="read.emptystsd">Die Sample-Beschreibung des Videos ist leer.</span>
+    <span data-phrase="read.encrypted">Die Videospur ist verschlüsselt.</span>
+    <span data-phrase="read.unknowncodec">Das Video liegt als &bdquo;{type}&ldquo; vor, und das kennt dieser Leser nicht.</span>
+    <span data-phrase="read.noconfig">Die Spur &bdquo;{type}&ldquo; führt keine Dekoder-Konfiguration mit sich.</span>
+    <span data-phrase="read.notmp4">Das ist keine MP4- oder MOV-Datei.</span>
+    <span data-phrase="read.nomoov">Die Datei hat keinen Film-Header.</span>
+    <span data-phrase="read.novideo">Die Datei hat keine Videospur, mit der dieser Leser etwas anfangen kann.</span>
+    <span data-phrase="read.notimescale">Die Videospur hat keine Zeitskala.</span>
+    <span data-phrase="read.nofragments">Die Fragmente in dieser Datei enthalten keine Einzelbilder für ihre Videospur.</span>
+    <span data-phrase="read.unreadable">Die Datei ließ sich nicht als MP4 lesen.</span>
+    <span data-phrase="read.notplayed">Dieses Format spielt dieser Browser nicht ab.</span>
+    <span data-phrase="read.layout">Der Aufbau dieser Datei ist keiner, den der Leser hier versteht.</span>
+    <span data-phrase="read.nodecoder">Dieser Browser dekodiert {codec} nicht direkt.</span>
+    <span data-phrase="read.nowebcodecs">Dieser Browser hat kein WebCodecs, also lassen sich die Einzelbilder nicht eines
+      nach dem anderen dekodieren.</span>
+    <span data-phrase="read.turned">Diese Datei ist gedreht gespeichert, und der Leser hier und der Player des Browsers
+      sind sich über die Drehung nicht einig.</span>
+    <span data-phrase="open.failed">Dieser Browser kann diese Datei nicht öffnen. {reason}</span>
+    <span data-phrase="path.seek">{reason} Deshalb werden die Einzelbilder dafür geholt, indem der Player zu jedem
+      Zeitpunkt gesprungen wird. Das ist langsamer, und welches Einzelbild ein Sprung
+      trifft, entscheidet der Browser &mdash; eine schnelle Stelle kann hier und da also
+      um ein Bild danebenliegen.</span>
     <span data-phrase="net.clean">Ihr Video ist nirgendwohin gegangen. {total}
       Dateien geladen. {platform}</span>
     <span data-phrase="net.dirty">Etwas hat {hosts} kontaktiert, und das tut

--- a/locales/es/tools/crop-video.html
+++ b/locales/es/tools/crop-video.html
@@ -151,6 +151,38 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">El archivo termina en mitad de un fotograma.</span>
+    <span data-phrase="read.avcshort">El registro de configuración H.264 es demasiado corto.</span>
+    <span data-phrase="read.hevcshort">El registro de configuración HEVC es demasiado corto.</span>
+    <span data-phrase="read.av1short">El registro de configuración AV1 es demasiado corto.</span>
+    <span data-phrase="read.compactsizes">Los tamaños de las muestras están en una tabla compacta que este lector no
+      decodifica.</span>
+    <span data-phrase="read.sampletables">Las tablas de muestras están incompletas.</span>
+    <span data-phrase="read.chunktable">La tabla de chunks está vacía.</span>
+    <span data-phrase="read.nosamples">La pista no contiene ninguna muestra.</span>
+    <span data-phrase="read.nostbl">A la pista de vídeo le faltan sus tablas de muestras.</span>
+    <span data-phrase="read.nostsd">La pista de vídeo no tiene descripción de muestra.</span>
+    <span data-phrase="read.emptystsd">La descripción de muestra del vídeo está vacía.</span>
+    <span data-phrase="read.encrypted">La pista de vídeo está cifrada.</span>
+    <span data-phrase="read.unknowncodec">El vídeo está guardado como &laquo;{type}&raquo;, y este lector no lo conoce.</span>
+    <span data-phrase="read.noconfig">La pista &laquo;{type}&raquo; no lleva ninguna configuración de decodificador.</span>
+    <span data-phrase="read.notmp4">Esto no es un archivo MP4 ni MOV.</span>
+    <span data-phrase="read.nomoov">El archivo no tiene cabecera de película.</span>
+    <span data-phrase="read.novideo">El archivo no tiene ninguna pista de vídeo que este lector pueda usar.</span>
+    <span data-phrase="read.notimescale">La pista de vídeo no tiene escala de tiempo.</span>
+    <span data-phrase="read.nofragments">Los fragmentos de este archivo no contienen ningún fotograma de su pista de vídeo.</span>
+    <span data-phrase="read.unreadable">El archivo no se pudo leer como MP4.</span>
+    <span data-phrase="read.notplayed">Este formato no es de los que reproduce este navegador.</span>
+    <span data-phrase="read.layout">La disposición de este archivo no es de las que entiende el lector de aquí.</span>
+    <span data-phrase="read.nodecoder">Este navegador no decodifica {codec} directamente.</span>
+    <span data-phrase="read.nowebcodecs">Este navegador no tiene WebCodecs, así que los fotogramas no se pueden decodificar
+      uno a uno.</span>
+    <span data-phrase="read.turned">Este archivo está guardado girado, y el lector de aquí y el reproductor del
+      navegador no se ponen de acuerdo sobre el giro.</span>
+    <span data-phrase="open.failed">Este navegador no puede abrir este archivo. {reason}</span>
+    <span data-phrase="open.norecord">Este navegador no puede grabar vídeo, así que tampoco puede recortar este archivo.</span>
+    <span data-phrase="path.record">{reason} Por eso este se recorta reproduciéndolo y grabando lo que sale: tarda lo
+      que dure el vídeo, y el sonido se recodifica en vez de copiarse.</span>
     <span data-phrase="net.clean">tu vídeo no ha ido a ninguna parte. {total}
       archivos cargados. {platform}</span>
     <span data-phrase="net.dirty">algo ha contactado con {hosts}, cosa que esta

--- a/locales/es/tools/grab-frame.html
+++ b/locales/es/tools/grab-frame.html
@@ -139,6 +139,42 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">El archivo termina en mitad de un fotograma.</span>
+    <span data-phrase="read.avcshort">El registro de configuración H.264 es demasiado corto.</span>
+    <span data-phrase="read.hevcshort">El registro de configuración HEVC es demasiado corto.</span>
+    <span data-phrase="read.av1short">El registro de configuración AV1 es demasiado corto.</span>
+    <span data-phrase="read.compactsizes">Los tamaños de las muestras están en una tabla compacta que este lector no
+      decodifica.</span>
+    <span data-phrase="read.sampletables">Las tablas de muestras están incompletas.</span>
+    <span data-phrase="read.chunktable">La tabla de chunks está vacía.</span>
+    <span data-phrase="read.nosamples">La pista no contiene ninguna muestra.</span>
+    <span data-phrase="read.nostbl">A la pista de vídeo le faltan sus tablas de muestras.</span>
+    <span data-phrase="read.nostsd">La pista de vídeo no tiene descripción de muestra.</span>
+    <span data-phrase="read.emptystsd">La descripción de muestra del vídeo está vacía.</span>
+    <span data-phrase="read.encrypted">La pista de vídeo está cifrada.</span>
+    <span data-phrase="read.unknowncodec">El vídeo está guardado como &laquo;{type}&raquo;, y este lector no lo conoce.</span>
+    <span data-phrase="read.noconfig">La pista &laquo;{type}&raquo; no lleva ninguna configuración de decodificador.</span>
+    <span data-phrase="read.notmp4">Esto no es un archivo MP4 ni MOV.</span>
+    <span data-phrase="read.nomoov">El archivo no tiene cabecera de película.</span>
+    <span data-phrase="read.novideo">El archivo no tiene ninguna pista de vídeo que este lector pueda usar.</span>
+    <span data-phrase="read.notimescale">La pista de vídeo no tiene escala de tiempo.</span>
+    <span data-phrase="read.nofragments">Los fragmentos de este archivo no contienen ningún fotograma de su pista de vídeo.</span>
+    <span data-phrase="read.unreadable">El archivo no se pudo leer como MP4.</span>
+    <span data-phrase="read.notplayed">Este formato no es de los que reproduce este navegador.</span>
+    <span data-phrase="read.layout">La disposición de este archivo no es de las que entiende el lector de aquí.</span>
+    <span data-phrase="read.nodecoder">Este navegador no decodifica {codec} directamente.</span>
+    <span data-phrase="read.nowebcodecs">Este navegador no tiene WebCodecs, así que los fotogramas no se pueden decodificar
+      uno a uno.</span>
+    <span data-phrase="read.turned">Este archivo está guardado girado, y el lector de aquí y el reproductor del
+      navegador no se ponen de acuerdo sobre el giro.</span>
+    <span data-phrase="open.failed">Este navegador no puede abrir este archivo. {reason}</span>
+    <span data-phrase="path.player">{reason} Por eso este archivo lo lee el reproductor del navegador y no se lee
+      fotograma a fotograma: la imagen se sigue guardando al tamaño real del vídeo, pero
+      el fotograma en el que caes lo elige el reproductor, y cada paso avanza más o menos
+      un fotograma en vez de exactamente uno.</span>
+    <span data-phrase="path.nopreview">Este navegador no reproduce este archivo, así que no hay nada que darle a
+      reproducir. Decodificarlo sí puede, y de ahí salen las imágenes: muévete por el
+      vídeo con el deslizador y las flechas.</span>
     <span data-phrase="net.clean">tu vídeo no ha ido a ninguna parte. {total}
       archivos cargados. {platform}</span>
     <span data-phrase="net.dirty">algo ha contactado con {hosts}, cosa que esta

--- a/locales/es/tools/timelapse-video.html
+++ b/locales/es/tools/timelapse-video.html
@@ -159,6 +159,40 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">El archivo termina en mitad de un fotograma.</span>
+    <span data-phrase="read.avcshort">El registro de configuración H.264 es demasiado corto.</span>
+    <span data-phrase="read.hevcshort">El registro de configuración HEVC es demasiado corto.</span>
+    <span data-phrase="read.av1short">El registro de configuración AV1 es demasiado corto.</span>
+    <span data-phrase="read.compactsizes">Los tamaños de las muestras están en una tabla compacta que este lector no
+      decodifica.</span>
+    <span data-phrase="read.sampletables">Las tablas de muestras están incompletas.</span>
+    <span data-phrase="read.chunktable">La tabla de chunks está vacía.</span>
+    <span data-phrase="read.nosamples">La pista no contiene ninguna muestra.</span>
+    <span data-phrase="read.nostbl">A la pista de vídeo le faltan sus tablas de muestras.</span>
+    <span data-phrase="read.nostsd">La pista de vídeo no tiene descripción de muestra.</span>
+    <span data-phrase="read.emptystsd">La descripción de muestra del vídeo está vacía.</span>
+    <span data-phrase="read.encrypted">La pista de vídeo está cifrada.</span>
+    <span data-phrase="read.unknowncodec">El vídeo está guardado como &laquo;{type}&raquo;, y este lector no lo conoce.</span>
+    <span data-phrase="read.noconfig">La pista &laquo;{type}&raquo; no lleva ninguna configuración de decodificador.</span>
+    <span data-phrase="read.notmp4">Esto no es un archivo MP4 ni MOV.</span>
+    <span data-phrase="read.nomoov">El archivo no tiene cabecera de película.</span>
+    <span data-phrase="read.novideo">El archivo no tiene ninguna pista de vídeo que este lector pueda usar.</span>
+    <span data-phrase="read.notimescale">La pista de vídeo no tiene escala de tiempo.</span>
+    <span data-phrase="read.nofragments">Los fragmentos de este archivo no contienen ningún fotograma de su pista de vídeo.</span>
+    <span data-phrase="read.unreadable">El archivo no se pudo leer como MP4.</span>
+    <span data-phrase="read.notplayed">Este formato no es de los que reproduce este navegador.</span>
+    <span data-phrase="read.layout">La disposición de este archivo no es de las que entiende el lector de aquí.</span>
+    <span data-phrase="read.nodecoder">Este navegador no decodifica {codec} directamente.</span>
+    <span data-phrase="read.nowebcodecs">Este navegador no tiene WebCodecs, así que los fotogramas no se pueden decodificar
+      uno a uno.</span>
+    <span data-phrase="open.failed">Este navegador no puede abrir este archivo. {reason}</span>
+    <span data-phrase="open.nodecode">Este navegador abrió el archivo pero no puede decodificar el vídeo que lleva dentro.
+      Suele ser Dolby Vision, o HEVC en una máquina sin soporte por hardware: el
+      contenedor se lee perfectamente y la imagen no llega nunca. Conviértelo antes a un
+      MP4 normal (H.264) y esta herramienta lo leerá directamente.</span>
+    <span data-phrase="path.seek">{reason} Por eso este se lee llevando el reproductor del navegador a cada instante:
+      eso funciona con todos los formatos que el navegador reproduce, y es un poco más
+      lento.</span>
     <span data-phrase="net.clean">tu vídeo no ha ido a ninguna parte. {total}
       archivos cargados. {platform}</span>
     <span data-phrase="net.dirty">algo ha contactado con {hosts}, cosa que esta

--- a/locales/es/tools/video-to-gif.html
+++ b/locales/es/tools/video-to-gif.html
@@ -175,6 +175,38 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">El archivo termina en mitad de un fotograma.</span>
+    <span data-phrase="read.avcshort">El registro de configuración H.264 es demasiado corto.</span>
+    <span data-phrase="read.hevcshort">El registro de configuración HEVC es demasiado corto.</span>
+    <span data-phrase="read.av1short">El registro de configuración AV1 es demasiado corto.</span>
+    <span data-phrase="read.compactsizes">Los tamaños de las muestras están en una tabla compacta que este lector no
+      decodifica.</span>
+    <span data-phrase="read.sampletables">Las tablas de muestras están incompletas.</span>
+    <span data-phrase="read.chunktable">La tabla de chunks está vacía.</span>
+    <span data-phrase="read.nosamples">La pista no contiene ninguna muestra.</span>
+    <span data-phrase="read.nostbl">A la pista de vídeo le faltan sus tablas de muestras.</span>
+    <span data-phrase="read.nostsd">La pista de vídeo no tiene descripción de muestra.</span>
+    <span data-phrase="read.emptystsd">La descripción de muestra del vídeo está vacía.</span>
+    <span data-phrase="read.encrypted">La pista de vídeo está cifrada.</span>
+    <span data-phrase="read.unknowncodec">El vídeo está guardado como &laquo;{type}&raquo;, y este lector no lo conoce.</span>
+    <span data-phrase="read.noconfig">La pista &laquo;{type}&raquo; no lleva ninguna configuración de decodificador.</span>
+    <span data-phrase="read.notmp4">Esto no es un archivo MP4 ni MOV.</span>
+    <span data-phrase="read.nomoov">El archivo no tiene cabecera de película.</span>
+    <span data-phrase="read.novideo">El archivo no tiene ninguna pista de vídeo que este lector pueda usar.</span>
+    <span data-phrase="read.notimescale">La pista de vídeo no tiene escala de tiempo.</span>
+    <span data-phrase="read.nofragments">Los fragmentos de este archivo no contienen ningún fotograma de su pista de vídeo.</span>
+    <span data-phrase="read.unreadable">El archivo no se pudo leer como MP4.</span>
+    <span data-phrase="read.notplayed">Este formato no es de los que reproduce este navegador.</span>
+    <span data-phrase="read.layout">La disposición de este archivo no es de las que entiende el lector de aquí.</span>
+    <span data-phrase="read.nodecoder">Este navegador no decodifica {codec} directamente.</span>
+    <span data-phrase="read.nowebcodecs">Este navegador no tiene WebCodecs, así que los fotogramas no se pueden decodificar
+      uno a uno.</span>
+    <span data-phrase="read.turned">Este archivo está guardado girado, y el lector de aquí y el reproductor del
+      navegador no se ponen de acuerdo sobre el giro.</span>
+    <span data-phrase="open.failed">Este navegador no puede abrir este archivo. {reason}</span>
+    <span data-phrase="path.seek">{reason} Por eso los fotogramas se recogen llevando el reproductor a cada instante.
+      Es más lento, y el navegador decide en qué fotograma cae cada salto, así que un
+      trozo rápido puede salir desplazado un fotograma de vez en cuando.</span>
     <span data-phrase="net.clean">tu vídeo no ha ido a ninguna parte. {total}
       archivos cargados. {platform}</span>
     <span data-phrase="net.dirty">algo ha contactado con {hosts}, cosa que esta

--- a/locales/fr/tools/crop-video.html
+++ b/locales/fr/tools/crop-video.html
@@ -152,6 +152,40 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">Le fichier se termine au milieu d&rsquo;une image.</span>
+    <span data-phrase="read.avcshort">L&rsquo;enregistrement de configuration H.264 est trop court.</span>
+    <span data-phrase="read.hevcshort">L&rsquo;enregistrement de configuration HEVC est trop court.</span>
+    <span data-phrase="read.av1short">L&rsquo;enregistrement de configuration AV1 est trop court.</span>
+    <span data-phrase="read.compactsizes">Les tailles d&rsquo;échantillons sont dans une table compacte que ce lecteur ne
+      décode pas.</span>
+    <span data-phrase="read.sampletables">Les tables d&rsquo;échantillons sont incomplètes.</span>
+    <span data-phrase="read.chunktable">La table des chunks est vide.</span>
+    <span data-phrase="read.nosamples">La piste ne contient aucun échantillon.</span>
+    <span data-phrase="read.nostbl">Il manque à la piste vidéo ses tables d&rsquo;échantillons.</span>
+    <span data-phrase="read.nostsd">La piste vidéo n&rsquo;a pas de description d&rsquo;échantillon.</span>
+    <span data-phrase="read.emptystsd">La description d&rsquo;échantillon de la vidéo est vide.</span>
+    <span data-phrase="read.encrypted">La piste vidéo est chiffrée.</span>
+    <span data-phrase="read.unknowncodec">La vidéo est stockée en &laquo;&nbsp;{type}&nbsp;&raquo;, que ce lecteur ne connaît
+      pas.</span>
+    <span data-phrase="read.noconfig">La piste &laquo;&nbsp;{type}&nbsp;&raquo; ne porte aucune configuration de décodeur.</span>
+    <span data-phrase="read.notmp4">Ce n&rsquo;est pas un fichier MP4 ni MOV.</span>
+    <span data-phrase="read.nomoov">Le fichier n&rsquo;a pas d&rsquo;en-tête de film.</span>
+    <span data-phrase="read.novideo">Le fichier n&rsquo;a aucune piste vidéo utilisable par ce lecteur.</span>
+    <span data-phrase="read.notimescale">La piste vidéo n&rsquo;a pas d&rsquo;échelle de temps.</span>
+    <span data-phrase="read.nofragments">Les fragments de ce fichier ne contiennent aucune image pour sa piste vidéo.</span>
+    <span data-phrase="read.unreadable">Le fichier n&rsquo;a pas pu être lu comme un MP4.</span>
+    <span data-phrase="read.notplayed">Ce format n&rsquo;est pas de ceux que ce navigateur lit.</span>
+    <span data-phrase="read.layout">La disposition de ce fichier n&rsquo;est pas de celles que le lecteur comprend ici.</span>
+    <span data-phrase="read.nodecoder">Ce navigateur ne décode pas {codec} directement.</span>
+    <span data-phrase="read.nowebcodecs">Ce navigateur n&rsquo;a pas WebCodecs, les images ne peuvent donc pas être décodées
+      une par une.</span>
+    <span data-phrase="read.turned">Ce fichier est stocké tourné, et le lecteur d&rsquo;ici et celui du navigateur ne
+      s&rsquo;accordent pas sur la rotation.</span>
+    <span data-phrase="open.failed">Ce navigateur ne peut pas ouvrir ce fichier. {reason}</span>
+    <span data-phrase="open.norecord">Ce navigateur ne sait pas enregistrer de vidéo, il ne peut donc pas rogner ce
+      fichier.</span>
+    <span data-phrase="path.record">{reason} Celle-ci est donc rognée en la lisant et en enregistrant ce qui sort&nbsp;:
+      cela prend le temps que dure la vidéo, et le son est réencodé plutôt que copié.</span>
     <span data-phrase="net.clean">votre vidéo n'est allée nulle part. {total}
       fichiers chargés. {platform}</span>
     <span data-phrase="net.dirty">quelque chose a contacté {hosts}, ce que cet

--- a/locales/fr/tools/grab-frame.html
+++ b/locales/fr/tools/grab-frame.html
@@ -139,6 +139,44 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">Le fichier se termine au milieu d&rsquo;une image.</span>
+    <span data-phrase="read.avcshort">L&rsquo;enregistrement de configuration H.264 est trop court.</span>
+    <span data-phrase="read.hevcshort">L&rsquo;enregistrement de configuration HEVC est trop court.</span>
+    <span data-phrase="read.av1short">L&rsquo;enregistrement de configuration AV1 est trop court.</span>
+    <span data-phrase="read.compactsizes">Les tailles d&rsquo;échantillons sont dans une table compacte que ce lecteur ne
+      décode pas.</span>
+    <span data-phrase="read.sampletables">Les tables d&rsquo;échantillons sont incomplètes.</span>
+    <span data-phrase="read.chunktable">La table des chunks est vide.</span>
+    <span data-phrase="read.nosamples">La piste ne contient aucun échantillon.</span>
+    <span data-phrase="read.nostbl">Il manque à la piste vidéo ses tables d&rsquo;échantillons.</span>
+    <span data-phrase="read.nostsd">La piste vidéo n&rsquo;a pas de description d&rsquo;échantillon.</span>
+    <span data-phrase="read.emptystsd">La description d&rsquo;échantillon de la vidéo est vide.</span>
+    <span data-phrase="read.encrypted">La piste vidéo est chiffrée.</span>
+    <span data-phrase="read.unknowncodec">La vidéo est stockée en &laquo;&nbsp;{type}&nbsp;&raquo;, que ce lecteur ne connaît
+      pas.</span>
+    <span data-phrase="read.noconfig">La piste &laquo;&nbsp;{type}&nbsp;&raquo; ne porte aucune configuration de décodeur.</span>
+    <span data-phrase="read.notmp4">Ce n&rsquo;est pas un fichier MP4 ni MOV.</span>
+    <span data-phrase="read.nomoov">Le fichier n&rsquo;a pas d&rsquo;en-tête de film.</span>
+    <span data-phrase="read.novideo">Le fichier n&rsquo;a aucune piste vidéo utilisable par ce lecteur.</span>
+    <span data-phrase="read.notimescale">La piste vidéo n&rsquo;a pas d&rsquo;échelle de temps.</span>
+    <span data-phrase="read.nofragments">Les fragments de ce fichier ne contiennent aucune image pour sa piste vidéo.</span>
+    <span data-phrase="read.unreadable">Le fichier n&rsquo;a pas pu être lu comme un MP4.</span>
+    <span data-phrase="read.notplayed">Ce format n&rsquo;est pas de ceux que ce navigateur lit.</span>
+    <span data-phrase="read.layout">La disposition de ce fichier n&rsquo;est pas de celles que le lecteur comprend ici.</span>
+    <span data-phrase="read.nodecoder">Ce navigateur ne décode pas {codec} directement.</span>
+    <span data-phrase="read.nowebcodecs">Ce navigateur n&rsquo;a pas WebCodecs, les images ne peuvent donc pas être décodées
+      une par une.</span>
+    <span data-phrase="read.turned">Ce fichier est stocké tourné, et le lecteur d&rsquo;ici et celui du navigateur ne
+      s&rsquo;accordent pas sur la rotation.</span>
+    <span data-phrase="open.failed">Ce navigateur ne peut pas ouvrir ce fichier. {reason}</span>
+    <span data-phrase="path.player">{reason} Ce fichier est donc lu par le lecteur du navigateur et non image par
+      image&nbsp;: la photo est toujours enregistrée à la taille réelle de la vidéo, mais
+      l&rsquo;image sur laquelle vous tombez est celle que choisit le lecteur, et un pas
+      avance d&rsquo;environ une image plutôt que d&rsquo;une exactement.</span>
+    <span data-phrase="path.nopreview">Ce navigateur ne lit pas ce fichier, il n&rsquo;y a donc rien sur quoi appuyer pour
+      lancer la lecture. Il sait le décoder, en revanche, et c&rsquo;est de là que
+      viennent les images&nbsp;: servez-vous du curseur et des flèches pour vous y
+      déplacer.</span>
     <span data-phrase="net.clean">votre vidéo n'est allée nulle part. {total}
       fichiers chargés. {platform}</span>
     <span data-phrase="net.dirty">quelque chose a contacté {hosts}, ce que cet

--- a/locales/fr/tools/timelapse-video.html
+++ b/locales/fr/tools/timelapse-video.html
@@ -160,6 +160,42 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">Le fichier se termine au milieu d&rsquo;une image.</span>
+    <span data-phrase="read.avcshort">L&rsquo;enregistrement de configuration H.264 est trop court.</span>
+    <span data-phrase="read.hevcshort">L&rsquo;enregistrement de configuration HEVC est trop court.</span>
+    <span data-phrase="read.av1short">L&rsquo;enregistrement de configuration AV1 est trop court.</span>
+    <span data-phrase="read.compactsizes">Les tailles d&rsquo;échantillons sont dans une table compacte que ce lecteur ne
+      décode pas.</span>
+    <span data-phrase="read.sampletables">Les tables d&rsquo;échantillons sont incomplètes.</span>
+    <span data-phrase="read.chunktable">La table des chunks est vide.</span>
+    <span data-phrase="read.nosamples">La piste ne contient aucun échantillon.</span>
+    <span data-phrase="read.nostbl">Il manque à la piste vidéo ses tables d&rsquo;échantillons.</span>
+    <span data-phrase="read.nostsd">La piste vidéo n&rsquo;a pas de description d&rsquo;échantillon.</span>
+    <span data-phrase="read.emptystsd">La description d&rsquo;échantillon de la vidéo est vide.</span>
+    <span data-phrase="read.encrypted">La piste vidéo est chiffrée.</span>
+    <span data-phrase="read.unknowncodec">La vidéo est stockée en &laquo;&nbsp;{type}&nbsp;&raquo;, que ce lecteur ne connaît
+      pas.</span>
+    <span data-phrase="read.noconfig">La piste &laquo;&nbsp;{type}&nbsp;&raquo; ne porte aucune configuration de décodeur.</span>
+    <span data-phrase="read.notmp4">Ce n&rsquo;est pas un fichier MP4 ni MOV.</span>
+    <span data-phrase="read.nomoov">Le fichier n&rsquo;a pas d&rsquo;en-tête de film.</span>
+    <span data-phrase="read.novideo">Le fichier n&rsquo;a aucune piste vidéo utilisable par ce lecteur.</span>
+    <span data-phrase="read.notimescale">La piste vidéo n&rsquo;a pas d&rsquo;échelle de temps.</span>
+    <span data-phrase="read.nofragments">Les fragments de ce fichier ne contiennent aucune image pour sa piste vidéo.</span>
+    <span data-phrase="read.unreadable">Le fichier n&rsquo;a pas pu être lu comme un MP4.</span>
+    <span data-phrase="read.notplayed">Ce format n&rsquo;est pas de ceux que ce navigateur lit.</span>
+    <span data-phrase="read.layout">La disposition de ce fichier n&rsquo;est pas de celles que le lecteur comprend ici.</span>
+    <span data-phrase="read.nodecoder">Ce navigateur ne décode pas {codec} directement.</span>
+    <span data-phrase="read.nowebcodecs">Ce navigateur n&rsquo;a pas WebCodecs, les images ne peuvent donc pas être décodées
+      une par une.</span>
+    <span data-phrase="open.failed">Ce navigateur ne peut pas ouvrir ce fichier. {reason}</span>
+    <span data-phrase="open.nodecode">Ce navigateur a ouvert le fichier mais ne sait pas décoder la vidéo qu&rsquo;il
+      contient. C&rsquo;est en général du Dolby Vision, ou du HEVC sur une machine sans
+      prise en charge matérielle&nbsp;: le conteneur se lit très bien et l&rsquo;image
+      n&rsquo;arrive jamais. Convertissez-le d&rsquo;abord en MP4 ordinaire (H.264) et cet
+      outil le lira directement.</span>
+    <span data-phrase="path.seek">{reason} Celle-ci est donc lue en amenant le lecteur du navigateur à chaque instant
+      voulu&nbsp;: cela marche avec tous les formats que le navigateur lit, et c&rsquo;est
+      un peu plus lent.</span>
     <span data-phrase="net.clean">votre vidéo n'est allée nulle part. {total}
       fichiers chargés. {platform}</span>
     <span data-phrase="net.dirty">quelque chose a contacté {hosts}, ce que cet

--- a/locales/fr/tools/video-to-gif.html
+++ b/locales/fr/tools/video-to-gif.html
@@ -175,6 +175,40 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">Le fichier se termine au milieu d&rsquo;une image.</span>
+    <span data-phrase="read.avcshort">L&rsquo;enregistrement de configuration H.264 est trop court.</span>
+    <span data-phrase="read.hevcshort">L&rsquo;enregistrement de configuration HEVC est trop court.</span>
+    <span data-phrase="read.av1short">L&rsquo;enregistrement de configuration AV1 est trop court.</span>
+    <span data-phrase="read.compactsizes">Les tailles d&rsquo;échantillons sont dans une table compacte que ce lecteur ne
+      décode pas.</span>
+    <span data-phrase="read.sampletables">Les tables d&rsquo;échantillons sont incomplètes.</span>
+    <span data-phrase="read.chunktable">La table des chunks est vide.</span>
+    <span data-phrase="read.nosamples">La piste ne contient aucun échantillon.</span>
+    <span data-phrase="read.nostbl">Il manque à la piste vidéo ses tables d&rsquo;échantillons.</span>
+    <span data-phrase="read.nostsd">La piste vidéo n&rsquo;a pas de description d&rsquo;échantillon.</span>
+    <span data-phrase="read.emptystsd">La description d&rsquo;échantillon de la vidéo est vide.</span>
+    <span data-phrase="read.encrypted">La piste vidéo est chiffrée.</span>
+    <span data-phrase="read.unknowncodec">La vidéo est stockée en &laquo;&nbsp;{type}&nbsp;&raquo;, que ce lecteur ne connaît
+      pas.</span>
+    <span data-phrase="read.noconfig">La piste &laquo;&nbsp;{type}&nbsp;&raquo; ne porte aucune configuration de décodeur.</span>
+    <span data-phrase="read.notmp4">Ce n&rsquo;est pas un fichier MP4 ni MOV.</span>
+    <span data-phrase="read.nomoov">Le fichier n&rsquo;a pas d&rsquo;en-tête de film.</span>
+    <span data-phrase="read.novideo">Le fichier n&rsquo;a aucune piste vidéo utilisable par ce lecteur.</span>
+    <span data-phrase="read.notimescale">La piste vidéo n&rsquo;a pas d&rsquo;échelle de temps.</span>
+    <span data-phrase="read.nofragments">Les fragments de ce fichier ne contiennent aucune image pour sa piste vidéo.</span>
+    <span data-phrase="read.unreadable">Le fichier n&rsquo;a pas pu être lu comme un MP4.</span>
+    <span data-phrase="read.notplayed">Ce format n&rsquo;est pas de ceux que ce navigateur lit.</span>
+    <span data-phrase="read.layout">La disposition de ce fichier n&rsquo;est pas de celles que le lecteur comprend ici.</span>
+    <span data-phrase="read.nodecoder">Ce navigateur ne décode pas {codec} directement.</span>
+    <span data-phrase="read.nowebcodecs">Ce navigateur n&rsquo;a pas WebCodecs, les images ne peuvent donc pas être décodées
+      une par une.</span>
+    <span data-phrase="read.turned">Ce fichier est stocké tourné, et le lecteur d&rsquo;ici et celui du navigateur ne
+      s&rsquo;accordent pas sur la rotation.</span>
+    <span data-phrase="open.failed">Ce navigateur ne peut pas ouvrir ce fichier. {reason}</span>
+    <span data-phrase="path.seek">{reason} Les images sont donc récupérées en amenant le lecteur à chaque instant
+      voulu. C&rsquo;est plus lent, et c&rsquo;est le navigateur qui décide sur quelle
+      image chaque saut tombe&nbsp;: un passage rapide peut donc être décalé d&rsquo;une
+      image ici ou là.</span>
     <span data-phrase="net.clean">votre vidéo n'est allée nulle part. {total}
       fichiers chargés. {platform}</span>
     <span data-phrase="net.dirty">quelque chose a contacté {hosts}, ce que cet

--- a/locales/hi/tools/crop-video.html
+++ b/locales/hi/tools/crop-video.html
@@ -151,6 +151,36 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">फ़ाइल एक फ़्रेम के बीचोंबीच ख़त्म हो जाती है।</span>
+    <span data-phrase="read.avcshort">H.264 का कॉन्फ़िगरेशन रिकॉर्ड बहुत छोटा है।</span>
+    <span data-phrase="read.hevcshort">HEVC का कॉन्फ़िगरेशन रिकॉर्ड बहुत छोटा है।</span>
+    <span data-phrase="read.av1short">AV1 का कॉन्फ़िगरेशन रिकॉर्ड बहुत छोटा है।</span>
+    <span data-phrase="read.compactsizes">सैंपल के आकार एक सिकुड़ी हुई तालिका में हैं, जिसे यह रीडर नहीं खोलता।</span>
+    <span data-phrase="read.sampletables">सैंपल तालिकाएँ अधूरी हैं।</span>
+    <span data-phrase="read.chunktable">चंक तालिका ख़ाली है।</span>
+    <span data-phrase="read.nosamples">उस ट्रैक में एक भी सैंपल नहीं है।</span>
+    <span data-phrase="read.nostbl">वीडियो ट्रैक की सैंपल तालिकाएँ ग़ायब हैं।</span>
+    <span data-phrase="read.nostsd">वीडियो ट्रैक में सैंपल का विवरण नहीं है।</span>
+    <span data-phrase="read.emptystsd">वीडियो के सैंपल का विवरण ख़ाली है।</span>
+    <span data-phrase="read.encrypted">वीडियो ट्रैक एन्क्रिप्टेड है।</span>
+    <span data-phrase="read.unknowncodec">यह वीडियो &ldquo;{type}&rdquo; के रूप में रखा गया है, और यह रीडर उसे नहीं जानता।</span>
+    <span data-phrase="read.noconfig">&ldquo;{type}&rdquo; ट्रैक अपने साथ कोई डिकोडर कॉन्फ़िगरेशन नहीं ले जाता।</span>
+    <span data-phrase="read.notmp4">यह न MP4 फ़ाइल है, न MOV।</span>
+    <span data-phrase="read.nomoov">फ़ाइल में मूवी हेडर नहीं है।</span>
+    <span data-phrase="read.novideo">इस फ़ाइल में ऐसा कोई वीडियो ट्रैक नहीं जिसे यह रीडर काम में ले सके।</span>
+    <span data-phrase="read.notimescale">वीडियो ट्रैक का कोई टाइमस्केल नहीं है।</span>
+    <span data-phrase="read.nofragments">इस फ़ाइल के फ़्रैगमेंट में इसके वीडियो ट्रैक का एक भी फ़्रेम नहीं है।</span>
+    <span data-phrase="read.unreadable">फ़ाइल MP4 की तरह पढ़ी नहीं जा सकी।</span>
+    <span data-phrase="read.notplayed">यह फ़ॉर्मैट उनमें से नहीं जिन्हें यह ब्राउज़र चलाता है।</span>
+    <span data-phrase="read.layout">इस फ़ाइल की बनावट वैसी नहीं जैसी यहाँ का रीडर समझता है।</span>
+    <span data-phrase="read.nodecoder">यह ब्राउज़र {codec} को सीधे डिकोड नहीं करता।</span>
+    <span data-phrase="read.nowebcodecs">इस ब्राउज़र में WebCodecs नहीं है, इसलिए फ़्रेम एक-एक करके डिकोड नहीं किए जा सकते।</span>
+    <span data-phrase="read.turned">यह फ़ाइल घुमाकर रखी गई है, और यहाँ का रीडर तथा ब्राउज़र का प्लेयर उस घुमाव पर एकमत
+      नहीं हैं।</span>
+    <span data-phrase="open.failed">यह ब्राउज़र इस फ़ाइल को नहीं खोल सकता। {reason}</span>
+    <span data-phrase="open.norecord">यह ब्राउज़र वीडियो रिकॉर्ड नहीं कर सकता, इसलिए इस फ़ाइल को काट-छाँट भी नहीं सकता।</span>
+    <span data-phrase="path.record">{reason} इसीलिए इसे चलाकर और रिकॉर्ड करके काटा-छाँटा जाता है: इसमें उतना ही समय लगता
+      है जितना वीडियो लंबा है, और आवाज़ नक़ल होने के बजाय दोबारा एन्कोड होती है।</span>
     <span data-phrase="net.clean">आपका वीडियो कहीं नहीं गया। {total} फ़ाइलें लोड
       हुईं। {platform}</span>
     <span data-phrase="net.dirty">किसी चीज़ ने {hosts} से संपर्क किया, और यह टूल

--- a/locales/hi/tools/grab-frame.html
+++ b/locales/hi/tools/grab-frame.html
@@ -139,6 +139,40 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">फ़ाइल एक फ़्रेम के बीचोंबीच ख़त्म हो जाती है।</span>
+    <span data-phrase="read.avcshort">H.264 का कॉन्फ़िगरेशन रिकॉर्ड बहुत छोटा है।</span>
+    <span data-phrase="read.hevcshort">HEVC का कॉन्फ़िगरेशन रिकॉर्ड बहुत छोटा है।</span>
+    <span data-phrase="read.av1short">AV1 का कॉन्फ़िगरेशन रिकॉर्ड बहुत छोटा है।</span>
+    <span data-phrase="read.compactsizes">सैंपल के आकार एक सिकुड़ी हुई तालिका में हैं, जिसे यह रीडर नहीं खोलता।</span>
+    <span data-phrase="read.sampletables">सैंपल तालिकाएँ अधूरी हैं।</span>
+    <span data-phrase="read.chunktable">चंक तालिका ख़ाली है।</span>
+    <span data-phrase="read.nosamples">उस ट्रैक में एक भी सैंपल नहीं है।</span>
+    <span data-phrase="read.nostbl">वीडियो ट्रैक की सैंपल तालिकाएँ ग़ायब हैं।</span>
+    <span data-phrase="read.nostsd">वीडियो ट्रैक में सैंपल का विवरण नहीं है।</span>
+    <span data-phrase="read.emptystsd">वीडियो के सैंपल का विवरण ख़ाली है।</span>
+    <span data-phrase="read.encrypted">वीडियो ट्रैक एन्क्रिप्टेड है।</span>
+    <span data-phrase="read.unknowncodec">यह वीडियो &ldquo;{type}&rdquo; के रूप में रखा गया है, और यह रीडर उसे नहीं जानता।</span>
+    <span data-phrase="read.noconfig">&ldquo;{type}&rdquo; ट्रैक अपने साथ कोई डिकोडर कॉन्फ़िगरेशन नहीं ले जाता।</span>
+    <span data-phrase="read.notmp4">यह न MP4 फ़ाइल है, न MOV।</span>
+    <span data-phrase="read.nomoov">फ़ाइल में मूवी हेडर नहीं है।</span>
+    <span data-phrase="read.novideo">इस फ़ाइल में ऐसा कोई वीडियो ट्रैक नहीं जिसे यह रीडर काम में ले सके।</span>
+    <span data-phrase="read.notimescale">वीडियो ट्रैक का कोई टाइमस्केल नहीं है।</span>
+    <span data-phrase="read.nofragments">इस फ़ाइल के फ़्रैगमेंट में इसके वीडियो ट्रैक का एक भी फ़्रेम नहीं है।</span>
+    <span data-phrase="read.unreadable">फ़ाइल MP4 की तरह पढ़ी नहीं जा सकी।</span>
+    <span data-phrase="read.notplayed">यह फ़ॉर्मैट उनमें से नहीं जिन्हें यह ब्राउज़र चलाता है।</span>
+    <span data-phrase="read.layout">इस फ़ाइल की बनावट वैसी नहीं जैसी यहाँ का रीडर समझता है।</span>
+    <span data-phrase="read.nodecoder">यह ब्राउज़र {codec} को सीधे डिकोड नहीं करता।</span>
+    <span data-phrase="read.nowebcodecs">इस ब्राउज़र में WebCodecs नहीं है, इसलिए फ़्रेम एक-एक करके डिकोड नहीं किए जा सकते।</span>
+    <span data-phrase="read.turned">यह फ़ाइल घुमाकर रखी गई है, और यहाँ का रीडर तथा ब्राउज़र का प्लेयर उस घुमाव पर एकमत
+      नहीं हैं।</span>
+    <span data-phrase="open.failed">यह ब्राउज़र इस फ़ाइल को नहीं खोल सकता। {reason}</span>
+    <span data-phrase="path.player">{reason} इसीलिए यह फ़ाइल फ़्रेम-दर-फ़्रेम नहीं, बल्कि ब्राउज़र के अपने प्लेयर से
+      पढ़ी जाती है: तस्वीर अब भी वीडियो के पूरे आकार में सहेजी जाती है, पर आप किस फ़्रेम
+      पर पहुँचेंगे यह प्लेयर तय करता है, और एक क़दम ठीक एक फ़्रेम नहीं, लगभग एक फ़्रेम आगे
+      बढ़ता है।</span>
+    <span data-phrase="path.nopreview">यह ब्राउज़र इस फ़ाइल को चलाता नहीं, इसलिए यहाँ दबाने को कोई प्ले नहीं है। डिकोड यह
+      कर लेता है, और तस्वीरें वहीं से बनती हैं; वीडियो में घूमने के लिए स्लाइडर और तीर
+      कुंजियों का इस्तेमाल कीजिए।</span>
     <span data-phrase="net.clean">आपका वीडियो कहीं नहीं गया। {total} फ़ाइलें लोड
       हुईं। {platform}</span>
     <span data-phrase="net.dirty">किसी चीज़ ने {hosts} से संपर्क किया, और यह टूल

--- a/locales/hi/tools/timelapse-video.html
+++ b/locales/hi/tools/timelapse-video.html
@@ -158,6 +158,37 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">फ़ाइल एक फ़्रेम के बीचोंबीच ख़त्म हो जाती है।</span>
+    <span data-phrase="read.avcshort">H.264 का कॉन्फ़िगरेशन रिकॉर्ड बहुत छोटा है।</span>
+    <span data-phrase="read.hevcshort">HEVC का कॉन्फ़िगरेशन रिकॉर्ड बहुत छोटा है।</span>
+    <span data-phrase="read.av1short">AV1 का कॉन्फ़िगरेशन रिकॉर्ड बहुत छोटा है।</span>
+    <span data-phrase="read.compactsizes">सैंपल के आकार एक सिकुड़ी हुई तालिका में हैं, जिसे यह रीडर नहीं खोलता।</span>
+    <span data-phrase="read.sampletables">सैंपल तालिकाएँ अधूरी हैं।</span>
+    <span data-phrase="read.chunktable">चंक तालिका ख़ाली है।</span>
+    <span data-phrase="read.nosamples">उस ट्रैक में एक भी सैंपल नहीं है।</span>
+    <span data-phrase="read.nostbl">वीडियो ट्रैक की सैंपल तालिकाएँ ग़ायब हैं।</span>
+    <span data-phrase="read.nostsd">वीडियो ट्रैक में सैंपल का विवरण नहीं है।</span>
+    <span data-phrase="read.emptystsd">वीडियो के सैंपल का विवरण ख़ाली है।</span>
+    <span data-phrase="read.encrypted">वीडियो ट्रैक एन्क्रिप्टेड है।</span>
+    <span data-phrase="read.unknowncodec">यह वीडियो &ldquo;{type}&rdquo; के रूप में रखा गया है, और यह रीडर उसे नहीं जानता।</span>
+    <span data-phrase="read.noconfig">&ldquo;{type}&rdquo; ट्रैक अपने साथ कोई डिकोडर कॉन्फ़िगरेशन नहीं ले जाता।</span>
+    <span data-phrase="read.notmp4">यह न MP4 फ़ाइल है, न MOV।</span>
+    <span data-phrase="read.nomoov">फ़ाइल में मूवी हेडर नहीं है।</span>
+    <span data-phrase="read.novideo">इस फ़ाइल में ऐसा कोई वीडियो ट्रैक नहीं जिसे यह रीडर काम में ले सके।</span>
+    <span data-phrase="read.notimescale">वीडियो ट्रैक का कोई टाइमस्केल नहीं है।</span>
+    <span data-phrase="read.nofragments">इस फ़ाइल के फ़्रैगमेंट में इसके वीडियो ट्रैक का एक भी फ़्रेम नहीं है।</span>
+    <span data-phrase="read.unreadable">फ़ाइल MP4 की तरह पढ़ी नहीं जा सकी।</span>
+    <span data-phrase="read.notplayed">यह फ़ॉर्मैट उनमें से नहीं जिन्हें यह ब्राउज़र चलाता है।</span>
+    <span data-phrase="read.layout">इस फ़ाइल की बनावट वैसी नहीं जैसी यहाँ का रीडर समझता है।</span>
+    <span data-phrase="read.nodecoder">यह ब्राउज़र {codec} को सीधे डिकोड नहीं करता।</span>
+    <span data-phrase="read.nowebcodecs">इस ब्राउज़र में WebCodecs नहीं है, इसलिए फ़्रेम एक-एक करके डिकोड नहीं किए जा सकते।</span>
+    <span data-phrase="open.failed">यह ब्राउज़र इस फ़ाइल को नहीं खोल सकता। {reason}</span>
+    <span data-phrase="open.nodecode">इस ब्राउज़र ने फ़ाइल तो खोल ली, पर उसके भीतर का वीडियो डिकोड नहीं कर पा रहा। आम तौर
+      पर यह Dolby Vision होता है, या फिर बिना हार्डवेयर सहारे वाली मशीन पर HEVC: कंटेनर
+      ठीक-ठाक पढ़ा जाता है और तस्वीर कभी आती ही नहीं। पहले इसे साधारण MP4 (H.264) में बदल
+      लीजिए, फिर यह औज़ार इसे सीधे पढ़ लेगा।</span>
+    <span data-phrase="path.seek">{reason} इसीलिए इसे ब्राउज़र के अपने प्लेयर को हर पल पर ले जाकर पढ़ा जाता है: यह हर
+      उस फ़ॉर्मैट पर चलता है जिसे ब्राउज़र चलाता है, और थोड़ा धीमा है।</span>
     <span data-phrase="net.clean">आपका वीडियो कहीं नहीं गया। {total} फ़ाइलें लोड
       हुईं। {platform}</span>
     <span data-phrase="net.dirty">किसी चीज़ ने {hosts} से संपर्क किया, और यह टूल

--- a/locales/hi/tools/video-to-gif.html
+++ b/locales/hi/tools/video-to-gif.html
@@ -174,6 +174,36 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">फ़ाइल एक फ़्रेम के बीचोंबीच ख़त्म हो जाती है।</span>
+    <span data-phrase="read.avcshort">H.264 का कॉन्फ़िगरेशन रिकॉर्ड बहुत छोटा है।</span>
+    <span data-phrase="read.hevcshort">HEVC का कॉन्फ़िगरेशन रिकॉर्ड बहुत छोटा है।</span>
+    <span data-phrase="read.av1short">AV1 का कॉन्फ़िगरेशन रिकॉर्ड बहुत छोटा है।</span>
+    <span data-phrase="read.compactsizes">सैंपल के आकार एक सिकुड़ी हुई तालिका में हैं, जिसे यह रीडर नहीं खोलता।</span>
+    <span data-phrase="read.sampletables">सैंपल तालिकाएँ अधूरी हैं।</span>
+    <span data-phrase="read.chunktable">चंक तालिका ख़ाली है।</span>
+    <span data-phrase="read.nosamples">उस ट्रैक में एक भी सैंपल नहीं है।</span>
+    <span data-phrase="read.nostbl">वीडियो ट्रैक की सैंपल तालिकाएँ ग़ायब हैं।</span>
+    <span data-phrase="read.nostsd">वीडियो ट्रैक में सैंपल का विवरण नहीं है।</span>
+    <span data-phrase="read.emptystsd">वीडियो के सैंपल का विवरण ख़ाली है।</span>
+    <span data-phrase="read.encrypted">वीडियो ट्रैक एन्क्रिप्टेड है।</span>
+    <span data-phrase="read.unknowncodec">यह वीडियो &ldquo;{type}&rdquo; के रूप में रखा गया है, और यह रीडर उसे नहीं जानता।</span>
+    <span data-phrase="read.noconfig">&ldquo;{type}&rdquo; ट्रैक अपने साथ कोई डिकोडर कॉन्फ़िगरेशन नहीं ले जाता।</span>
+    <span data-phrase="read.notmp4">यह न MP4 फ़ाइल है, न MOV।</span>
+    <span data-phrase="read.nomoov">फ़ाइल में मूवी हेडर नहीं है।</span>
+    <span data-phrase="read.novideo">इस फ़ाइल में ऐसा कोई वीडियो ट्रैक नहीं जिसे यह रीडर काम में ले सके।</span>
+    <span data-phrase="read.notimescale">वीडियो ट्रैक का कोई टाइमस्केल नहीं है।</span>
+    <span data-phrase="read.nofragments">इस फ़ाइल के फ़्रैगमेंट में इसके वीडियो ट्रैक का एक भी फ़्रेम नहीं है।</span>
+    <span data-phrase="read.unreadable">फ़ाइल MP4 की तरह पढ़ी नहीं जा सकी।</span>
+    <span data-phrase="read.notplayed">यह फ़ॉर्मैट उनमें से नहीं जिन्हें यह ब्राउज़र चलाता है।</span>
+    <span data-phrase="read.layout">इस फ़ाइल की बनावट वैसी नहीं जैसी यहाँ का रीडर समझता है।</span>
+    <span data-phrase="read.nodecoder">यह ब्राउज़र {codec} को सीधे डिकोड नहीं करता।</span>
+    <span data-phrase="read.nowebcodecs">इस ब्राउज़र में WebCodecs नहीं है, इसलिए फ़्रेम एक-एक करके डिकोड नहीं किए जा सकते।</span>
+    <span data-phrase="read.turned">यह फ़ाइल घुमाकर रखी गई है, और यहाँ का रीडर तथा ब्राउज़र का प्लेयर उस घुमाव पर एकमत
+      नहीं हैं।</span>
+    <span data-phrase="open.failed">यह ब्राउज़र इस फ़ाइल को नहीं खोल सकता। {reason}</span>
+    <span data-phrase="path.seek">{reason} इसीलिए इसके फ़्रेम प्लेयर को हर पल पर ले जाकर इकट्ठे किए जाते हैं। यह धीमा
+      है, और हर छलाँग किस फ़्रेम पर गिरेगी यह ब्राउज़र तय करता है, इसलिए तेज़ चलने वाला
+      हिस्सा कहीं-कहीं एक फ़्रेम इधर-उधर निकल सकता है।</span>
     <span data-phrase="net.clean">आपका वीडियो कहीं नहीं गया। {total} फ़ाइलें लोड
       हुईं। {platform}</span>
     <span data-phrase="net.dirty">किसी चीज़ ने {hosts} से संपर्क किया, और यह टूल

--- a/locales/id/tools/crop-video.html
+++ b/locales/id/tools/crop-video.html
@@ -158,6 +158,38 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">File-nya berhenti di tengah sebuah bingkai.</span>
+    <span data-phrase="read.avcshort">Rekaman konfigurasi H.264 terlalu pendek.</span>
+    <span data-phrase="read.hevcshort">Rekaman konfigurasi HEVC terlalu pendek.</span>
+    <span data-phrase="read.av1short">Rekaman konfigurasi AV1 terlalu pendek.</span>
+    <span data-phrase="read.compactsizes">Ukuran sampelnya ada di tabel ringkas yang tidak didekode pembaca ini.</span>
+    <span data-phrase="read.sampletables">Tabel sampelnya tidak lengkap.</span>
+    <span data-phrase="read.chunktable">Tabel chunk-nya kosong.</span>
+    <span data-phrase="read.nosamples">Trek itu tidak memuat sampel sama sekali.</span>
+    <span data-phrase="read.nostbl">Trek video itu kehilangan tabel sampelnya.</span>
+    <span data-phrase="read.nostsd">Trek video itu tidak punya deskripsi sampel.</span>
+    <span data-phrase="read.emptystsd">Deskripsi sampel videonya kosong.</span>
+    <span data-phrase="read.encrypted">Trek videonya terenkripsi.</span>
+    <span data-phrase="read.unknowncodec">Videonya disimpan sebagai &ldquo;{type}&rdquo;, dan pembaca ini tidak mengenalnya.</span>
+    <span data-phrase="read.noconfig">Trek &ldquo;{type}&rdquo; tidak membawa konfigurasi dekoder apa pun.</span>
+    <span data-phrase="read.notmp4">Ini bukan file MP4 maupun MOV.</span>
+    <span data-phrase="read.nomoov">File ini tidak punya header film.</span>
+    <span data-phrase="read.novideo">File ini tidak punya trek video yang bisa dipakai pembaca ini.</span>
+    <span data-phrase="read.notimescale">Trek videonya tidak punya skala waktu.</span>
+    <span data-phrase="read.nofragments">Fragmen di dalam file ini tidak memuat bingkai apa pun untuk trek videonya.</span>
+    <span data-phrase="read.unreadable">File-nya tidak bisa dibaca sebagai MP4.</span>
+    <span data-phrase="read.notplayed">Format ini bukan yang bisa diputar peramban ini.</span>
+    <span data-phrase="read.layout">Tata letak file ini bukan yang dipahami pembaca di sini.</span>
+    <span data-phrase="read.nodecoder">Peramban ini tidak mendekode {codec} secara langsung.</span>
+    <span data-phrase="read.nowebcodecs">Peramban ini tidak punya WebCodecs, jadi bingkainya tidak bisa didekode satu per
+      satu.</span>
+    <span data-phrase="read.turned">File ini disimpan dalam keadaan diputar, dan pembaca di sini dengan pemutar peramban
+      tidak sepakat soal putaran itu.</span>
+    <span data-phrase="open.failed">Peramban ini tidak bisa membuka file ini. {reason}</span>
+    <span data-phrase="open.norecord">Peramban ini tidak bisa merekam video, jadi tidak bisa memangkas file ini juga.</span>
+    <span data-phrase="path.record">{reason} Karena itu yang satu ini dipangkas dengan cara diputar lalu direkam
+      hasilnya: itu memakan waktu selama videonya, dan suaranya dikodekan ulang, bukan
+      disalin.</span>
     <span data-phrase="net.clean">video Anda tidak pergi ke mana pun. {total}
       file dimuat. {platform}</span>
     <span data-phrase="net.dirty">sesuatu menghubungi {hosts}, dan itu tidak

--- a/locales/id/tools/grab-frame.html
+++ b/locales/id/tools/grab-frame.html
@@ -145,6 +145,41 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">File-nya berhenti di tengah sebuah bingkai.</span>
+    <span data-phrase="read.avcshort">Rekaman konfigurasi H.264 terlalu pendek.</span>
+    <span data-phrase="read.hevcshort">Rekaman konfigurasi HEVC terlalu pendek.</span>
+    <span data-phrase="read.av1short">Rekaman konfigurasi AV1 terlalu pendek.</span>
+    <span data-phrase="read.compactsizes">Ukuran sampelnya ada di tabel ringkas yang tidak didekode pembaca ini.</span>
+    <span data-phrase="read.sampletables">Tabel sampelnya tidak lengkap.</span>
+    <span data-phrase="read.chunktable">Tabel chunk-nya kosong.</span>
+    <span data-phrase="read.nosamples">Trek itu tidak memuat sampel sama sekali.</span>
+    <span data-phrase="read.nostbl">Trek video itu kehilangan tabel sampelnya.</span>
+    <span data-phrase="read.nostsd">Trek video itu tidak punya deskripsi sampel.</span>
+    <span data-phrase="read.emptystsd">Deskripsi sampel videonya kosong.</span>
+    <span data-phrase="read.encrypted">Trek videonya terenkripsi.</span>
+    <span data-phrase="read.unknowncodec">Videonya disimpan sebagai &ldquo;{type}&rdquo;, dan pembaca ini tidak mengenalnya.</span>
+    <span data-phrase="read.noconfig">Trek &ldquo;{type}&rdquo; tidak membawa konfigurasi dekoder apa pun.</span>
+    <span data-phrase="read.notmp4">Ini bukan file MP4 maupun MOV.</span>
+    <span data-phrase="read.nomoov">File ini tidak punya header film.</span>
+    <span data-phrase="read.novideo">File ini tidak punya trek video yang bisa dipakai pembaca ini.</span>
+    <span data-phrase="read.notimescale">Trek videonya tidak punya skala waktu.</span>
+    <span data-phrase="read.nofragments">Fragmen di dalam file ini tidak memuat bingkai apa pun untuk trek videonya.</span>
+    <span data-phrase="read.unreadable">File-nya tidak bisa dibaca sebagai MP4.</span>
+    <span data-phrase="read.notplayed">Format ini bukan yang bisa diputar peramban ini.</span>
+    <span data-phrase="read.layout">Tata letak file ini bukan yang dipahami pembaca di sini.</span>
+    <span data-phrase="read.nodecoder">Peramban ini tidak mendekode {codec} secara langsung.</span>
+    <span data-phrase="read.nowebcodecs">Peramban ini tidak punya WebCodecs, jadi bingkainya tidak bisa didekode satu per
+      satu.</span>
+    <span data-phrase="read.turned">File ini disimpan dalam keadaan diputar, dan pembaca di sini dengan pemutar peramban
+      tidak sepakat soal putaran itu.</span>
+    <span data-phrase="open.failed">Peramban ini tidak bisa membuka file ini. {reason}</span>
+    <span data-phrase="path.player">{reason} Karena itu file ini dibaca oleh pemutar peramban sendiri, bukan bingkai
+      demi bingkai: gambarnya tetap disimpan seukuran penuh videonya, tapi bingkai mana
+      yang Anda dapat ditentukan pemutarnya, dan satu langkah bergerak kira-kira satu
+      bingkai, bukan tepat satu.</span>
+    <span data-phrase="path.nopreview">Peramban ini tidak memutar file ini, jadi tidak ada yang bisa ditekan putar.
+      Mendekode masih bisa, dan dari situlah gambar diamnya datang; pakai penggeser dan
+      tombol panah untuk menyusurinya.</span>
     <span data-phrase="net.clean">video Anda tidak pergi ke mana pun. {total}
       file dimuat. {platform}</span>
     <span data-phrase="net.dirty">sesuatu menghubungi {hosts}, dan itu tidak

--- a/locales/id/tools/timelapse-video.html
+++ b/locales/id/tools/timelapse-video.html
@@ -167,6 +167,39 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">File-nya berhenti di tengah sebuah bingkai.</span>
+    <span data-phrase="read.avcshort">Rekaman konfigurasi H.264 terlalu pendek.</span>
+    <span data-phrase="read.hevcshort">Rekaman konfigurasi HEVC terlalu pendek.</span>
+    <span data-phrase="read.av1short">Rekaman konfigurasi AV1 terlalu pendek.</span>
+    <span data-phrase="read.compactsizes">Ukuran sampelnya ada di tabel ringkas yang tidak didekode pembaca ini.</span>
+    <span data-phrase="read.sampletables">Tabel sampelnya tidak lengkap.</span>
+    <span data-phrase="read.chunktable">Tabel chunk-nya kosong.</span>
+    <span data-phrase="read.nosamples">Trek itu tidak memuat sampel sama sekali.</span>
+    <span data-phrase="read.nostbl">Trek video itu kehilangan tabel sampelnya.</span>
+    <span data-phrase="read.nostsd">Trek video itu tidak punya deskripsi sampel.</span>
+    <span data-phrase="read.emptystsd">Deskripsi sampel videonya kosong.</span>
+    <span data-phrase="read.encrypted">Trek videonya terenkripsi.</span>
+    <span data-phrase="read.unknowncodec">Videonya disimpan sebagai &ldquo;{type}&rdquo;, dan pembaca ini tidak mengenalnya.</span>
+    <span data-phrase="read.noconfig">Trek &ldquo;{type}&rdquo; tidak membawa konfigurasi dekoder apa pun.</span>
+    <span data-phrase="read.notmp4">Ini bukan file MP4 maupun MOV.</span>
+    <span data-phrase="read.nomoov">File ini tidak punya header film.</span>
+    <span data-phrase="read.novideo">File ini tidak punya trek video yang bisa dipakai pembaca ini.</span>
+    <span data-phrase="read.notimescale">Trek videonya tidak punya skala waktu.</span>
+    <span data-phrase="read.nofragments">Fragmen di dalam file ini tidak memuat bingkai apa pun untuk trek videonya.</span>
+    <span data-phrase="read.unreadable">File-nya tidak bisa dibaca sebagai MP4.</span>
+    <span data-phrase="read.notplayed">Format ini bukan yang bisa diputar peramban ini.</span>
+    <span data-phrase="read.layout">Tata letak file ini bukan yang dipahami pembaca di sini.</span>
+    <span data-phrase="read.nodecoder">Peramban ini tidak mendekode {codec} secara langsung.</span>
+    <span data-phrase="read.nowebcodecs">Peramban ini tidak punya WebCodecs, jadi bingkainya tidak bisa didekode satu per
+      satu.</span>
+    <span data-phrase="open.failed">Peramban ini tidak bisa membuka file ini. {reason}</span>
+    <span data-phrase="open.nodecode">Peramban ini membuka file-nya tapi tidak bisa mendekode video di dalamnya. Biasanya
+      itu Dolby Vision, atau HEVC di mesin tanpa dukungan perangkat keras untuknya:
+      wadahnya terbaca baik-baik saja dan gambarnya tidak pernah sampai. Ubah dulu ke MP4
+      biasa (H.264), maka alat ini akan membacanya langsung.</span>
+    <span data-phrase="path.seek">{reason} Karena itu yang satu ini dibaca dengan memindahkan pemutar peramban ke tiap
+      saat: itu jalan di semua format yang bisa diputar peramban, dan sedikit lebih
+      lambat.</span>
     <span data-phrase="net.clean">video Anda tidak pergi ke mana pun. {total}
       file dimuat. {platform}</span>
     <span data-phrase="net.dirty">sesuatu menghubungi {hosts}, dan itu tidak

--- a/locales/id/tools/video-to-gif.html
+++ b/locales/id/tools/video-to-gif.html
@@ -180,6 +180,37 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">File-nya berhenti di tengah sebuah bingkai.</span>
+    <span data-phrase="read.avcshort">Rekaman konfigurasi H.264 terlalu pendek.</span>
+    <span data-phrase="read.hevcshort">Rekaman konfigurasi HEVC terlalu pendek.</span>
+    <span data-phrase="read.av1short">Rekaman konfigurasi AV1 terlalu pendek.</span>
+    <span data-phrase="read.compactsizes">Ukuran sampelnya ada di tabel ringkas yang tidak didekode pembaca ini.</span>
+    <span data-phrase="read.sampletables">Tabel sampelnya tidak lengkap.</span>
+    <span data-phrase="read.chunktable">Tabel chunk-nya kosong.</span>
+    <span data-phrase="read.nosamples">Trek itu tidak memuat sampel sama sekali.</span>
+    <span data-phrase="read.nostbl">Trek video itu kehilangan tabel sampelnya.</span>
+    <span data-phrase="read.nostsd">Trek video itu tidak punya deskripsi sampel.</span>
+    <span data-phrase="read.emptystsd">Deskripsi sampel videonya kosong.</span>
+    <span data-phrase="read.encrypted">Trek videonya terenkripsi.</span>
+    <span data-phrase="read.unknowncodec">Videonya disimpan sebagai &ldquo;{type}&rdquo;, dan pembaca ini tidak mengenalnya.</span>
+    <span data-phrase="read.noconfig">Trek &ldquo;{type}&rdquo; tidak membawa konfigurasi dekoder apa pun.</span>
+    <span data-phrase="read.notmp4">Ini bukan file MP4 maupun MOV.</span>
+    <span data-phrase="read.nomoov">File ini tidak punya header film.</span>
+    <span data-phrase="read.novideo">File ini tidak punya trek video yang bisa dipakai pembaca ini.</span>
+    <span data-phrase="read.notimescale">Trek videonya tidak punya skala waktu.</span>
+    <span data-phrase="read.nofragments">Fragmen di dalam file ini tidak memuat bingkai apa pun untuk trek videonya.</span>
+    <span data-phrase="read.unreadable">File-nya tidak bisa dibaca sebagai MP4.</span>
+    <span data-phrase="read.notplayed">Format ini bukan yang bisa diputar peramban ini.</span>
+    <span data-phrase="read.layout">Tata letak file ini bukan yang dipahami pembaca di sini.</span>
+    <span data-phrase="read.nodecoder">Peramban ini tidak mendekode {codec} secara langsung.</span>
+    <span data-phrase="read.nowebcodecs">Peramban ini tidak punya WebCodecs, jadi bingkainya tidak bisa didekode satu per
+      satu.</span>
+    <span data-phrase="read.turned">File ini disimpan dalam keadaan diputar, dan pembaca di sini dengan pemutar peramban
+      tidak sepakat soal putaran itu.</span>
+    <span data-phrase="open.failed">Peramban ini tidak bisa membuka file ini. {reason}</span>
+    <span data-phrase="path.seek">{reason} Karena itu bingkainya dikumpulkan dengan memindahkan pemutar ke tiap saat.
+      Itu lebih lambat, dan peramban yang menentukan bingkai mana yang kena tiap lompatan,
+      jadi bagian yang cepat bisa meleset satu bingkai di sana-sini.</span>
     <span data-phrase="net.clean">video Anda tidak pergi ke mana pun. {total}
       file dimuat. {platform}</span>
     <span data-phrase="net.dirty">sesuatu menghubungi {hosts}, dan itu tidak

--- a/locales/it/tools/crop-video.html
+++ b/locales/it/tools/crop-video.html
@@ -151,6 +151,40 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">Il file finisce a metà di un fotogramma.</span>
+    <span data-phrase="read.avcshort">Il record di configurazione H.264 è troppo corto.</span>
+    <span data-phrase="read.hevcshort">Il record di configurazione HEVC è troppo corto.</span>
+    <span data-phrase="read.av1short">Il record di configurazione AV1 è troppo corto.</span>
+    <span data-phrase="read.compactsizes">Le dimensioni dei campioni stanno in una tabella compatta che questo lettore non
+      decodifica.</span>
+    <span data-phrase="read.sampletables">Le tabelle dei campioni sono incomplete.</span>
+    <span data-phrase="read.chunktable">La tabella dei chunk è vuota.</span>
+    <span data-phrase="read.nosamples">La traccia non contiene campioni.</span>
+    <span data-phrase="read.nostbl">Alla traccia video mancano le sue tabelle dei campioni.</span>
+    <span data-phrase="read.nostsd">La traccia video non ha una descrizione dei campioni.</span>
+    <span data-phrase="read.emptystsd">La descrizione dei campioni del video è vuota.</span>
+    <span data-phrase="read.encrypted">La traccia video è cifrata.</span>
+    <span data-phrase="read.unknowncodec">Il video è memorizzato come &laquo;{type}&raquo;, e questo lettore non lo conosce.</span>
+    <span data-phrase="read.noconfig">La traccia &laquo;{type}&raquo; non porta con sé alcuna configurazione del
+      decodificatore.</span>
+    <span data-phrase="read.notmp4">Questo non è un file MP4 né MOV.</span>
+    <span data-phrase="read.nomoov">Il file non ha l&rsquo;intestazione del filmato.</span>
+    <span data-phrase="read.novideo">Il file non ha nessuna traccia video utilizzabile da questo lettore.</span>
+    <span data-phrase="read.notimescale">La traccia video non ha una scala dei tempi.</span>
+    <span data-phrase="read.nofragments">I frammenti di questo file non contengono fotogrammi per la sua traccia video.</span>
+    <span data-phrase="read.unreadable">Il file non si è potuto leggere come MP4.</span>
+    <span data-phrase="read.notplayed">Questo formato non è tra quelli che questo browser riproduce.</span>
+    <span data-phrase="read.layout">La disposizione di questo file non è tra quelle che il lettore qui capisce.</span>
+    <span data-phrase="read.nodecoder">Questo browser non decodifica {codec} direttamente.</span>
+    <span data-phrase="read.nowebcodecs">Questo browser non ha WebCodecs, quindi i fotogrammi non si possono decodificare uno
+      per uno.</span>
+    <span data-phrase="read.turned">Questo file è memorizzato ruotato, e il lettore qui e il riproduttore del browser
+      non vanno d&rsquo;accordo sulla rotazione.</span>
+    <span data-phrase="open.failed">Questo browser non riesce ad aprire questo file. {reason}</span>
+    <span data-phrase="open.norecord">Questo browser non riesce a registrare video, quindi non può ritagliare questo file.</span>
+    <span data-phrase="path.record">{reason} Perciò questo viene ritagliato facendolo scorrere e registrando quello che
+      esce: ci vuole tanto quanto dura il video, e l&rsquo;audio viene ricodificato invece
+      che copiato.</span>
     <span data-phrase="net.clean">Il tuo video non è andato da nessuna parte.
       {total} file caricati. {platform}</span>
     <span data-phrase="net.dirty">Qualcosa ha contattato {hosts}, e questo

--- a/locales/it/tools/grab-frame.html
+++ b/locales/it/tools/grab-frame.html
@@ -139,6 +139,43 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">Il file finisce a metà di un fotogramma.</span>
+    <span data-phrase="read.avcshort">Il record di configurazione H.264 è troppo corto.</span>
+    <span data-phrase="read.hevcshort">Il record di configurazione HEVC è troppo corto.</span>
+    <span data-phrase="read.av1short">Il record di configurazione AV1 è troppo corto.</span>
+    <span data-phrase="read.compactsizes">Le dimensioni dei campioni stanno in una tabella compatta che questo lettore non
+      decodifica.</span>
+    <span data-phrase="read.sampletables">Le tabelle dei campioni sono incomplete.</span>
+    <span data-phrase="read.chunktable">La tabella dei chunk è vuota.</span>
+    <span data-phrase="read.nosamples">La traccia non contiene campioni.</span>
+    <span data-phrase="read.nostbl">Alla traccia video mancano le sue tabelle dei campioni.</span>
+    <span data-phrase="read.nostsd">La traccia video non ha una descrizione dei campioni.</span>
+    <span data-phrase="read.emptystsd">La descrizione dei campioni del video è vuota.</span>
+    <span data-phrase="read.encrypted">La traccia video è cifrata.</span>
+    <span data-phrase="read.unknowncodec">Il video è memorizzato come &laquo;{type}&raquo;, e questo lettore non lo conosce.</span>
+    <span data-phrase="read.noconfig">La traccia &laquo;{type}&raquo; non porta con sé alcuna configurazione del
+      decodificatore.</span>
+    <span data-phrase="read.notmp4">Questo non è un file MP4 né MOV.</span>
+    <span data-phrase="read.nomoov">Il file non ha l&rsquo;intestazione del filmato.</span>
+    <span data-phrase="read.novideo">Il file non ha nessuna traccia video utilizzabile da questo lettore.</span>
+    <span data-phrase="read.notimescale">La traccia video non ha una scala dei tempi.</span>
+    <span data-phrase="read.nofragments">I frammenti di questo file non contengono fotogrammi per la sua traccia video.</span>
+    <span data-phrase="read.unreadable">Il file non si è potuto leggere come MP4.</span>
+    <span data-phrase="read.notplayed">Questo formato non è tra quelli che questo browser riproduce.</span>
+    <span data-phrase="read.layout">La disposizione di questo file non è tra quelle che il lettore qui capisce.</span>
+    <span data-phrase="read.nodecoder">Questo browser non decodifica {codec} direttamente.</span>
+    <span data-phrase="read.nowebcodecs">Questo browser non ha WebCodecs, quindi i fotogrammi non si possono decodificare uno
+      per uno.</span>
+    <span data-phrase="read.turned">Questo file è memorizzato ruotato, e il lettore qui e il riproduttore del browser
+      non vanno d&rsquo;accordo sulla rotazione.</span>
+    <span data-phrase="open.failed">Questo browser non riesce ad aprire questo file. {reason}</span>
+    <span data-phrase="path.player">{reason} Perciò questo file lo legge il riproduttore del browser e non lo si legge
+      fotogramma per fotogramma: l&rsquo;immagine viene comunque salvata alla dimensione
+      piena del video, ma su quale fotogramma capiti lo decide il riproduttore, e un passo
+      si sposta di circa un fotogramma invece che di uno esatto.</span>
+    <span data-phrase="path.nopreview">Questo browser non riproduce questo file, quindi non c&rsquo;è niente da far
+      partire. Decodificarlo però lo sa fare, ed è da lì che vengono i fermi immagine:
+      muoviti nel video con il cursore e con le frecce.</span>
     <span data-phrase="net.clean">Il tuo video non è andato da nessuna parte.
       {total} file caricati. {platform}</span>
     <span data-phrase="net.dirty">Qualcosa ha contattato {hosts}, e questo

--- a/locales/it/tools/timelapse-video.html
+++ b/locales/it/tools/timelapse-video.html
@@ -159,6 +159,41 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">Il file finisce a metà di un fotogramma.</span>
+    <span data-phrase="read.avcshort">Il record di configurazione H.264 è troppo corto.</span>
+    <span data-phrase="read.hevcshort">Il record di configurazione HEVC è troppo corto.</span>
+    <span data-phrase="read.av1short">Il record di configurazione AV1 è troppo corto.</span>
+    <span data-phrase="read.compactsizes">Le dimensioni dei campioni stanno in una tabella compatta che questo lettore non
+      decodifica.</span>
+    <span data-phrase="read.sampletables">Le tabelle dei campioni sono incomplete.</span>
+    <span data-phrase="read.chunktable">La tabella dei chunk è vuota.</span>
+    <span data-phrase="read.nosamples">La traccia non contiene campioni.</span>
+    <span data-phrase="read.nostbl">Alla traccia video mancano le sue tabelle dei campioni.</span>
+    <span data-phrase="read.nostsd">La traccia video non ha una descrizione dei campioni.</span>
+    <span data-phrase="read.emptystsd">La descrizione dei campioni del video è vuota.</span>
+    <span data-phrase="read.encrypted">La traccia video è cifrata.</span>
+    <span data-phrase="read.unknowncodec">Il video è memorizzato come &laquo;{type}&raquo;, e questo lettore non lo conosce.</span>
+    <span data-phrase="read.noconfig">La traccia &laquo;{type}&raquo; non porta con sé alcuna configurazione del
+      decodificatore.</span>
+    <span data-phrase="read.notmp4">Questo non è un file MP4 né MOV.</span>
+    <span data-phrase="read.nomoov">Il file non ha l&rsquo;intestazione del filmato.</span>
+    <span data-phrase="read.novideo">Il file non ha nessuna traccia video utilizzabile da questo lettore.</span>
+    <span data-phrase="read.notimescale">La traccia video non ha una scala dei tempi.</span>
+    <span data-phrase="read.nofragments">I frammenti di questo file non contengono fotogrammi per la sua traccia video.</span>
+    <span data-phrase="read.unreadable">Il file non si è potuto leggere come MP4.</span>
+    <span data-phrase="read.notplayed">Questo formato non è tra quelli che questo browser riproduce.</span>
+    <span data-phrase="read.layout">La disposizione di questo file non è tra quelle che il lettore qui capisce.</span>
+    <span data-phrase="read.nodecoder">Questo browser non decodifica {codec} direttamente.</span>
+    <span data-phrase="read.nowebcodecs">Questo browser non ha WebCodecs, quindi i fotogrammi non si possono decodificare uno
+      per uno.</span>
+    <span data-phrase="open.failed">Questo browser non riesce ad aprire questo file. {reason}</span>
+    <span data-phrase="open.nodecode">Questo browser ha aperto il file ma non riesce a decodificare il video che contiene.
+      Di solito è Dolby Vision, oppure HEVC su una macchina senza supporto hardware: il
+      contenitore si legge benissimo e l&rsquo;immagine non arriva mai. Convertilo prima
+      in un MP4 normale (H.264) e questo strumento lo leggerà direttamente.</span>
+    <span data-phrase="path.seek">{reason} Perciò questo viene letto portando il riproduttore del browser a ogni
+      istante: funziona con ogni formato che il browser riproduce, ed è un po&rsquo; più
+      lento.</span>
     <span data-phrase="net.clean">Il tuo video non è andato da nessuna parte.
       {total} file caricati. {platform}</span>
     <span data-phrase="net.dirty">Qualcosa ha contattato {hosts}, e questo

--- a/locales/it/tools/video-to-gif.html
+++ b/locales/it/tools/video-to-gif.html
@@ -174,6 +174,39 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">Il file finisce a metà di un fotogramma.</span>
+    <span data-phrase="read.avcshort">Il record di configurazione H.264 è troppo corto.</span>
+    <span data-phrase="read.hevcshort">Il record di configurazione HEVC è troppo corto.</span>
+    <span data-phrase="read.av1short">Il record di configurazione AV1 è troppo corto.</span>
+    <span data-phrase="read.compactsizes">Le dimensioni dei campioni stanno in una tabella compatta che questo lettore non
+      decodifica.</span>
+    <span data-phrase="read.sampletables">Le tabelle dei campioni sono incomplete.</span>
+    <span data-phrase="read.chunktable">La tabella dei chunk è vuota.</span>
+    <span data-phrase="read.nosamples">La traccia non contiene campioni.</span>
+    <span data-phrase="read.nostbl">Alla traccia video mancano le sue tabelle dei campioni.</span>
+    <span data-phrase="read.nostsd">La traccia video non ha una descrizione dei campioni.</span>
+    <span data-phrase="read.emptystsd">La descrizione dei campioni del video è vuota.</span>
+    <span data-phrase="read.encrypted">La traccia video è cifrata.</span>
+    <span data-phrase="read.unknowncodec">Il video è memorizzato come &laquo;{type}&raquo;, e questo lettore non lo conosce.</span>
+    <span data-phrase="read.noconfig">La traccia &laquo;{type}&raquo; non porta con sé alcuna configurazione del
+      decodificatore.</span>
+    <span data-phrase="read.notmp4">Questo non è un file MP4 né MOV.</span>
+    <span data-phrase="read.nomoov">Il file non ha l&rsquo;intestazione del filmato.</span>
+    <span data-phrase="read.novideo">Il file non ha nessuna traccia video utilizzabile da questo lettore.</span>
+    <span data-phrase="read.notimescale">La traccia video non ha una scala dei tempi.</span>
+    <span data-phrase="read.nofragments">I frammenti di questo file non contengono fotogrammi per la sua traccia video.</span>
+    <span data-phrase="read.unreadable">Il file non si è potuto leggere come MP4.</span>
+    <span data-phrase="read.notplayed">Questo formato non è tra quelli che questo browser riproduce.</span>
+    <span data-phrase="read.layout">La disposizione di questo file non è tra quelle che il lettore qui capisce.</span>
+    <span data-phrase="read.nodecoder">Questo browser non decodifica {codec} direttamente.</span>
+    <span data-phrase="read.nowebcodecs">Questo browser non ha WebCodecs, quindi i fotogrammi non si possono decodificare uno
+      per uno.</span>
+    <span data-phrase="read.turned">Questo file è memorizzato ruotato, e il lettore qui e il riproduttore del browser
+      non vanno d&rsquo;accordo sulla rotazione.</span>
+    <span data-phrase="open.failed">Questo browser non riesce ad aprire questo file. {reason}</span>
+    <span data-phrase="path.seek">{reason} Perciò i fotogrammi si raccolgono portando il riproduttore a ogni istante.
+      È più lento, e su quale fotogramma cada ogni salto lo decide il browser, così un
+      tratto veloce ogni tanto può venire fuori spostato di un fotogramma.</span>
     <span data-phrase="net.clean">Il tuo video non è andato da nessuna parte.
       {total} file caricati. {platform}</span>
     <span data-phrase="net.dirty">Qualcosa ha contattato {hosts}, e questo

--- a/locales/ja/tools/crop-video.html
+++ b/locales/ja/tools/crop-video.html
@@ -146,6 +146,34 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">ファイルが1コマの途中で終わっています。</span>
+    <span data-phrase="read.avcshort">H.264の設定レコードが短すぎます。</span>
+    <span data-phrase="read.hevcshort">HEVCの設定レコードが短すぎます。</span>
+    <span data-phrase="read.av1short">AV1の設定レコードが短すぎます。</span>
+    <span data-phrase="read.compactsizes">サンプルの大きさが、このリーダーの解さない圧縮テーブルに入っています。</span>
+    <span data-phrase="read.sampletables">サンプルテーブルが欠けています。</span>
+    <span data-phrase="read.chunktable">チャンクテーブルが空です。</span>
+    <span data-phrase="read.nosamples">そのトラックにサンプルが1つもありません。</span>
+    <span data-phrase="read.nostbl">映像トラックにサンプルテーブルがありません。</span>
+    <span data-phrase="read.nostsd">映像トラックにサンプル記述がありません。</span>
+    <span data-phrase="read.emptystsd">映像のサンプル記述が空です。</span>
+    <span data-phrase="read.encrypted">映像トラックが暗号化されています。</span>
+    <span data-phrase="read.unknowncodec">映像は「{type}」として保存されていますが、このリーダーはそれを知りません。</span>
+    <span data-phrase="read.noconfig">「{type}」トラックはデコーダー設定を持っていません。</span>
+    <span data-phrase="read.notmp4">これはMP4でもMOVでもありません。</span>
+    <span data-phrase="read.nomoov">ファイルにムービーヘッダーがありません。</span>
+    <span data-phrase="read.novideo">このファイルには、このリーダーが使える映像トラックがありません。</span>
+    <span data-phrase="read.notimescale">映像トラックにタイムスケールがありません。</span>
+    <span data-phrase="read.nofragments">このファイルのフラグメントには、映像トラックのコマが1つも入っていません。</span>
+    <span data-phrase="read.unreadable">このファイルはMP4として読めませんでした。</span>
+    <span data-phrase="read.notplayed">この形式は、このブラウザーが再生できるものではありません。</span>
+    <span data-phrase="read.layout">このファイルの構造は、ここのリーダーが解するものではありません。</span>
+    <span data-phrase="read.nodecoder">このブラウザーは{codec}を直接デコードしません。</span>
+    <span data-phrase="read.nowebcodecs">このブラウザーにはWebCodecsがないので、コマを1つずつデコードできません。</span>
+    <span data-phrase="read.turned">このファイルは回転した状態で保存されていて、ここのリーダーとブラウザーのプレーヤーとで回転の解釈が食い違っています。</span>
+    <span data-phrase="open.failed">このブラウザーはこのファイルを開けません。{reason}</span>
+    <span data-phrase="open.norecord">このブラウザーは動画を録画できないので、このファイルを切り抜けません。</span>
+    <span data-phrase="path.record">{reason}そのためこれは、再生しながら録画する形で切り抜きます。動画の長さと同じだけ時間がかかり、音はコピーではなく再エンコードされます。</span>
     <span data-phrase="net.clean">動画はどこへも出ていません。{total}件のファイルを読み込みました。{platform}</span>
     <span data-phrase="net.dirty">何かが{hosts}へ接続しました。この道具は決してそれをしません。{platform}</span>
     <span data-phrase="net.platform.one">広告・計測・寄付ボタンのためのサイト自身のスクリプトが{hosts}のホストから読み込まれました。そのどれにも、ファイルは渡っていません。</span>

--- a/locales/ja/tools/grab-frame.html
+++ b/locales/ja/tools/grab-frame.html
@@ -134,6 +134,34 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">ファイルが1コマの途中で終わっています。</span>
+    <span data-phrase="read.avcshort">H.264の設定レコードが短すぎます。</span>
+    <span data-phrase="read.hevcshort">HEVCの設定レコードが短すぎます。</span>
+    <span data-phrase="read.av1short">AV1の設定レコードが短すぎます。</span>
+    <span data-phrase="read.compactsizes">サンプルの大きさが、このリーダーの解さない圧縮テーブルに入っています。</span>
+    <span data-phrase="read.sampletables">サンプルテーブルが欠けています。</span>
+    <span data-phrase="read.chunktable">チャンクテーブルが空です。</span>
+    <span data-phrase="read.nosamples">そのトラックにサンプルが1つもありません。</span>
+    <span data-phrase="read.nostbl">映像トラックにサンプルテーブルがありません。</span>
+    <span data-phrase="read.nostsd">映像トラックにサンプル記述がありません。</span>
+    <span data-phrase="read.emptystsd">映像のサンプル記述が空です。</span>
+    <span data-phrase="read.encrypted">映像トラックが暗号化されています。</span>
+    <span data-phrase="read.unknowncodec">映像は「{type}」として保存されていますが、このリーダーはそれを知りません。</span>
+    <span data-phrase="read.noconfig">「{type}」トラックはデコーダー設定を持っていません。</span>
+    <span data-phrase="read.notmp4">これはMP4でもMOVでもありません。</span>
+    <span data-phrase="read.nomoov">ファイルにムービーヘッダーがありません。</span>
+    <span data-phrase="read.novideo">このファイルには、このリーダーが使える映像トラックがありません。</span>
+    <span data-phrase="read.notimescale">映像トラックにタイムスケールがありません。</span>
+    <span data-phrase="read.nofragments">このファイルのフラグメントには、映像トラックのコマが1つも入っていません。</span>
+    <span data-phrase="read.unreadable">このファイルはMP4として読めませんでした。</span>
+    <span data-phrase="read.notplayed">この形式は、このブラウザーが再生できるものではありません。</span>
+    <span data-phrase="read.layout">このファイルの構造は、ここのリーダーが解するものではありません。</span>
+    <span data-phrase="read.nodecoder">このブラウザーは{codec}を直接デコードしません。</span>
+    <span data-phrase="read.nowebcodecs">このブラウザーにはWebCodecsがないので、コマを1つずつデコードできません。</span>
+    <span data-phrase="read.turned">このファイルは回転した状態で保存されていて、ここのリーダーとブラウザーのプレーヤーとで回転の解釈が食い違っています。</span>
+    <span data-phrase="open.failed">このブラウザーはこのファイルを開けません。{reason}</span>
+    <span data-phrase="path.player">{reason}そのためこのファイルは、1コマずつではなくブラウザー自身のプレーヤーで読みます。写真は動画の実寸のまま保存されますが、どのコマに当たるかを決めるのはプレーヤーで、1歩は正確に1コマではなくおよそ1コマ分進みます。</span>
+    <span data-phrase="path.nopreview">このブラウザーはこのファイルを再生しないので、押して再生するものはありません。ただしデコードはできて、静止画はそこから作られます。スライダーと矢印キーで動画の中を移動してください。</span>
     <span data-phrase="net.clean">動画はどこへも出ていません。{total}件のファイルを読み込みました。{platform}</span>
     <span data-phrase="net.dirty">何かが{hosts}へ接続しました。この道具は決してそれをしません。{platform}</span>
     <span data-phrase="net.platform.one">広告・計測・寄付ボタンのためのサイト自身のスクリプトが{hosts}のホストから読み込まれました。そのどれにも、ファイルは渡っていません。</span>

--- a/locales/ja/tools/timelapse-video.html
+++ b/locales/ja/tools/timelapse-video.html
@@ -152,6 +152,33 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">ファイルが1コマの途中で終わっています。</span>
+    <span data-phrase="read.avcshort">H.264の設定レコードが短すぎます。</span>
+    <span data-phrase="read.hevcshort">HEVCの設定レコードが短すぎます。</span>
+    <span data-phrase="read.av1short">AV1の設定レコードが短すぎます。</span>
+    <span data-phrase="read.compactsizes">サンプルの大きさが、このリーダーの解さない圧縮テーブルに入っています。</span>
+    <span data-phrase="read.sampletables">サンプルテーブルが欠けています。</span>
+    <span data-phrase="read.chunktable">チャンクテーブルが空です。</span>
+    <span data-phrase="read.nosamples">そのトラックにサンプルが1つもありません。</span>
+    <span data-phrase="read.nostbl">映像トラックにサンプルテーブルがありません。</span>
+    <span data-phrase="read.nostsd">映像トラックにサンプル記述がありません。</span>
+    <span data-phrase="read.emptystsd">映像のサンプル記述が空です。</span>
+    <span data-phrase="read.encrypted">映像トラックが暗号化されています。</span>
+    <span data-phrase="read.unknowncodec">映像は「{type}」として保存されていますが、このリーダーはそれを知りません。</span>
+    <span data-phrase="read.noconfig">「{type}」トラックはデコーダー設定を持っていません。</span>
+    <span data-phrase="read.notmp4">これはMP4でもMOVでもありません。</span>
+    <span data-phrase="read.nomoov">ファイルにムービーヘッダーがありません。</span>
+    <span data-phrase="read.novideo">このファイルには、このリーダーが使える映像トラックがありません。</span>
+    <span data-phrase="read.notimescale">映像トラックにタイムスケールがありません。</span>
+    <span data-phrase="read.nofragments">このファイルのフラグメントには、映像トラックのコマが1つも入っていません。</span>
+    <span data-phrase="read.unreadable">このファイルはMP4として読めませんでした。</span>
+    <span data-phrase="read.notplayed">この形式は、このブラウザーが再生できるものではありません。</span>
+    <span data-phrase="read.layout">このファイルの構造は、ここのリーダーが解するものではありません。</span>
+    <span data-phrase="read.nodecoder">このブラウザーは{codec}を直接デコードしません。</span>
+    <span data-phrase="read.nowebcodecs">このブラウザーにはWebCodecsがないので、コマを1つずつデコードできません。</span>
+    <span data-phrase="open.failed">このブラウザーはこのファイルを開けません。{reason}</span>
+    <span data-phrase="open.nodecode">このブラウザーはファイルを開けましたが、中の映像をデコードできません。たいていはDolby Vision、またはハードウェア対応のない機械でのHEVCです。コンテナはきちんと読めるのに、絵がいつまでも届きません。まず普通のMP4（H.264）に変換してください。そうすればこの道具が直接読みます。</span>
+    <span data-phrase="path.seek">{reason}そのためこれは、ブラウザー自身のプレーヤーをその時刻へ送りながら読みます。ブラウザーが再生できる形式ならどれでも通り、少しだけ遅くなります。</span>
     <span data-phrase="net.clean">動画はどこへも出ていません。{total}件のファイルを読み込みました。{platform}</span>
     <span data-phrase="net.dirty">何かが{hosts}へ接続しました。この道具は決してそれをしません。{platform}</span>
     <span data-phrase="net.platform.one">広告・計測・寄付ボタンのためのサイト自身のスクリプトが{hosts}のホストから読み込まれました。そのどれにも、ファイルは渡っていません。</span>

--- a/locales/ja/tools/video-to-gif.html
+++ b/locales/ja/tools/video-to-gif.html
@@ -168,6 +168,33 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">ファイルが1コマの途中で終わっています。</span>
+    <span data-phrase="read.avcshort">H.264の設定レコードが短すぎます。</span>
+    <span data-phrase="read.hevcshort">HEVCの設定レコードが短すぎます。</span>
+    <span data-phrase="read.av1short">AV1の設定レコードが短すぎます。</span>
+    <span data-phrase="read.compactsizes">サンプルの大きさが、このリーダーの解さない圧縮テーブルに入っています。</span>
+    <span data-phrase="read.sampletables">サンプルテーブルが欠けています。</span>
+    <span data-phrase="read.chunktable">チャンクテーブルが空です。</span>
+    <span data-phrase="read.nosamples">そのトラックにサンプルが1つもありません。</span>
+    <span data-phrase="read.nostbl">映像トラックにサンプルテーブルがありません。</span>
+    <span data-phrase="read.nostsd">映像トラックにサンプル記述がありません。</span>
+    <span data-phrase="read.emptystsd">映像のサンプル記述が空です。</span>
+    <span data-phrase="read.encrypted">映像トラックが暗号化されています。</span>
+    <span data-phrase="read.unknowncodec">映像は「{type}」として保存されていますが、このリーダーはそれを知りません。</span>
+    <span data-phrase="read.noconfig">「{type}」トラックはデコーダー設定を持っていません。</span>
+    <span data-phrase="read.notmp4">これはMP4でもMOVでもありません。</span>
+    <span data-phrase="read.nomoov">ファイルにムービーヘッダーがありません。</span>
+    <span data-phrase="read.novideo">このファイルには、このリーダーが使える映像トラックがありません。</span>
+    <span data-phrase="read.notimescale">映像トラックにタイムスケールがありません。</span>
+    <span data-phrase="read.nofragments">このファイルのフラグメントには、映像トラックのコマが1つも入っていません。</span>
+    <span data-phrase="read.unreadable">このファイルはMP4として読めませんでした。</span>
+    <span data-phrase="read.notplayed">この形式は、このブラウザーが再生できるものではありません。</span>
+    <span data-phrase="read.layout">このファイルの構造は、ここのリーダーが解するものではありません。</span>
+    <span data-phrase="read.nodecoder">このブラウザーは{codec}を直接デコードしません。</span>
+    <span data-phrase="read.nowebcodecs">このブラウザーにはWebCodecsがないので、コマを1つずつデコードできません。</span>
+    <span data-phrase="read.turned">このファイルは回転した状態で保存されていて、ここのリーダーとブラウザーのプレーヤーとで回転の解釈が食い違っています。</span>
+    <span data-phrase="open.failed">このブラウザーはこのファイルを開けません。{reason}</span>
+    <span data-phrase="path.seek">{reason}そのためコマは、プレーヤーをその時刻へ送りながら集めます。そのぶん遅くなりますし、どのコマに当たるかを決めるのはブラウザーなので、動きの速いところはときどき1コマずれて出ることがあります。</span>
     <span data-phrase="net.clean">動画はどこへも出ていません。{total}件のファイルを読み込みました。{platform}</span>
     <span data-phrase="net.dirty">何かが{hosts}へ接続しました。この道具は決してそれをしません。{platform}</span>
     <span data-phrase="net.platform.one">広告・計測・寄付ボタンのためのサイト自身のスクリプトが{hosts}のホストから読み込まれました。そのどれにも、ファイルは渡っていません。</span>

--- a/locales/ko/tools/crop-video.html
+++ b/locales/ko/tools/crop-video.html
@@ -151,6 +151,35 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">파일이 프레임 한가운데에서 끝났습니다.</span>
+    <span data-phrase="read.avcshort">H.264 설정 레코드가 너무 짧습니다.</span>
+    <span data-phrase="read.hevcshort">HEVC 설정 레코드가 너무 짧습니다.</span>
+    <span data-phrase="read.av1short">AV1 설정 레코드가 너무 짧습니다.</span>
+    <span data-phrase="read.compactsizes">샘플 크기가 이 리더는 풀지 않는 압축 표에 들어 있습니다.</span>
+    <span data-phrase="read.sampletables">샘플 테이블이 온전하지 않습니다.</span>
+    <span data-phrase="read.chunktable">청크 테이블이 비어 있습니다.</span>
+    <span data-phrase="read.nosamples">그 트랙에는 샘플이 하나도 없습니다.</span>
+    <span data-phrase="read.nostbl">비디오 트랙에 샘플 테이블이 없습니다.</span>
+    <span data-phrase="read.nostsd">비디오 트랙에 샘플 설명이 없습니다.</span>
+    <span data-phrase="read.emptystsd">비디오의 샘플 설명이 비어 있습니다.</span>
+    <span data-phrase="read.encrypted">비디오 트랙이 암호화되어 있습니다.</span>
+    <span data-phrase="read.unknowncodec">이 영상은 &ldquo;{type}&rdquo; 형식으로 저장되어 있는데, 이 리더가 모르는 형식입니다.</span>
+    <span data-phrase="read.noconfig">&ldquo;{type}&rdquo; 트랙은 디코더 설정을 함께 담고 있지 않습니다.</span>
+    <span data-phrase="read.notmp4">MP4도 MOV도 아닙니다.</span>
+    <span data-phrase="read.nomoov">파일에 무비 헤더가 없습니다.</span>
+    <span data-phrase="read.novideo">이 파일에는 이 리더가 쓸 수 있는 비디오 트랙이 없습니다.</span>
+    <span data-phrase="read.notimescale">비디오 트랙에 타임스케일이 없습니다.</span>
+    <span data-phrase="read.nofragments">이 파일의 프래그먼트에는 비디오 트랙의 프레임이 하나도 없습니다.</span>
+    <span data-phrase="read.unreadable">이 파일은 MP4로 읽히지 않았습니다.</span>
+    <span data-phrase="read.notplayed">이 형식은 이 브라우저가 재생하는 형식이 아닙니다.</span>
+    <span data-phrase="read.layout">이 파일의 구성은 여기 리더가 이해하는 구성이 아닙니다.</span>
+    <span data-phrase="read.nodecoder">이 브라우저는 {codec}을 직접 디코딩하지 않습니다.</span>
+    <span data-phrase="read.nowebcodecs">이 브라우저에는 WebCodecs가 없어서 프레임을 하나씩 디코딩할 수 없습니다.</span>
+    <span data-phrase="read.turned">이 파일은 돌아간 채로 저장되어 있고, 여기 리더와 브라우저의 재생기가 그 회전을 두고 서로 다르게 봅니다.</span>
+    <span data-phrase="open.failed">이 브라우저는 이 파일을 열지 못합니다. {reason}</span>
+    <span data-phrase="open.norecord">이 브라우저는 영상을 녹화하지 못해서, 이 파일을 잘라내지도 못합니다.</span>
+    <span data-phrase="path.record">{reason} 그래서 이 파일은 재생하면서 그 결과를 녹화하는 방식으로 잘라냅니다. 영상 길이만큼 시간이 걸리고, 소리는 복사가 아니라 다시
+      인코딩됩니다.</span>
     <span data-phrase="net.clean">동영상은 어디로도 가지 않았습니다. 파일 {total}개를 불러왔습니다.
       {platform}</span>
     <span data-phrase="net.dirty">무언가가 {hosts}에 접속했는데, 이 도구는 절대 그러지 않습니다.

--- a/locales/ko/tools/grab-frame.html
+++ b/locales/ko/tools/grab-frame.html
@@ -139,6 +139,36 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">파일이 프레임 한가운데에서 끝났습니다.</span>
+    <span data-phrase="read.avcshort">H.264 설정 레코드가 너무 짧습니다.</span>
+    <span data-phrase="read.hevcshort">HEVC 설정 레코드가 너무 짧습니다.</span>
+    <span data-phrase="read.av1short">AV1 설정 레코드가 너무 짧습니다.</span>
+    <span data-phrase="read.compactsizes">샘플 크기가 이 리더는 풀지 않는 압축 표에 들어 있습니다.</span>
+    <span data-phrase="read.sampletables">샘플 테이블이 온전하지 않습니다.</span>
+    <span data-phrase="read.chunktable">청크 테이블이 비어 있습니다.</span>
+    <span data-phrase="read.nosamples">그 트랙에는 샘플이 하나도 없습니다.</span>
+    <span data-phrase="read.nostbl">비디오 트랙에 샘플 테이블이 없습니다.</span>
+    <span data-phrase="read.nostsd">비디오 트랙에 샘플 설명이 없습니다.</span>
+    <span data-phrase="read.emptystsd">비디오의 샘플 설명이 비어 있습니다.</span>
+    <span data-phrase="read.encrypted">비디오 트랙이 암호화되어 있습니다.</span>
+    <span data-phrase="read.unknowncodec">이 영상은 &ldquo;{type}&rdquo; 형식으로 저장되어 있는데, 이 리더가 모르는 형식입니다.</span>
+    <span data-phrase="read.noconfig">&ldquo;{type}&rdquo; 트랙은 디코더 설정을 함께 담고 있지 않습니다.</span>
+    <span data-phrase="read.notmp4">MP4도 MOV도 아닙니다.</span>
+    <span data-phrase="read.nomoov">파일에 무비 헤더가 없습니다.</span>
+    <span data-phrase="read.novideo">이 파일에는 이 리더가 쓸 수 있는 비디오 트랙이 없습니다.</span>
+    <span data-phrase="read.notimescale">비디오 트랙에 타임스케일이 없습니다.</span>
+    <span data-phrase="read.nofragments">이 파일의 프래그먼트에는 비디오 트랙의 프레임이 하나도 없습니다.</span>
+    <span data-phrase="read.unreadable">이 파일은 MP4로 읽히지 않았습니다.</span>
+    <span data-phrase="read.notplayed">이 형식은 이 브라우저가 재생하는 형식이 아닙니다.</span>
+    <span data-phrase="read.layout">이 파일의 구성은 여기 리더가 이해하는 구성이 아닙니다.</span>
+    <span data-phrase="read.nodecoder">이 브라우저는 {codec}을 직접 디코딩하지 않습니다.</span>
+    <span data-phrase="read.nowebcodecs">이 브라우저에는 WebCodecs가 없어서 프레임을 하나씩 디코딩할 수 없습니다.</span>
+    <span data-phrase="read.turned">이 파일은 돌아간 채로 저장되어 있고, 여기 리더와 브라우저의 재생기가 그 회전을 두고 서로 다르게 봅니다.</span>
+    <span data-phrase="open.failed">이 브라우저는 이 파일을 열지 못합니다. {reason}</span>
+    <span data-phrase="path.player">{reason} 그래서 이 파일은 프레임 단위가 아니라 브라우저 자신의 재생기로 읽습니다. 사진은 여전히 영상의 원래 크기로 저장되지만, 어느 프레임에
+      멈추는지는 재생기가 정하고, 한 걸음은 정확히 한 프레임이 아니라 대략 한 프레임씩 움직입니다.</span>
+    <span data-phrase="path.nopreview">이 브라우저는 이 파일을 재생하지 못해서 눌러 볼 재생 버튼이 없습니다. 디코딩은 되고, 사진은 거기서 나옵니다. 슬라이더와 화살표 키로 영상 안을
+      옮겨 다니세요.</span>
     <span data-phrase="net.clean">동영상은 어디로도 가지 않았습니다. 파일 {total}개를 불러왔습니다.
       {platform}</span>
     <span data-phrase="net.dirty">무언가가 {hosts}에 접속했는데, 이 도구는 절대 그러지 않습니다.

--- a/locales/ko/tools/timelapse-video.html
+++ b/locales/ko/tools/timelapse-video.html
@@ -157,6 +157,35 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">파일이 프레임 한가운데에서 끝났습니다.</span>
+    <span data-phrase="read.avcshort">H.264 설정 레코드가 너무 짧습니다.</span>
+    <span data-phrase="read.hevcshort">HEVC 설정 레코드가 너무 짧습니다.</span>
+    <span data-phrase="read.av1short">AV1 설정 레코드가 너무 짧습니다.</span>
+    <span data-phrase="read.compactsizes">샘플 크기가 이 리더는 풀지 않는 압축 표에 들어 있습니다.</span>
+    <span data-phrase="read.sampletables">샘플 테이블이 온전하지 않습니다.</span>
+    <span data-phrase="read.chunktable">청크 테이블이 비어 있습니다.</span>
+    <span data-phrase="read.nosamples">그 트랙에는 샘플이 하나도 없습니다.</span>
+    <span data-phrase="read.nostbl">비디오 트랙에 샘플 테이블이 없습니다.</span>
+    <span data-phrase="read.nostsd">비디오 트랙에 샘플 설명이 없습니다.</span>
+    <span data-phrase="read.emptystsd">비디오의 샘플 설명이 비어 있습니다.</span>
+    <span data-phrase="read.encrypted">비디오 트랙이 암호화되어 있습니다.</span>
+    <span data-phrase="read.unknowncodec">이 영상은 &ldquo;{type}&rdquo; 형식으로 저장되어 있는데, 이 리더가 모르는 형식입니다.</span>
+    <span data-phrase="read.noconfig">&ldquo;{type}&rdquo; 트랙은 디코더 설정을 함께 담고 있지 않습니다.</span>
+    <span data-phrase="read.notmp4">MP4도 MOV도 아닙니다.</span>
+    <span data-phrase="read.nomoov">파일에 무비 헤더가 없습니다.</span>
+    <span data-phrase="read.novideo">이 파일에는 이 리더가 쓸 수 있는 비디오 트랙이 없습니다.</span>
+    <span data-phrase="read.notimescale">비디오 트랙에 타임스케일이 없습니다.</span>
+    <span data-phrase="read.nofragments">이 파일의 프래그먼트에는 비디오 트랙의 프레임이 하나도 없습니다.</span>
+    <span data-phrase="read.unreadable">이 파일은 MP4로 읽히지 않았습니다.</span>
+    <span data-phrase="read.notplayed">이 형식은 이 브라우저가 재생하는 형식이 아닙니다.</span>
+    <span data-phrase="read.layout">이 파일의 구성은 여기 리더가 이해하는 구성이 아닙니다.</span>
+    <span data-phrase="read.nodecoder">이 브라우저는 {codec}을 직접 디코딩하지 않습니다.</span>
+    <span data-phrase="read.nowebcodecs">이 브라우저에는 WebCodecs가 없어서 프레임을 하나씩 디코딩할 수 없습니다.</span>
+    <span data-phrase="open.failed">이 브라우저는 이 파일을 열지 못합니다. {reason}</span>
+    <span data-phrase="open.nodecode">이 브라우저가 파일은 열었지만 안에 든 영상을 디코딩하지 못합니다. 보통 Dolby Vision이거나, 하드웨어 지원이 없는 기기에서의 HEVC입니다.
+      컨테이너는 멀쩡히 읽히는데 화면이 끝내 오지 않는 것이죠. 먼저 보통 MP4(H.264)로 바꾸면 이 도구가 곧바로 읽습니다.</span>
+    <span data-phrase="path.seek">{reason} 그래서 이 파일은 브라우저 자신의 재생기를 매 순간으로 옮겨 가며 읽습니다. 브라우저가 재생하는 모든 형식에서 통하고, 조금 더
+      느립니다.</span>
     <span data-phrase="net.clean">동영상은 어디로도 가지 않았습니다. 파일 {total}개를 불러왔습니다.
       {platform}</span>
     <span data-phrase="net.dirty">무언가가 {hosts}에 접속했는데, 이 도구는 절대 그러지 않습니다.

--- a/locales/ko/tools/video-to-gif.html
+++ b/locales/ko/tools/video-to-gif.html
@@ -174,6 +174,34 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">파일이 프레임 한가운데에서 끝났습니다.</span>
+    <span data-phrase="read.avcshort">H.264 설정 레코드가 너무 짧습니다.</span>
+    <span data-phrase="read.hevcshort">HEVC 설정 레코드가 너무 짧습니다.</span>
+    <span data-phrase="read.av1short">AV1 설정 레코드가 너무 짧습니다.</span>
+    <span data-phrase="read.compactsizes">샘플 크기가 이 리더는 풀지 않는 압축 표에 들어 있습니다.</span>
+    <span data-phrase="read.sampletables">샘플 테이블이 온전하지 않습니다.</span>
+    <span data-phrase="read.chunktable">청크 테이블이 비어 있습니다.</span>
+    <span data-phrase="read.nosamples">그 트랙에는 샘플이 하나도 없습니다.</span>
+    <span data-phrase="read.nostbl">비디오 트랙에 샘플 테이블이 없습니다.</span>
+    <span data-phrase="read.nostsd">비디오 트랙에 샘플 설명이 없습니다.</span>
+    <span data-phrase="read.emptystsd">비디오의 샘플 설명이 비어 있습니다.</span>
+    <span data-phrase="read.encrypted">비디오 트랙이 암호화되어 있습니다.</span>
+    <span data-phrase="read.unknowncodec">이 영상은 &ldquo;{type}&rdquo; 형식으로 저장되어 있는데, 이 리더가 모르는 형식입니다.</span>
+    <span data-phrase="read.noconfig">&ldquo;{type}&rdquo; 트랙은 디코더 설정을 함께 담고 있지 않습니다.</span>
+    <span data-phrase="read.notmp4">MP4도 MOV도 아닙니다.</span>
+    <span data-phrase="read.nomoov">파일에 무비 헤더가 없습니다.</span>
+    <span data-phrase="read.novideo">이 파일에는 이 리더가 쓸 수 있는 비디오 트랙이 없습니다.</span>
+    <span data-phrase="read.notimescale">비디오 트랙에 타임스케일이 없습니다.</span>
+    <span data-phrase="read.nofragments">이 파일의 프래그먼트에는 비디오 트랙의 프레임이 하나도 없습니다.</span>
+    <span data-phrase="read.unreadable">이 파일은 MP4로 읽히지 않았습니다.</span>
+    <span data-phrase="read.notplayed">이 형식은 이 브라우저가 재생하는 형식이 아닙니다.</span>
+    <span data-phrase="read.layout">이 파일의 구성은 여기 리더가 이해하는 구성이 아닙니다.</span>
+    <span data-phrase="read.nodecoder">이 브라우저는 {codec}을 직접 디코딩하지 않습니다.</span>
+    <span data-phrase="read.nowebcodecs">이 브라우저에는 WebCodecs가 없어서 프레임을 하나씩 디코딩할 수 없습니다.</span>
+    <span data-phrase="read.turned">이 파일은 돌아간 채로 저장되어 있고, 여기 리더와 브라우저의 재생기가 그 회전을 두고 서로 다르게 봅니다.</span>
+    <span data-phrase="open.failed">이 브라우저는 이 파일을 열지 못합니다. {reason}</span>
+    <span data-phrase="path.seek">{reason} 그래서 프레임은 재생기를 매 순간으로 옮겨 가며 모읍니다. 더 느리고, 각 이동이 어느 프레임에 닿을지는 브라우저가 정하기 때문에 빠른
+      구간은 군데군데 한 프레임쯤 어긋나 나올 수 있습니다.</span>
     <span data-phrase="net.clean">동영상은 어디로도 가지 않았습니다. 파일 {total}개를 불러왔습니다.
       {platform}</span>
     <span data-phrase="net.dirty">무언가가 {hosts}에 접속했는데, 이 도구는 절대 그러지 않습니다.

--- a/locales/nl/tools/crop-video.html
+++ b/locales/nl/tools/crop-video.html
@@ -151,6 +151,38 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">Het bestand houdt midden in een frame op.</span>
+    <span data-phrase="read.avcshort">Het H.264-configuratierecord is te kort.</span>
+    <span data-phrase="read.hevcshort">Het HEVC-configuratierecord is te kort.</span>
+    <span data-phrase="read.av1short">Het AV1-configuratierecord is te kort.</span>
+    <span data-phrase="read.compactsizes">De samplegroottes staan in een compacte tabel die deze lezer niet decodeert.</span>
+    <span data-phrase="read.sampletables">De sampletabellen zijn onvolledig.</span>
+    <span data-phrase="read.chunktable">De chunk-tabel is leeg.</span>
+    <span data-phrase="read.nosamples">Het spoor bevat geen samples.</span>
+    <span data-phrase="read.nostbl">Het videospoor mist zijn sampletabellen.</span>
+    <span data-phrase="read.nostsd">Het videospoor heeft geen samplebeschrijving.</span>
+    <span data-phrase="read.emptystsd">De samplebeschrijving van de video is leeg.</span>
+    <span data-phrase="read.encrypted">Het videospoor is versleuteld.</span>
+    <span data-phrase="read.unknowncodec">De video is opgeslagen als &lsquo;{type}&rsquo;, en dat kent deze lezer niet.</span>
+    <span data-phrase="read.noconfig">Het spoor &lsquo;{type}&rsquo; draagt geen decoderconfiguratie bij zich.</span>
+    <span data-phrase="read.notmp4">Dit is geen MP4- of MOV-bestand.</span>
+    <span data-phrase="read.nomoov">Het bestand heeft geen filmheader.</span>
+    <span data-phrase="read.novideo">Het bestand heeft geen videospoor waar deze lezer iets mee kan.</span>
+    <span data-phrase="read.notimescale">Het videospoor heeft geen tijdschaal.</span>
+    <span data-phrase="read.nofragments">De fragmenten in dit bestand bevatten geen frames voor het videospoor ervan.</span>
+    <span data-phrase="read.unreadable">Het bestand kon niet als MP4 gelezen worden.</span>
+    <span data-phrase="read.notplayed">Dit formaat speelt deze browser niet af.</span>
+    <span data-phrase="read.layout">De indeling van dit bestand is er geen die de lezer hier begrijpt.</span>
+    <span data-phrase="read.nodecoder">Deze browser decodeert {codec} niet rechtstreeks.</span>
+    <span data-phrase="read.nowebcodecs">Deze browser heeft geen WebCodecs, dus de frames kunnen niet één voor één
+      gedecodeerd worden.</span>
+    <span data-phrase="read.turned">Dit bestand is gedraaid opgeslagen, en de lezer hier en de speler van de browser
+      zijn het over die draaiing niet eens.</span>
+    <span data-phrase="open.failed">Deze browser kan dit bestand niet openen. {reason}</span>
+    <span data-phrase="open.norecord">Deze browser kan geen video opnemen, en kan dit bestand dus ook niet bijsnijden.</span>
+    <span data-phrase="path.record">{reason} Daarom wordt deze bijgesneden door hem af te spelen en op te nemen: dat
+      duurt zo lang als de video duurt, en het geluid wordt opnieuw gecodeerd in plaats
+      van gekopieerd.</span>
     <span data-phrase="net.clean">Je video is nergens heen gegaan. {total}
       bestanden geladen. {platform}</span>
     <span data-phrase="net.dirty">Iets heeft {hosts} benaderd, en dat doet dit

--- a/locales/nl/tools/grab-frame.html
+++ b/locales/nl/tools/grab-frame.html
@@ -139,6 +139,41 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">Het bestand houdt midden in een frame op.</span>
+    <span data-phrase="read.avcshort">Het H.264-configuratierecord is te kort.</span>
+    <span data-phrase="read.hevcshort">Het HEVC-configuratierecord is te kort.</span>
+    <span data-phrase="read.av1short">Het AV1-configuratierecord is te kort.</span>
+    <span data-phrase="read.compactsizes">De samplegroottes staan in een compacte tabel die deze lezer niet decodeert.</span>
+    <span data-phrase="read.sampletables">De sampletabellen zijn onvolledig.</span>
+    <span data-phrase="read.chunktable">De chunk-tabel is leeg.</span>
+    <span data-phrase="read.nosamples">Het spoor bevat geen samples.</span>
+    <span data-phrase="read.nostbl">Het videospoor mist zijn sampletabellen.</span>
+    <span data-phrase="read.nostsd">Het videospoor heeft geen samplebeschrijving.</span>
+    <span data-phrase="read.emptystsd">De samplebeschrijving van de video is leeg.</span>
+    <span data-phrase="read.encrypted">Het videospoor is versleuteld.</span>
+    <span data-phrase="read.unknowncodec">De video is opgeslagen als &lsquo;{type}&rsquo;, en dat kent deze lezer niet.</span>
+    <span data-phrase="read.noconfig">Het spoor &lsquo;{type}&rsquo; draagt geen decoderconfiguratie bij zich.</span>
+    <span data-phrase="read.notmp4">Dit is geen MP4- of MOV-bestand.</span>
+    <span data-phrase="read.nomoov">Het bestand heeft geen filmheader.</span>
+    <span data-phrase="read.novideo">Het bestand heeft geen videospoor waar deze lezer iets mee kan.</span>
+    <span data-phrase="read.notimescale">Het videospoor heeft geen tijdschaal.</span>
+    <span data-phrase="read.nofragments">De fragmenten in dit bestand bevatten geen frames voor het videospoor ervan.</span>
+    <span data-phrase="read.unreadable">Het bestand kon niet als MP4 gelezen worden.</span>
+    <span data-phrase="read.notplayed">Dit formaat speelt deze browser niet af.</span>
+    <span data-phrase="read.layout">De indeling van dit bestand is er geen die de lezer hier begrijpt.</span>
+    <span data-phrase="read.nodecoder">Deze browser decodeert {codec} niet rechtstreeks.</span>
+    <span data-phrase="read.nowebcodecs">Deze browser heeft geen WebCodecs, dus de frames kunnen niet één voor één
+      gedecodeerd worden.</span>
+    <span data-phrase="read.turned">Dit bestand is gedraaid opgeslagen, en de lezer hier en de speler van de browser
+      zijn het over die draaiing niet eens.</span>
+    <span data-phrase="open.failed">Deze browser kan dit bestand niet openen. {reason}</span>
+    <span data-phrase="path.player">{reason} Daarom wordt dit bestand gelezen door de eigen speler van de browser en
+      niet frame voor frame: de afbeelding wordt nog steeds op de volle grootte van de
+      video opgeslagen, maar op welk frame je uitkomt bepaalt de speler, en een stap gaat
+      ongeveer een frame vooruit in plaats van precies één.</span>
+    <span data-phrase="path.nopreview">Deze browser speelt dit bestand niet af, dus er valt niets af te spelen. Decoderen
+      kan hij het wel, en daar komen de stills vandaan: gebruik de schuifregelaar en de
+      pijltjestoetsen om erdoorheen te gaan.</span>
     <span data-phrase="net.clean">Je video is nergens heen gegaan. {total}
       bestanden geladen. {platform}</span>
     <span data-phrase="net.dirty">Iets heeft {hosts} benaderd, en dat doet dit

--- a/locales/nl/tools/timelapse-video.html
+++ b/locales/nl/tools/timelapse-video.html
@@ -159,6 +159,39 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">Het bestand houdt midden in een frame op.</span>
+    <span data-phrase="read.avcshort">Het H.264-configuratierecord is te kort.</span>
+    <span data-phrase="read.hevcshort">Het HEVC-configuratierecord is te kort.</span>
+    <span data-phrase="read.av1short">Het AV1-configuratierecord is te kort.</span>
+    <span data-phrase="read.compactsizes">De samplegroottes staan in een compacte tabel die deze lezer niet decodeert.</span>
+    <span data-phrase="read.sampletables">De sampletabellen zijn onvolledig.</span>
+    <span data-phrase="read.chunktable">De chunk-tabel is leeg.</span>
+    <span data-phrase="read.nosamples">Het spoor bevat geen samples.</span>
+    <span data-phrase="read.nostbl">Het videospoor mist zijn sampletabellen.</span>
+    <span data-phrase="read.nostsd">Het videospoor heeft geen samplebeschrijving.</span>
+    <span data-phrase="read.emptystsd">De samplebeschrijving van de video is leeg.</span>
+    <span data-phrase="read.encrypted">Het videospoor is versleuteld.</span>
+    <span data-phrase="read.unknowncodec">De video is opgeslagen als &lsquo;{type}&rsquo;, en dat kent deze lezer niet.</span>
+    <span data-phrase="read.noconfig">Het spoor &lsquo;{type}&rsquo; draagt geen decoderconfiguratie bij zich.</span>
+    <span data-phrase="read.notmp4">Dit is geen MP4- of MOV-bestand.</span>
+    <span data-phrase="read.nomoov">Het bestand heeft geen filmheader.</span>
+    <span data-phrase="read.novideo">Het bestand heeft geen videospoor waar deze lezer iets mee kan.</span>
+    <span data-phrase="read.notimescale">Het videospoor heeft geen tijdschaal.</span>
+    <span data-phrase="read.nofragments">De fragmenten in dit bestand bevatten geen frames voor het videospoor ervan.</span>
+    <span data-phrase="read.unreadable">Het bestand kon niet als MP4 gelezen worden.</span>
+    <span data-phrase="read.notplayed">Dit formaat speelt deze browser niet af.</span>
+    <span data-phrase="read.layout">De indeling van dit bestand is er geen die de lezer hier begrijpt.</span>
+    <span data-phrase="read.nodecoder">Deze browser decodeert {codec} niet rechtstreeks.</span>
+    <span data-phrase="read.nowebcodecs">Deze browser heeft geen WebCodecs, dus de frames kunnen niet één voor één
+      gedecodeerd worden.</span>
+    <span data-phrase="open.failed">Deze browser kan dit bestand niet openen. {reason}</span>
+    <span data-phrase="open.nodecode">Deze browser heeft het bestand geopend maar kan de video erin niet decoderen. Dat is
+      meestal Dolby Vision, of HEVC op een machine zonder hardware-ondersteuning ervoor:
+      de container leest prima en het beeld komt nooit aan. Zet het eerst om naar een
+      gewone MP4 (H.264), dan leest dit gereedschap het rechtstreeks.</span>
+    <span data-phrase="path.seek">{reason} Daarom wordt deze gelezen door de eigen speler van de browser naar elk
+      moment te laten springen: dat werkt bij elk formaat dat de browser afspeelt, en is
+      een beetje langzamer.</span>
     <span data-phrase="net.clean">Je video is nergens heen gegaan. {total}
       bestanden geladen. {platform}</span>
     <span data-phrase="net.dirty">Iets heeft {hosts} benaderd, en dat doet dit

--- a/locales/nl/tools/video-to-gif.html
+++ b/locales/nl/tools/video-to-gif.html
@@ -174,6 +174,37 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">Het bestand houdt midden in een frame op.</span>
+    <span data-phrase="read.avcshort">Het H.264-configuratierecord is te kort.</span>
+    <span data-phrase="read.hevcshort">Het HEVC-configuratierecord is te kort.</span>
+    <span data-phrase="read.av1short">Het AV1-configuratierecord is te kort.</span>
+    <span data-phrase="read.compactsizes">De samplegroottes staan in een compacte tabel die deze lezer niet decodeert.</span>
+    <span data-phrase="read.sampletables">De sampletabellen zijn onvolledig.</span>
+    <span data-phrase="read.chunktable">De chunk-tabel is leeg.</span>
+    <span data-phrase="read.nosamples">Het spoor bevat geen samples.</span>
+    <span data-phrase="read.nostbl">Het videospoor mist zijn sampletabellen.</span>
+    <span data-phrase="read.nostsd">Het videospoor heeft geen samplebeschrijving.</span>
+    <span data-phrase="read.emptystsd">De samplebeschrijving van de video is leeg.</span>
+    <span data-phrase="read.encrypted">Het videospoor is versleuteld.</span>
+    <span data-phrase="read.unknowncodec">De video is opgeslagen als &lsquo;{type}&rsquo;, en dat kent deze lezer niet.</span>
+    <span data-phrase="read.noconfig">Het spoor &lsquo;{type}&rsquo; draagt geen decoderconfiguratie bij zich.</span>
+    <span data-phrase="read.notmp4">Dit is geen MP4- of MOV-bestand.</span>
+    <span data-phrase="read.nomoov">Het bestand heeft geen filmheader.</span>
+    <span data-phrase="read.novideo">Het bestand heeft geen videospoor waar deze lezer iets mee kan.</span>
+    <span data-phrase="read.notimescale">Het videospoor heeft geen tijdschaal.</span>
+    <span data-phrase="read.nofragments">De fragmenten in dit bestand bevatten geen frames voor het videospoor ervan.</span>
+    <span data-phrase="read.unreadable">Het bestand kon niet als MP4 gelezen worden.</span>
+    <span data-phrase="read.notplayed">Dit formaat speelt deze browser niet af.</span>
+    <span data-phrase="read.layout">De indeling van dit bestand is er geen die de lezer hier begrijpt.</span>
+    <span data-phrase="read.nodecoder">Deze browser decodeert {codec} niet rechtstreeks.</span>
+    <span data-phrase="read.nowebcodecs">Deze browser heeft geen WebCodecs, dus de frames kunnen niet één voor één
+      gedecodeerd worden.</span>
+    <span data-phrase="read.turned">Dit bestand is gedraaid opgeslagen, en de lezer hier en de speler van de browser
+      zijn het over die draaiing niet eens.</span>
+    <span data-phrase="open.failed">Deze browser kan dit bestand niet openen. {reason}</span>
+    <span data-phrase="path.seek">{reason} Daarom worden de frames hiervoor verzameld door de speler naar elk moment
+      te laten springen. Dat is langzamer, en de browser bepaalt op welk frame elke sprong
+      uitkomt, dus een snel stuk kan er hier en daar een frame naast zitten.</span>
     <span data-phrase="net.clean">Je video is nergens heen gegaan. {total}
       bestanden geladen. {platform}</span>
     <span data-phrase="net.dirty">Iets heeft {hosts} benaderd, en dat doet dit

--- a/locales/pt/tools/crop-video.html
+++ b/locales/pt/tools/crop-video.html
@@ -151,6 +151,38 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">O arquivo termina no meio de um quadro.</span>
+    <span data-phrase="read.avcshort">O registro de configuração H.264 é curto demais.</span>
+    <span data-phrase="read.hevcshort">O registro de configuração HEVC é curto demais.</span>
+    <span data-phrase="read.av1short">O registro de configuração AV1 é curto demais.</span>
+    <span data-phrase="read.compactsizes">Os tamanhos das amostras estão numa tabela compacta que este leitor não decodifica.</span>
+    <span data-phrase="read.sampletables">As tabelas de amostras estão incompletas.</span>
+    <span data-phrase="read.chunktable">A tabela de chunks está vazia.</span>
+    <span data-phrase="read.nosamples">A faixa não contém nenhuma amostra.</span>
+    <span data-phrase="read.nostbl">Faltam à faixa de vídeo as suas tabelas de amostras.</span>
+    <span data-phrase="read.nostsd">A faixa de vídeo não tem descrição de amostra.</span>
+    <span data-phrase="read.emptystsd">A descrição de amostra do vídeo está vazia.</span>
+    <span data-phrase="read.encrypted">A faixa de vídeo está criptografada.</span>
+    <span data-phrase="read.unknowncodec">O vídeo está guardado como &ldquo;{type}&rdquo;, e este leitor não conhece isso.</span>
+    <span data-phrase="read.noconfig">A faixa &ldquo;{type}&rdquo; não carrega nenhuma configuração de decodificador.</span>
+    <span data-phrase="read.notmp4">Isto não é um arquivo MP4 nem MOV.</span>
+    <span data-phrase="read.nomoov">O arquivo não tem cabeçalho de filme.</span>
+    <span data-phrase="read.novideo">O arquivo não tem nenhuma faixa de vídeo que este leitor consiga usar.</span>
+    <span data-phrase="read.notimescale">A faixa de vídeo não tem escala de tempo.</span>
+    <span data-phrase="read.nofragments">Os fragmentos deste arquivo não contêm nenhum quadro da sua faixa de vídeo.</span>
+    <span data-phrase="read.unreadable">O arquivo não pôde ser lido como MP4.</span>
+    <span data-phrase="read.notplayed">Este formato não é dos que este navegador toca.</span>
+    <span data-phrase="read.layout">O desenho deste arquivo não é dos que o leitor daqui entende.</span>
+    <span data-phrase="read.nodecoder">Este navegador não decodifica {codec} diretamente.</span>
+    <span data-phrase="read.nowebcodecs">Este navegador não tem WebCodecs, então os quadros não podem ser decodificados um a
+      um.</span>
+    <span data-phrase="read.turned">Este arquivo está guardado girado, e o leitor daqui e o player do navegador não
+      concordam sobre o giro.</span>
+    <span data-phrase="open.failed">Este navegador não consegue abrir este arquivo. {reason}</span>
+    <span data-phrase="open.norecord">Este navegador não consegue gravar vídeo, então também não consegue recortar este
+      arquivo.</span>
+    <span data-phrase="path.record">{reason} Por isso este é recortado tocando o vídeo e gravando o que sai: demora o
+      tempo que o vídeo durar, e o som é recodificado em vez de copiado.</span>
     <span data-phrase="net.clean">O seu vídeo não foi a lugar nenhum. {total}
       arquivos carregados. {platform}</span>
     <span data-phrase="net.dirty">Alguma coisa contatou {hosts}, e esta

--- a/locales/pt/tools/grab-frame.html
+++ b/locales/pt/tools/grab-frame.html
@@ -138,6 +138,41 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">O arquivo termina no meio de um quadro.</span>
+    <span data-phrase="read.avcshort">O registro de configuração H.264 é curto demais.</span>
+    <span data-phrase="read.hevcshort">O registro de configuração HEVC é curto demais.</span>
+    <span data-phrase="read.av1short">O registro de configuração AV1 é curto demais.</span>
+    <span data-phrase="read.compactsizes">Os tamanhos das amostras estão numa tabela compacta que este leitor não decodifica.</span>
+    <span data-phrase="read.sampletables">As tabelas de amostras estão incompletas.</span>
+    <span data-phrase="read.chunktable">A tabela de chunks está vazia.</span>
+    <span data-phrase="read.nosamples">A faixa não contém nenhuma amostra.</span>
+    <span data-phrase="read.nostbl">Faltam à faixa de vídeo as suas tabelas de amostras.</span>
+    <span data-phrase="read.nostsd">A faixa de vídeo não tem descrição de amostra.</span>
+    <span data-phrase="read.emptystsd">A descrição de amostra do vídeo está vazia.</span>
+    <span data-phrase="read.encrypted">A faixa de vídeo está criptografada.</span>
+    <span data-phrase="read.unknowncodec">O vídeo está guardado como &ldquo;{type}&rdquo;, e este leitor não conhece isso.</span>
+    <span data-phrase="read.noconfig">A faixa &ldquo;{type}&rdquo; não carrega nenhuma configuração de decodificador.</span>
+    <span data-phrase="read.notmp4">Isto não é um arquivo MP4 nem MOV.</span>
+    <span data-phrase="read.nomoov">O arquivo não tem cabeçalho de filme.</span>
+    <span data-phrase="read.novideo">O arquivo não tem nenhuma faixa de vídeo que este leitor consiga usar.</span>
+    <span data-phrase="read.notimescale">A faixa de vídeo não tem escala de tempo.</span>
+    <span data-phrase="read.nofragments">Os fragmentos deste arquivo não contêm nenhum quadro da sua faixa de vídeo.</span>
+    <span data-phrase="read.unreadable">O arquivo não pôde ser lido como MP4.</span>
+    <span data-phrase="read.notplayed">Este formato não é dos que este navegador toca.</span>
+    <span data-phrase="read.layout">O desenho deste arquivo não é dos que o leitor daqui entende.</span>
+    <span data-phrase="read.nodecoder">Este navegador não decodifica {codec} diretamente.</span>
+    <span data-phrase="read.nowebcodecs">Este navegador não tem WebCodecs, então os quadros não podem ser decodificados um a
+      um.</span>
+    <span data-phrase="read.turned">Este arquivo está guardado girado, e o leitor daqui e o player do navegador não
+      concordam sobre o giro.</span>
+    <span data-phrase="open.failed">Este navegador não consegue abrir este arquivo. {reason}</span>
+    <span data-phrase="path.player">{reason} Por isso este arquivo é lido pelo player do próprio navegador e não quadro
+      a quadro: a imagem continua sendo salva no tamanho real do vídeo, mas o quadro em
+      que você cai é o que o player escolhe, e cada passo anda mais ou menos um quadro em
+      vez de exatamente um.</span>
+    <span data-phrase="path.nopreview">Este navegador não toca este arquivo, então não há nada para apertar play.
+      Decodificar ele consegue, e é daí que saem os quadros: use o controle deslizante e
+      as setas para andar pelo vídeo.</span>
     <span data-phrase="net.clean">O seu vídeo não foi a lugar nenhum. {total}
       arquivos carregados. {platform}</span>
     <span data-phrase="net.dirty">Alguma coisa contatou {hosts}, e esta

--- a/locales/pt/tools/timelapse-video.html
+++ b/locales/pt/tools/timelapse-video.html
@@ -158,6 +158,38 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">O arquivo termina no meio de um quadro.</span>
+    <span data-phrase="read.avcshort">O registro de configuração H.264 é curto demais.</span>
+    <span data-phrase="read.hevcshort">O registro de configuração HEVC é curto demais.</span>
+    <span data-phrase="read.av1short">O registro de configuração AV1 é curto demais.</span>
+    <span data-phrase="read.compactsizes">Os tamanhos das amostras estão numa tabela compacta que este leitor não decodifica.</span>
+    <span data-phrase="read.sampletables">As tabelas de amostras estão incompletas.</span>
+    <span data-phrase="read.chunktable">A tabela de chunks está vazia.</span>
+    <span data-phrase="read.nosamples">A faixa não contém nenhuma amostra.</span>
+    <span data-phrase="read.nostbl">Faltam à faixa de vídeo as suas tabelas de amostras.</span>
+    <span data-phrase="read.nostsd">A faixa de vídeo não tem descrição de amostra.</span>
+    <span data-phrase="read.emptystsd">A descrição de amostra do vídeo está vazia.</span>
+    <span data-phrase="read.encrypted">A faixa de vídeo está criptografada.</span>
+    <span data-phrase="read.unknowncodec">O vídeo está guardado como &ldquo;{type}&rdquo;, e este leitor não conhece isso.</span>
+    <span data-phrase="read.noconfig">A faixa &ldquo;{type}&rdquo; não carrega nenhuma configuração de decodificador.</span>
+    <span data-phrase="read.notmp4">Isto não é um arquivo MP4 nem MOV.</span>
+    <span data-phrase="read.nomoov">O arquivo não tem cabeçalho de filme.</span>
+    <span data-phrase="read.novideo">O arquivo não tem nenhuma faixa de vídeo que este leitor consiga usar.</span>
+    <span data-phrase="read.notimescale">A faixa de vídeo não tem escala de tempo.</span>
+    <span data-phrase="read.nofragments">Os fragmentos deste arquivo não contêm nenhum quadro da sua faixa de vídeo.</span>
+    <span data-phrase="read.unreadable">O arquivo não pôde ser lido como MP4.</span>
+    <span data-phrase="read.notplayed">Este formato não é dos que este navegador toca.</span>
+    <span data-phrase="read.layout">O desenho deste arquivo não é dos que o leitor daqui entende.</span>
+    <span data-phrase="read.nodecoder">Este navegador não decodifica {codec} diretamente.</span>
+    <span data-phrase="read.nowebcodecs">Este navegador não tem WebCodecs, então os quadros não podem ser decodificados um a
+      um.</span>
+    <span data-phrase="open.failed">Este navegador não consegue abrir este arquivo. {reason}</span>
+    <span data-phrase="open.nodecode">Este navegador abriu o arquivo mas não consegue decodificar o vídeo dentro dele.
+      Costuma ser Dolby Vision, ou HEVC numa máquina sem suporte por hardware: o contêiner
+      lê perfeitamente e a imagem nunca chega. Converta antes para um MP4 comum (H.264) e
+      esta ferramenta vai ler direto.</span>
+    <span data-phrase="path.seek">{reason} Por isso este é lido levando o player do próprio navegador a cada instante:
+      funciona com todo formato que o navegador toca, e é um pouco mais lento.</span>
     <span data-phrase="net.clean">O seu vídeo não foi a lugar nenhum. {total}
       arquivos carregados. {platform}</span>
     <span data-phrase="net.dirty">Alguma coisa contatou {hosts}, e esta

--- a/locales/pt/tools/video-to-gif.html
+++ b/locales/pt/tools/video-to-gif.html
@@ -174,6 +174,37 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">O arquivo termina no meio de um quadro.</span>
+    <span data-phrase="read.avcshort">O registro de configuração H.264 é curto demais.</span>
+    <span data-phrase="read.hevcshort">O registro de configuração HEVC é curto demais.</span>
+    <span data-phrase="read.av1short">O registro de configuração AV1 é curto demais.</span>
+    <span data-phrase="read.compactsizes">Os tamanhos das amostras estão numa tabela compacta que este leitor não decodifica.</span>
+    <span data-phrase="read.sampletables">As tabelas de amostras estão incompletas.</span>
+    <span data-phrase="read.chunktable">A tabela de chunks está vazia.</span>
+    <span data-phrase="read.nosamples">A faixa não contém nenhuma amostra.</span>
+    <span data-phrase="read.nostbl">Faltam à faixa de vídeo as suas tabelas de amostras.</span>
+    <span data-phrase="read.nostsd">A faixa de vídeo não tem descrição de amostra.</span>
+    <span data-phrase="read.emptystsd">A descrição de amostra do vídeo está vazia.</span>
+    <span data-phrase="read.encrypted">A faixa de vídeo está criptografada.</span>
+    <span data-phrase="read.unknowncodec">O vídeo está guardado como &ldquo;{type}&rdquo;, e este leitor não conhece isso.</span>
+    <span data-phrase="read.noconfig">A faixa &ldquo;{type}&rdquo; não carrega nenhuma configuração de decodificador.</span>
+    <span data-phrase="read.notmp4">Isto não é um arquivo MP4 nem MOV.</span>
+    <span data-phrase="read.nomoov">O arquivo não tem cabeçalho de filme.</span>
+    <span data-phrase="read.novideo">O arquivo não tem nenhuma faixa de vídeo que este leitor consiga usar.</span>
+    <span data-phrase="read.notimescale">A faixa de vídeo não tem escala de tempo.</span>
+    <span data-phrase="read.nofragments">Os fragmentos deste arquivo não contêm nenhum quadro da sua faixa de vídeo.</span>
+    <span data-phrase="read.unreadable">O arquivo não pôde ser lido como MP4.</span>
+    <span data-phrase="read.notplayed">Este formato não é dos que este navegador toca.</span>
+    <span data-phrase="read.layout">O desenho deste arquivo não é dos que o leitor daqui entende.</span>
+    <span data-phrase="read.nodecoder">Este navegador não decodifica {codec} diretamente.</span>
+    <span data-phrase="read.nowebcodecs">Este navegador não tem WebCodecs, então os quadros não podem ser decodificados um a
+      um.</span>
+    <span data-phrase="read.turned">Este arquivo está guardado girado, e o leitor daqui e o player do navegador não
+      concordam sobre o giro.</span>
+    <span data-phrase="open.failed">Este navegador não consegue abrir este arquivo. {reason}</span>
+    <span data-phrase="path.seek">{reason} Por isso os quadros são colhidos levando o player a cada instante. É mais
+      lento, e quem decide em que quadro cada pulo cai é o navegador, então um trecho
+      rápido pode sair um quadro fora aqui e ali.</span>
     <span data-phrase="net.clean">O seu vídeo não foi a lugar nenhum. {total}
       arquivos carregados. {platform}</span>
     <span data-phrase="net.dirty">Alguma coisa contatou {hosts}, e esta

--- a/locales/tr/tools/crop-video.html
+++ b/locales/tr/tools/crop-video.html
@@ -157,6 +157,36 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">Dosya bir karenin ortasında bitiyor.</span>
+    <span data-phrase="read.avcshort">H.264 yapılandırma kaydı fazla kısa.</span>
+    <span data-phrase="read.hevcshort">HEVC yapılandırma kaydı fazla kısa.</span>
+    <span data-phrase="read.av1short">AV1 yapılandırma kaydı fazla kısa.</span>
+    <span data-phrase="read.compactsizes">Örnek boyutları, bu okuyucunun çözmediği sıkışık bir tabloda duruyor.</span>
+    <span data-phrase="read.sampletables">Örnek tabloları eksik.</span>
+    <span data-phrase="read.chunktable">Chunk tablosu boş.</span>
+    <span data-phrase="read.nosamples">İzde hiç örnek yok.</span>
+    <span data-phrase="read.nostbl">Video izinin örnek tabloları eksik.</span>
+    <span data-phrase="read.nostsd">Video izinin örnek tanımı yok.</span>
+    <span data-phrase="read.emptystsd">Videonun örnek tanımı boş.</span>
+    <span data-phrase="read.encrypted">Video izi şifreli.</span>
+    <span data-phrase="read.unknowncodec">Video &ldquo;{type}&rdquo; olarak saklanmış ve bu okuyucu onu tanımıyor.</span>
+    <span data-phrase="read.noconfig">&ldquo;{type}&rdquo; izi yanında hiçbir çözücü yapılandırması taşımıyor.</span>
+    <span data-phrase="read.notmp4">Bu bir MP4 ya da MOV dosyası değil.</span>
+    <span data-phrase="read.nomoov">Dosyanın film başlığı yok.</span>
+    <span data-phrase="read.novideo">Dosyada bu okuyucunun kullanabileceği bir video izi yok.</span>
+    <span data-phrase="read.notimescale">Video izinin zaman ölçeği yok.</span>
+    <span data-phrase="read.nofragments">Bu dosyadaki parçalar, video izi için hiçbir kare içermiyor.</span>
+    <span data-phrase="read.unreadable">Dosya MP4 olarak okunamadı.</span>
+    <span data-phrase="read.notplayed">Bu biçim, bu tarayıcının oynattıklarından değil.</span>
+    <span data-phrase="read.layout">Bu dosyanın düzeni, buradaki okuyucunun anladıklarından değil.</span>
+    <span data-phrase="read.nodecoder">Bu tarayıcı {codec} biçimini doğrudan çözmüyor.</span>
+    <span data-phrase="read.nowebcodecs">Bu tarayıcıda WebCodecs yok, dolayısıyla kareler teker teker çözülemiyor.</span>
+    <span data-phrase="read.turned">Bu dosya döndürülmüş olarak saklanmış ve buradaki okuyucu ile tarayıcının oynatıcısı
+      bu dönme konusunda anlaşamıyor.</span>
+    <span data-phrase="open.failed">Bu tarayıcı bu dosyayı açamıyor. {reason}</span>
+    <span data-phrase="open.norecord">Bu tarayıcı video kaydedemiyor, dolayısıyla bu dosyayı kırpamıyor da.</span>
+    <span data-phrase="path.record">{reason} Bu yüzden bu dosya, oynatılıp kaydedilerek kırpılıyor: bu, videonun süresi
+      kadar zaman alır ve ses kopyalanmak yerine yeniden kodlanır.</span>
     <span data-phrase="net.clean">videonuz hiçbir yere gitmedi. {total} dosya
       yüklendi. {platform}</span>
     <span data-phrase="net.dirty">bir şey {hosts} ile iletişim kurdu; bu araç

--- a/locales/tr/tools/grab-frame.html
+++ b/locales/tr/tools/grab-frame.html
@@ -145,6 +145,40 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">Dosya bir karenin ortasında bitiyor.</span>
+    <span data-phrase="read.avcshort">H.264 yapılandırma kaydı fazla kısa.</span>
+    <span data-phrase="read.hevcshort">HEVC yapılandırma kaydı fazla kısa.</span>
+    <span data-phrase="read.av1short">AV1 yapılandırma kaydı fazla kısa.</span>
+    <span data-phrase="read.compactsizes">Örnek boyutları, bu okuyucunun çözmediği sıkışık bir tabloda duruyor.</span>
+    <span data-phrase="read.sampletables">Örnek tabloları eksik.</span>
+    <span data-phrase="read.chunktable">Chunk tablosu boş.</span>
+    <span data-phrase="read.nosamples">İzde hiç örnek yok.</span>
+    <span data-phrase="read.nostbl">Video izinin örnek tabloları eksik.</span>
+    <span data-phrase="read.nostsd">Video izinin örnek tanımı yok.</span>
+    <span data-phrase="read.emptystsd">Videonun örnek tanımı boş.</span>
+    <span data-phrase="read.encrypted">Video izi şifreli.</span>
+    <span data-phrase="read.unknowncodec">Video &ldquo;{type}&rdquo; olarak saklanmış ve bu okuyucu onu tanımıyor.</span>
+    <span data-phrase="read.noconfig">&ldquo;{type}&rdquo; izi yanında hiçbir çözücü yapılandırması taşımıyor.</span>
+    <span data-phrase="read.notmp4">Bu bir MP4 ya da MOV dosyası değil.</span>
+    <span data-phrase="read.nomoov">Dosyanın film başlığı yok.</span>
+    <span data-phrase="read.novideo">Dosyada bu okuyucunun kullanabileceği bir video izi yok.</span>
+    <span data-phrase="read.notimescale">Video izinin zaman ölçeği yok.</span>
+    <span data-phrase="read.nofragments">Bu dosyadaki parçalar, video izi için hiçbir kare içermiyor.</span>
+    <span data-phrase="read.unreadable">Dosya MP4 olarak okunamadı.</span>
+    <span data-phrase="read.notplayed">Bu biçim, bu tarayıcının oynattıklarından değil.</span>
+    <span data-phrase="read.layout">Bu dosyanın düzeni, buradaki okuyucunun anladıklarından değil.</span>
+    <span data-phrase="read.nodecoder">Bu tarayıcı {codec} biçimini doğrudan çözmüyor.</span>
+    <span data-phrase="read.nowebcodecs">Bu tarayıcıda WebCodecs yok, dolayısıyla kareler teker teker çözülemiyor.</span>
+    <span data-phrase="read.turned">Bu dosya döndürülmüş olarak saklanmış ve buradaki okuyucu ile tarayıcının oynatıcısı
+      bu dönme konusunda anlaşamıyor.</span>
+    <span data-phrase="open.failed">Bu tarayıcı bu dosyayı açamıyor. {reason}</span>
+    <span data-phrase="path.player">{reason} Bu yüzden bu dosya kare kare değil, tarayıcının kendi oynatıcısıyla
+      okunuyor: görüntü yine videonun tam boyutunda kaydedilir, ama hangi kareye denk
+      geleceğinize oynatıcı karar verir ve bir adım tam bir kare değil, aşağı yukarı bir
+      kare ilerler.</span>
+    <span data-phrase="path.nopreview">Bu tarayıcı bu dosyayı oynatmıyor, dolayısıyla oynatılacak bir şey yok. Ama
+      çözebiliyor ve kareler oradan çıkıyor; videoda gezinmek için kaydırıcı ve ok
+      tuşlarını kullanın.</span>
     <span data-phrase="net.clean">videonuz hiçbir yere gitmedi. {total} dosya
       yüklendi. {platform}</span>
     <span data-phrase="net.dirty">bir şey {hosts} ile iletişim kurdu; bu araç

--- a/locales/tr/tools/timelapse-video.html
+++ b/locales/tr/tools/timelapse-video.html
@@ -166,6 +166,37 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">Dosya bir karenin ortasında bitiyor.</span>
+    <span data-phrase="read.avcshort">H.264 yapılandırma kaydı fazla kısa.</span>
+    <span data-phrase="read.hevcshort">HEVC yapılandırma kaydı fazla kısa.</span>
+    <span data-phrase="read.av1short">AV1 yapılandırma kaydı fazla kısa.</span>
+    <span data-phrase="read.compactsizes">Örnek boyutları, bu okuyucunun çözmediği sıkışık bir tabloda duruyor.</span>
+    <span data-phrase="read.sampletables">Örnek tabloları eksik.</span>
+    <span data-phrase="read.chunktable">Chunk tablosu boş.</span>
+    <span data-phrase="read.nosamples">İzde hiç örnek yok.</span>
+    <span data-phrase="read.nostbl">Video izinin örnek tabloları eksik.</span>
+    <span data-phrase="read.nostsd">Video izinin örnek tanımı yok.</span>
+    <span data-phrase="read.emptystsd">Videonun örnek tanımı boş.</span>
+    <span data-phrase="read.encrypted">Video izi şifreli.</span>
+    <span data-phrase="read.unknowncodec">Video &ldquo;{type}&rdquo; olarak saklanmış ve bu okuyucu onu tanımıyor.</span>
+    <span data-phrase="read.noconfig">&ldquo;{type}&rdquo; izi yanında hiçbir çözücü yapılandırması taşımıyor.</span>
+    <span data-phrase="read.notmp4">Bu bir MP4 ya da MOV dosyası değil.</span>
+    <span data-phrase="read.nomoov">Dosyanın film başlığı yok.</span>
+    <span data-phrase="read.novideo">Dosyada bu okuyucunun kullanabileceği bir video izi yok.</span>
+    <span data-phrase="read.notimescale">Video izinin zaman ölçeği yok.</span>
+    <span data-phrase="read.nofragments">Bu dosyadaki parçalar, video izi için hiçbir kare içermiyor.</span>
+    <span data-phrase="read.unreadable">Dosya MP4 olarak okunamadı.</span>
+    <span data-phrase="read.notplayed">Bu biçim, bu tarayıcının oynattıklarından değil.</span>
+    <span data-phrase="read.layout">Bu dosyanın düzeni, buradaki okuyucunun anladıklarından değil.</span>
+    <span data-phrase="read.nodecoder">Bu tarayıcı {codec} biçimini doğrudan çözmüyor.</span>
+    <span data-phrase="read.nowebcodecs">Bu tarayıcıda WebCodecs yok, dolayısıyla kareler teker teker çözülemiyor.</span>
+    <span data-phrase="open.failed">Bu tarayıcı bu dosyayı açamıyor. {reason}</span>
+    <span data-phrase="open.nodecode">Bu tarayıcı dosyayı açtı ama içindeki videoyu çözemiyor. Bu genelde Dolby Vision
+      olur ya da donanım desteği olmayan bir makinede HEVC: kapsayıcı sorunsuz okunur,
+      görüntü hiç gelmez. Önce sıradan bir MP4&rsquo;e (H.264) çevirin, o zaman bu araç
+      dosyayı doğrudan okur.</span>
+    <span data-phrase="path.seek">{reason} Bu yüzden bu dosya, tarayıcının kendi oynatıcısı her ana sarılarak
+      okunuyor: bu, tarayıcının oynattığı her biçimde işe yarar ve biraz daha yavaştır.</span>
     <span data-phrase="net.clean">videonuz hiçbir yere gitmedi. {total} dosya
       yüklendi. {platform}</span>
     <span data-phrase="net.dirty">bir şey {hosts} ile iletişim kurdu; bu araç

--- a/locales/tr/tools/video-to-gif.html
+++ b/locales/tr/tools/video-to-gif.html
@@ -180,6 +180,36 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">Dosya bir karenin ortasında bitiyor.</span>
+    <span data-phrase="read.avcshort">H.264 yapılandırma kaydı fazla kısa.</span>
+    <span data-phrase="read.hevcshort">HEVC yapılandırma kaydı fazla kısa.</span>
+    <span data-phrase="read.av1short">AV1 yapılandırma kaydı fazla kısa.</span>
+    <span data-phrase="read.compactsizes">Örnek boyutları, bu okuyucunun çözmediği sıkışık bir tabloda duruyor.</span>
+    <span data-phrase="read.sampletables">Örnek tabloları eksik.</span>
+    <span data-phrase="read.chunktable">Chunk tablosu boş.</span>
+    <span data-phrase="read.nosamples">İzde hiç örnek yok.</span>
+    <span data-phrase="read.nostbl">Video izinin örnek tabloları eksik.</span>
+    <span data-phrase="read.nostsd">Video izinin örnek tanımı yok.</span>
+    <span data-phrase="read.emptystsd">Videonun örnek tanımı boş.</span>
+    <span data-phrase="read.encrypted">Video izi şifreli.</span>
+    <span data-phrase="read.unknowncodec">Video &ldquo;{type}&rdquo; olarak saklanmış ve bu okuyucu onu tanımıyor.</span>
+    <span data-phrase="read.noconfig">&ldquo;{type}&rdquo; izi yanında hiçbir çözücü yapılandırması taşımıyor.</span>
+    <span data-phrase="read.notmp4">Bu bir MP4 ya da MOV dosyası değil.</span>
+    <span data-phrase="read.nomoov">Dosyanın film başlığı yok.</span>
+    <span data-phrase="read.novideo">Dosyada bu okuyucunun kullanabileceği bir video izi yok.</span>
+    <span data-phrase="read.notimescale">Video izinin zaman ölçeği yok.</span>
+    <span data-phrase="read.nofragments">Bu dosyadaki parçalar, video izi için hiçbir kare içermiyor.</span>
+    <span data-phrase="read.unreadable">Dosya MP4 olarak okunamadı.</span>
+    <span data-phrase="read.notplayed">Bu biçim, bu tarayıcının oynattıklarından değil.</span>
+    <span data-phrase="read.layout">Bu dosyanın düzeni, buradaki okuyucunun anladıklarından değil.</span>
+    <span data-phrase="read.nodecoder">Bu tarayıcı {codec} biçimini doğrudan çözmüyor.</span>
+    <span data-phrase="read.nowebcodecs">Bu tarayıcıda WebCodecs yok, dolayısıyla kareler teker teker çözülemiyor.</span>
+    <span data-phrase="read.turned">Bu dosya döndürülmüş olarak saklanmış ve buradaki okuyucu ile tarayıcının oynatıcısı
+      bu dönme konusunda anlaşamıyor.</span>
+    <span data-phrase="open.failed">Bu tarayıcı bu dosyayı açamıyor. {reason}</span>
+    <span data-phrase="path.seek">{reason} Bu yüzden kareler, oynatıcı her ana sarılarak toplanıyor. Bu daha yavaştır
+      ve her sarmanın hangi kareye denk geleceğine tarayıcı karar verir; yani hızlı bir
+      bölüm arada bir kare şaşabilir.</span>
     <span data-phrase="net.clean">videonuz hiçbir yere gitmedi. {total} dosya
       yüklendi. {platform}</span>
     <span data-phrase="net.dirty">bir şey {hosts} ile iletişim kurdu; bu araç

--- a/locales/zh-TW/locale.toml
+++ b/locales/zh-TW/locale.toml
@@ -240,8 +240,8 @@ guarantees_note = """
       怎麼判斷一個工具是不是真需要你的檔案</a>\
     裡有四項你自己動手就能做的檢查，用在本站管用，用在別家也一樣。"""
 
-hub_filter_label = "尋找工具"
-hub_filter_none = "沒有符合的工具。"
+hub_filter_label = "查詢工具"
+hub_filter_none = "沒有匹配的工具。"
 
 hub_guides_note = """
     不知道該動哪個設定，也不清楚代價？\

--- a/locales/zh-TW/tools/crop-video.html
+++ b/locales/zh-TW/tools/crop-video.html
@@ -153,6 +153,34 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">檔案斷在一幀的中間。</span>
+    <span data-phrase="read.avcshort">H.264 的配置記錄太短。</span>
+    <span data-phrase="read.hevcshort">HEVC 的配置記錄太短。</span>
+    <span data-phrase="read.av1short">AV1 的配置記錄太短。</span>
+    <span data-phrase="read.compactsizes">樣本大小放在一張壓縮表裡，這個讀取器不解這種表。</span>
+    <span data-phrase="read.sampletables">樣本表不完整。</span>
+    <span data-phrase="read.chunktable">資料塊表是空的。</span>
+    <span data-phrase="read.nosamples">這條軌道裡一個樣本都沒有。</span>
+    <span data-phrase="read.nostbl">影片軌道缺了它的樣本表。</span>
+    <span data-phrase="read.nostsd">影片軌道沒有樣本描述。</span>
+    <span data-phrase="read.emptystsd">影片的樣本描述是空的。</span>
+    <span data-phrase="read.encrypted">影片軌道是加密的。</span>
+    <span data-phrase="read.unknowncodec">這段影片存成了「{type}」，這個讀取器不認識它。</span>
+    <span data-phrase="read.noconfig">「{type}」這條軌道沒帶解碼器配置。</span>
+    <span data-phrase="read.notmp4">這不是 MP4，也不是 MOV。</span>
+    <span data-phrase="read.nomoov">這個檔案沒有影片頭。</span>
+    <span data-phrase="read.novideo">這個檔案裡沒有這個讀取器用得上的影片軌道。</span>
+    <span data-phrase="read.notimescale">影片軌道沒有時間刻度。</span>
+    <span data-phrase="read.nofragments">這個檔案裡的分片，一幀影片軌道的畫面都沒有。</span>
+    <span data-phrase="read.unreadable">這個檔案按 MP4 讀不出來。</span>
+    <span data-phrase="read.notplayed">這種格式不是這個瀏覽器能播的。</span>
+    <span data-phrase="read.layout">這個檔案的排布，這裡的讀取器看不懂。</span>
+    <span data-phrase="read.nodecoder">這個瀏覽器不直接解碼 {codec}。</span>
+    <span data-phrase="read.nowebcodecs">這個瀏覽器沒有 WebCodecs，畫面沒法一幀一幀解碼。</span>
+    <span data-phrase="read.turned">這個檔案是轉著存的，這裡的讀取器和瀏覽器的播放器對這個旋轉的看法不一致。</span>
+    <span data-phrase="open.failed">這個瀏覽器打不開這個檔案。{reason}</span>
+    <span data-phrase="open.norecord">這個瀏覽器錄不了影片，所以也裁不了這個檔案。</span>
+    <span data-phrase="path.record">{reason}所以這個只能一邊播一邊錄著裁：影片有多長就要花多長時間，聲音也是重新編碼而不是照搬。</span>
     <span data-phrase="net.clean">你的影片沒有去任何地方。載入了 {total} 個檔案。{platform}</span>
     <span data-phrase="net.dirty">有東西聯絡了 {hosts}，而這個工具從不這麼做。{platform}</span>
     <span data-phrase="net.platform.one">本站自己用於廣告、統計和捐贈按鈕的指令碼來自 {hosts} 個主機，它們誰也沒拿到任何檔案。</span>

--- a/locales/zh-TW/tools/grab-frame.html
+++ b/locales/zh-TW/tools/grab-frame.html
@@ -135,6 +135,34 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">檔案斷在一幀的中間。</span>
+    <span data-phrase="read.avcshort">H.264 的配置記錄太短。</span>
+    <span data-phrase="read.hevcshort">HEVC 的配置記錄太短。</span>
+    <span data-phrase="read.av1short">AV1 的配置記錄太短。</span>
+    <span data-phrase="read.compactsizes">樣本大小放在一張壓縮表裡，這個讀取器不解這種表。</span>
+    <span data-phrase="read.sampletables">樣本表不完整。</span>
+    <span data-phrase="read.chunktable">資料塊表是空的。</span>
+    <span data-phrase="read.nosamples">這條軌道裡一個樣本都沒有。</span>
+    <span data-phrase="read.nostbl">影片軌道缺了它的樣本表。</span>
+    <span data-phrase="read.nostsd">影片軌道沒有樣本描述。</span>
+    <span data-phrase="read.emptystsd">影片的樣本描述是空的。</span>
+    <span data-phrase="read.encrypted">影片軌道是加密的。</span>
+    <span data-phrase="read.unknowncodec">這段影片存成了「{type}」，這個讀取器不認識它。</span>
+    <span data-phrase="read.noconfig">「{type}」這條軌道沒帶解碼器配置。</span>
+    <span data-phrase="read.notmp4">這不是 MP4，也不是 MOV。</span>
+    <span data-phrase="read.nomoov">這個檔案沒有影片頭。</span>
+    <span data-phrase="read.novideo">這個檔案裡沒有這個讀取器用得上的影片軌道。</span>
+    <span data-phrase="read.notimescale">影片軌道沒有時間刻度。</span>
+    <span data-phrase="read.nofragments">這個檔案裡的分片，一幀影片軌道的畫面都沒有。</span>
+    <span data-phrase="read.unreadable">這個檔案按 MP4 讀不出來。</span>
+    <span data-phrase="read.notplayed">這種格式不是這個瀏覽器能播的。</span>
+    <span data-phrase="read.layout">這個檔案的排布，這裡的讀取器看不懂。</span>
+    <span data-phrase="read.nodecoder">這個瀏覽器不直接解碼 {codec}。</span>
+    <span data-phrase="read.nowebcodecs">這個瀏覽器沒有 WebCodecs，畫面沒法一幀一幀解碼。</span>
+    <span data-phrase="read.turned">這個檔案是轉著存的，這裡的讀取器和瀏覽器的播放器對這個旋轉的看法不一致。</span>
+    <span data-phrase="open.failed">這個瀏覽器打不開這個檔案。{reason}</span>
+    <span data-phrase="path.player">{reason}所以這個檔案不是一幀一幀讀的，而是交給瀏覽器自己的播放器。圖片還是按影片的原始尺寸儲存，但落在哪一幀由播放器說了算，走一步是大約一幀，而不是正好一幀。</span>
+    <span data-phrase="path.nopreview">這個瀏覽器播不了這個檔案，所以沒有可按的播放鍵。但它能解碼，畫面就是從這裡來的。用滑塊和方向鍵在影片裡挪。</span>
     <span data-phrase="net.clean">你的影片沒有去任何地方。載入了 {total} 個檔案。{platform}</span>
     <span data-phrase="net.dirty">有東西聯絡了 {hosts}，而這個工具從不這麼做。{platform}</span>
     <span data-phrase="net.platform.one">本站自己用於廣告、統計和捐贈按鈕的指令碼來自 {hosts} 個主機，它們誰也沒拿到任何檔案。</span>

--- a/locales/zh-TW/tools/timelapse-video.html
+++ b/locales/zh-TW/tools/timelapse-video.html
@@ -152,6 +152,33 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">檔案斷在一幀的中間。</span>
+    <span data-phrase="read.avcshort">H.264 的配置記錄太短。</span>
+    <span data-phrase="read.hevcshort">HEVC 的配置記錄太短。</span>
+    <span data-phrase="read.av1short">AV1 的配置記錄太短。</span>
+    <span data-phrase="read.compactsizes">樣本大小放在一張壓縮表裡，這個讀取器不解這種表。</span>
+    <span data-phrase="read.sampletables">樣本表不完整。</span>
+    <span data-phrase="read.chunktable">資料塊表是空的。</span>
+    <span data-phrase="read.nosamples">這條軌道裡一個樣本都沒有。</span>
+    <span data-phrase="read.nostbl">影片軌道缺了它的樣本表。</span>
+    <span data-phrase="read.nostsd">影片軌道沒有樣本描述。</span>
+    <span data-phrase="read.emptystsd">影片的樣本描述是空的。</span>
+    <span data-phrase="read.encrypted">影片軌道是加密的。</span>
+    <span data-phrase="read.unknowncodec">這段影片存成了「{type}」，這個讀取器不認識它。</span>
+    <span data-phrase="read.noconfig">「{type}」這條軌道沒帶解碼器配置。</span>
+    <span data-phrase="read.notmp4">這不是 MP4，也不是 MOV。</span>
+    <span data-phrase="read.nomoov">這個檔案沒有影片頭。</span>
+    <span data-phrase="read.novideo">這個檔案裡沒有這個讀取器用得上的影片軌道。</span>
+    <span data-phrase="read.notimescale">影片軌道沒有時間刻度。</span>
+    <span data-phrase="read.nofragments">這個檔案裡的分片，一幀影片軌道的畫面都沒有。</span>
+    <span data-phrase="read.unreadable">這個檔案按 MP4 讀不出來。</span>
+    <span data-phrase="read.notplayed">這種格式不是這個瀏覽器能播的。</span>
+    <span data-phrase="read.layout">這個檔案的排布，這裡的讀取器看不懂。</span>
+    <span data-phrase="read.nodecoder">這個瀏覽器不直接解碼 {codec}。</span>
+    <span data-phrase="read.nowebcodecs">這個瀏覽器沒有 WebCodecs，畫面沒法一幀一幀解碼。</span>
+    <span data-phrase="open.failed">這個瀏覽器打不開這個檔案。{reason}</span>
+    <span data-phrase="open.nodecode">這個瀏覽器把檔案開啟了，卻解不了裡面的影片。多半是 Dolby Vision，或者是在沒有硬體支援的機器上碰到 HEVC：容器讀得好好的，畫面卻始終不來。先把它轉成普通的 MP4（H.264），這個工具就能直接讀了。</span>
+    <span data-phrase="path.seek">{reason}所以這個只能把瀏覽器自己的播放器一個時刻一個時刻地跳過去讀：瀏覽器能播的格式它都吃得下，就是慢一點。</span>
     <span data-phrase="net.clean">你的影片沒有去任何地方。載入了 {total} 個檔案。{platform}</span>
     <span data-phrase="net.dirty">有東西聯絡了 {hosts}，而這個工具從不這麼做。{platform}</span>
     <span data-phrase="net.platform.one">本站自己用於廣告、統計和捐贈按鈕的指令碼來自 {hosts} 個主機，它們誰也沒拿到任何檔案。</span>

--- a/locales/zh-TW/tools/video-to-gif.html
+++ b/locales/zh-TW/tools/video-to-gif.html
@@ -175,6 +175,33 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">檔案斷在一幀的中間。</span>
+    <span data-phrase="read.avcshort">H.264 的配置記錄太短。</span>
+    <span data-phrase="read.hevcshort">HEVC 的配置記錄太短。</span>
+    <span data-phrase="read.av1short">AV1 的配置記錄太短。</span>
+    <span data-phrase="read.compactsizes">樣本大小放在一張壓縮表裡，這個讀取器不解這種表。</span>
+    <span data-phrase="read.sampletables">樣本表不完整。</span>
+    <span data-phrase="read.chunktable">資料塊表是空的。</span>
+    <span data-phrase="read.nosamples">這條軌道裡一個樣本都沒有。</span>
+    <span data-phrase="read.nostbl">影片軌道缺了它的樣本表。</span>
+    <span data-phrase="read.nostsd">影片軌道沒有樣本描述。</span>
+    <span data-phrase="read.emptystsd">影片的樣本描述是空的。</span>
+    <span data-phrase="read.encrypted">影片軌道是加密的。</span>
+    <span data-phrase="read.unknowncodec">這段影片存成了「{type}」，這個讀取器不認識它。</span>
+    <span data-phrase="read.noconfig">「{type}」這條軌道沒帶解碼器配置。</span>
+    <span data-phrase="read.notmp4">這不是 MP4，也不是 MOV。</span>
+    <span data-phrase="read.nomoov">這個檔案沒有影片頭。</span>
+    <span data-phrase="read.novideo">這個檔案裡沒有這個讀取器用得上的影片軌道。</span>
+    <span data-phrase="read.notimescale">影片軌道沒有時間刻度。</span>
+    <span data-phrase="read.nofragments">這個檔案裡的分片，一幀影片軌道的畫面都沒有。</span>
+    <span data-phrase="read.unreadable">這個檔案按 MP4 讀不出來。</span>
+    <span data-phrase="read.notplayed">這種格式不是這個瀏覽器能播的。</span>
+    <span data-phrase="read.layout">這個檔案的排布，這裡的讀取器看不懂。</span>
+    <span data-phrase="read.nodecoder">這個瀏覽器不直接解碼 {codec}。</span>
+    <span data-phrase="read.nowebcodecs">這個瀏覽器沒有 WebCodecs，畫面沒法一幀一幀解碼。</span>
+    <span data-phrase="read.turned">這個檔案是轉著存的，這裡的讀取器和瀏覽器的播放器對這個旋轉的看法不一致。</span>
+    <span data-phrase="open.failed">這個瀏覽器打不開這個檔案。{reason}</span>
+    <span data-phrase="path.seek">{reason}所以這些幀是把播放器一個時刻一個時刻地跳過去收的。這樣慢一些，而且每次跳落在哪一幀由瀏覽器決定，動作快的地方偶爾會差出一幀。</span>
     <span data-phrase="net.clean">你的影片沒有去任何地方。載入了 {total} 個檔案。{platform}</span>
     <span data-phrase="net.dirty">有東西聯絡了 {hosts}，而這個工具從不這麼做。{platform}</span>
     <span data-phrase="net.platform.one">本站自己用於廣告、統計和捐贈按鈕的指令碼來自 {hosts} 個主機，它們誰也沒拿到任何檔案。</span>

--- a/locales/zh/tools/crop-video.html
+++ b/locales/zh/tools/crop-video.html
@@ -153,6 +153,34 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">文件断在一帧的中间。</span>
+    <span data-phrase="read.avcshort">H.264 的配置记录太短。</span>
+    <span data-phrase="read.hevcshort">HEVC 的配置记录太短。</span>
+    <span data-phrase="read.av1short">AV1 的配置记录太短。</span>
+    <span data-phrase="read.compactsizes">样本大小放在一张压缩表里，这个读取器不解这种表。</span>
+    <span data-phrase="read.sampletables">样本表不完整。</span>
+    <span data-phrase="read.chunktable">数据块表是空的。</span>
+    <span data-phrase="read.nosamples">这条轨道里一个样本都没有。</span>
+    <span data-phrase="read.nostbl">视频轨道缺了它的样本表。</span>
+    <span data-phrase="read.nostsd">视频轨道没有样本描述。</span>
+    <span data-phrase="read.emptystsd">视频的样本描述是空的。</span>
+    <span data-phrase="read.encrypted">视频轨道是加密的。</span>
+    <span data-phrase="read.unknowncodec">这段视频存成了「{type}」，这个读取器不认识它。</span>
+    <span data-phrase="read.noconfig">「{type}」这条轨道没带解码器配置。</span>
+    <span data-phrase="read.notmp4">这不是 MP4，也不是 MOV。</span>
+    <span data-phrase="read.nomoov">这个文件没有影片头。</span>
+    <span data-phrase="read.novideo">这个文件里没有这个读取器用得上的视频轨道。</span>
+    <span data-phrase="read.notimescale">视频轨道没有时间刻度。</span>
+    <span data-phrase="read.nofragments">这个文件里的分片，一帧视频轨道的画面都没有。</span>
+    <span data-phrase="read.unreadable">这个文件按 MP4 读不出来。</span>
+    <span data-phrase="read.notplayed">这种格式不是这个浏览器能播的。</span>
+    <span data-phrase="read.layout">这个文件的排布，这里的读取器看不懂。</span>
+    <span data-phrase="read.nodecoder">这个浏览器不直接解码 {codec}。</span>
+    <span data-phrase="read.nowebcodecs">这个浏览器没有 WebCodecs，画面没法一帧一帧解码。</span>
+    <span data-phrase="read.turned">这个文件是转着存的，这里的读取器和浏览器的播放器对这个旋转的看法不一致。</span>
+    <span data-phrase="open.failed">这个浏览器打不开这个文件。{reason}</span>
+    <span data-phrase="open.norecord">这个浏览器录不了视频，所以也裁不了这个文件。</span>
+    <span data-phrase="path.record">{reason}所以这个只能一边播一边录着裁：视频有多长就要花多长时间，声音也是重新编码而不是照搬。</span>
     <span data-phrase="net.clean">你的视频没有去任何地方。加载了 {total} 个文件。{platform}</span>
     <span data-phrase="net.dirty">有东西联系了 {hosts}，而这个工具从不这么做。{platform}</span>
     <span data-phrase="net.platform.one">本站自己用于广告、统计和捐赠按钮的脚本来自 {hosts} 个主机，它们谁也没拿到任何文件。</span>

--- a/locales/zh/tools/grab-frame.html
+++ b/locales/zh/tools/grab-frame.html
@@ -135,6 +135,34 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">文件断在一帧的中间。</span>
+    <span data-phrase="read.avcshort">H.264 的配置记录太短。</span>
+    <span data-phrase="read.hevcshort">HEVC 的配置记录太短。</span>
+    <span data-phrase="read.av1short">AV1 的配置记录太短。</span>
+    <span data-phrase="read.compactsizes">样本大小放在一张压缩表里，这个读取器不解这种表。</span>
+    <span data-phrase="read.sampletables">样本表不完整。</span>
+    <span data-phrase="read.chunktable">数据块表是空的。</span>
+    <span data-phrase="read.nosamples">这条轨道里一个样本都没有。</span>
+    <span data-phrase="read.nostbl">视频轨道缺了它的样本表。</span>
+    <span data-phrase="read.nostsd">视频轨道没有样本描述。</span>
+    <span data-phrase="read.emptystsd">视频的样本描述是空的。</span>
+    <span data-phrase="read.encrypted">视频轨道是加密的。</span>
+    <span data-phrase="read.unknowncodec">这段视频存成了「{type}」，这个读取器不认识它。</span>
+    <span data-phrase="read.noconfig">「{type}」这条轨道没带解码器配置。</span>
+    <span data-phrase="read.notmp4">这不是 MP4，也不是 MOV。</span>
+    <span data-phrase="read.nomoov">这个文件没有影片头。</span>
+    <span data-phrase="read.novideo">这个文件里没有这个读取器用得上的视频轨道。</span>
+    <span data-phrase="read.notimescale">视频轨道没有时间刻度。</span>
+    <span data-phrase="read.nofragments">这个文件里的分片，一帧视频轨道的画面都没有。</span>
+    <span data-phrase="read.unreadable">这个文件按 MP4 读不出来。</span>
+    <span data-phrase="read.notplayed">这种格式不是这个浏览器能播的。</span>
+    <span data-phrase="read.layout">这个文件的排布，这里的读取器看不懂。</span>
+    <span data-phrase="read.nodecoder">这个浏览器不直接解码 {codec}。</span>
+    <span data-phrase="read.nowebcodecs">这个浏览器没有 WebCodecs，画面没法一帧一帧解码。</span>
+    <span data-phrase="read.turned">这个文件是转着存的，这里的读取器和浏览器的播放器对这个旋转的看法不一致。</span>
+    <span data-phrase="open.failed">这个浏览器打不开这个文件。{reason}</span>
+    <span data-phrase="path.player">{reason}所以这个文件不是一帧一帧读的，而是交给浏览器自己的播放器。图片还是按视频的原始尺寸保存，但落在哪一帧由播放器说了算，走一步是大约一帧，而不是正好一帧。</span>
+    <span data-phrase="path.nopreview">这个浏览器播不了这个文件，所以没有可按的播放键。但它能解码，画面就是从这儿来的。用滑块和方向键在视频里挪。</span>
     <span data-phrase="net.clean">你的视频没有去任何地方。加载了 {total} 个文件。{platform}</span>
     <span data-phrase="net.dirty">有东西联系了 {hosts}，而这个工具从不这么做。{platform}</span>
     <span data-phrase="net.platform.one">本站自己用于广告、统计和捐赠按钮的脚本来自 {hosts} 个主机，它们谁也没拿到任何文件。</span>

--- a/locales/zh/tools/timelapse-video.html
+++ b/locales/zh/tools/timelapse-video.html
@@ -152,6 +152,33 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">文件断在一帧的中间。</span>
+    <span data-phrase="read.avcshort">H.264 的配置记录太短。</span>
+    <span data-phrase="read.hevcshort">HEVC 的配置记录太短。</span>
+    <span data-phrase="read.av1short">AV1 的配置记录太短。</span>
+    <span data-phrase="read.compactsizes">样本大小放在一张压缩表里，这个读取器不解这种表。</span>
+    <span data-phrase="read.sampletables">样本表不完整。</span>
+    <span data-phrase="read.chunktable">数据块表是空的。</span>
+    <span data-phrase="read.nosamples">这条轨道里一个样本都没有。</span>
+    <span data-phrase="read.nostbl">视频轨道缺了它的样本表。</span>
+    <span data-phrase="read.nostsd">视频轨道没有样本描述。</span>
+    <span data-phrase="read.emptystsd">视频的样本描述是空的。</span>
+    <span data-phrase="read.encrypted">视频轨道是加密的。</span>
+    <span data-phrase="read.unknowncodec">这段视频存成了「{type}」，这个读取器不认识它。</span>
+    <span data-phrase="read.noconfig">「{type}」这条轨道没带解码器配置。</span>
+    <span data-phrase="read.notmp4">这不是 MP4，也不是 MOV。</span>
+    <span data-phrase="read.nomoov">这个文件没有影片头。</span>
+    <span data-phrase="read.novideo">这个文件里没有这个读取器用得上的视频轨道。</span>
+    <span data-phrase="read.notimescale">视频轨道没有时间刻度。</span>
+    <span data-phrase="read.nofragments">这个文件里的分片，一帧视频轨道的画面都没有。</span>
+    <span data-phrase="read.unreadable">这个文件按 MP4 读不出来。</span>
+    <span data-phrase="read.notplayed">这种格式不是这个浏览器能播的。</span>
+    <span data-phrase="read.layout">这个文件的排布，这里的读取器看不懂。</span>
+    <span data-phrase="read.nodecoder">这个浏览器不直接解码 {codec}。</span>
+    <span data-phrase="read.nowebcodecs">这个浏览器没有 WebCodecs，画面没法一帧一帧解码。</span>
+    <span data-phrase="open.failed">这个浏览器打不开这个文件。{reason}</span>
+    <span data-phrase="open.nodecode">这个浏览器把文件打开了，却解不了里面的视频。多半是 Dolby Vision，或者是在没有硬件支持的机器上碰到 HEVC：容器读得好好的，画面却始终不来。先把它转成普通的 MP4（H.264），这个工具就能直接读了。</span>
+    <span data-phrase="path.seek">{reason}所以这个只能把浏览器自己的播放器一个时刻一个时刻地跳过去读：浏览器能播的格式它都吃得下，就是慢一点。</span>
     <span data-phrase="net.clean">你的视频没有去任何地方。加载了 {total} 个文件。{platform}</span>
     <span data-phrase="net.dirty">有东西联系了 {hosts}，而这个工具从不这么做。{platform}</span>
     <span data-phrase="net.platform.one">本站自己用于广告、统计和捐赠按钮的脚本来自 {hosts} 个主机，它们谁也没拿到任何文件。</span>

--- a/locales/zh/tools/video-to-gif.html
+++ b/locales/zh/tools/video-to-gif.html
@@ -175,6 +175,33 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">文件断在一帧的中间。</span>
+    <span data-phrase="read.avcshort">H.264 的配置记录太短。</span>
+    <span data-phrase="read.hevcshort">HEVC 的配置记录太短。</span>
+    <span data-phrase="read.av1short">AV1 的配置记录太短。</span>
+    <span data-phrase="read.compactsizes">样本大小放在一张压缩表里，这个读取器不解这种表。</span>
+    <span data-phrase="read.sampletables">样本表不完整。</span>
+    <span data-phrase="read.chunktable">数据块表是空的。</span>
+    <span data-phrase="read.nosamples">这条轨道里一个样本都没有。</span>
+    <span data-phrase="read.nostbl">视频轨道缺了它的样本表。</span>
+    <span data-phrase="read.nostsd">视频轨道没有样本描述。</span>
+    <span data-phrase="read.emptystsd">视频的样本描述是空的。</span>
+    <span data-phrase="read.encrypted">视频轨道是加密的。</span>
+    <span data-phrase="read.unknowncodec">这段视频存成了「{type}」，这个读取器不认识它。</span>
+    <span data-phrase="read.noconfig">「{type}」这条轨道没带解码器配置。</span>
+    <span data-phrase="read.notmp4">这不是 MP4，也不是 MOV。</span>
+    <span data-phrase="read.nomoov">这个文件没有影片头。</span>
+    <span data-phrase="read.novideo">这个文件里没有这个读取器用得上的视频轨道。</span>
+    <span data-phrase="read.notimescale">视频轨道没有时间刻度。</span>
+    <span data-phrase="read.nofragments">这个文件里的分片，一帧视频轨道的画面都没有。</span>
+    <span data-phrase="read.unreadable">这个文件按 MP4 读不出来。</span>
+    <span data-phrase="read.notplayed">这种格式不是这个浏览器能播的。</span>
+    <span data-phrase="read.layout">这个文件的排布，这里的读取器看不懂。</span>
+    <span data-phrase="read.nodecoder">这个浏览器不直接解码 {codec}。</span>
+    <span data-phrase="read.nowebcodecs">这个浏览器没有 WebCodecs，画面没法一帧一帧解码。</span>
+    <span data-phrase="read.turned">这个文件是转着存的，这里的读取器和浏览器的播放器对这个旋转的看法不一致。</span>
+    <span data-phrase="open.failed">这个浏览器打不开这个文件。{reason}</span>
+    <span data-phrase="path.seek">{reason}所以这些帧是把播放器一个时刻一个时刻地跳过去收的。这样慢一些，而且每次跳落在哪一帧由浏览器决定，动作快的地方偶尔会差出一帧。</span>
     <span data-phrase="net.clean">你的视频没有去任何地方。加载了 {total} 个文件。{platform}</span>
     <span data-phrase="net.dirty">有东西联系了 {hosts}，而这个工具从不这么做。{platform}</span>
     <span data-phrase="net.platform.one">本站自己用于广告、统计和捐赠按钮的脚本来自 {hosts} 个主机，它们谁也没拿到任何文件。</span>

--- a/tests/python/test_english_in_js.py
+++ b/tests/python/test_english_in_js.py
@@ -60,7 +60,7 @@ BASELINE = {
     'compare-text': 3,
     'compress-image': 2,
     'compress-pdf': 66,
-    'crop-video': 55,
+    'crop-video': 31,
     'dicom-viewer': 15,
     'document-scanner': 13,
     'edit-audio': 25,
@@ -69,7 +69,7 @@ BASELINE = {
     'format-json': 61,
     'gif-analyzer': 71,
     'gif-maker': 22,
-    'grab-frame': 47,
+    'grab-frame': 22,
     'hash-checksum': 10,
     'heic-to-jpg': 35,
     'id-photo': 106,
@@ -89,10 +89,10 @@ BASELINE = {
     'split-gif': 36,
     'stack-images': 7,
     'svg-to-image': 27,
-    'timelapse-video': 57,
+    'timelapse-video': 34,
     'trim-audio': 41,
     'trim-video': 75,
-    'video-to-gif': 47,
+    'video-to-gif': 23,
 }
 
 # Modules that hold somebody else's vocabulary rather than this site's prose.

--- a/tools/crop-video/body.html
+++ b/tools/crop-video/body.html
@@ -151,6 +151,35 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">The file ends in the middle of a frame.</span>
+    <span data-phrase="read.avcshort">The H.264 configuration record is too short.</span>
+    <span data-phrase="read.hevcshort">The HEVC configuration record is too short.</span>
+    <span data-phrase="read.av1short">The AV1 configuration record is too short.</span>
+    <span data-phrase="read.compactsizes">The sample sizes are in a compact table this reader does not decode.</span>
+    <span data-phrase="read.sampletables">The sample tables are incomplete.</span>
+    <span data-phrase="read.chunktable">The chunk table is empty.</span>
+    <span data-phrase="read.nosamples">The track holds no samples.</span>
+    <span data-phrase="read.nostbl">The video track is missing its sample tables.</span>
+    <span data-phrase="read.nostsd">The video track has no sample description.</span>
+    <span data-phrase="read.emptystsd">The video sample description is empty.</span>
+    <span data-phrase="read.encrypted">The video track is encrypted.</span>
+    <span data-phrase="read.unknowncodec">The video is stored as &ldquo;{type}&rdquo;, which this reader does not know.</span>
+    <span data-phrase="read.noconfig">The &ldquo;{type}&rdquo; track carries no decoder configuration.</span>
+    <span data-phrase="read.notmp4">This is not an MP4 or MOV file.</span>
+    <span data-phrase="read.nomoov">The file has no movie header.</span>
+    <span data-phrase="read.novideo">The file has no video track this reader can use.</span>
+    <span data-phrase="read.notimescale">The video track has no timescale.</span>
+    <span data-phrase="read.nofragments">The fragments in this file hold no frames for its video track.</span>
+    <span data-phrase="read.unreadable">The file could not be read as an MP4.</span>
+    <span data-phrase="read.notplayed">The format is not one this browser plays.</span>
+    <span data-phrase="read.layout">The layout of this file is not one the reader here understands.</span>
+    <span data-phrase="read.nodecoder">This browser will not decode {codec} directly.</span>
+    <span data-phrase="read.nowebcodecs">This browser has no WebCodecs, so frames cannot be decoded one by one.</span>
+    <span data-phrase="read.turned">This file is stored turned in a way the reader and the player disagree on.</span>
+    <span data-phrase="open.failed">This browser cannot open this file. {reason}</span>
+    <span data-phrase="open.norecord">This browser cannot record video, so it cannot crop this file.</span>
+    <span data-phrase="path.record">{reason} So this one is cropped by playing it and recording the result, which takes
+      as long as the video is long and re-encodes the sound rather than copying it.</span>
     <span data-phrase="net.clean">your video has gone nowhere. {total} files
       loaded. {platform}</span>
     <span data-phrase="net.dirty">something contacted {hosts}, which this tool

--- a/tools/crop-video/src/demux.js
+++ b/tools/crop-video/src/demux.js
@@ -28,12 +28,21 @@
  * description of what is in it.
  */
 
-/** Thrown when the file is well-formed but out of this demuxer's scope. */
+/**
+ * Thrown when the file is well-formed but out of this demuxer's scope.
+ *
+ * `reason` is a phrase key, not a sentence: this module is copied byte for
+ * byte into fifteen languages, so the sentence lives in the tool's body.html
+ * and main.js resolves the key against it. `values` carries what a sentence
+ * cannot know in advance - the four characters naming a codec this reader has
+ * never heard of.
+ */
 export class UnsupportedFile extends Error {
-  constructor(reason) {
+  constructor(reason, values) {
     super(reason);
     this.name = 'UnsupportedFile';
     this.reason = reason;
+    this.values = values;
   }
 }
 
@@ -129,7 +138,7 @@ export class FileWindow {
     }
     const at = offset - this.start;
     if (at + length > this.bytes.length) {
-      throw new UnsupportedFile('the file ends in the middle of a frame.');
+      throw new UnsupportedFile('read.midframe');
     }
     return this.bytes.subarray(at, at + length);
   }
@@ -170,7 +179,7 @@ const hex = (n) => n.toString(16).padStart(2, '0');
 
 /** avcC -> "avc1.640028", the string VideoDecoder wants. */
 function avcCodec(prefix, config) {
-  if (config.length < 4) throw new UnsupportedFile('the H.264 configuration record is too short.');
+  if (config.length < 4) throw new UnsupportedFile('read.avcshort');
   return `${prefix}.${hex(config[1])}${hex(config[2])}${hex(config[3])}`;
 }
 
@@ -183,7 +192,7 @@ function avcCodec(prefix, config) {
  * at least fails loudly rather than decoding something else.
  */
 function hevcCodec(prefix, config) {
-  if (config.length < 13) throw new UnsupportedFile('the HEVC configuration record is too short.');
+  if (config.length < 13) throw new UnsupportedFile('read.hevcshort');
 
   const space = ['', 'A', 'B', 'C'][(config[1] >> 6) & 0x3];
   const tier = ((config[1] >> 5) & 0x1) ? 'H' : 'L';
@@ -208,7 +217,7 @@ function hevcCodec(prefix, config) {
 
 /** av1C -> "av01.0.08M.08". */
 function av1Codec(config) {
-  if (config.length < 3) throw new UnsupportedFile('the AV1 configuration record is too short.');
+  if (config.length < 3) throw new UnsupportedFile('read.av1short');
   const profile = (config[1] >> 5) & 0x7;
   const level = config[1] & 0x1f;
   const tier = ((config[2] >> 7) & 0x1) ? 'H' : 'M';
@@ -249,10 +258,10 @@ function readSamples(view, stbl) {
   const stss = findBox(view, stbl.body, stbl.end, 'stss');
 
   if (!stsz && findBox(view, stbl.body, stbl.end, 'stz2')) {
-    throw new UnsupportedFile('sample sizes are in a compact table this reader does not decode.');
+    throw new UnsupportedFile('read.compactsizes');
   }
   if (!stts || !stsc || !stsz || !stco) {
-    throw new UnsupportedFile('the sample tables are incomplete.');
+    throw new UnsupportedFile('read.sampletables');
   }
 
   // Sizes. A non-zero uniform size means every sample is that size and there is
@@ -329,7 +338,7 @@ function readSamples(view, stbl) {
       perChunk: view.getUint32(runsHead.at + 8 + r * 12),
     });
   }
-  if (!runs.length) throw new UnsupportedFile('the chunk table is empty.');
+  if (!runs.length) throw new UnsupportedFile('read.chunktable');
 
   const samples = [];
   let index = 0;
@@ -353,7 +362,7 @@ function readSamples(view, stbl) {
     }
   }
 
-  if (!samples.length) throw new UnsupportedFile('the track holds no samples.');
+  if (!samples.length) throw new UnsupportedFile('read.nosamples');
   return samples;
 }
 
@@ -508,7 +517,7 @@ const VIDEO_ENTRIES = new Set(['avc1', 'avc3', 'hvc1', 'hev1', 'av01', 'vp09']);
 function readVideoTrack(view, trak, timescale, duration, fragmented) {
   const tkhd = findBox(view, trak.body, trak.end, 'tkhd');
   const stbl = findPath(view, trak, 'mdia', 'minf', 'stbl');
-  if (!tkhd || !stbl) throw new UnsupportedFile('the video track is missing its sample tables.');
+  if (!tkhd || !stbl) throw new UnsupportedFile('read.nostbl');
 
   const head = fullBox(view, tkhd);
   const trackId = view.getUint32(head.at + (head.version === 1 ? 16 : 8));
@@ -520,16 +529,15 @@ function readVideoTrack(view, trak, timescale, duration, fragmented) {
   const rotation = rotationOf(view, tkhd.end - 44);
 
   const stsd = findBox(view, stbl.body, stbl.end, 'stsd');
-  if (!stsd) throw new UnsupportedFile('the video track has no sample description.');
+  if (!stsd) throw new UnsupportedFile('read.nostsd');
   const [entry] = [...boxes(view, fullBox(view, stsd).at + 4, stsd.end)];
-  if (!entry) throw new UnsupportedFile('the video sample description is empty.');
+  if (!entry) throw new UnsupportedFile('read.emptystsd');
 
   if (entry.type === 'encv' || findBox(view, entry.body + 78, entry.end, 'sinf')) {
-    throw new UnsupportedFile('the video track is encrypted.');
+    throw new UnsupportedFile('read.encrypted');
   }
   if (!VIDEO_ENTRIES.has(entry.type)) {
-    throw new UnsupportedFile(
-      `the video is stored as "${entry.type}", which this reader does not know.`);
+    throw new UnsupportedFile('read.unknowncodec', { type: entry.type });
   }
 
   const codedWidth = view.getUint16(entry.body + 24);
@@ -558,7 +566,7 @@ function readVideoTrack(view, trak, timescale, duration, fragmented) {
     }
     if (codec) break;
   }
-  if (!codec) throw new UnsupportedFile(`the "${entry.type}" track carries no decoder configuration.`);
+  if (!codec) throw new UnsupportedFile('read.noconfig', { type: entry.type });
 
   const samples = fragmented ? [] : readSamples(view, stbl);
   const turned = rotation === 90 || rotation === 270;
@@ -619,11 +627,11 @@ function readAudioTrack(view, trak, timescale, duration, fragmented) {
 export async function demux(file) {
   const top = await topLevel(file);
   if (!top.some((box) => box.type === 'ftyp' || box.type === 'moov')) {
-    throw new UnsupportedFile('this is not an MP4 or MOV file.');
+    throw new UnsupportedFile('read.notmp4');
   }
 
   const outer = top.find((box) => box.type === 'moov');
-  if (!outer) throw new UnsupportedFile('the file has no movie header.');
+  if (!outer) throw new UnsupportedFile('read.nomoov');
 
   const bytes = new Uint8Array(await file.slice(outer.start, outer.end).arrayBuffer());
   const view = new DataView(bytes.buffer);
@@ -660,8 +668,8 @@ export async function demux(file) {
     }
   }
 
-  if (!video) throw new UnsupportedFile('the file has no video track this reader can use.');
-  if (!video.timescale) throw new UnsupportedFile('the video track has no timescale.');
+  if (!video) throw new UnsupportedFile('read.novideo');
+  if (!video.timescale) throw new UnsupportedFile('read.notimescale');
 
   if (fragmented) {
     const wanted = new Map([[video.trackId, video.samples]]);
@@ -669,7 +677,7 @@ export async function demux(file) {
 
     const clocks = await readFragments(file, top, fragmentDefaults(view, moov), wanted);
     if (!video.samples.length) {
-      throw new UnsupportedFile('the fragments in this file hold no frames for its video track.');
+      throw new UnsupportedFile('read.nofragments');
     }
 
     // A fragmented file usually declares a duration of zero in the header,

--- a/tools/crop-video/src/main.js
+++ b/tools/crop-video/src/main.js
@@ -8,6 +8,16 @@ import { cropByRecording } from './record.js';
 import { Cropper } from './cropper.js';
 import { hasWebCodecs, hasMediaRecorder, canDecode } from './support.js';
 
+/**
+ * A reader refusal, in the reader's language. The demuxer is copied byte for
+ * byte into fifteen languages, so what it hands back is a phrase key and its
+ * values; `absent` is the sentence for the file that was never given to it at
+ * all - the browser's own player took it instead.
+ */
+function why(fallback, absent) {
+  return phrase(fallback?.key ?? absent, fallback?.values);
+}
+
 const $ = (id) => document.getElementById(id);
 
 const el = {
@@ -147,18 +157,18 @@ async function loadFile(picked) {
     } catch (error) {
       media = null;
       fallbackReason = error instanceof UnsupportedFile
-        ? error.reason
-        : (error.message || 'the file could not be read as an MP4.');
+        ? { key: error.reason, values: error.values }
+        : { key: error.message || 'read.unreadable' };
     }
 
     let decodable = false;
     if (media && hasWebCodecs()) {
       decodable = await canDecode(decoderConfig(media.video));
       if (!decodable) {
-        fallbackReason = `this browser will not decode ${media.video.codec} directly.`;
+        fallbackReason = { key: 'read.nodecoder', values: { codec: media.video.codec } };
       }
     } else if (media && !hasWebCodecs()) {
-      fallbackReason = 'this browser has no WebCodecs, so frames cannot be decoded one by one.';
+      fallbackReason = { key: 'read.nowebcodecs' };
     }
 
     // If the demuxer and the player disagree about the shape of the picture,
@@ -168,7 +178,7 @@ async function loadFile(picked) {
     if (decodable && played.ok
       && (played.width !== media.video.displayWidth || played.height !== media.video.displayHeight)) {
       decodable = false;
-      fallbackReason = 'this file is stored turned in a way the reader and the player disagree on.';
+      fallbackReason = { key: 'read.turned' };
     }
 
     canCropExactly = decodable;
@@ -176,8 +186,8 @@ async function loadFile(picked) {
 
     if (!canCropExactly && !canRecord) {
       showError(played.ok
-        ? 'This browser cannot record video, so it cannot crop this file.'
-        : `This browser cannot open this file: ${fallbackReason ?? 'the format is not one it plays.'}`);
+        ? phrase('open.norecord')
+        : phrase('open.failed', { reason: why(fallbackReason, 'read.notplayed') }));
       resetView();
       return;
     }
@@ -265,9 +275,9 @@ function describeSource(played) {
 
   el.pathNote.hidden = canCropExactly;
   if (!canCropExactly) {
-    el.pathNote.textContent = `This one is cropped by playing it and recording the result, `
-      + `because ${fallbackReason ?? 'its layout is not one the reader here understands.'} `
-      + 'That takes as long as the video is long, and the sound is re-encoded rather than copied.';
+    el.pathNote.textContent = phrase('path.record', {
+      reason: why(fallbackReason, 'read.layout'),
+    });
   }
 }
 

--- a/tools/grab-frame/body.html
+++ b/tools/grab-frame/body.html
@@ -139,6 +139,39 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">The file ends in the middle of a frame.</span>
+    <span data-phrase="read.avcshort">The H.264 configuration record is too short.</span>
+    <span data-phrase="read.hevcshort">The HEVC configuration record is too short.</span>
+    <span data-phrase="read.av1short">The AV1 configuration record is too short.</span>
+    <span data-phrase="read.compactsizes">The sample sizes are in a compact table this reader does not decode.</span>
+    <span data-phrase="read.sampletables">The sample tables are incomplete.</span>
+    <span data-phrase="read.chunktable">The chunk table is empty.</span>
+    <span data-phrase="read.nosamples">The track holds no samples.</span>
+    <span data-phrase="read.nostbl">The video track is missing its sample tables.</span>
+    <span data-phrase="read.nostsd">The video track has no sample description.</span>
+    <span data-phrase="read.emptystsd">The video sample description is empty.</span>
+    <span data-phrase="read.encrypted">The video track is encrypted.</span>
+    <span data-phrase="read.unknowncodec">The video is stored as &ldquo;{type}&rdquo;, which this reader does not know.</span>
+    <span data-phrase="read.noconfig">The &ldquo;{type}&rdquo; track carries no decoder configuration.</span>
+    <span data-phrase="read.notmp4">This is not an MP4 or MOV file.</span>
+    <span data-phrase="read.nomoov">The file has no movie header.</span>
+    <span data-phrase="read.novideo">The file has no video track this reader can use.</span>
+    <span data-phrase="read.notimescale">The video track has no timescale.</span>
+    <span data-phrase="read.nofragments">The fragments in this file hold no frames for its video track.</span>
+    <span data-phrase="read.unreadable">The file could not be read as an MP4.</span>
+    <span data-phrase="read.notplayed">The format is not one this browser plays.</span>
+    <span data-phrase="read.layout">The layout of this file is not one the reader here understands.</span>
+    <span data-phrase="read.nodecoder">This browser will not decode {codec} directly.</span>
+    <span data-phrase="read.nowebcodecs">This browser has no WebCodecs, so frames cannot be decoded one by one.</span>
+    <span data-phrase="read.turned">This file is stored turned in a way the reader and the player disagree on.</span>
+    <span data-phrase="open.failed">This browser cannot open this file. {reason}</span>
+    <span data-phrase="path.player">{reason} So this file is read by the browser&rsquo;s own player rather than frame by
+      frame: the picture is still saved at the video&rsquo;s full size, but the frame you
+      land on is the one the player chooses, and stepping moves by roughly a frame rather
+      than exactly one.</span>
+    <span data-phrase="path.nopreview">This browser will not play this file, so there is nothing to press play on. It will
+      decode it, though, which is what the stills are made from; use the slider and the
+      arrow keys to move through it.</span>
     <span data-phrase="net.clean">your video has gone nowhere. {total} files
       loaded. {platform}</span>
     <span data-phrase="net.dirty">something contacted {hosts}, which this tool

--- a/tools/grab-frame/src/demux.js
+++ b/tools/grab-frame/src/demux.js
@@ -33,12 +33,21 @@
  * description of what is in it.
  */
 
-/** Thrown when the file is well-formed but out of this demuxer's scope. */
+/**
+ * Thrown when the file is well-formed but out of this demuxer's scope.
+ *
+ * `reason` is a phrase key, not a sentence: this module is copied byte for
+ * byte into fifteen languages, so the sentence lives in the tool's body.html
+ * and main.js resolves the key against it. `values` carries what a sentence
+ * cannot know in advance - the four characters naming a codec this reader has
+ * never heard of.
+ */
 export class UnsupportedFile extends Error {
-  constructor(reason) {
+  constructor(reason, values) {
     super(reason);
     this.name = 'UnsupportedFile';
     this.reason = reason;
+    this.values = values;
   }
 }
 
@@ -134,7 +143,7 @@ export class FileWindow {
     }
     const at = offset - this.start;
     if (at + length > this.bytes.length) {
-      throw new UnsupportedFile('the file ends in the middle of a frame.');
+      throw new UnsupportedFile('read.midframe');
     }
     return this.bytes.subarray(at, at + length);
   }
@@ -175,7 +184,7 @@ const hex = (n) => n.toString(16).padStart(2, '0');
 
 /** avcC -> "avc1.640028", the string VideoDecoder wants. */
 function avcCodec(prefix, config) {
-  if (config.length < 4) throw new UnsupportedFile('the H.264 configuration record is too short.');
+  if (config.length < 4) throw new UnsupportedFile('read.avcshort');
   return `${prefix}.${hex(config[1])}${hex(config[2])}${hex(config[3])}`;
 }
 
@@ -188,7 +197,7 @@ function avcCodec(prefix, config) {
  * at least fails loudly rather than decoding something else.
  */
 function hevcCodec(prefix, config) {
-  if (config.length < 13) throw new UnsupportedFile('the HEVC configuration record is too short.');
+  if (config.length < 13) throw new UnsupportedFile('read.hevcshort');
 
   const space = ['', 'A', 'B', 'C'][(config[1] >> 6) & 0x3];
   const tier = ((config[1] >> 5) & 0x1) ? 'H' : 'L';
@@ -213,7 +222,7 @@ function hevcCodec(prefix, config) {
 
 /** av1C -> "av01.0.08M.08". */
 function av1Codec(config) {
-  if (config.length < 3) throw new UnsupportedFile('the AV1 configuration record is too short.');
+  if (config.length < 3) throw new UnsupportedFile('read.av1short');
   const profile = (config[1] >> 5) & 0x7;
   const level = config[1] & 0x1f;
   const tier = ((config[2] >> 7) & 0x1) ? 'H' : 'M';
@@ -254,10 +263,10 @@ function readSamples(view, stbl) {
   const stss = findBox(view, stbl.body, stbl.end, 'stss');
 
   if (!stsz && findBox(view, stbl.body, stbl.end, 'stz2')) {
-    throw new UnsupportedFile('sample sizes are in a compact table this reader does not decode.');
+    throw new UnsupportedFile('read.compactsizes');
   }
   if (!stts || !stsc || !stsz || !stco) {
-    throw new UnsupportedFile('the sample tables are incomplete.');
+    throw new UnsupportedFile('read.sampletables');
   }
 
   // Sizes. A non-zero uniform size means every sample is that size and there is
@@ -334,7 +343,7 @@ function readSamples(view, stbl) {
       perChunk: view.getUint32(runsHead.at + 8 + r * 12),
     });
   }
-  if (!runs.length) throw new UnsupportedFile('the chunk table is empty.');
+  if (!runs.length) throw new UnsupportedFile('read.chunktable');
 
   const samples = [];
   let index = 0;
@@ -358,7 +367,7 @@ function readSamples(view, stbl) {
     }
   }
 
-  if (!samples.length) throw new UnsupportedFile('the track holds no samples.');
+  if (!samples.length) throw new UnsupportedFile('read.nosamples');
   return samples;
 }
 
@@ -513,7 +522,7 @@ const VIDEO_ENTRIES = new Set(['avc1', 'avc3', 'hvc1', 'hev1', 'av01', 'vp09']);
 function readVideoTrack(view, trak, timescale, duration, fragmented) {
   const tkhd = findBox(view, trak.body, trak.end, 'tkhd');
   const stbl = findPath(view, trak, 'mdia', 'minf', 'stbl');
-  if (!tkhd || !stbl) throw new UnsupportedFile('the video track is missing its sample tables.');
+  if (!tkhd || !stbl) throw new UnsupportedFile('read.nostbl');
 
   const head = fullBox(view, tkhd);
   const trackId = view.getUint32(head.at + (head.version === 1 ? 16 : 8));
@@ -525,16 +534,15 @@ function readVideoTrack(view, trak, timescale, duration, fragmented) {
   const rotation = rotationOf(view, tkhd.end - 44);
 
   const stsd = findBox(view, stbl.body, stbl.end, 'stsd');
-  if (!stsd) throw new UnsupportedFile('the video track has no sample description.');
+  if (!stsd) throw new UnsupportedFile('read.nostsd');
   const [entry] = [...boxes(view, fullBox(view, stsd).at + 4, stsd.end)];
-  if (!entry) throw new UnsupportedFile('the video sample description is empty.');
+  if (!entry) throw new UnsupportedFile('read.emptystsd');
 
   if (entry.type === 'encv' || findBox(view, entry.body + 78, entry.end, 'sinf')) {
-    throw new UnsupportedFile('the video track is encrypted.');
+    throw new UnsupportedFile('read.encrypted');
   }
   if (!VIDEO_ENTRIES.has(entry.type)) {
-    throw new UnsupportedFile(
-      `the video is stored as "${entry.type}", which this reader does not know.`);
+    throw new UnsupportedFile('read.unknowncodec', { type: entry.type });
   }
 
   const codedWidth = view.getUint16(entry.body + 24);
@@ -563,7 +571,7 @@ function readVideoTrack(view, trak, timescale, duration, fragmented) {
     }
     if (codec) break;
   }
-  if (!codec) throw new UnsupportedFile(`the "${entry.type}" track carries no decoder configuration.`);
+  if (!codec) throw new UnsupportedFile('read.noconfig', { type: entry.type });
 
   const samples = fragmented ? [] : readSamples(view, stbl);
   const turned = rotation === 90 || rotation === 270;
@@ -624,11 +632,11 @@ function readAudioTrack(view, trak, timescale, duration, fragmented) {
 export async function demux(file) {
   const top = await topLevel(file);
   if (!top.some((box) => box.type === 'ftyp' || box.type === 'moov')) {
-    throw new UnsupportedFile('this is not an MP4 or MOV file.');
+    throw new UnsupportedFile('read.notmp4');
   }
 
   const outer = top.find((box) => box.type === 'moov');
-  if (!outer) throw new UnsupportedFile('the file has no movie header.');
+  if (!outer) throw new UnsupportedFile('read.nomoov');
 
   const bytes = new Uint8Array(await file.slice(outer.start, outer.end).arrayBuffer());
   const view = new DataView(bytes.buffer);
@@ -665,8 +673,8 @@ export async function demux(file) {
     }
   }
 
-  if (!video) throw new UnsupportedFile('the file has no video track this reader can use.');
-  if (!video.timescale) throw new UnsupportedFile('the video track has no timescale.');
+  if (!video) throw new UnsupportedFile('read.novideo');
+  if (!video.timescale) throw new UnsupportedFile('read.notimescale');
 
   if (fragmented) {
     const wanted = new Map([[video.trackId, video.samples]]);
@@ -674,7 +682,7 @@ export async function demux(file) {
 
     const clocks = await readFragments(file, top, fragmentDefaults(view, moov), wanted);
     if (!video.samples.length) {
-      throw new UnsupportedFile('the fragments in this file hold no frames for its video track.');
+      throw new UnsupportedFile('read.nofragments');
     }
 
     // A fragmented file usually declares a duration of zero in the header,

--- a/tools/grab-frame/src/main.js
+++ b/tools/grab-frame/src/main.js
@@ -9,6 +9,16 @@ import { FORMATS, clockTime, encodeStill, stillName } from './still.js';
 import { makeZip } from './shared/zip.js';
 import { hasWebCodecs, canDecode, encodableTypes } from './support.js';
 
+/**
+ * A reader refusal, in the reader's language. The demuxer is copied byte for
+ * byte into fifteen languages, so what it hands back is a phrase key and its
+ * values; `absent` is the sentence for the file that was never given to it at
+ * all - the browser's own player took it instead.
+ */
+function why(fallback, absent) {
+  return phrase(fallback?.key ?? absent, fallback?.values);
+}
+
 const $ = (id) => document.getElementById(id);
 
 const el = {
@@ -165,8 +175,8 @@ async function loadFile(picked) {
     } catch (error) {
       media = null;
       fallbackReason = error instanceof UnsupportedFile
-        ? error.reason
-        : (error.message || 'the file could not be read as an MP4.');
+        ? { key: error.reason, values: error.values }
+        : { key: error.message || 'read.unreadable' };
     }
 
     let decodable = false;
@@ -178,10 +188,10 @@ async function loadFile(picked) {
         ...(media.video.description ? { description: media.video.description } : {}),
       });
       if (!decodable) {
-        fallbackReason = `this browser will not decode ${media.video.codec} directly.`;
+        fallbackReason = { key: 'read.nodecoder', values: { codec: media.video.codec } };
       }
     } else if (media && !hasWebCodecs()) {
-      fallbackReason = 'this browser has no WebCodecs, so frames cannot be decoded one by one.';
+      fallbackReason = { key: 'read.nowebcodecs' };
     }
 
     // If the reader and the player disagree about the shape of the picture, one
@@ -191,14 +201,14 @@ async function loadFile(picked) {
     if (decodable && played.ok
       && (played.width !== media.video.displayWidth || played.height !== media.video.displayHeight)) {
       decodable = false;
-      fallbackReason = 'this file is stored turned in a way the reader and the player disagree on.';
+      fallbackReason = { key: 'read.turned' };
     }
 
     exact = decodable;
     playable = played.ok;
 
     if (!exact && !playable) {
-      showError(`This browser cannot open this file: ${fallbackReason ?? 'the format is not one it plays.'}`);
+      showError(phrase('open.failed', { reason: why(fallbackReason, 'read.notplayed') }));
       resetView();
       return;
     }
@@ -259,14 +269,11 @@ function describeSource() {
 
   el.pathNote.hidden = exact && playable;
   if (!exact) {
-    el.pathNote.textContent = 'This file is read by the browser\'s own player rather than '
-      + `frame by frame, because ${fallbackReason ?? 'its layout is not one the reader here understands.'} `
-      + 'The picture is still saved at the video\'s full size, but the frame you land on is the '
-      + 'one the player chooses, and stepping moves by roughly a frame rather than exactly one.';
+    el.pathNote.textContent = phrase('path.player', {
+      reason: why(fallbackReason, 'read.layout'),
+    });
   } else if (!playable) {
-    el.pathNote.textContent = 'This browser will not play this file, so there is nothing to press '
-      + 'play on - but it will decode it, which is what the stills are made from. Use the slider '
-      + 'and the arrow keys to move through it.';
+    el.pathNote.textContent = phrase('path.nopreview');
   }
 }
 

--- a/tools/timelapse-video/body.html
+++ b/tools/timelapse-video/body.html
@@ -157,6 +157,37 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">The file ends in the middle of a frame.</span>
+    <span data-phrase="read.avcshort">The H.264 configuration record is too short.</span>
+    <span data-phrase="read.hevcshort">The HEVC configuration record is too short.</span>
+    <span data-phrase="read.av1short">The AV1 configuration record is too short.</span>
+    <span data-phrase="read.compactsizes">The sample sizes are in a compact table this reader does not decode.</span>
+    <span data-phrase="read.sampletables">The sample tables are incomplete.</span>
+    <span data-phrase="read.chunktable">The chunk table is empty.</span>
+    <span data-phrase="read.nosamples">The track holds no samples.</span>
+    <span data-phrase="read.nostbl">The video track is missing its sample tables.</span>
+    <span data-phrase="read.nostsd">The video track has no sample description.</span>
+    <span data-phrase="read.emptystsd">The video sample description is empty.</span>
+    <span data-phrase="read.encrypted">The video track is encrypted.</span>
+    <span data-phrase="read.unknowncodec">The video is stored as &ldquo;{type}&rdquo;, which this reader does not know.</span>
+    <span data-phrase="read.noconfig">The &ldquo;{type}&rdquo; track carries no decoder configuration.</span>
+    <span data-phrase="read.notmp4">This is not an MP4 or MOV file.</span>
+    <span data-phrase="read.nomoov">The file has no movie header.</span>
+    <span data-phrase="read.novideo">The file has no video track this reader can use.</span>
+    <span data-phrase="read.notimescale">The video track has no timescale.</span>
+    <span data-phrase="read.nofragments">The fragments in this file hold no frames for its video track.</span>
+    <span data-phrase="read.unreadable">The file could not be read as an MP4.</span>
+    <span data-phrase="read.notplayed">The format is not one this browser plays.</span>
+    <span data-phrase="read.layout">The layout of this file is not one the reader here understands.</span>
+    <span data-phrase="read.nodecoder">This browser will not decode {codec} directly.</span>
+    <span data-phrase="read.nowebcodecs">This browser has no WebCodecs, so frames cannot be decoded one by one.</span>
+    <span data-phrase="open.failed">This browser cannot open this file. {reason}</span>
+    <span data-phrase="open.nodecode">This browser opened the file but cannot decode the video in it. That is usually
+      Dolby Vision, or HEVC on a machine with no hardware support for it: the container
+      reads fine and the picture never arrives. Convert it to an ordinary MP4 (H.264)
+      first, and this will read it directly.</span>
+    <span data-phrase="path.seek">{reason} So this one is read by seeking the browser&rsquo;s own player to each
+      instant, which works on every format the browser plays and is a little slower.</span>
     <span data-phrase="net.clean">your video has gone nowhere. {total} files
       loaded. {platform}</span>
     <span data-phrase="net.dirty">something contacted {hosts}, which this tool

--- a/tools/timelapse-video/src/demux.js
+++ b/tools/timelapse-video/src/demux.js
@@ -32,12 +32,21 @@
  * description of what is in it.
  */
 
-/** Thrown when the file is well-formed but out of this demuxer's scope. */
+/**
+ * Thrown when the file is well-formed but out of this demuxer's scope.
+ *
+ * `reason` is a phrase key, not a sentence: this module is copied byte for
+ * byte into fifteen languages, so the sentence lives in the tool's body.html
+ * and main.js resolves the key against it. `values` carries what a sentence
+ * cannot know in advance - the four characters naming a codec this reader has
+ * never heard of.
+ */
 export class UnsupportedFile extends Error {
-  constructor(reason) {
+  constructor(reason, values) {
     super(reason);
     this.name = 'UnsupportedFile';
     this.reason = reason;
+    this.values = values;
   }
 }
 
@@ -133,7 +142,7 @@ export class FileWindow {
     }
     const at = offset - this.start;
     if (at + length > this.bytes.length) {
-      throw new UnsupportedFile('the file ends in the middle of a frame.');
+      throw new UnsupportedFile('read.midframe');
     }
     return this.bytes.subarray(at, at + length);
   }
@@ -174,7 +183,7 @@ const hex = (n) => n.toString(16).padStart(2, '0');
 
 /** avcC -> "avc1.640028", the string VideoDecoder wants. */
 function avcCodec(prefix, config) {
-  if (config.length < 4) throw new UnsupportedFile('the H.264 configuration record is too short.');
+  if (config.length < 4) throw new UnsupportedFile('read.avcshort');
   return `${prefix}.${hex(config[1])}${hex(config[2])}${hex(config[3])}`;
 }
 
@@ -187,7 +196,7 @@ function avcCodec(prefix, config) {
  * at least fails loudly rather than decoding something else.
  */
 function hevcCodec(prefix, config) {
-  if (config.length < 13) throw new UnsupportedFile('the HEVC configuration record is too short.');
+  if (config.length < 13) throw new UnsupportedFile('read.hevcshort');
 
   const space = ['', 'A', 'B', 'C'][(config[1] >> 6) & 0x3];
   const tier = ((config[1] >> 5) & 0x1) ? 'H' : 'L';
@@ -212,7 +221,7 @@ function hevcCodec(prefix, config) {
 
 /** av1C -> "av01.0.08M.08". */
 function av1Codec(config) {
-  if (config.length < 3) throw new UnsupportedFile('the AV1 configuration record is too short.');
+  if (config.length < 3) throw new UnsupportedFile('read.av1short');
   const profile = (config[1] >> 5) & 0x7;
   const level = config[1] & 0x1f;
   const tier = ((config[2] >> 7) & 0x1) ? 'H' : 'M';
@@ -253,10 +262,10 @@ function readSamples(view, stbl) {
   const stss = findBox(view, stbl.body, stbl.end, 'stss');
 
   if (!stsz && findBox(view, stbl.body, stbl.end, 'stz2')) {
-    throw new UnsupportedFile('sample sizes are in a compact table this reader does not decode.');
+    throw new UnsupportedFile('read.compactsizes');
   }
   if (!stts || !stsc || !stsz || !stco) {
-    throw new UnsupportedFile('the sample tables are incomplete.');
+    throw new UnsupportedFile('read.sampletables');
   }
 
   // Sizes. A non-zero uniform size means every sample is that size and there is
@@ -333,7 +342,7 @@ function readSamples(view, stbl) {
       perChunk: view.getUint32(runsHead.at + 8 + r * 12),
     });
   }
-  if (!runs.length) throw new UnsupportedFile('the chunk table is empty.');
+  if (!runs.length) throw new UnsupportedFile('read.chunktable');
 
   const samples = [];
   let index = 0;
@@ -357,7 +366,7 @@ function readSamples(view, stbl) {
     }
   }
 
-  if (!samples.length) throw new UnsupportedFile('the track holds no samples.');
+  if (!samples.length) throw new UnsupportedFile('read.nosamples');
   return samples;
 }
 
@@ -512,7 +521,7 @@ const VIDEO_ENTRIES = new Set(['avc1', 'avc3', 'hvc1', 'hev1', 'av01', 'vp09']);
 function readVideoTrack(view, trak, timescale, duration, fragmented) {
   const tkhd = findBox(view, trak.body, trak.end, 'tkhd');
   const stbl = findPath(view, trak, 'mdia', 'minf', 'stbl');
-  if (!tkhd || !stbl) throw new UnsupportedFile('the video track is missing its sample tables.');
+  if (!tkhd || !stbl) throw new UnsupportedFile('read.nostbl');
 
   const head = fullBox(view, tkhd);
   const trackId = view.getUint32(head.at + (head.version === 1 ? 16 : 8));
@@ -524,16 +533,15 @@ function readVideoTrack(view, trak, timescale, duration, fragmented) {
   const rotation = rotationOf(view, tkhd.end - 44);
 
   const stsd = findBox(view, stbl.body, stbl.end, 'stsd');
-  if (!stsd) throw new UnsupportedFile('the video track has no sample description.');
+  if (!stsd) throw new UnsupportedFile('read.nostsd');
   const [entry] = [...boxes(view, fullBox(view, stsd).at + 4, stsd.end)];
-  if (!entry) throw new UnsupportedFile('the video sample description is empty.');
+  if (!entry) throw new UnsupportedFile('read.emptystsd');
 
   if (entry.type === 'encv' || findBox(view, entry.body + 78, entry.end, 'sinf')) {
-    throw new UnsupportedFile('the video track is encrypted.');
+    throw new UnsupportedFile('read.encrypted');
   }
   if (!VIDEO_ENTRIES.has(entry.type)) {
-    throw new UnsupportedFile(
-      `the video is stored as "${entry.type}", which this reader does not know.`);
+    throw new UnsupportedFile('read.unknowncodec', { type: entry.type });
   }
 
   const codedWidth = view.getUint16(entry.body + 24);
@@ -562,7 +570,7 @@ function readVideoTrack(view, trak, timescale, duration, fragmented) {
     }
     if (codec) break;
   }
-  if (!codec) throw new UnsupportedFile(`the "${entry.type}" track carries no decoder configuration.`);
+  if (!codec) throw new UnsupportedFile('read.noconfig', { type: entry.type });
 
   const samples = fragmented ? [] : readSamples(view, stbl);
   const turned = rotation === 90 || rotation === 270;
@@ -623,11 +631,11 @@ function readAudioTrack(view, trak, timescale, duration, fragmented) {
 export async function demux(file) {
   const top = await topLevel(file);
   if (!top.some((box) => box.type === 'ftyp' || box.type === 'moov')) {
-    throw new UnsupportedFile('this is not an MP4 or MOV file.');
+    throw new UnsupportedFile('read.notmp4');
   }
 
   const outer = top.find((box) => box.type === 'moov');
-  if (!outer) throw new UnsupportedFile('the file has no movie header.');
+  if (!outer) throw new UnsupportedFile('read.nomoov');
 
   const bytes = new Uint8Array(await file.slice(outer.start, outer.end).arrayBuffer());
   const view = new DataView(bytes.buffer);
@@ -664,8 +672,8 @@ export async function demux(file) {
     }
   }
 
-  if (!video) throw new UnsupportedFile('the file has no video track this reader can use.');
-  if (!video.timescale) throw new UnsupportedFile('the video track has no timescale.');
+  if (!video) throw new UnsupportedFile('read.novideo');
+  if (!video.timescale) throw new UnsupportedFile('read.notimescale');
 
   if (fragmented) {
     const wanted = new Map([[video.trackId, video.samples]]);
@@ -673,7 +681,7 @@ export async function demux(file) {
 
     const clocks = await readFragments(file, top, fragmentDefaults(view, moov), wanted);
     if (!video.samples.length) {
-      throw new UnsupportedFile('the fragments in this file hold no frames for its video track.');
+      throw new UnsupportedFile('read.nofragments');
     }
 
     // A fragmented file usually declares a duration of zero in the header,

--- a/tools/timelapse-video/src/main.js
+++ b/tools/timelapse-video/src/main.js
@@ -13,6 +13,16 @@ import {
   outputSize, chooseBitrate, estimateBytes, decodeRuns, decodeCost,
 } from './plan.js';
 
+/**
+ * A reader refusal, in the reader's language. The demuxer is copied byte for
+ * byte into fifteen languages, so what it hands back is a phrase key and its
+ * values; `absent` is the sentence for the file that was never given to it at
+ * all - the browser's own player took it instead.
+ */
+function why(fallback, absent) {
+  return phrase(fallback?.key ?? absent, fallback?.values);
+}
+
 const $ = (id) => document.getElementById(id);
 
 const el = {
@@ -211,18 +221,18 @@ async function loadFile(picked) {
     } catch (error) {
       media = null;
       fallbackReason = error instanceof UnsupportedFile
-        ? error.reason
-        : (error.message || 'the file could not be read as an MP4.');
+        ? { key: error.reason, values: error.values }
+        : { key: error.message || 'read.unreadable' };
     }
 
     let readable = false;
     if (media && hasWebCodecs()) {
       readable = await canDecode(decoderConfig(media.video));
       if (!readable) {
-        fallbackReason = `this browser will not decode ${media.video.codec} directly.`;
+        fallbackReason = { key: 'read.nodecoder', values: { codec: media.video.codec } };
       }
     } else if (media && !hasWebCodecs()) {
-      fallbackReason = 'this browser has no WebCodecs, so frames cannot be decoded one by one.';
+      fallbackReason = { key: 'read.nowebcodecs' };
     }
 
     canReadDirectly = readable;
@@ -248,13 +258,8 @@ async function loadFile(picked) {
       // then could not decode a frame of it" send you to different answers,
       // and the second one is the case that used to fail an hour in.
       showError(opensButCannotDecode
-        ? 'This browser opened the file but cannot decode the video in it. '
-          + 'That is usually Dolby Vision, or HEVC on a machine with no '
-          + 'hardware support for it - the container reads fine and the '
-          + 'picture never arrives. Convert it to an ordinary MP4 (H.264) '
-          + 'first, and this will read it directly.'
-        : `This browser cannot open this file: ${fallbackReason
-          ?? 'the format is not one it plays.'}`);
+        ? phrase('open.nodecode')
+        : phrase('open.failed', { reason: why(fallbackReason, 'read.notplayed') }));
       resetView();
       return;
     }
@@ -345,9 +350,9 @@ function describeSource() {
 
   el.pathNote.hidden = canReadDirectly;
   if (!canReadDirectly) {
-    el.pathNote.textContent = 'This one is read by seeking the browser\'s own player to each '
-      + `instant, because ${fallbackReason ?? 'its layout is not one the reader here understands.'} `
-      + 'That works on every format the browser plays, and is a little slower.';
+    el.pathNote.textContent = phrase('path.seek', {
+      reason: why(fallbackReason, 'read.layout'),
+    });
   }
 }
 

--- a/tools/video-to-gif/body.html
+++ b/tools/video-to-gif/body.html
@@ -173,6 +173,35 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.midframe">The file ends in the middle of a frame.</span>
+    <span data-phrase="read.avcshort">The H.264 configuration record is too short.</span>
+    <span data-phrase="read.hevcshort">The HEVC configuration record is too short.</span>
+    <span data-phrase="read.av1short">The AV1 configuration record is too short.</span>
+    <span data-phrase="read.compactsizes">The sample sizes are in a compact table this reader does not decode.</span>
+    <span data-phrase="read.sampletables">The sample tables are incomplete.</span>
+    <span data-phrase="read.chunktable">The chunk table is empty.</span>
+    <span data-phrase="read.nosamples">The track holds no samples.</span>
+    <span data-phrase="read.nostbl">The video track is missing its sample tables.</span>
+    <span data-phrase="read.nostsd">The video track has no sample description.</span>
+    <span data-phrase="read.emptystsd">The video sample description is empty.</span>
+    <span data-phrase="read.encrypted">The video track is encrypted.</span>
+    <span data-phrase="read.unknowncodec">The video is stored as &ldquo;{type}&rdquo;, which this reader does not know.</span>
+    <span data-phrase="read.noconfig">The &ldquo;{type}&rdquo; track carries no decoder configuration.</span>
+    <span data-phrase="read.notmp4">This is not an MP4 or MOV file.</span>
+    <span data-phrase="read.nomoov">The file has no movie header.</span>
+    <span data-phrase="read.novideo">The file has no video track this reader can use.</span>
+    <span data-phrase="read.notimescale">The video track has no timescale.</span>
+    <span data-phrase="read.nofragments">The fragments in this file hold no frames for its video track.</span>
+    <span data-phrase="read.unreadable">The file could not be read as an MP4.</span>
+    <span data-phrase="read.notplayed">The format is not one this browser plays.</span>
+    <span data-phrase="read.layout">The layout of this file is not one the reader here understands.</span>
+    <span data-phrase="read.nodecoder">This browser will not decode {codec} directly.</span>
+    <span data-phrase="read.nowebcodecs">This browser has no WebCodecs, so frames cannot be decoded one by one.</span>
+    <span data-phrase="read.turned">This file is stored turned in a way the reader and the player disagree on.</span>
+    <span data-phrase="open.failed">This browser cannot open this file. {reason}</span>
+    <span data-phrase="path.seek">{reason} So the frames for this one are collected by seeking the player to each
+      instant. That is slower, and the browser decides which frame each seek lands on, so
+      a fast section can come out a frame out here and there.</span>
     <span data-phrase="net.clean">your video has gone nowhere. {total} files
       loaded. {platform}</span>
     <span data-phrase="net.dirty">something contacted {hosts}, which this tool

--- a/tools/video-to-gif/src/demux.js
+++ b/tools/video-to-gif/src/demux.js
@@ -36,12 +36,21 @@
  * description of what is in it.
  */
 
-/** Thrown when the file is well-formed but out of this demuxer's scope. */
+/**
+ * Thrown when the file is well-formed but out of this demuxer's scope.
+ *
+ * `reason` is a phrase key, not a sentence: this module is copied byte for
+ * byte into fifteen languages, so the sentence lives in the tool's body.html
+ * and main.js resolves the key against it. `values` carries what a sentence
+ * cannot know in advance - the four characters naming a codec this reader has
+ * never heard of.
+ */
 export class UnsupportedFile extends Error {
-  constructor(reason) {
+  constructor(reason, values) {
     super(reason);
     this.name = 'UnsupportedFile';
     this.reason = reason;
+    this.values = values;
   }
 }
 
@@ -137,7 +146,7 @@ export class FileWindow {
     }
     const at = offset - this.start;
     if (at + length > this.bytes.length) {
-      throw new UnsupportedFile('the file ends in the middle of a frame.');
+      throw new UnsupportedFile('read.midframe');
     }
     return this.bytes.subarray(at, at + length);
   }
@@ -178,7 +187,7 @@ const hex = (n) => n.toString(16).padStart(2, '0');
 
 /** avcC -> "avc1.640028", the string VideoDecoder wants. */
 function avcCodec(prefix, config) {
-  if (config.length < 4) throw new UnsupportedFile('the H.264 configuration record is too short.');
+  if (config.length < 4) throw new UnsupportedFile('read.avcshort');
   return `${prefix}.${hex(config[1])}${hex(config[2])}${hex(config[3])}`;
 }
 
@@ -191,7 +200,7 @@ function avcCodec(prefix, config) {
  * at least fails loudly rather than decoding something else.
  */
 function hevcCodec(prefix, config) {
-  if (config.length < 13) throw new UnsupportedFile('the HEVC configuration record is too short.');
+  if (config.length < 13) throw new UnsupportedFile('read.hevcshort');
 
   const space = ['', 'A', 'B', 'C'][(config[1] >> 6) & 0x3];
   const tier = ((config[1] >> 5) & 0x1) ? 'H' : 'L';
@@ -216,7 +225,7 @@ function hevcCodec(prefix, config) {
 
 /** av1C -> "av01.0.08M.08". */
 function av1Codec(config) {
-  if (config.length < 3) throw new UnsupportedFile('the AV1 configuration record is too short.');
+  if (config.length < 3) throw new UnsupportedFile('read.av1short');
   const profile = (config[1] >> 5) & 0x7;
   const level = config[1] & 0x1f;
   const tier = ((config[2] >> 7) & 0x1) ? 'H' : 'M';
@@ -257,10 +266,10 @@ function readSamples(view, stbl) {
   const stss = findBox(view, stbl.body, stbl.end, 'stss');
 
   if (!stsz && findBox(view, stbl.body, stbl.end, 'stz2')) {
-    throw new UnsupportedFile('sample sizes are in a compact table this reader does not decode.');
+    throw new UnsupportedFile('read.compactsizes');
   }
   if (!stts || !stsc || !stsz || !stco) {
-    throw new UnsupportedFile('the sample tables are incomplete.');
+    throw new UnsupportedFile('read.sampletables');
   }
 
   // Sizes. A non-zero uniform size means every sample is that size and there is
@@ -337,7 +346,7 @@ function readSamples(view, stbl) {
       perChunk: view.getUint32(runsHead.at + 8 + r * 12),
     });
   }
-  if (!runs.length) throw new UnsupportedFile('the chunk table is empty.');
+  if (!runs.length) throw new UnsupportedFile('read.chunktable');
 
   const samples = [];
   let index = 0;
@@ -361,7 +370,7 @@ function readSamples(view, stbl) {
     }
   }
 
-  if (!samples.length) throw new UnsupportedFile('the track holds no samples.');
+  if (!samples.length) throw new UnsupportedFile('read.nosamples');
   return samples;
 }
 
@@ -516,7 +525,7 @@ const VIDEO_ENTRIES = new Set(['avc1', 'avc3', 'hvc1', 'hev1', 'av01', 'vp09']);
 function readVideoTrack(view, trak, timescale, duration, fragmented) {
   const tkhd = findBox(view, trak.body, trak.end, 'tkhd');
   const stbl = findPath(view, trak, 'mdia', 'minf', 'stbl');
-  if (!tkhd || !stbl) throw new UnsupportedFile('the video track is missing its sample tables.');
+  if (!tkhd || !stbl) throw new UnsupportedFile('read.nostbl');
 
   const head = fullBox(view, tkhd);
   const trackId = view.getUint32(head.at + (head.version === 1 ? 16 : 8));
@@ -528,16 +537,15 @@ function readVideoTrack(view, trak, timescale, duration, fragmented) {
   const rotation = rotationOf(view, tkhd.end - 44);
 
   const stsd = findBox(view, stbl.body, stbl.end, 'stsd');
-  if (!stsd) throw new UnsupportedFile('the video track has no sample description.');
+  if (!stsd) throw new UnsupportedFile('read.nostsd');
   const [entry] = [...boxes(view, fullBox(view, stsd).at + 4, stsd.end)];
-  if (!entry) throw new UnsupportedFile('the video sample description is empty.');
+  if (!entry) throw new UnsupportedFile('read.emptystsd');
 
   if (entry.type === 'encv' || findBox(view, entry.body + 78, entry.end, 'sinf')) {
-    throw new UnsupportedFile('the video track is encrypted.');
+    throw new UnsupportedFile('read.encrypted');
   }
   if (!VIDEO_ENTRIES.has(entry.type)) {
-    throw new UnsupportedFile(
-      `the video is stored as "${entry.type}", which this reader does not know.`);
+    throw new UnsupportedFile('read.unknowncodec', { type: entry.type });
   }
 
   const codedWidth = view.getUint16(entry.body + 24);
@@ -566,7 +574,7 @@ function readVideoTrack(view, trak, timescale, duration, fragmented) {
     }
     if (codec) break;
   }
-  if (!codec) throw new UnsupportedFile(`the "${entry.type}" track carries no decoder configuration.`);
+  if (!codec) throw new UnsupportedFile('read.noconfig', { type: entry.type });
 
   const samples = fragmented ? [] : readSamples(view, stbl);
   const turned = rotation === 90 || rotation === 270;
@@ -627,11 +635,11 @@ function readAudioTrack(view, trak, timescale, duration, fragmented) {
 export async function demux(file) {
   const top = await topLevel(file);
   if (!top.some((box) => box.type === 'ftyp' || box.type === 'moov')) {
-    throw new UnsupportedFile('this is not an MP4 or MOV file.');
+    throw new UnsupportedFile('read.notmp4');
   }
 
   const outer = top.find((box) => box.type === 'moov');
-  if (!outer) throw new UnsupportedFile('the file has no movie header.');
+  if (!outer) throw new UnsupportedFile('read.nomoov');
 
   const bytes = new Uint8Array(await file.slice(outer.start, outer.end).arrayBuffer());
   const view = new DataView(bytes.buffer);
@@ -668,8 +676,8 @@ export async function demux(file) {
     }
   }
 
-  if (!video) throw new UnsupportedFile('the file has no video track this reader can use.');
-  if (!video.timescale) throw new UnsupportedFile('the video track has no timescale.');
+  if (!video) throw new UnsupportedFile('read.novideo');
+  if (!video.timescale) throw new UnsupportedFile('read.notimescale');
 
   if (fragmented) {
     const wanted = new Map([[video.trackId, video.samples]]);
@@ -677,7 +685,7 @@ export async function demux(file) {
 
     const clocks = await readFragments(file, top, fragmentDefaults(view, moov), wanted);
     if (!video.samples.length) {
-      throw new UnsupportedFile('the fragments in this file hold no frames for its video track.');
+      throw new UnsupportedFile('read.nofragments');
     }
 
     // A fragmented file usually declares a duration of zero in the header,

--- a/tools/video-to-gif/src/main.js
+++ b/tools/video-to-gif/src/main.js
@@ -9,6 +9,16 @@ import { RangeBar, formatTime, parseTime } from './range.js';
 import { frameTimes, frameDelays, outputSize, workingBytes, estimateBytes, MAX_FPS } from './plan.js';
 import { hasWebCodecs, canDecode } from './support.js';
 
+/**
+ * A reader refusal, in the reader's language. The demuxer is copied byte for
+ * byte into fifteen languages, so what it hands back is a phrase key and its
+ * values; `absent` is the sentence for the file that was never given to it at
+ * all - the browser's own player took it instead.
+ */
+function why(fallback, absent) {
+  return phrase(fallback?.key ?? absent, fallback?.values);
+}
+
 const $ = (id) => document.getElementById(id);
 
 const el = {
@@ -175,18 +185,18 @@ async function loadFile(picked) {
     } catch (error) {
       media = null;
       fallbackReason = error instanceof UnsupportedFile
-        ? error.reason
-        : (error.message || 'the file could not be read as an MP4.');
+        ? { key: error.reason, values: error.values }
+        : { key: error.message || 'read.unreadable' };
     }
 
     let decodable = false;
     if (media && hasWebCodecs()) {
       decodable = await canDecode(decoderConfig(media.video));
       if (!decodable) {
-        fallbackReason = `this browser will not decode ${media.video.codec} directly.`;
+        fallbackReason = { key: 'read.nodecoder', values: { codec: media.video.codec } };
       }
     } else if (media && !hasWebCodecs()) {
-      fallbackReason = 'this browser has no WebCodecs, so frames cannot be decoded one by one.';
+      fallbackReason = { key: 'read.nowebcodecs' };
     }
 
     // If the reader and the player disagree about the shape of the picture, one
@@ -196,15 +206,14 @@ async function loadFile(picked) {
     if (decodable && played.ok
       && (played.width !== media.video.displayWidth || played.height !== media.video.displayHeight)) {
       decodable = false;
-      fallbackReason = 'this file is stored turned in a way the reader and the player disagree on.';
+      fallbackReason = { key: 'read.turned' };
     }
 
     canRead = decodable;
     canPlay = played.ok;
 
     if (!canRead && !canPlay) {
-      showError('This browser cannot open this file: '
-        + `${fallbackReason ?? 'the format is not one it plays.'}`);
+      showError(phrase('open.failed', { reason: why(fallbackReason, 'read.notplayed') }));
       resetView();
       return;
     }
@@ -271,10 +280,9 @@ function describeSource() {
 
   el.pathNote.hidden = canRead;
   if (!canRead) {
-    el.pathNote.textContent = 'The frames for this one are collected by seeking the player to '
-      + `each instant, because ${fallbackReason ?? 'its layout is not one the reader here understands.'} `
-      + 'That is slower, and the browser decides which frame each seek lands on, so a fast '
-      + 'section can come out a frame out here and there.';
+    el.pathNote.textContent = phrase('path.seek', {
+      reason: why(fallbackReason, 'read.layout'),
+    });
   }
 }
 


### PR DESCRIPTION
The MP4 reader exists twice in this repository. [#229](https://github.com/A-Box-of-Tools/website/pull/229) gave the copy that trim and reverse carry a phrase key for each of its refusals; this gives the other copy the same, in the four tools that share it — **crop-video, grab-frame, timelapse-video, video-to-gif**.

The nineteen sentences are word for word the ones already written and reviewed, so what these pages say when they cannot read a file is what the trim page says, in the same fifteen languages: *The video track is encrypted.* / *Die Videospur ist verschlüsselt.* / *映像トラックが暗号化されています。*

## Why these four, and why not their writers

`tests/python/test_duplicates.py` declares this `demux.js` one copy shared by the four and compares tokens, so they move together or not at all. Their writers stay behind: crop-video has its own `mp4.js` and the other three build no MP4, so the `write.*` keys remain with the tools that throw them.

## What is actually new

The sentence each tool puts around a reason — four different sentences, because these four do four different things with a file they cannot read frame by frame: crop by recording, read through the player, seek to each instant, collect frames by seeking. Each takes the reason as `{reason}` and puts it where its own language puts it.

Two more sentences came along because they sit in the same `if`/`else` and would otherwise have been the English half of a translated pair: grab-frame's note for a file the browser will decode but not play, and timelapse-video's Dolby Vision advice.

timelapse-video never compares the reader's shape against the player's, so it is the one tool here with no rotation disagreement to report and therefore no `read.turned`.

## Checks

- `python build.py --out _plain --clean --no-minify` — clean
- `python -m unittest discover -t . -s tests/python` — all pass
- `node --test "tests/js/*.test.js"` — 1935 pass
- `python zh-tw-sync.py --check` — `0 of 0 files differ`; the four Traditional pages here are regenerated with the 里 rule that landed with #229
- Driven in the built pages: a text file dropped on the Spanish crop page gave **Este navegador no puede abrir este archivo. Esto no es un archivo MP4 ni MOV.**, and the composed notes were read back through each page's own `phrase()` — Spanish with a codec filled in, Japanese joining its sentences with no space after the full stop

Baselines: crop-video 55 → 31, grab-frame 47 → 22, timelapse-video 57 → 34, video-to-gif 47 → 23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
