### PR TITLE
Say what a photo gives away in the reader's own language

### DIFF
--- a/locales/ar/tools/exif-editor.html
+++ b/locales/ar/tools/exif-editor.html
@@ -152,6 +152,60 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="find.clean.title">لا شيء في هذا الملف يفشي عنك شيئاً</span>
+    <span data-phrase="find.clean.cleared">أُزيل كل ما كان يفشي. احفظ الصورة لتُكتَب على هذا الحال.</span>
+    <span data-phrase="find.clean.never">لا مكان، ولا أختام زمنية، ولا كاميرا، ولا أسماء. فإما أنها لم تحمل ذلك قط، وإما أن
+      شيئاً أزاله من قبل.</span>
+    <span data-phrase="find.exifempty.title">كتلة EXIF لا شيء فيها</span>
+    <span data-phrase="find.exifempty.detail">{size} من EXIF تُقرأ قراءةً سليمة ولا تحمل أي وسم. غير ضارّة، وتُزال مع كل شيء آخر.</span>
+    <span data-phrase="find.exifbad.title">كتلة EXIF لا يستطيع أحد قراءتها</span>
+    <span data-phrase="find.exifbad.detail">هنا EXIF ولم يمكن قراءتها: {reason} وكل ما تحت هو ما أمكن قراءته من بقية الملف،
+      فعُدَّ هذه الكتلة مجهولاً &mdash; وذلك سبب لإزالتها لا لإبقائها.</span>
+    <span data-phrase="find.gps.title">أين التُقطت الصورة</span>
+    <span data-phrase="find.gps.detail">{position}. وهذه دقّة تكفي لتسمية مبنى بعينه، وهي تسافر مع الملف إلى كل مكان تنشره
+      فيه.</span>
+    <span data-phrase="find.gps.detailalt">{position}, {altitude}. وهذه دقّة تكفي لتسمية مبنى بعينه، وهي تسافر مع الملف إلى كل
+      مكان تنشره فيه.</span>
+    <span data-phrase="find.gpspart.title">أوسام موقع، دون موضع كامل</span>
+    <span data-phrase="find.gpspart.one">هنا وسم GPS واحد لكن دون خط عرض وخط طول صالحين. ومع ذلك قد يكون بينها اتجاه السير
+      والارتفاع وساعة GPS.</span>
+    <span data-phrase="find.gpspart.many">هنا {count} من أوسام GPS لكن دون خط عرض وخط طول صالحين. ومع ذلك قد يكون بينها اتجاه
+      السير والارتفاع وساعة GPS.</span>
+    <span data-phrase="find.taken.title">متى التُقطت</span>
+    <span data-phrase="find.taken.detail">{when}، إلى الثانية. ومع موضعٍ يضع هذا شخصاً في مكان بعينه في لحظة بعينها.</span>
+    <span data-phrase="find.device.title">الجهاز الذي جاءت منه</span>
+    <span data-phrase="find.device.detail">{device}. غير ضارّ وحده؛ ويصير علامةً تدلّ عليك حين تحمل كل صورة تنشرها العلامةَ
+      نفسها.</span>
+    <span data-phrase="find.identity.title">شيء يسمّيك أو يسمّي عدّتك</span>
+    <span data-phrase="find.identity.detail">{found}. الرقم التسلسلي يربط كل صورة خرجت من ذلك الجسم بعضها ببعض، مهما يكن ناشرها
+      ومهما يكن المكان.</span>
+    <span data-phrase="find.id.cameraserial">الرقم التسلسلي للكاميرا</span>
+    <span data-phrase="find.id.lensserial">الرقم التسلسلي للعدسة</span>
+    <span data-phrase="find.id.owner">مالك الكاميرا</span>
+    <span data-phrase="find.id.uniqueid">المعرّف الفريد للصورة</span>
+    <span data-phrase="find.id.artist">المصوِّر</span>
+    <span data-phrase="find.id.author">المؤلف</span>
+    <span data-phrase="find.id.copyright">حقوق النشر</span>
+    <span data-phrase="find.software.title">ما الذي حرّرها</span>
+    <span data-phrase="find.software.detail">{software}. وهذا في الغالب إصدار البرنامج الثابت للهاتف، وهو أضيق مما يُنشَر من
+      الطراز وحده.</span>
+    <span data-phrase="find.makernote.title">ملاحظة الصانع</span>
+    <span data-phrase="find.makernote.detail">{size} من بيانات الصانع الخاصة به. غير موثَّقة، وتختلف من طراز إلى طراز، وفيها تميل
+      الأرقام التسلسلية ونقاط التبئير وعدّادات الغالق إلى الاختباء.</span>
+    <span data-phrase="find.thumbnail.title">نسخة ثانية من الصورة</span>
+    <span data-phrase="find.thumbnail.detail">{size} تحمل معاينة JPEG صغيرة. فإن قُصّت الصورة بعد أن كتبتها الكاميرا، تركت بعض
+      البرامج المصغَّرة تعرض الإطار قبل القصّ.</span>
+    <span data-phrase="find.xmp.title">حزمة XMP</span>
+    <span data-phrase="find.xmp.detail">{size} من XML. تكرّر عادةً الكاميرا والأختام الزمنية، وتضيف تاريخ التحرير: أي
+      برنامج، وأي إصدار، وكل مرة حُفظ فيها الملف.</span>
+    <span data-phrase="find.iptc.title">كتلة IPTC</span>
+    <span data-phrase="find.iptc.detail">{size} من الحقول التي يملؤها قسم الصور: التوقيع والتعليق والمدينة ونسبة الصورة. فإن
+      كانت هذه من بنك صور أو غرفة أخبار، فالأرجح أن فيها اسم أحدهم.</span>
+    <span data-phrase="find.comment.title">تعليق</span>
+    <span data-phrase="find.comment.detail">&laquo;{comment}&raquo;</span>
+    <span data-phrase="find.text.title">نص: {keyword}</span>
+    <span data-phrase="find.unknown.title">كتل لا تستطيع هذه الأداة قراءتها</span>
+    <span data-phrase="find.unknown.detail">{blocks}. وتعذّر القراءة ليس كالفراغ، فهذه أيضاً تُزال مع كل شيء آخر.</span>
     <span data-phrase="read.notjpeg">هذا لا يبدأ بداية ملف JPEG.</span>
     <span data-phrase="read.jpeglost">ضاع بناء المقاطع &mdash; ويبدو الملف تالفاً.</span>
     <span data-phrase="read.jpegoverrun">مقطعٌ يدّعي طولاً يتجاوز نهاية الملف.</span>

--- a/locales/de/tools/exif-editor.html
+++ b/locales/de/tools/exif-editor.html
@@ -156,6 +156,69 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="find.clean.title">Diese Datei verrät nichts</span>
+    <span data-phrase="find.clean.cleared">Alles, was etwas verriet, ist entfernt. Speichern Sie das Foto, um es
+      hinauszuschreiben.</span>
+    <span data-phrase="find.clean.never">Kein Ort, keine Zeitstempel, keine Kamera, keine Namen. Entweder gab es das nie,
+      oder etwas hat es schon entfernt.</span>
+    <span data-phrase="find.exifempty.title">Ein EXIF-Block ohne Inhalt</span>
+    <span data-phrase="find.exifempty.detail">{size} EXIF, das sauber liest und keine Tags enthält. Harmlos, und wird mit allem
+      anderen zusammen entfernt.</span>
+    <span data-phrase="find.exifbad.title">Ein EXIF-Block, den niemand lesen kann</span>
+    <span data-phrase="find.exifbad.detail">Hier ist EXIF, und es ließ sich nicht lesen: {reason} Alles Folgende ist das, was
+      vom Rest der Datei zu lesen war &mdash; nehmen Sie diesen Block also als unbekannte
+      Größe, und das ist ein Grund, ihn zu entfernen, nicht ihn zu behalten.</span>
+    <span data-phrase="find.gps.title">Wo das Foto aufgenommen wurde</span>
+    <span data-phrase="find.gps.detail">{position}. Das ist genau genug, um ein Gebäude zu benennen, und es reist mit der
+      Datei überall dorthin, wo Sie sie hochladen.</span>
+    <span data-phrase="find.gps.detailalt">{position}, {altitude}. Das ist genau genug, um ein Gebäude zu benennen, und es
+      reist mit der Datei überall dorthin, wo Sie sie hochladen.</span>
+    <span data-phrase="find.gpspart.title">Orts-Tags, ohne vollständige Position</span>
+    <span data-phrase="find.gpspart.one">Ein GPS-Tag ist hier, aber kein brauchbarer Längen- und Breitengrad. Fahrtrichtung,
+      Höhe und die GPS-Uhr können trotzdem darunter sein.</span>
+    <span data-phrase="find.gpspart.many">{count} GPS-Tags sind hier, aber kein brauchbarer Längen- und Breitengrad.
+      Fahrtrichtung, Höhe und die GPS-Uhr können trotzdem darunter sein.</span>
+    <span data-phrase="find.taken.title">Wann es aufgenommen wurde</span>
+    <span data-phrase="find.taken.detail">{when}, auf die Sekunde genau. Zusammen mit einem Ort setzt das eine Person zu einem
+      bestimmten Zeitpunkt an einen bestimmten Platz.</span>
+    <span data-phrase="find.device.title">Das Gerät, aus dem es kam</span>
+    <span data-phrase="find.device.detail">{device}. Für sich genommen harmlos; zum Erkennungsmerkmal wird es, wenn jedes Foto,
+      das Sie veröffentlichen, dasselbe trägt.</span>
+    <span data-phrase="find.identity.title">Etwas, das Sie oder Ihre Ausrüstung benennt</span>
+    <span data-phrase="find.identity.detail">{found}. Eine Seriennummer verbindet jedes Foto aus diesem Gehäuse miteinander, wer
+      immer es hochgeladen hat und wo immer.</span>
+    <span data-phrase="find.id.cameraserial">Seriennummer der Kamera</span>
+    <span data-phrase="find.id.lensserial">Seriennummer des Objektivs</span>
+    <span data-phrase="find.id.owner">Besitzer der Kamera</span>
+    <span data-phrase="find.id.uniqueid">Eindeutige Bild-ID</span>
+    <span data-phrase="find.id.artist">Urheber</span>
+    <span data-phrase="find.id.author">Autor</span>
+    <span data-phrase="find.id.copyright">Copyright</span>
+    <span data-phrase="find.software.title">Was es bearbeitet hat</span>
+    <span data-phrase="find.software.detail">{software}. Das ist oft die Firmware-Version des Telefons, und die ist enger gefasst
+      als das Modell allein.</span>
+    <span data-phrase="find.makernote.title">Die Herstellernotiz</span>
+    <span data-phrase="find.makernote.detail">{size} eigener, privater Daten des Herstellers. Sie ist nicht dokumentiert, sie
+      unterscheidet sich je nach Modell, und dort verstecken sich gern Seriennummern,
+      Fokuspunkte und Auslösezählungen.</span>
+    <span data-phrase="find.thumbnail.title">Eine zweite Kopie des Bildes</span>
+    <span data-phrase="find.thumbnail.detail">{size} mit einer kleinen JPEG-Vorschau. Wurde das Foto nach der Aufnahme
+      beschnitten, zeigen manche Programme im Vorschaubild weiterhin den unbeschnittenen
+      Ausschnitt.</span>
+    <span data-phrase="find.xmp.title">Ein XMP-Paket</span>
+    <span data-phrase="find.xmp.detail">{size} XML. Es wiederholt meist die Kamera und die Zeitstempel und fügt die
+      Bearbeitungsgeschichte hinzu: welches Programm, welche Version, und jedes Mal, wenn
+      die Datei gespeichert wurde.</span>
+    <span data-phrase="find.iptc.title">Ein IPTC-Block</span>
+    <span data-phrase="find.iptc.detail">{size} der Felder, die eine Bildredaktion ausfüllt &mdash; Bildnachweis,
+      Bildunterschrift, Ort, Quelle. Kam das aus einer Bildagentur oder einer Redaktion,
+      steht darin wahrscheinlich ein Name.</span>
+    <span data-phrase="find.comment.title">Ein Kommentar</span>
+    <span data-phrase="find.comment.detail">&bdquo;{comment}&ldquo;</span>
+    <span data-phrase="find.text.title">Text: {keyword}</span>
+    <span data-phrase="find.unknown.title">Blöcke, die dieses Werkzeug nicht lesen kann</span>
+    <span data-phrase="find.unknown.detail">{blocks}. Unlesbar ist nicht dasselbe wie leer, also werden auch diese mit allem
+      anderen zusammen entfernt.</span>
     <span data-phrase="read.notjpeg">Das fängt nicht an wie ein JPEG.</span>
     <span data-phrase="read.jpeglost">Die Segmentstruktur ist verloren &mdash; die Datei sieht beschädigt aus.</span>
     <span data-phrase="read.jpegoverrun">Ein Segment nennt eine Länge, die über das Dateiende hinausläuft.</span>

--- a/locales/es/tools/exif-editor.html
+++ b/locales/es/tools/exif-editor.html
@@ -155,6 +155,66 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="find.clean.title">En este archivo no hay nada que te delate</span>
+    <span data-phrase="find.clean.cleared">Todo lo que lo hacía ya se ha quitado. Guarda la foto para escribirla.</span>
+    <span data-phrase="find.clean.never">Ni ubicación, ni fechas, ni cámara, ni nombres. O nunca los tuvo, o algo se los
+      quitó antes.</span>
+    <span data-phrase="find.exifempty.title">Un bloque EXIF sin nada dentro</span>
+    <span data-phrase="find.exifempty.detail">{size} de EXIF que se lee limpio y no contiene ninguna etiqueta. Inofensivo, y se
+      quita junto con todo lo demás.</span>
+    <span data-phrase="find.exifbad.title">Un bloque EXIF que no puede leer nadie</span>
+    <span data-phrase="find.exifbad.detail">Aquí hay EXIF y no se ha podido leer: {reason} Todo lo de abajo es lo que se ha
+      podido leer del resto del archivo, así que trata este bloque como una incógnita, y
+      eso es una razón para quitarlo, no para dejarlo.</span>
+    <span data-phrase="find.gps.title">Dónde se hizo la foto</span>
+    <span data-phrase="find.gps.detail">{position}. Eso es lo bastante preciso como para nombrar un edificio, y viaja con el
+      archivo a cualquier sitio donde lo publiques.</span>
+    <span data-phrase="find.gps.detailalt">{position}, {altitude}. Eso es lo bastante preciso como para nombrar un edificio, y
+      viaja con el archivo a cualquier sitio donde lo publiques.</span>
+    <span data-phrase="find.gpspart.title">Etiquetas de ubicación, sin una posición completa</span>
+    <span data-phrase="find.gpspart.one">Hay una etiqueta GPS, pero sin latitud y longitud utilizables. El rumbo, la altitud
+      y el reloj GPS todavía pueden estar entre ellas.</span>
+    <span data-phrase="find.gpspart.many">Hay {count} etiquetas GPS, pero sin latitud y longitud utilizables. El rumbo, la
+      altitud y el reloj GPS todavía pueden estar entre ellas.</span>
+    <span data-phrase="find.taken.title">Cuándo se hizo</span>
+    <span data-phrase="find.taken.detail">{when}, al segundo. Junto con una ubicación, eso sitúa a una persona en un lugar en
+      un momento concreto.</span>
+    <span data-phrase="find.device.title">El aparato del que salió</span>
+    <span data-phrase="find.device.detail">{device}. Por sí solo es inofensivo; se convierte en un identificador cuando todas
+      las fotos que publicas llevan el mismo.</span>
+    <span data-phrase="find.identity.title">Algo que te nombra a ti o a tu equipo</span>
+    <span data-phrase="find.identity.detail">{found}. Un número de serie ata entre sí todas las fotos de ese cuerpo, las publique
+      quien las publique y donde sea.</span>
+    <span data-phrase="find.id.cameraserial">Número de serie de la cámara</span>
+    <span data-phrase="find.id.lensserial">Número de serie del objetivo</span>
+    <span data-phrase="find.id.owner">Propietario de la cámara</span>
+    <span data-phrase="find.id.uniqueid">Identificador único de la imagen</span>
+    <span data-phrase="find.id.artist">Autor de la toma</span>
+    <span data-phrase="find.id.author">Autor</span>
+    <span data-phrase="find.id.copyright">Derechos de autor</span>
+    <span data-phrase="find.software.title">Qué la editó</span>
+    <span data-phrase="find.software.detail">{software}. Muchas veces es la versión del firmware del móvil, que es algo más
+      concreto de publicar que el modelo a secas.</span>
+    <span data-phrase="find.makernote.title">La nota del fabricante</span>
+    <span data-phrase="find.makernote.detail">{size} de datos privados del propio fabricante. No está documentada, cambia según el
+      modelo, y ahí es donde suelen esconderse números de serie, puntos de enfoque y
+      disparos acumulados.</span>
+    <span data-phrase="find.thumbnail.title">Una segunda copia de la imagen</span>
+    <span data-phrase="find.thumbnail.detail">{size} con una miniatura JPEG. Si la foto se recortó después de que la cámara la
+      escribiera, algunos editores dejan la miniatura mostrando el encuadre sin recortar.</span>
+    <span data-phrase="find.xmp.title">Un paquete XMP</span>
+    <span data-phrase="find.xmp.detail">{size} de XML. Suele repetir la cámara y las fechas, y añade el historial de
+      edición: qué programa, qué versión y cada vez que se guardó el archivo.</span>
+    <span data-phrase="find.iptc.title">Un bloque IPTC</span>
+    <span data-phrase="find.iptc.detail">{size} de los campos que rellena una redacción gráfica: firma, pie de foto, ciudad,
+      crédito. Si esto viene de un banco de imágenes o de un periódico, es probable que
+      dentro haya el nombre de alguien.</span>
+    <span data-phrase="find.comment.title">Un comentario</span>
+    <span data-phrase="find.comment.detail">&laquo;{comment}&raquo;</span>
+    <span data-phrase="find.text.title">Texto: {keyword}</span>
+    <span data-phrase="find.unknown.title">Bloques que esta herramienta no sabe leer</span>
+    <span data-phrase="find.unknown.detail">{blocks}. Ilegible no es lo mismo que vacío, así que estos también se quitan junto
+      con todo lo demás.</span>
     <span data-phrase="read.notjpeg">Esto no empieza como un JPEG.</span>
     <span data-phrase="read.jpeglost">Se perdió la estructura de segmentos: el archivo parece dañado.</span>
     <span data-phrase="read.jpegoverrun">Un segmento declara una longitud que se sale del final del archivo.</span>

--- a/locales/fr/tools/exif-editor.html
+++ b/locales/fr/tools/exif-editor.html
@@ -155,6 +155,67 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="find.clean.title">Rien dans ce fichier ne vous trahit</span>
+    <span data-phrase="find.clean.cleared">Tout ce qui le faisait a été retiré. Enregistrez la photo pour l&rsquo;écrire.</span>
+    <span data-phrase="find.clean.never">Pas de lieu, pas d&rsquo;horodatage, pas d&rsquo;appareil, pas de noms. Ou bien il
+      n&rsquo;y en a jamais eu, ou bien quelque chose les a déjà enlevés.</span>
+    <span data-phrase="find.exifempty.title">Un bloc EXIF sans rien dedans</span>
+    <span data-phrase="find.exifempty.detail">{size} d&rsquo;EXIF qui se lit proprement et ne contient aucune étiquette.
+      Inoffensif, et retiré avec tout le reste.</span>
+    <span data-phrase="find.exifbad.title">Un bloc EXIF que personne ne peut lire</span>
+    <span data-phrase="find.exifbad.detail">Il y a de l&rsquo;EXIF ici et il n&rsquo;a pas pu être lu&nbsp;: {reason} Tout ce
+      qui suit est ce qui a pu être lu du reste du fichier&nbsp;; tenez donc ce bloc-ci
+      pour une inconnue &mdash; ce qui est une raison de le retirer, pas de le garder.</span>
+    <span data-phrase="find.gps.title">Où la photo a été prise</span>
+    <span data-phrase="find.gps.detail">{position}. C&rsquo;est assez précis pour nommer un bâtiment, et cela voyage avec le
+      fichier partout où vous le publiez.</span>
+    <span data-phrase="find.gps.detailalt">{position}, {altitude}. C&rsquo;est assez précis pour nommer un bâtiment, et cela
+      voyage avec le fichier partout où vous le publiez.</span>
+    <span data-phrase="find.gpspart.title">Des étiquettes de lieu, sans position complète</span>
+    <span data-phrase="find.gpspart.one">Une étiquette GPS est là, mais sans latitude ni longitude exploitables. Le cap,
+      l&rsquo;altitude et l&rsquo;horloge GPS peuvent tout de même s&rsquo;y trouver.</span>
+    <span data-phrase="find.gpspart.many">{count} étiquettes GPS sont là, mais sans latitude ni longitude exploitables. Le
+      cap, l&rsquo;altitude et l&rsquo;horloge GPS peuvent tout de même s&rsquo;y trouver.</span>
+    <span data-phrase="find.taken.title">Quand elle a été prise</span>
+    <span data-phrase="find.taken.detail">{when}, à la seconde près. Avec un lieu, cela place quelqu&rsquo;un quelque part à
+      un moment précis.</span>
+    <span data-phrase="find.device.title">L&rsquo;appareil d&rsquo;où elle vient</span>
+    <span data-phrase="find.device.detail">{device}. Anodin en soi&nbsp;; cela devient un identifiant quand chaque photo que
+      vous publiez porte le même.</span>
+    <span data-phrase="find.identity.title">Quelque chose qui vous nomme, vous ou votre matériel</span>
+    <span data-phrase="find.identity.detail">{found}. Un numéro de série relie entre elles toutes les photos sorties de ce
+      boîtier, qui que ce soit qui les ait publiées et où que ce soit.</span>
+    <span data-phrase="find.id.cameraserial">Numéro de série du boîtier</span>
+    <span data-phrase="find.id.lensserial">Numéro de série de l&rsquo;objectif</span>
+    <span data-phrase="find.id.owner">Propriétaire de l&rsquo;appareil</span>
+    <span data-phrase="find.id.uniqueid">Identifiant unique de l&rsquo;image</span>
+    <span data-phrase="find.id.artist">Auteur de la prise de vue</span>
+    <span data-phrase="find.id.author">Auteur</span>
+    <span data-phrase="find.id.copyright">Droits d&rsquo;auteur</span>
+    <span data-phrase="find.software.title">Ce qui l&rsquo;a modifiée</span>
+    <span data-phrase="find.software.detail">{software}. C&rsquo;est souvent la version du micrologiciel du téléphone, ce qui est
+      plus étroit à publier que le modèle seul.</span>
+    <span data-phrase="find.makernote.title">La note du fabricant</span>
+    <span data-phrase="find.makernote.detail">{size} de données privées propres au fabricant. Elle n&rsquo;est pas documentée,
+      elle change d&rsquo;un modèle à l&rsquo;autre, et c&rsquo;est là que se cachent
+      volontiers numéros de série, points de mise au point et compteurs de déclenchements.</span>
+    <span data-phrase="find.thumbnail.title">Une deuxième copie de l&rsquo;image</span>
+    <span data-phrase="find.thumbnail.detail">{size} contenant un petit aperçu JPEG. Si la photo a été recadrée après la prise de
+      vue, certains logiciels laissent la vignette montrer le cadrage d&rsquo;origine.</span>
+    <span data-phrase="find.xmp.title">Un paquet XMP</span>
+    <span data-phrase="find.xmp.detail">{size} de XML. Il répète en général l&rsquo;appareil et les horodatages, et y ajoute
+      l&rsquo;historique des retouches&nbsp;: quel logiciel, quelle version, et chaque
+      enregistrement du fichier.</span>
+    <span data-phrase="find.iptc.title">Un bloc IPTC</span>
+    <span data-phrase="find.iptc.detail">{size} des champs que remplit un service photo &mdash; signature, légende, ville,
+      crédit. Si cela vient d&rsquo;une banque d&rsquo;images ou d&rsquo;une rédaction, il
+      y a probablement le nom de quelqu&rsquo;un dedans.</span>
+    <span data-phrase="find.comment.title">Un commentaire</span>
+    <span data-phrase="find.comment.detail">&laquo;&nbsp;{comment}&nbsp;&raquo;</span>
+    <span data-phrase="find.text.title">Texte&nbsp;: {keyword}</span>
+    <span data-phrase="find.unknown.title">Des blocs que cet outil ne sait pas lire</span>
+    <span data-phrase="find.unknown.detail">{blocks}. Illisible n&rsquo;est pas la même chose que vide&nbsp;: ceux-là sont
+      retirés avec tout le reste.</span>
     <span data-phrase="read.notjpeg">Cela ne commence pas comme un JPEG.</span>
     <span data-phrase="read.jpeglost">La structure des segments est perdue &mdash; le fichier semble abîmé.</span>
     <span data-phrase="read.jpegoverrun">Un segment annonce une longueur qui dépasse la fin du fichier.</span>

--- a/locales/hi/tools/exif-editor.html
+++ b/locales/hi/tools/exif-editor.html
@@ -155,6 +155,65 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="find.clean.title">इस फ़ाइल में ऐसा कुछ नहीं जो आपको ज़ाहिर करे</span>
+    <span data-phrase="find.clean.cleared">जो कुछ ज़ाहिर करता था, वह सब हटा दिया गया है। इसे फ़ाइल में लिखने के लिए फ़ोटो
+      सहेजिए।</span>
+    <span data-phrase="find.clean.never">न जगह, न समय, न कैमरा, न नाम। या तो ये कभी थे ही नहीं, या किसी ने पहले ही हटा दिए।</span>
+    <span data-phrase="find.exifempty.title">एक EXIF ब्लॉक जिसमें कुछ है ही नहीं</span>
+    <span data-phrase="find.exifempty.detail">{size} का EXIF, जो साफ़-साफ़ पढ़ा जाता है और जिसमें एक भी टैग नहीं। बेज़रर, और बाक़ी
+      सबके साथ हटा दिया जाता है।</span>
+    <span data-phrase="find.exifbad.title">एक EXIF ब्लॉक जिसे कोई नहीं पढ़ सकता</span>
+    <span data-phrase="find.exifbad.detail">यहाँ EXIF है और वह पढ़ा नहीं जा सका: {reason} नीचे जो कुछ है, वह फ़ाइल के बाक़ी
+      हिस्से से जितना पढ़ा जा सका उतना है। इसलिए इस ब्लॉक को अनजानी चीज़ मानिए &mdash; और
+      यह इसे रहने देने की नहीं, हटाने की वजह है।</span>
+    <span data-phrase="find.gps.title">फ़ोटो कहाँ ली गई</span>
+    <span data-phrase="find.gps.detail">{position}। यह इतना सटीक है कि इमारत तक बताई जा सके, और आप जहाँ भी इसे डालें, यह
+      फ़ाइल के साथ वहीं चला जाता है।</span>
+    <span data-phrase="find.gps.detailalt">{position}, {altitude}। यह इतना सटीक है कि इमारत तक बताई जा सके, और आप जहाँ भी इसे
+      डालें, यह फ़ाइल के साथ वहीं चला जाता है।</span>
+    <span data-phrase="find.gpspart.title">जगह के टैग हैं, पर पूरी स्थिति नहीं</span>
+    <span data-phrase="find.gpspart.one">यहाँ एक GPS टैग है, पर काम लायक अक्षांश-देशांतर नहीं। चलने की दिशा, ऊँचाई और GPS की
+      घड़ी फिर भी इन्हीं में हो सकती है।</span>
+    <span data-phrase="find.gpspart.many">यहाँ {count} GPS टैग हैं, पर काम लायक अक्षांश-देशांतर नहीं। चलने की दिशा, ऊँचाई और
+      GPS की घड़ी फिर भी इन्हीं में हो सकती है।</span>
+    <span data-phrase="find.taken.title">कब ली गई</span>
+    <span data-phrase="find.taken.detail">{when}, सेकंड तक। किसी जगह के साथ मिलकर यह किसी व्यक्ति को एक ख़ास पल में एक ख़ास
+      जगह पर रख देता है।</span>
+    <span data-phrase="find.device.title">किस डिवाइस से आई</span>
+    <span data-phrase="find.device.detail">{device}। अकेले में यह बेज़रर है; पर आपकी डाली हुई हर फ़ोटो पर वही एक चीज़ हो, तो वह
+      पहचान का निशान बन जाती है।</span>
+    <span data-phrase="find.identity.title">कुछ जो आपका या आपके साज़ो-सामान का नाम लेता है</span>
+    <span data-phrase="find.identity.detail">{found}। एक सीरियल नंबर उस बॉडी से निकली हर फ़ोटो को आपस में बाँध देता है &mdash;
+      चाहे किसी ने भी डाली हो और कहीं भी डाली हो।</span>
+    <span data-phrase="find.id.cameraserial">कैमरे का सीरियल नंबर</span>
+    <span data-phrase="find.id.lensserial">लेंस का सीरियल नंबर</span>
+    <span data-phrase="find.id.owner">कैमरे का मालिक</span>
+    <span data-phrase="find.id.uniqueid">तस्वीर की अद्वितीय आईडी</span>
+    <span data-phrase="find.id.artist">फ़ोटो लेने वाला</span>
+    <span data-phrase="find.id.author">लेखक</span>
+    <span data-phrase="find.id.copyright">कॉपीराइट</span>
+    <span data-phrase="find.software.title">इसे किसने संपादित किया</span>
+    <span data-phrase="find.software.detail">{software}। यह अक्सर फ़ोन के फ़र्मवेयर का संस्करण होता है, और सिर्फ़ मॉडल बताने से
+      यह ज़्यादा सँकरी बात है।</span>
+    <span data-phrase="find.makernote.title">मेकर नोट</span>
+    <span data-phrase="find.makernote.detail">{size} का, बनाने वाली कंपनी का अपना निजी डेटा। इसका कोई दस्तावेज़ नहीं, हर मॉडल में
+      अलग होता है, और सीरियल नंबर, फ़ोकस बिंदु और शटर की गिनती यहीं छिपे मिलते हैं।</span>
+    <span data-phrase="find.thumbnail.title">तस्वीर की दूसरी नक़ल</span>
+    <span data-phrase="find.thumbnail.detail">{size}, जिसमें एक छोटा JPEG पूर्वावलोकन है। कैमरे के लिखने के बाद अगर फ़ोटो काटी गई
+      हो, तो कुछ संपादक थंबनेल में बिना कटा फ़्रेम ही दिखाते रह जाते हैं।</span>
+    <span data-phrase="find.xmp.title">एक XMP पैकेट</span>
+    <span data-phrase="find.xmp.detail">{size} का XML। यह आम तौर पर कैमरा और समय दोहराता है, और साथ में संपादन का इतिहास
+      जोड़ देता है: कौन-सा प्रोग्राम, कौन-सा संस्करण, और फ़ाइल हर बार कब सहेजी गई।</span>
+    <span data-phrase="find.iptc.title">एक IPTC ब्लॉक</span>
+    <span data-phrase="find.iptc.detail">{size}, यानी वे ख़ाने जो कोई फ़ोटो डेस्क भरता है &mdash; श्रेय, कैप्शन, शहर, स्रोत।
+      अगर यह किसी स्टॉक लाइब्रेरी या न्यूज़रूम से आई है, तो इसमें किसी का नाम होने की पूरी
+      संभावना है।</span>
+    <span data-phrase="find.comment.title">एक टिप्पणी</span>
+    <span data-phrase="find.comment.detail">&ldquo;{comment}&rdquo;</span>
+    <span data-phrase="find.text.title">पाठ: {keyword}</span>
+    <span data-phrase="find.unknown.title">वे ब्लॉक जिन्हें यह औज़ार नहीं पढ़ सकता</span>
+    <span data-phrase="find.unknown.detail">{blocks}। न पढ़ पाना और ख़ाली होना एक बात नहीं, इसलिए ये भी बाक़ी सबके साथ हटा दिए
+      जाते हैं।</span>
     <span data-phrase="read.notjpeg">इसकी शुरुआत JPEG जैसी नहीं है।</span>
     <span data-phrase="read.jpeglost">सेगमेंट का ढाँचा टूट गया, फ़ाइल ख़राब लगती है।</span>
     <span data-phrase="read.jpegoverrun">एक सेगमेंट ऐसी लंबाई बता रहा है जो फ़ाइल के अंत से आगे निकल जाती है।</span>

--- a/locales/id/tools/exif-editor.html
+++ b/locales/id/tools/exif-editor.html
@@ -161,6 +161,67 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="find.clean.title">Tidak ada apa pun di file ini yang membocorkan Anda</span>
+    <span data-phrase="find.clean.cleared">Semua yang tadinya membocorkan sudah dibuang. Simpan fotonya untuk menuliskannya.</span>
+    <span data-phrase="find.clean.never">Tidak ada lokasi, tidak ada waktu, tidak ada kamera, tidak ada nama. Entah memang
+      tidak pernah ada, entah sudah ada yang membersihkannya.</span>
+    <span data-phrase="find.exifempty.title">Blok EXIF yang isinya kosong</span>
+    <span data-phrase="find.exifempty.detail">{size} EXIF yang terbaca bersih dan tidak memuat satu tag pun. Tidak berbahaya, dan
+      dibuang bersama yang lain.</span>
+    <span data-phrase="find.exifbad.title">Blok EXIF yang tidak bisa dibaca siapa pun</span>
+    <span data-phrase="find.exifbad.detail">Ada EXIF di sini dan ia tidak bisa dibaca: {reason} Semua yang di bawah adalah
+      bagian file yang masih terbaca, jadi anggap blok yang satu ini sebagai barang tak
+      dikenal &mdash; dan itu alasan untuk membuangnya, bukan untuk membiarkannya.</span>
+    <span data-phrase="find.gps.title">Di mana foto ini diambil</span>
+    <span data-phrase="find.gps.detail">{position}. Itu cukup persis untuk menyebut sebuah gedung, dan ia ikut jalan bersama
+      file-nya ke mana pun Anda mengunggahnya.</span>
+    <span data-phrase="find.gps.detailalt">{position}, {altitude}. Itu cukup persis untuk menyebut sebuah gedung, dan ia ikut
+      jalan bersama file-nya ke mana pun Anda mengunggahnya.</span>
+    <span data-phrase="find.gpspart.title">Tag lokasi, tanpa posisi yang utuh</span>
+    <span data-phrase="find.gpspart.one">Ada satu tag GPS di sini tapi tanpa lintang dan bujur yang bisa dipakai. Arah gerak,
+      ketinggian dan jam GPS masih bisa ada di antaranya.</span>
+    <span data-phrase="find.gpspart.many">Ada {count} tag GPS di sini tapi tanpa lintang dan bujur yang bisa dipakai. Arah
+      gerak, ketinggian dan jam GPS masih bisa ada di antaranya.</span>
+    <span data-phrase="find.taken.title">Kapan foto ini diambil</span>
+    <span data-phrase="find.taken.detail">{when}, sampai ke detiknya. Digabung dengan lokasi, itu menaruh seseorang di suatu
+      tempat pada saat tertentu.</span>
+    <span data-phrase="find.device.title">Alat yang menghasilkannya</span>
+    <span data-phrase="find.device.detail">{device}. Sendirian ia tidak berbahaya; ia jadi penanda begitu semua foto yang Anda
+      unggah membawa yang sama.</span>
+    <span data-phrase="find.identity.title">Sesuatu yang menyebut nama Anda atau perkakas Anda</span>
+    <span data-phrase="find.identity.detail">{found}. Sebuah nomor seri mengikat semua foto dari bodi itu jadi satu, siapa pun
+      yang mengunggahnya dan di mana pun.</span>
+    <span data-phrase="find.id.cameraserial">Nomor seri kamera</span>
+    <span data-phrase="find.id.lensserial">Nomor seri lensa</span>
+    <span data-phrase="find.id.owner">Pemilik kamera</span>
+    <span data-phrase="find.id.uniqueid">ID unik gambar</span>
+    <span data-phrase="find.id.artist">Pemotret</span>
+    <span data-phrase="find.id.author">Penulis</span>
+    <span data-phrase="find.id.copyright">Hak cipta</span>
+    <span data-phrase="find.software.title">Apa yang menyuntingnya</span>
+    <span data-phrase="find.software.detail">{software}. Ini sering kali versi firmware ponselnya, dan itu hal yang lebih sempit
+      untuk diumumkan daripada modelnya saja.</span>
+    <span data-phrase="find.makernote.title">Catatan pabrikan</span>
+    <span data-phrase="find.makernote.detail">{size} data pribadi milik pabrikannya sendiri. Tidak ada dokumentasinya, isinya
+      beda-beda menurut model, dan di situlah nomor seri, titik fokus dan hitungan
+      jepretan suka bersembunyi.</span>
+    <span data-phrase="find.thumbnail.title">Salinan kedua dari gambarnya</span>
+    <span data-phrase="find.thumbnail.detail">{size} berisi pratinjau JPEG kecil. Kalau fotonya dipotong setelah kameranya menulis
+      file itu, sebagian penyunting membiarkan gambar mininya tetap menampilkan bingkai
+      yang belum dipotong.</span>
+    <span data-phrase="find.xmp.title">Paket XMP</span>
+    <span data-phrase="find.xmp.detail">{size} XML. Biasanya ia mengulang kamera dan waktunya, lalu menambahkan riwayat
+      penyuntingan: program mana, versi berapa, dan setiap kali file itu disimpan.</span>
+    <span data-phrase="find.iptc.title">Blok IPTC</span>
+    <span data-phrase="find.iptc.detail">{size} berisi kolom-kolom yang diisi meja foto: nama pemotret, teks foto, kota,
+      kredit. Kalau ini datang dari bank gambar atau ruang redaksi, besar kemungkinan ada
+      nama orang di dalamnya.</span>
+    <span data-phrase="find.comment.title">Sebuah komentar</span>
+    <span data-phrase="find.comment.detail">&ldquo;{comment}&rdquo;</span>
+    <span data-phrase="find.text.title">Teks: {keyword}</span>
+    <span data-phrase="find.unknown.title">Blok yang tidak bisa dibaca alat ini</span>
+    <span data-phrase="find.unknown.detail">{blocks}. Tidak terbaca bukan berarti kosong, jadi yang ini pun ikut dibuang bersama
+      yang lain.</span>
     <span data-phrase="read.notjpeg">Ini tidak dimulai seperti sebuah JPEG.</span>
     <span data-phrase="read.jpeglost">Struktur segmennya hilang &mdash; berkasnya tampak rusak.</span>
     <span data-phrase="read.jpegoverrun">Sebuah segmen mengaku punya panjang yang melewati ujung file.</span>

--- a/locales/it/tools/exif-editor.html
+++ b/locales/it/tools/exif-editor.html
@@ -155,6 +155,70 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="find.clean.title">In questo file non c&rsquo;è niente che ti tradisca</span>
+    <span data-phrase="find.clean.cleared">Tutto quello che lo faceva è stato tolto. Salva la foto per scriverla fuori.</span>
+    <span data-phrase="find.clean.never">Nessun luogo, nessuna data, nessuna macchina, nessun nome. O non ce ne sono mai
+      stati, o qualcosa li ha già tolti.</span>
+    <span data-phrase="find.exifempty.title">Un blocco EXIF senza niente dentro</span>
+    <span data-phrase="find.exifempty.detail">{size} di EXIF che si legge pulito e non contiene alcun tag. Innocuo, e viene tolto
+      insieme a tutto il resto.</span>
+    <span data-phrase="find.exifbad.title">Un blocco EXIF che non riesce a leggere nessuno</span>
+    <span data-phrase="find.exifbad.detail">Qui c&rsquo;è dell&rsquo;EXIF e non si è riusciti a leggerlo: {reason} Tutto quello
+      che segue è ciò che si è potuto leggere del resto del file, quindi prendi questo
+      blocco come un&rsquo;incognita &mdash; il che è una ragione per toglierlo, non per
+      lasciarlo.</span>
+    <span data-phrase="find.gps.title">Dove è stata scattata la foto</span>
+    <span data-phrase="find.gps.detail">{position}. È preciso abbastanza da nominare un edificio, e viaggia insieme al file
+      dovunque tu lo pubblichi.</span>
+    <span data-phrase="find.gps.detailalt">{position}, {altitude}. È preciso abbastanza da nominare un edificio, e viaggia
+      insieme al file dovunque tu lo pubblichi.</span>
+    <span data-phrase="find.gpspart.title">Tag di posizione, senza una posizione completa</span>
+    <span data-phrase="find.gpspart.one">C&rsquo;è un tag GPS ma nessuna latitudine e longitudine utilizzabile. La direzione
+      di marcia, la quota e l&rsquo;orologio GPS possono comunque essere lì in mezzo.</span>
+    <span data-phrase="find.gpspart.many">Ci sono {count} tag GPS ma nessuna latitudine e longitudine utilizzabile. La
+      direzione di marcia, la quota e l&rsquo;orologio GPS possono comunque essere lì in
+      mezzo.</span>
+    <span data-phrase="find.taken.title">Quando è stata scattata</span>
+    <span data-phrase="find.taken.detail">{when}, al secondo. Insieme a un luogo questo mette una persona da qualche parte in
+      un momento preciso.</span>
+    <span data-phrase="find.device.title">L&rsquo;apparecchio da cui è uscita</span>
+    <span data-phrase="find.device.detail">{device}. Da solo è innocuo; diventa un identificativo quando ogni foto che
+      pubblichi porta lo stesso.</span>
+    <span data-phrase="find.identity.title">Qualcosa che nomina te o la tua attrezzatura</span>
+    <span data-phrase="find.identity.detail">{found}. Un numero di serie lega insieme ogni foto uscita da quel corpo macchina,
+      chiunque le abbia pubblicate e dovunque.</span>
+    <span data-phrase="find.id.cameraserial">Numero di serie della macchina</span>
+    <span data-phrase="find.id.lensserial">Numero di serie dell&rsquo;obiettivo</span>
+    <span data-phrase="find.id.owner">Proprietario della macchina</span>
+    <span data-phrase="find.id.uniqueid">Identificativo univoco dell&rsquo;immagine</span>
+    <span data-phrase="find.id.artist">Autore dello scatto</span>
+    <span data-phrase="find.id.author">Autore</span>
+    <span data-phrase="find.id.copyright">Copyright</span>
+    <span data-phrase="find.software.title">Che cosa l&rsquo;ha modificata</span>
+    <span data-phrase="find.software.detail">{software}. Spesso è la versione del firmware del telefono, che è una cosa più
+      stretta da pubblicare del modello e basta.</span>
+    <span data-phrase="find.makernote.title">La nota del produttore</span>
+    <span data-phrase="find.makernote.detail">{size} di dati privati del produttore stesso. Non è documentata, cambia da modello a
+      modello, ed è lì che tendono a nascondersi numeri di serie, punti di messa a fuoco e
+      conteggi degli scatti.</span>
+    <span data-phrase="find.thumbnail.title">Una seconda copia dell&rsquo;immagine</span>
+    <span data-phrase="find.thumbnail.detail">{size} che contengono una piccola anteprima JPEG. Se la foto è stata ritagliata dopo
+      che la macchina l&rsquo;ha scritta, certi programmi lasciano la miniatura che mostra
+      ancora l&rsquo;inquadratura intera.</span>
+    <span data-phrase="find.xmp.title">Un pacchetto XMP</span>
+    <span data-phrase="find.xmp.detail">{size} di XML. Di solito ripete la macchina e le date, e aggiunge la storia delle
+      modifiche: quale programma, quale versione, e ogni volta che il file è stato
+      salvato.</span>
+    <span data-phrase="find.iptc.title">Un blocco IPTC</span>
+    <span data-phrase="find.iptc.detail">{size} dei campi che compila una redazione fotografica: firma, didascalia, città,
+      credito. Se questo viene da un archivio fotografico o da un giornale, è probabile
+      che dentro ci sia il nome di qualcuno.</span>
+    <span data-phrase="find.comment.title">Un commento</span>
+    <span data-phrase="find.comment.detail">&laquo;{comment}&raquo;</span>
+    <span data-phrase="find.text.title">Testo: {keyword}</span>
+    <span data-phrase="find.unknown.title">Blocchi che questo strumento non sa leggere</span>
+    <span data-phrase="find.unknown.detail">{blocks}. Illeggibile non è la stessa cosa di vuoto, quindi anche questi vengono
+      tolti insieme a tutto il resto.</span>
     <span data-phrase="read.notjpeg">Questo non comincia come un JPEG.</span>
     <span data-phrase="read.jpeglost">La struttura dei segmenti è andata persa: il file sembra danneggiato.</span>
     <span data-phrase="read.jpegoverrun">Un segmento dichiara una lunghezza che sfora la fine del file.</span>

--- a/locales/ja/tools/exif-editor.html
+++ b/locales/ja/tools/exif-editor.html
@@ -143,6 +143,47 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="find.clean.title">このファイルから漏れるものはありません</span>
+    <span data-phrase="find.clean.cleared">漏れていたものはすべて取り除きました。写真を保存すれば、その形で書き出します。</span>
+    <span data-phrase="find.clean.never">場所も、日時も、カメラも、名前もありません。もともとなかったか、何かがすでに取り除いたかのどちらかです。</span>
+    <span data-phrase="find.exifempty.title">中身のないEXIFブロック</span>
+    <span data-phrase="find.exifempty.detail">EXIFが{size}。きれいに読めますが、タグは1つも入っていません。害はなく、ほかのものと一緒に取り除かれます。</span>
+    <span data-phrase="find.exifbad.title">誰にも読めないEXIFブロック</span>
+    <span data-phrase="find.exifbad.detail">ここにEXIFがあり、読めませんでした。{reason} 以下はファイルの残りから読み取れた分です。ですからこのブロックは中身の分からないものとして扱ってください。それは残す理由ではなく、取り除く理由です。</span>
+    <span data-phrase="find.gps.title">写真が撮られた場所</span>
+    <span data-phrase="find.gps.detail">{position}。建物を名指しできるほどの精度で、どこに上げてもファイルについて回ります。</span>
+    <span data-phrase="find.gps.detailalt">{position}、{altitude}。建物を名指しできるほどの精度で、どこに上げてもファイルについて回ります。</span>
+    <span data-phrase="find.gpspart.title">位置のタグはあるが、座標がそろっていない</span>
+    <span data-phrase="find.gpspart.one">GPSタグが1つありますが、使える緯度と経度はありません。それでも進行方向や高度、GPSの時刻はこの中にありえます。</span>
+    <span data-phrase="find.gpspart.many">GPSタグが{count}個ありますが、使える緯度と経度はありません。それでも進行方向や高度、GPSの時刻はこの中にありえます。</span>
+    <span data-phrase="find.taken.title">いつ撮られたか</span>
+    <span data-phrase="find.taken.detail">{when}、秒まで。場所と合わされば、ある人がある瞬間にどこにいたかになります。</span>
+    <span data-phrase="find.device.title">どの機械から出てきたか</span>
+    <span data-phrase="find.device.detail">{device}。それだけなら害はありませんが、上げる写真がどれも同じものを抱えていると、身元を示す印になります。</span>
+    <span data-phrase="find.identity.title">あなたや機材を名指しするもの</span>
+    <span data-phrase="find.identity.detail">{found}。シリアル番号は、その個体から出た写真をすべて結びつけます。誰が上げたものでも、どこに上げたものでも同じです。</span>
+    <span data-phrase="find.id.cameraserial">カメラのシリアル番号</span>
+    <span data-phrase="find.id.lensserial">レンズのシリアル番号</span>
+    <span data-phrase="find.id.owner">カメラの所有者</span>
+    <span data-phrase="find.id.uniqueid">画像固有ID</span>
+    <span data-phrase="find.id.artist">撮影者</span>
+    <span data-phrase="find.id.author">作成者</span>
+    <span data-phrase="find.id.copyright">著作権表示</span>
+    <span data-phrase="find.software.title">何が手を加えたか</span>
+    <span data-phrase="find.software.detail">{software}。多くはスマホのファームウェアの版で、機種だけを公表するよりも絞り込まれた情報です。</span>
+    <span data-phrase="find.makernote.title">メーカーノート</span>
+    <span data-phrase="find.makernote.detail">メーカー独自の非公開データが{size}。仕様は公開されておらず、機種によって中身が違い、シリアル番号やピント位置、シャッター回数が潜んでいがちなところです。</span>
+    <span data-phrase="find.thumbnail.title">写真のもう1枚のコピー</span>
+    <span data-phrase="find.thumbnail.detail">小さなJPEGのプレビューが入った{size}。カメラが書き出したあとに写真を切り抜いた場合、ソフトによってはサムネイルが切り抜く前の画のままになります。</span>
+    <span data-phrase="find.xmp.title">XMPパケット</span>
+    <span data-phrase="find.xmp.detail">XMLが{size}。たいていはカメラと日時を繰り返し、そこに編集の履歴を足します。どのソフトか、どの版か、そしてファイルを保存したすべての回です。</span>
+    <span data-phrase="find.iptc.title">IPTCブロック</span>
+    <span data-phrase="find.iptc.detail">写真部が埋める項目が{size}。クレジット、説明文、都市、提供元です。ストックフォトや報道の現場から来たものなら、誰かの名前が入っている見込みが高いです。</span>
+    <span data-phrase="find.comment.title">コメント</span>
+    <span data-phrase="find.comment.detail">「{comment}」</span>
+    <span data-phrase="find.text.title">テキスト：{keyword}</span>
+    <span data-phrase="find.unknown.title">この道具に読めないブロック</span>
+    <span data-phrase="find.unknown.detail">{blocks}。読めないことと空であることは違うので、これらもほかのものと一緒に取り除かれます。</span>
     <span data-phrase="read.notjpeg">これはJPEGの始まり方をしていません。</span>
     <span data-phrase="read.jpeglost">セグメントの並びが途切れました。ファイルが壊れているようです。</span>
     <span data-phrase="read.jpegoverrun">あるセグメントが、ファイルの終わりを越える長さを名乗っています。</span>

--- a/locales/ko/tools/exif-editor.html
+++ b/locales/ko/tools/exif-editor.html
@@ -154,6 +154,50 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="find.clean.title">이 파일에는 흘릴 것이 없습니다</span>
+    <span data-phrase="find.clean.cleared">흘리던 것은 모두 지웠습니다. 사진을 저장하면 그대로 파일에 씁니다.</span>
+    <span data-phrase="find.clean.never">위치도, 시각도, 카메라도, 이름도 없습니다. 처음부터 없었거나, 이미 무언가가 지웠습니다.</span>
+    <span data-phrase="find.exifempty.title">안에 아무것도 없는 EXIF 블록</span>
+    <span data-phrase="find.exifempty.detail">EXIF {size}. 깨끗하게 읽히지만 태그가 하나도 없습니다. 해롭지 않고, 나머지와 함께 지워집니다.</span>
+    <span data-phrase="find.exifbad.title">아무도 읽지 못하는 EXIF 블록</span>
+    <span data-phrase="find.exifbad.detail">여기 EXIF가 있는데 읽히지 않았습니다. {reason} 아래에 있는 것은 파일의 나머지에서 읽어낸 것입니다. 그러니 이 블록은 정체를 모르는 것으로
+      치세요. 그것이 남길 이유가 아니라 지울 이유입니다.</span>
+    <span data-phrase="find.gps.title">사진을 찍은 곳</span>
+    <span data-phrase="find.gps.detail">{position}. 건물 하나를 짚을 만큼 정확하고, 어디에 올리든 파일을 따라 함께 갑니다.</span>
+    <span data-phrase="find.gps.detailalt">{position}, {altitude}. 건물 하나를 짚을 만큼 정확하고, 어디에 올리든 파일을 따라 함께 갑니다.</span>
+    <span data-phrase="find.gpspart.title">위치 태그는 있지만 좌표는 온전하지 않음</span>
+    <span data-phrase="find.gpspart.one">GPS 태그가 하나 있지만 쓸 만한 위도와 경도가 없습니다. 이동 방향, 고도, GPS 시계는 그래도 그 안에 있을 수 있습니다.</span>
+    <span data-phrase="find.gpspart.many">GPS 태그가 {count}개 있지만 쓸 만한 위도와 경도가 없습니다. 이동 방향, 고도, GPS 시계는 그래도 그 안에 있을 수 있습니다.</span>
+    <span data-phrase="find.taken.title">찍은 때</span>
+    <span data-phrase="find.taken.detail">{when}, 초 단위까지. 위치와 합쳐지면 어떤 사람이 어느 순간 어디에 있었는지가 됩니다.</span>
+    <span data-phrase="find.device.title">어느 기기에서 나왔는지</span>
+    <span data-phrase="find.device.detail">{device}. 그 자체로는 해롭지 않지만, 올리는 사진마다 같은 것이 붙어 있으면 식별자가 됩니다.</span>
+    <span data-phrase="find.identity.title">당신이나 당신 장비를 가리키는 것</span>
+    <span data-phrase="find.identity.detail">{found}. 일련번호는 그 바디에서 나온 모든 사진을 하나로 묶습니다. 누가 올렸든, 어디에 올렸든 마찬가지입니다.</span>
+    <span data-phrase="find.id.cameraserial">카메라 일련번호</span>
+    <span data-phrase="find.id.lensserial">렌즈 일련번호</span>
+    <span data-phrase="find.id.owner">카메라 소유자</span>
+    <span data-phrase="find.id.uniqueid">이미지 고유 ID</span>
+    <span data-phrase="find.id.artist">촬영자</span>
+    <span data-phrase="find.id.author">작성자</span>
+    <span data-phrase="find.id.copyright">저작권</span>
+    <span data-phrase="find.software.title">무엇으로 편집했는지</span>
+    <span data-phrase="find.software.detail">{software}. 흔히 휴대폰의 펌웨어 버전이고, 그것은 기종만 밝히는 것보다 더 좁혀진 정보입니다.</span>
+    <span data-phrase="find.makernote.title">제조사 노트</span>
+    <span data-phrase="find.makernote.detail">제조사가 제 마음대로 쓴 비공개 데이터 {size}. 문서로 공개된 적이 없고 기종마다 다르며, 일련번호와 초점 위치와 셔터 횟수가 숨어 있기 좋은
+      곳입니다.</span>
+    <span data-phrase="find.thumbnail.title">사진의 두 번째 사본</span>
+    <span data-phrase="find.thumbnail.detail">작은 JPEG 미리보기가 담긴 {size}. 카메라가 파일을 쓴 뒤에 사진을 잘랐다면, 일부 편집기는 썸네일에 자르기 전 화면을 그대로 남겨 둡니다.</span>
+    <span data-phrase="find.xmp.title">XMP 패킷</span>
+    <span data-phrase="find.xmp.detail">XML {size}. 보통 카메라와 시각을 다시 적고, 거기에 편집 이력을 더합니다. 어떤 프로그램, 어떤 버전, 그리고 파일을 저장한 모든 순간까지.</span>
+    <span data-phrase="find.iptc.title">IPTC 블록</span>
+    <span data-phrase="find.iptc.detail">사진 데스크가 채우는 항목 {size}. 크레딧, 설명, 도시, 출처 같은 것들입니다. 스톡 사진 회사나 편집국에서 온 파일이라면 누군가의 이름이 들어
+      있을 가능성이 큽니다.</span>
+    <span data-phrase="find.comment.title">주석</span>
+    <span data-phrase="find.comment.detail">&ldquo;{comment}&rdquo;</span>
+    <span data-phrase="find.text.title">텍스트: {keyword}</span>
+    <span data-phrase="find.unknown.title">이 도구가 읽지 못하는 블록</span>
+    <span data-phrase="find.unknown.detail">{blocks}. 읽지 못한다는 것과 비어 있다는 것은 다릅니다. 그래서 이 블록도 나머지와 함께 지워집니다.</span>
     <span data-phrase="read.notjpeg">이 파일은 JPEG처럼 시작하지 않습니다.</span>
     <span data-phrase="read.jpeglost">세그먼트 구조가 어긋났습니다. 파일이 손상된 것 같습니다.</span>
     <span data-phrase="read.jpegoverrun">어떤 세그먼트가 파일 끝을 넘어가는 길이를 적어 두었습니다.</span>

--- a/locales/nl/tools/exif-editor.html
+++ b/locales/nl/tools/exif-editor.html
@@ -155,6 +155,68 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="find.clean.title">Er zit niets in dit bestand dat iets verraadt</span>
+    <span data-phrase="find.clean.cleared">Alles wat dat wel deed is eruit. Sla de foto op om het weg te schrijven.</span>
+    <span data-phrase="find.clean.never">Geen locatie, geen tijdstempels, geen camera, geen namen. Of ze zaten er nooit in,
+      of iets heeft ze er al uit gehaald.</span>
+    <span data-phrase="find.exifempty.title">Een EXIF-blok met niets erin</span>
+    <span data-phrase="find.exifempty.detail">{size} EXIF dat netjes leest en geen enkele tag bevat. Onschuldig, en gaat er samen
+      met al het andere uit.</span>
+    <span data-phrase="find.exifbad.title">Een EXIF-blok dat niemand kan lezen</span>
+    <span data-phrase="find.exifbad.detail">Er zit hier EXIF en het liet zich niet lezen: {reason} Alles hieronder is wat er van
+      de rest van het bestand te lezen viel, dus beschouw dit blok als een onbekende
+      &mdash; en dat is een reden om het eruit te halen, niet om het te laten zitten.</span>
+    <span data-phrase="find.gps.title">Waar de foto gemaakt is</span>
+    <span data-phrase="find.gps.detail">{position}. Dat is nauwkeurig genoeg om een gebouw aan te wijzen, en het reist met
+      het bestand mee naar alles waar je het op zet.</span>
+    <span data-phrase="find.gps.detailalt">{position}, {altitude}. Dat is nauwkeurig genoeg om een gebouw aan te wijzen, en het
+      reist met het bestand mee naar alles waar je het op zet.</span>
+    <span data-phrase="find.gpspart.title">Locatietags, zonder volledige positie</span>
+    <span data-phrase="find.gpspart.one">Er zit één GPS-tag in, maar geen bruikbare lengte- en breedtegraad.
+      Bewegingsrichting, hoogte en de GPS-klok kunnen er nog steeds tussen zitten.</span>
+    <span data-phrase="find.gpspart.many">Er zitten {count} GPS-tags in, maar geen bruikbare lengte- en breedtegraad.
+      Bewegingsrichting, hoogte en de GPS-klok kunnen er nog steeds tussen zitten.</span>
+    <span data-phrase="find.taken.title">Wanneer hij gemaakt is</span>
+    <span data-phrase="find.taken.detail">{when}, op de seconde. Samen met een locatie zet dat iemand op een bepaald moment op
+      een bepaalde plek.</span>
+    <span data-phrase="find.device.title">Het apparaat waar hij vandaan komt</span>
+    <span data-phrase="find.device.detail">{device}. Op zichzelf onschuldig; het wordt een kenmerk zodra elke foto die je
+      plaatst dezelfde draagt.</span>
+    <span data-phrase="find.identity.title">Iets dat jou of je spullen benoemt</span>
+    <span data-phrase="find.identity.detail">{found}. Een serienummer knoopt elke foto uit dat huis aan elkaar, wie ze ook
+      geplaatst heeft en waar dan ook.</span>
+    <span data-phrase="find.id.cameraserial">Serienummer van de camera</span>
+    <span data-phrase="find.id.lensserial">Serienummer van de lens</span>
+    <span data-phrase="find.id.owner">Eigenaar van de camera</span>
+    <span data-phrase="find.id.uniqueid">Unieke afbeeldings-ID</span>
+    <span data-phrase="find.id.artist">Maker</span>
+    <span data-phrase="find.id.author">Auteur</span>
+    <span data-phrase="find.id.copyright">Copyright</span>
+    <span data-phrase="find.software.title">Wat hem bewerkt heeft</span>
+    <span data-phrase="find.software.detail">{software}. Dit is vaak de firmwareversie van de telefoon, en dat is een nauwere
+      mededeling dan het model alleen.</span>
+    <span data-phrase="find.makernote.title">De fabrikantnotitie</span>
+    <span data-phrase="find.makernote.detail">{size} aan eigen, particuliere gegevens van de fabrikant. Ze is niet gedocumenteerd,
+      ze verschilt per model, en daar verstoppen serienummers, scherpstelpunten en
+      sluitertellingen zich graag.</span>
+    <span data-phrase="find.thumbnail.title">Een tweede kopie van het plaatje</span>
+    <span data-phrase="find.thumbnail.detail">{size} met een kleine JPEG-voorvertoning. Is de foto bijgesneden nadat de camera hem
+      wegschreef, dan laten sommige programma&rsquo;s de miniatuur nog de onbijgesneden
+      uitsnede zien.</span>
+    <span data-phrase="find.xmp.title">Een XMP-pakket</span>
+    <span data-phrase="find.xmp.detail">{size} XML. Het herhaalt meestal de camera en de tijdstempels, en voegt de
+      bewerkingsgeschiedenis toe: welk programma, welke versie, en elke keer dat het
+      bestand is opgeslagen.</span>
+    <span data-phrase="find.iptc.title">Een IPTC-blok</span>
+    <span data-phrase="find.iptc.detail">{size} van de velden die een fotoredactie invult &mdash; naamsvermelding,
+      onderschrift, plaats, bron. Komt dit van een beeldbank of een redactie, dan staat er
+      waarschijnlijk iemands naam in.</span>
+    <span data-phrase="find.comment.title">Een opmerking</span>
+    <span data-phrase="find.comment.detail">&lsquo;{comment}&rsquo;</span>
+    <span data-phrase="find.text.title">Tekst: {keyword}</span>
+    <span data-phrase="find.unknown.title">Blokken die deze tool niet kan lezen</span>
+    <span data-phrase="find.unknown.detail">{blocks}. Onleesbaar is niet hetzelfde als leeg, dus ook deze gaan er samen met al
+      het andere uit.</span>
     <span data-phrase="read.notjpeg">Dit begint niet als een JPEG.</span>
     <span data-phrase="read.jpeglost">De segmentstructuur is kwijt &mdash; het bestand ziet er beschadigd uit.</span>
     <span data-phrase="read.jpegoverrun">Een segment claimt een lengte die voorbij het einde van het bestand loopt.</span>

--- a/locales/pt/tools/exif-editor.html
+++ b/locales/pt/tools/exif-editor.html
@@ -155,6 +155,66 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="find.clean.title">Não tem nada neste arquivo que entregue você</span>
+    <span data-phrase="find.clean.cleared">Tudo o que entregava já foi removido. Salve a foto para escrever isso no arquivo.</span>
+    <span data-phrase="find.clean.never">Sem lugar, sem datas, sem câmera, sem nomes. Ou nunca teve, ou alguma coisa já
+      tirou.</span>
+    <span data-phrase="find.exifempty.title">Um bloco EXIF sem nada dentro</span>
+    <span data-phrase="find.exifempty.detail">{size} de EXIF que lê direitinho e não tem nenhuma etiqueta. Inofensivo, e sai junto
+      com todo o resto.</span>
+    <span data-phrase="find.exifbad.title">Um bloco EXIF que ninguém consegue ler</span>
+    <span data-phrase="find.exifbad.detail">Tem EXIF aqui e não deu para ler: {reason} Tudo o que vem abaixo é o que deu para
+      ler do resto do arquivo, então trate este bloco como uma incógnita &mdash; o que é
+      motivo para tirar, não para deixar.</span>
+    <span data-phrase="find.gps.title">Onde a foto foi tirada</span>
+    <span data-phrase="find.gps.detail">{position}. Isso é preciso o bastante para dizer o prédio, e viaja com o arquivo
+      para qualquer lugar onde você o publicar.</span>
+    <span data-phrase="find.gps.detailalt">{position}, {altitude}. Isso é preciso o bastante para dizer o prédio, e viaja com o
+      arquivo para qualquer lugar onde você o publicar.</span>
+    <span data-phrase="find.gpspart.title">Etiquetas de lugar, sem uma posição completa</span>
+    <span data-phrase="find.gpspart.one">Tem uma etiqueta de GPS aqui, mas sem latitude e longitude aproveitáveis. Direção de
+      deslocamento, altitude e o relógio do GPS ainda podem estar entre elas.</span>
+    <span data-phrase="find.gpspart.many">Tem {count} etiquetas de GPS aqui, mas sem latitude e longitude aproveitáveis.
+      Direção de deslocamento, altitude e o relógio do GPS ainda podem estar entre elas.</span>
+    <span data-phrase="find.taken.title">Quando ela foi tirada</span>
+    <span data-phrase="find.taken.detail">{when}, no segundo. Junto com um lugar, isso põe uma pessoa em algum lugar num
+      momento certo.</span>
+    <span data-phrase="find.device.title">O aparelho de onde ela veio</span>
+    <span data-phrase="find.device.detail">{device}. Sozinho é inofensivo; vira um identificador quando toda foto que você
+      publica carrega o mesmo.</span>
+    <span data-phrase="find.identity.title">Alguma coisa que dá o nome de você ou do seu equipamento</span>
+    <span data-phrase="find.identity.detail">{found}. Um número de série amarra todas as fotos daquele corpo umas às outras, seja
+      quem for que publicou e onde for.</span>
+    <span data-phrase="find.id.cameraserial">Número de série da câmera</span>
+    <span data-phrase="find.id.lensserial">Número de série da lente</span>
+    <span data-phrase="find.id.owner">Dono da câmera</span>
+    <span data-phrase="find.id.uniqueid">Identificador único da imagem</span>
+    <span data-phrase="find.id.artist">Autor da foto</span>
+    <span data-phrase="find.id.author">Autor</span>
+    <span data-phrase="find.id.copyright">Direitos autorais</span>
+    <span data-phrase="find.software.title">O que editou a foto</span>
+    <span data-phrase="find.software.detail">{software}. Muitas vezes é a versão do firmware do celular, que é uma coisa mais
+      estreita de publicar do que só o modelo.</span>
+    <span data-phrase="find.makernote.title">A nota do fabricante</span>
+    <span data-phrase="find.makernote.detail">{size} de dados particulares do próprio fabricante. Não é documentada, muda de
+      modelo para modelo, e é ali que costumam se esconder números de série, pontos de
+      foco e contagem de disparos.</span>
+    <span data-phrase="find.thumbnail.title">Uma segunda cópia da imagem</span>
+    <span data-phrase="find.thumbnail.detail">{size} com uma miniatura JPEG. Se a foto foi cortada depois que a câmera escreveu o
+      arquivo, alguns editores deixam a miniatura mostrando o enquadramento inteiro.</span>
+    <span data-phrase="find.xmp.title">Um pacote XMP</span>
+    <span data-phrase="find.xmp.detail">{size} de XML. Costuma repetir a câmera e as datas, e acrescenta o histórico de
+      edição: qual programa, qual versão, e cada vez que o arquivo foi salvo.</span>
+    <span data-phrase="find.iptc.title">Um bloco IPTC</span>
+    <span data-phrase="find.iptc.detail">{size} dos campos que uma redação de fotografia preenche: crédito, legenda, cidade,
+      fonte. Se isto veio de um banco de imagens ou de um jornal, é provável que tenha o
+      nome de alguém aí dentro.</span>
+    <span data-phrase="find.comment.title">Um comentário</span>
+    <span data-phrase="find.comment.detail">&ldquo;{comment}&rdquo;</span>
+    <span data-phrase="find.text.title">Texto: {keyword}</span>
+    <span data-phrase="find.unknown.title">Blocos que esta ferramenta não sabe ler</span>
+    <span data-phrase="find.unknown.detail">{blocks}. Ilegível não é a mesma coisa que vazio, então esses também saem junto com
+      todo o resto.</span>
     <span data-phrase="read.notjpeg">Isto não começa como um JPEG.</span>
     <span data-phrase="read.jpeglost">A estrutura de segmentos se perdeu &mdash; o arquivo parece danificado.</span>
     <span data-phrase="read.jpegoverrun">Um segmento declara um comprimento que passa do fim do arquivo.</span>

--- a/locales/tr/tools/exif-editor.html
+++ b/locales/tr/tools/exif-editor.html
@@ -161,6 +161,66 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="find.clean.title">Bu dosyada sizi ele veren bir şey yok</span>
+    <span data-phrase="find.clean.cleared">Ele veren ne varsa kaldırıldı. Bunu dosyaya yazmak için fotoğrafı kaydedin.</span>
+    <span data-phrase="find.clean.never">Konum yok, zaman damgası yok, kamera yok, isim yok. Ya hiç olmadı ya da bir şey
+      bunları çoktan silmiş.</span>
+    <span data-phrase="find.exifempty.title">İçinde hiçbir şey olmayan bir EXIF bloğu</span>
+    <span data-phrase="find.exifempty.detail">{size} EXIF; temiz okunuyor ve içinde tek bir etiket yok. Zararsız, ve diğer her
+      şeyle birlikte kaldırılıyor.</span>
+    <span data-phrase="find.exifbad.title">Kimsenin okuyamadığı bir EXIF bloğu</span>
+    <span data-phrase="find.exifbad.detail">Burada EXIF var ve okunamadı: {reason} Aşağıdaki her şey, dosyanın geri kalanından
+      okunabilen kısım; dolayısıyla bu bloğu bilinmeyen bir büyüklük sayın &mdash; ki bu,
+      onu bırakmak için değil kaldırmak için bir sebeptir.</span>
+    <span data-phrase="find.gps.title">Fotoğrafın nerede çekildiği</span>
+    <span data-phrase="find.gps.detail">{position}. Bu, bir binayı adıyla söyleyecek kadar kesin ve dosyayı nereye
+      yüklerseniz oraya birlikte gidiyor.</span>
+    <span data-phrase="find.gps.detailalt">{position}, {altitude}. Bu, bir binayı adıyla söyleyecek kadar kesin ve dosyayı
+      nereye yüklerseniz oraya birlikte gidiyor.</span>
+    <span data-phrase="find.gpspart.title">Konum etiketleri, ama tam bir konum yok</span>
+    <span data-phrase="find.gpspart.one">Burada bir GPS etiketi var ama kullanılabilir bir enlem ve boylam yok. Gidiş yönü,
+      yükseklik ve GPS saati yine de bunların arasında olabilir.</span>
+    <span data-phrase="find.gpspart.many">Burada {count} GPS etiketi var ama kullanılabilir bir enlem ve boylam yok. Gidiş
+      yönü, yükseklik ve GPS saati yine de bunların arasında olabilir.</span>
+    <span data-phrase="find.taken.title">Ne zaman çekildiği</span>
+    <span data-phrase="find.taken.detail">{when}, saniyesine kadar. Bir konumla birlikte bu, bir kişiyi belirli bir anda
+      belirli bir yere koyar.</span>
+    <span data-phrase="find.device.title">Hangi cihazdan geldiği</span>
+    <span data-phrase="find.device.detail">{device}. Tek başına zararsız; paylaştığınız her fotoğraf aynısını taşıdığında bir
+      kimlik işaretine dönüşür.</span>
+    <span data-phrase="find.identity.title">Sizi ya da ekipmanınızı adıyla söyleyen bir şey</span>
+    <span data-phrase="find.identity.detail">{found}. Bir seri numarası, o gövdeden çıkan her fotoğrafı birbirine bağlar &mdash;
+      kim paylaşmış olursa olsun, nerede olursa olsun.</span>
+    <span data-phrase="find.id.cameraserial">Fotoğraf makinesinin seri numarası</span>
+    <span data-phrase="find.id.lensserial">Objektifin seri numarası</span>
+    <span data-phrase="find.id.owner">Makinenin sahibi</span>
+    <span data-phrase="find.id.uniqueid">Görüntünün benzersiz kimliği</span>
+    <span data-phrase="find.id.artist">Çeken kişi</span>
+    <span data-phrase="find.id.author">Yazar</span>
+    <span data-phrase="find.id.copyright">Telif hakkı</span>
+    <span data-phrase="find.software.title">Onu neyin düzenlediği</span>
+    <span data-phrase="find.software.detail">{software}. Bu çoğu zaman telefonun ürün yazılımı sürümüdür ve yayımlanması, modelin
+      tek başına yayımlanmasından daha dar bir bilgidir.</span>
+    <span data-phrase="find.makernote.title">Üretici notu</span>
+    <span data-phrase="find.makernote.detail">{size} üreticinin kendi özel verisi. Belgelenmemiştir, modelden modele değişir ve
+      seri numaralarının, odak noktalarının ve deklanşör sayaçlarının saklanmayı sevdiği
+      yer burasıdır.</span>
+    <span data-phrase="find.thumbnail.title">Resmin ikinci bir kopyası</span>
+    <span data-phrase="find.thumbnail.detail">{size}, içinde küçük bir JPEG önizleme. Fotoğraf, makine dosyayı yazdıktan sonra
+      kırpıldıysa bazı programlar küçük resimde hâlâ kırpılmamış kareyi gösterir.</span>
+    <span data-phrase="find.xmp.title">Bir XMP paketi</span>
+    <span data-phrase="find.xmp.detail">{size} XML. Çoğunlukla makineyi ve zaman damgalarını tekrarlar, üstüne de düzenleme
+      geçmişini ekler: hangi program, hangi sürüm ve dosyanın kaydedildiği her an.</span>
+    <span data-phrase="find.iptc.title">Bir IPTC bloğu</span>
+    <span data-phrase="find.iptc.detail">{size}, bir fotoğraf servisinin doldurduğu alanlar &mdash; imza, altyazı, şehir,
+      kaynak. Bu bir görsel bankasından ya da bir haber merkezinden geldiyse içinde büyük
+      ihtimalle birinin adı vardır.</span>
+    <span data-phrase="find.comment.title">Bir yorum</span>
+    <span data-phrase="find.comment.detail">&ldquo;{comment}&rdquo;</span>
+    <span data-phrase="find.text.title">Metin: {keyword}</span>
+    <span data-phrase="find.unknown.title">Bu aracın okuyamadığı bloklar</span>
+    <span data-phrase="find.unknown.detail">{blocks}. Okunamaz olmak boş olmakla aynı şey değil; bunlar da diğer her şeyle
+      birlikte kaldırılıyor.</span>
     <span data-phrase="read.notjpeg">Bu, bir JPEG gibi başlamıyor.</span>
     <span data-phrase="read.jpeglost">Segment yapısı kayboldu &mdash; dosya bozuk görünüyor.</span>
     <span data-phrase="read.jpegoverrun">Bir segment, dosyanın sonunu aşan bir uzunluk bildiriyor.</span>

--- a/locales/zh-TW/tools/exif-editor.html
+++ b/locales/zh-TW/tools/exif-editor.html
@@ -147,6 +147,47 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="find.clean.title">這個檔案裡沒有能交代出去的東西</span>
+    <span data-phrase="find.clean.cleared">會交代出去的都已經清掉了。儲存照片，就把這個樣子寫進檔案。</span>
+    <span data-phrase="find.clean.never">沒有位置，沒有時間，沒有相機，沒有名字。要麼本來就沒有，要麼已經被什麼清乾淨了。</span>
+    <span data-phrase="find.exifempty.title">一塊什麼都沒有的 EXIF</span>
+    <span data-phrase="find.exifempty.detail">{size} 的 EXIF，讀得乾乾淨淨，一個標籤都沒有。沒什麼害處，跟別的一起清掉。</span>
+    <span data-phrase="find.exifbad.title">一塊誰也讀不了的 EXIF</span>
+    <span data-phrase="find.exifbad.detail">這裡有 EXIF，而且讀不出來：{reason} 下面這些是檔案其餘部分能讀出來的，所以這一塊就當成來路不明的東西看待——這是該刪掉它的理由，不是留著它的理由。</span>
+    <span data-phrase="find.gps.title">照片是在哪裡拍的</span>
+    <span data-phrase="find.gps.detail">{position}。這個精度足夠指到一棟樓，而且你發到哪裡，它就跟著檔案到哪裡。</span>
+    <span data-phrase="find.gps.detailalt">{position}，{altitude}。這個精度足夠指到一棟樓，而且你發到哪裡，它就跟著檔案到哪裡。</span>
+    <span data-phrase="find.gpspart.title">有位置標籤，但湊不出完整座標</span>
+    <span data-phrase="find.gpspart.one">這裡有 1 個 GPS 標籤，但沒有能用的經緯度。行進方向、海拔和 GPS 時鐘仍然可能在裡面。</span>
+    <span data-phrase="find.gpspart.many">這裡有 {count} 個 GPS 標籤，但沒有能用的經緯度。行進方向、海拔和 GPS 時鐘仍然可能在裡面。</span>
+    <span data-phrase="find.taken.title">什麼時候拍的</span>
+    <span data-phrase="find.taken.detail">{when}，精確到秒。跟位置湊到一起，就是某個人在某一刻出現在某個地方。</span>
+    <span data-phrase="find.device.title">從哪臺機器出來的</span>
+    <span data-phrase="find.device.detail">{device}。單看沒什麼，可你發出去的每張照片都帶著同一個，它就成了認人的記號。</span>
+    <span data-phrase="find.identity.title">能點出你或者你器材的東西</span>
+    <span data-phrase="find.identity.detail">{found}。一個序列號能把那臺機身拍的所有照片串到一塊兒，不管是誰發的，也不管發到哪裡。</span>
+    <span data-phrase="find.id.cameraserial">相機序列號</span>
+    <span data-phrase="find.id.lensserial">鏡頭序列號</span>
+    <span data-phrase="find.id.owner">相機所有者</span>
+    <span data-phrase="find.id.uniqueid">影像唯一 ID</span>
+    <span data-phrase="find.id.artist">拍攝者</span>
+    <span data-phrase="find.id.author">作者</span>
+    <span data-phrase="find.id.copyright">版權</span>
+    <span data-phrase="find.software.title">是什麼改過它</span>
+    <span data-phrase="find.software.detail">{software}。這多半是手機的韌體版本，公開出去比只說個型號還要窄。</span>
+    <span data-phrase="find.makernote.title">廠商備註</span>
+    <span data-phrase="find.makernote.detail">{size} 廠商自己的私有資料。沒有公開文件，各型號都不一樣，序列號、對焦點和快門數最愛藏在這裡。</span>
+    <span data-phrase="find.thumbnail.title">畫面的第二份副本</span>
+    <span data-phrase="find.thumbnail.detail">{size}，裡面是一張小的 JPEG 預覽圖。要是相機寫完之後照片又被裁過，有些編輯軟體會讓縮圖還顯示沒裁之前的畫面。</span>
+    <span data-phrase="find.xmp.title">一個 XMP 包</span>
+    <span data-phrase="find.xmp.detail">{size} 的 XML。通常把相機和時間又說了一遍，還加上編輯歷史：用的哪個軟體、哪個版本，以及每一次儲存。</span>
+    <span data-phrase="find.iptc.title">一塊 IPTC</span>
+    <span data-phrase="find.iptc.detail">{size}，都是圖片編輯部要填的欄位：署名、圖說、城市、來源。要是這張圖出自相簿或者新聞編輯室，裡頭多半有個人的名字。</span>
+    <span data-phrase="find.comment.title">一條註釋</span>
+    <span data-phrase="find.comment.detail">「{comment}」</span>
+    <span data-phrase="find.text.title">文字：{keyword}</span>
+    <span data-phrase="find.unknown.title">這個工具讀不了的塊</span>
+    <span data-phrase="find.unknown.detail">{blocks}。讀不了不等於是空的，所以這些也跟別的一起清掉。</span>
     <span data-phrase="read.notjpeg">這個開頭不像 JPEG。</span>
     <span data-phrase="read.jpeglost">分段的結構斷了，檔案看起來是壞的。</span>
     <span data-phrase="read.jpegoverrun">有一段聲稱的長度已經越過了檔案末尾。</span>

--- a/locales/zh/tools/exif-editor.html
+++ b/locales/zh/tools/exif-editor.html
@@ -147,6 +147,47 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="find.clean.title">这个文件里没有能交代出去的东西</span>
+    <span data-phrase="find.clean.cleared">会交代出去的都已经清掉了。保存照片，就把这个样子写进文件。</span>
+    <span data-phrase="find.clean.never">没有位置，没有时间，没有相机，没有名字。要么本来就没有，要么已经被什么清干净了。</span>
+    <span data-phrase="find.exifempty.title">一块什么都没有的 EXIF</span>
+    <span data-phrase="find.exifempty.detail">{size} 的 EXIF，读得干干净净，一个标签都没有。没什么害处，跟别的一起清掉。</span>
+    <span data-phrase="find.exifbad.title">一块谁也读不了的 EXIF</span>
+    <span data-phrase="find.exifbad.detail">这儿有 EXIF，而且读不出来：{reason} 下面这些是文件其余部分能读出来的，所以这一块就当成来路不明的东西看待——这是该删掉它的理由，不是留着它的理由。</span>
+    <span data-phrase="find.gps.title">照片是在哪儿拍的</span>
+    <span data-phrase="find.gps.detail">{position}。这个精度足够指到一栋楼，而且你发到哪儿，它就跟着文件到哪儿。</span>
+    <span data-phrase="find.gps.detailalt">{position}，{altitude}。这个精度足够指到一栋楼，而且你发到哪儿，它就跟着文件到哪儿。</span>
+    <span data-phrase="find.gpspart.title">有位置标签，但凑不出完整坐标</span>
+    <span data-phrase="find.gpspart.one">这儿有 1 个 GPS 标签，但没有能用的经纬度。行进方向、海拔和 GPS 时钟仍然可能在里面。</span>
+    <span data-phrase="find.gpspart.many">这儿有 {count} 个 GPS 标签，但没有能用的经纬度。行进方向、海拔和 GPS 时钟仍然可能在里面。</span>
+    <span data-phrase="find.taken.title">什么时候拍的</span>
+    <span data-phrase="find.taken.detail">{when}，精确到秒。跟位置凑到一起，就是某个人在某一刻出现在某个地方。</span>
+    <span data-phrase="find.device.title">从哪台机器出来的</span>
+    <span data-phrase="find.device.detail">{device}。单看没什么，可你发出去的每张照片都带着同一个，它就成了认人的记号。</span>
+    <span data-phrase="find.identity.title">能点出你或者你器材的东西</span>
+    <span data-phrase="find.identity.detail">{found}。一个序列号能把那台机身拍的所有照片串到一块儿，不管是谁发的，也不管发到哪儿。</span>
+    <span data-phrase="find.id.cameraserial">相机序列号</span>
+    <span data-phrase="find.id.lensserial">镜头序列号</span>
+    <span data-phrase="find.id.owner">相机所有者</span>
+    <span data-phrase="find.id.uniqueid">图像唯一 ID</span>
+    <span data-phrase="find.id.artist">拍摄者</span>
+    <span data-phrase="find.id.author">作者</span>
+    <span data-phrase="find.id.copyright">版权</span>
+    <span data-phrase="find.software.title">是什么改过它</span>
+    <span data-phrase="find.software.detail">{software}。这多半是手机的固件版本，公开出去比只说个型号还要窄。</span>
+    <span data-phrase="find.makernote.title">厂商备注</span>
+    <span data-phrase="find.makernote.detail">{size} 厂商自己的私有数据。没有公开文档，各型号都不一样，序列号、对焦点和快门数最爱藏在这儿。</span>
+    <span data-phrase="find.thumbnail.title">画面的第二份副本</span>
+    <span data-phrase="find.thumbnail.detail">{size}，里面是一张小的 JPEG 预览图。要是相机写完之后照片又被裁过，有些编辑软件会让缩略图还显示没裁之前的画面。</span>
+    <span data-phrase="find.xmp.title">一个 XMP 包</span>
+    <span data-phrase="find.xmp.detail">{size} 的 XML。通常把相机和时间又说了一遍，还加上编辑历史：用的哪个软件、哪个版本，以及每一次保存。</span>
+    <span data-phrase="find.iptc.title">一块 IPTC</span>
+    <span data-phrase="find.iptc.detail">{size}，都是图片编辑部要填的字段：署名、图说、城市、来源。要是这张图出自图库或者新闻编辑室，里头多半有个人的名字。</span>
+    <span data-phrase="find.comment.title">一条注释</span>
+    <span data-phrase="find.comment.detail">「{comment}」</span>
+    <span data-phrase="find.text.title">文本：{keyword}</span>
+    <span data-phrase="find.unknown.title">这个工具读不了的块</span>
+    <span data-phrase="find.unknown.detail">{blocks}。读不了不等于是空的，所以这些也跟别的一起清掉。</span>
     <span data-phrase="read.notjpeg">这个开头不像 JPEG。</span>
     <span data-phrase="read.jpeglost">分段的结构断了，文件看着是坏的。</span>
     <span data-phrase="read.jpegoverrun">有一段声称的长度已经越过了文件末尾。</span>

--- a/tests/js/exif-container-door.test.js
+++ b/tests/js/exif-container-door.test.js
@@ -164,8 +164,8 @@ test('outputType: the extension and type each format is saved as', () => {
 /* ================================================================ report */
 
 test('bytes: sizes in the units a person would say them in', () => {
-  assert.equal(sizeText(0), '0 bytes');
-  assert.equal(sizeText(1023), '1023 bytes');
+  assert.equal(sizeText(0), '0 B');
+  assert.equal(sizeText(1023), '1023 B');
   assert.equal(sizeText(1024), '1.0 KB');
   assert.equal(sizeText(10240), '10 KB');
   assert.equal(sizeText(1024 * 1024), '1.0 MB');
@@ -226,6 +226,11 @@ function itemWith({ groups = {}, meta = {}, ...rest } = {}) {
   };
 }
 
+// buildFindings takes a resolver. This one answers with the key, which is what
+// phrase() does when the page has no such phrase - so a finding's title in
+// these tests is the key that names it.
+const key = (name) => name;
+
 test('findings: a location is the headline finding', () => {
   const item = itemWith({
     meta: { exif: ascii('block') },
@@ -236,31 +241,31 @@ test('findings: a location is the headline finding', () => {
       ],
     },
   });
-  const found = buildFindings(item);
+  const found = buildFindings(item, key);
   assert.equal(found[0].level, 'high');
-  assert.match(found[0].title, /Where the photo was taken/);
+  assert.equal(found[0].title, 'find.gps.title');
 });
 
 test('findings: EXIF that will not parse is a reason to remove it', () => {
   const item = itemWith({
     exifUnreadable: true,
-    exifError: 'The TIFF magic number is wrong.',
+    exifError: 'read.exifmagic',
     meta: { exif: ascii('block') },
   });
-  const found = buildFindings(item);
-  assert.ok(found.some((f) => f.level === 'high' && /nobody can read/.test(f.title)));
+  const found = buildFindings(item, key);
+  assert.ok(found.some((f) => f.level === 'high' && f.title === 'find.exifbad.title'));
 });
 
 test('findings: an EXIF block that parses to nothing is only worth a note', () => {
   const item = itemWith({ meta: { exif: ascii('block') } });
-  const found = buildFindings(item);
+  const found = buildFindings(item, key);
   assert.equal(found.length, 1);
   assert.equal(found[0].level, 'low');
-  assert.match(found[0].title, /nothing in it/);
+  assert.equal(found[0].title, 'find.exifempty.title');
 });
 
 test('findings: a clean file has none', () => {
-  assert.deepEqual(buildFindings(itemWith()), []);
+  assert.deepEqual(buildFindings(itemWith(), key), []);
 });
 
 test('countTags: across every directory', () => {

--- a/tests/python/test_english_in_js.py
+++ b/tests/python/test_english_in_js.py
@@ -65,7 +65,7 @@ BASELINE = {
     'document-scanner': 13,
     'edit-audio': 25,
     'encode-text': 23,
-    'exif-editor': 78,
+    'exif-editor': 63,
     'format-json': 61,
     'gif-analyzer': 71,
     'gif-maker': 22,

--- a/tools/exif-editor/body.html
+++ b/tools/exif-editor/body.html
@@ -152,6 +152,65 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="find.clean.title">Nothing in this file gives anything away</span>
+    <span data-phrase="find.clean.cleared">Everything that did has been removed. Save the photo to write it out.</span>
+    <span data-phrase="find.clean.never">No location, no timestamps, no camera, no names. Either it never had any, or
+      something has already stripped it.</span>
+    <span data-phrase="find.exifempty.title">An EXIF block with nothing in it</span>
+    <span data-phrase="find.exifempty.detail">{size} of EXIF that parses cleanly and holds no tags. Harmless, and removed along
+      with everything else.</span>
+    <span data-phrase="find.exifbad.title">An EXIF block nobody can read</span>
+    <span data-phrase="find.exifbad.detail">There is EXIF here and it would not parse: {reason} Everything below is what could
+      be read of the rest of the file, so treat this one as an unknown quantity &mdash;
+      which is a reason to remove it, not to leave it.</span>
+    <span data-phrase="find.gps.title">Where the photo was taken</span>
+    <span data-phrase="find.gps.detail">{position}. That is precise enough to name a building, and it travels with the file
+      into anything you post it to.</span>
+    <span data-phrase="find.gps.detailalt">{position}, {altitude}. That is precise enough to name a building, and it travels
+      with the file into anything you post it to.</span>
+    <span data-phrase="find.gpspart.title">Location tags, without a full position</span>
+    <span data-phrase="find.gpspart.one">One GPS tag is here but no usable latitude and longitude. Direction of travel,
+      altitude and the GPS clock can still be among them.</span>
+    <span data-phrase="find.gpspart.many">{count} GPS tags are here but no usable latitude and longitude. Direction of travel,
+      altitude and the GPS clock can still be among them.</span>
+    <span data-phrase="find.taken.title">When it was taken</span>
+    <span data-phrase="find.taken.detail">{when}, to the second. Combined with a location this places a person somewhere at a
+      particular moment.</span>
+    <span data-phrase="find.device.title">The device it came from</span>
+    <span data-phrase="find.device.detail">{device}. Harmless on its own; it becomes an identifier when every photo you post
+      carries the same one.</span>
+    <span data-phrase="find.identity.title">Something that names you or your kit</span>
+    <span data-phrase="find.identity.detail">{found}. A serial number ties every photo from that body together, whoever posted
+      them and wherever.</span>
+    <span data-phrase="find.id.cameraserial">Camera serial number</span>
+    <span data-phrase="find.id.lensserial">Lens serial number</span>
+    <span data-phrase="find.id.owner">Camera owner</span>
+    <span data-phrase="find.id.uniqueid">Image unique ID</span>
+    <span data-phrase="find.id.artist">Artist</span>
+    <span data-phrase="find.id.author">Author</span>
+    <span data-phrase="find.id.copyright">Copyright</span>
+    <span data-phrase="find.software.title">What edited it</span>
+    <span data-phrase="find.software.detail">{software}. This is often the phone&rsquo;s firmware version, which is a narrower
+      thing to publish than the model alone.</span>
+    <span data-phrase="find.makernote.title">The maker note</span>
+    <span data-phrase="find.makernote.detail">{size} of the manufacturer&rsquo;s own private data. It is undocumented, it varies
+      by model, and it is where serial numbers, focus points and shutter counts tend to
+      hide.</span>
+    <span data-phrase="find.thumbnail.title">A second copy of the picture</span>
+    <span data-phrase="find.thumbnail.detail">{size} holding a small JPEG preview. If the photo was cropped after the camera wrote
+      it, some editors leave the thumbnail showing the uncropped frame.</span>
+    <span data-phrase="find.xmp.title">An XMP packet</span>
+    <span data-phrase="find.xmp.detail">{size} of XML. It usually repeats the camera and the timestamps, and adds the edit
+      history: which program, which version, and every time the file was saved.</span>
+    <span data-phrase="find.iptc.title">An IPTC block</span>
+    <span data-phrase="find.iptc.detail">{size} of the fields a photo desk fills in &mdash; byline, caption, city, credit. If
+      this came from a stock library or a newsroom, someone&rsquo;s name is likely in it.</span>
+    <span data-phrase="find.comment.title">A comment</span>
+    <span data-phrase="find.comment.detail">&ldquo;{comment}&rdquo;</span>
+    <span data-phrase="find.text.title">Text: {keyword}</span>
+    <span data-phrase="find.unknown.title">Blocks this tool cannot read</span>
+    <span data-phrase="find.unknown.detail">{blocks}. Unreadable is not the same as empty, so these are removed along with
+      everything else.</span>
     <span data-phrase="read.notjpeg">This does not start like a JPEG.</span>
     <span data-phrase="read.jpeglost">Lost the segment structure &mdash; the file looks damaged.</span>
     <span data-phrase="read.jpegoverrun">A segment claims a length that runs off the end of the file.</span>

--- a/tools/exif-editor/src/main.js
+++ b/tools/exif-editor/src/main.js
@@ -364,19 +364,17 @@ el.inspectSelect.addEventListener('change', () => {
 
 function renderFindings(item) {
   el.findingsList.replaceChildren();
-  const findings = buildFindings(item);
+  const findings = buildFindings(item, phrase);
 
   if (!findings.length) {
     const li = document.createElement('li');
     li.className = 'finding finding-clean';
     const title = document.createElement('p');
     title.className = 'finding-title';
-    title.textContent = 'Nothing in this file gives anything away';
+    title.textContent = phrase('find.clean.title');
     const detail = document.createElement('p');
     detail.className = 'finding-detail';
-    detail.textContent = item.dirty
-      ? 'Everything that did has been removed. Save the photo to write it out.'
-      : 'No location, no timestamps, no camera, no names. Either it never had any, or something has already stripped it.';
+    detail.textContent = phrase(item.dirty ? 'find.clean.cleared' : 'find.clean.never');
     li.append(title, detail);
     el.findingsList.appendChild(li);
     return;

--- a/tools/exif-editor/src/report.js
+++ b/tools/exif-editor/src/report.js
@@ -105,9 +105,13 @@ const asText = (v) => (typeof v === 'string' && v.trim() ? v.trim() : null);
  * the full table further down the page, where nobody has been promised that
  * everything listed is important.
  *
+ * `t` resolves a phrase key against the page, which is where the sentences
+ * live: this module is copied byte for byte into fifteen languages. It is the
+ * same resolver report() takes, and for the same reason.
+ *
  * @returns {{level: 'high'|'medium'|'low', title: string, detail: string}[]}
  */
-export function buildFindings(item) {
+export function buildFindings(item, t) {
   const out = [];
   const groups = item.exif?.ok ? item.exif.groups : null;
   const meta = item.meta;
@@ -115,16 +119,16 @@ export function buildFindings(item) {
   if (!item.exifUnreadable && meta.exif && !countTags(item)) {
     out.push({
       level: 'low',
-      title: 'An EXIF block with nothing in it',
-      detail: `${bytes(meta.exif.length)} of EXIF that parses cleanly and holds no tags. Harmless, and removed along with everything else.`,
+      title: t('find.exifempty.title'),
+      detail: t('find.exifempty.detail', { size: bytes(meta.exif.length) }),
     });
   }
 
   if (item.exifUnreadable) {
     out.push({
       level: 'high',
-      title: 'An EXIF block nobody can read',
-      detail: `There is EXIF here and it would not parse: ${item.exifError} Everything below is what could be read of the rest of the file, so treat this one as an unknown quantity - which is a reason to remove it, not to leave it.`,
+      title: t('find.exifbad.title'),
+      detail: t('find.exifbad.detail', { reason: t(item.exifError) }),
     });
   }
 
@@ -132,14 +136,17 @@ export function buildFindings(item) {
   if (position) {
     out.push({
       level: 'high',
-      title: 'Where the photo was taken',
-      detail: `${position.text}${position.altitude ? `, ${position.altitude}` : ''}. That is precise enough to name a building, and it travels with the file into anything you post it to.`,
+      title: t('find.gps.title'),
+      detail: position.altitude
+        ? t('find.gps.detailalt', { position: position.text, altitude: position.altitude })
+        : t('find.gps.detail', { position: position.text }),
     });
   } else if (groups?.gps?.length) {
     out.push({
       level: 'high',
-      title: 'Location tags, without a full position',
-      detail: `${groups.gps.length} GPS tag${groups.gps.length === 1 ? '' : 's'} are here but no usable latitude and longitude. Direction of travel, altitude and the GPS clock can still be among them.`,
+      title: t('find.gpspart.title'),
+      detail: t(groups.gps.length === 1 ? 'find.gpspart.one' : 'find.gpspart.many',
+                { count: groups.gps.length }),
     });
   }
 
@@ -147,8 +154,8 @@ export function buildFindings(item) {
   if (taken) {
     out.push({
       level: 'medium',
-      title: 'When it was taken',
-      detail: `${taken}, to the second. Combined with a location this places a person somewhere at a particular moment.`,
+      title: t('find.taken.title'),
+      detail: t('find.taken.detail', { when: taken }),
     });
   }
 
@@ -162,28 +169,30 @@ export function buildFindings(item) {
       : (model ?? make);
     out.push({
       level: 'medium',
-      title: 'The device it came from',
-      detail: `${device}. Harmless on its own; it becomes an identifier when every photo you post carries the same one.`,
+      title: t('find.device.title'),
+      detail: t('find.device.detail', { device }),
     });
   }
 
   const identifiers = [
-    [groups?.exif, 0xa431, 'Camera serial number'],
-    [groups?.exif, 0xa435, 'Lens serial number'],
-    [groups?.exif, 0xa430, 'Camera owner'],
-    [groups?.exif, 0xa420, 'Image unique ID'],
-    [groups?.ifd0, 0x013b, 'Artist'],
-    [groups?.ifd0, 0x9c9d, 'Author'],
-    [groups?.ifd0, 0x8298, 'Copyright'],
+    [groups?.exif, 0xa431, 'find.id.cameraserial'],
+    [groups?.exif, 0xa435, 'find.id.lensserial'],
+    [groups?.exif, 0xa430, 'find.id.owner'],
+    [groups?.exif, 0xa420, 'find.id.uniqueid'],
+    [groups?.ifd0, 0x013b, 'find.id.artist'],
+    [groups?.ifd0, 0x9c9d, 'find.id.author'],
+    [groups?.ifd0, 0x8298, 'find.id.copyright'],
   ]
-    .map(([group, tag, label]) => ({ label, value: asText(tagValue(group, tag)) }))
+    .map(([group, tag, key]) => ({ label: t(key), value: asText(tagValue(group, tag)) }))
     .filter((x) => x.value);
 
   if (identifiers.length) {
     out.push({
       level: 'high',
-      title: 'Something that names you or your kit',
-      detail: `${identifiers.map((x) => `${x.label}: ${x.value}`).join('. ')}. A serial number ties every photo from that body together, whoever posted them and wherever.`,
+      title: t('find.identity.title'),
+      detail: t('find.identity.detail', {
+        found: identifiers.map((x) => `${x.label}: ${x.value}`).join('. '),
+      }),
     });
   }
 
@@ -191,8 +200,8 @@ export function buildFindings(item) {
   if (software) {
     out.push({
       level: 'medium',
-      title: 'What edited it',
-      detail: `${software}. This is often the phone's firmware version, which is a narrower thing to publish than the model alone.`,
+      title: t('find.software.title'),
+      detail: t('find.software.detail', { software }),
     });
   }
 
@@ -200,38 +209,42 @@ export function buildFindings(item) {
   if (makerNote) {
     out.push({
       level: 'high',
-      title: 'The maker note',
-      detail: `${bytes(makerNote.raw.length)} of the manufacturer's own private data. It is undocumented, it varies by model, and it is where serial numbers, focus points and shutter counts tend to hide.`,
+      title: t('find.makernote.title'),
+      detail: t('find.makernote.detail', { size: bytes(makerNote.raw.length) }),
     });
   }
 
   if (item.exif?.thumbnail?.length) {
     out.push({
       level: 'medium',
-      title: 'A second copy of the picture',
-      detail: `${bytes(item.exif.thumbnail.length)} holding a small JPEG preview. If the photo was cropped after the camera wrote it, some editors leave the thumbnail showing the uncropped frame.`,
+      title: t('find.thumbnail.title'),
+      detail: t('find.thumbnail.detail', { size: bytes(item.exif.thumbnail.length) }),
     });
   }
 
   if (meta.xmp) {
     out.push({
       level: 'medium',
-      title: 'An XMP packet',
-      detail: `${bytes(meta.xmp.length)} of XML. It usually repeats the camera and the timestamps, and adds the edit history: which program, which version, and every time the file was saved.`,
+      title: t('find.xmp.title'),
+      detail: t('find.xmp.detail', { size: bytes(meta.xmp.length) }),
     });
   }
 
   if (meta.iptc) {
     out.push({
       level: 'high',
-      title: 'An IPTC block',
-      detail: `${bytes(meta.iptc.length)} of the fields a photo desk fills in - byline, caption, city, credit. If this came from a stock library or a newsroom, someone's name is likely in it.`,
+      title: t('find.iptc.title'),
+      detail: t('find.iptc.detail', { size: bytes(meta.iptc.length) }),
     });
   }
 
   for (const comment of meta.comments) {
     if (comment.trim()) {
-      out.push({ level: 'medium', title: 'A comment', detail: `"${comment.trim().slice(0, 300)}"` });
+      out.push({
+        level: 'medium',
+        title: t('find.comment.title'),
+        detail: t('find.comment.detail', { comment: comment.trim().slice(0, 300) }),
+      });
     }
   }
 
@@ -239,7 +252,7 @@ export function buildFindings(item) {
     if (text.value?.trim()) {
       out.push({
         level: /author|artist|creat|copyright|owner|comment|source|url/i.test(text.keyword) ? 'high' : 'low',
-        title: `Text: ${text.keyword}`,
+        title: t('find.text.title', { keyword: text.keyword }),
         detail: text.value.trim().slice(0, 300),
       });
     }
@@ -248,17 +261,25 @@ export function buildFindings(item) {
   if (meta.extras.length) {
     out.push({
       level: 'low',
-      title: 'Blocks this tool cannot read',
-      detail: `${meta.extras.map((x) => `${x.label} (${bytes(x.size)})`).join(', ')}. Unreadable is not the same as empty, so these are removed along with everything else.`,
+      title: t('find.unknown.title'),
+      detail: t('find.unknown.detail', {
+        blocks: meta.extras.map((x) => `${x.label} (${bytes(x.size)})`).join(', '),
+      }),
     });
   }
 
   return out;
 }
 
-/** Sizes, in the units a person would say them in. */
+/**
+ * Sizes, in the units a person would say them in.
+ *
+ * The unit is the symbol rather than the word, because every one of these ends
+ * up inside a sentence that is translated around it - a German finding reading
+ * "512 B von EXIF" is right, and "512 bytes von EXIF" is half English.
+ */
 export function bytes(n) {
-  if (n < 1024) return `${n} bytes`;
+  if (n < 1024) return `${n} B`;
   if (n < 1024 * 1024) return `${(n / 1024).toFixed(n < 10240 ? 1 : 0)} KB`;
   return `${(n / (1024 * 1024)).toFixed(1)} MB`;
 }


### PR DESCRIPTION
The findings panel is what this tool is *for*. Someone drops a photo in and the panel names what is in it and why that matters: where it was taken, to the second when, the serial number that ties every frame from that body together. Every one of those sentences was English on a page translated into fifteen languages, because they lived in `src/report.js`.

## What moved

`buildFindings` takes the resolver, the way `report()` next door already does, and each finding is a phrase key with the values its sentence needs. Three of them needed more than a straight key:

- **The GPS finding is two sentences**, not one with a comma spliced in. An altitude is only sometimes there, and the join between a position and an altitude is not a comma in every language.
- **The partial-GPS finding is two sentences** for the same reason a plural is: *1 GPS tag* and *5 GPS tags* are one sentence in English and are not in Arabic or Japanese.
- **The seven identifier labels** — camera serial number, lens serial number, owner — are keys too, because they are read out *inside* the sentence that follows them.

## Sizes

`bytes()` writes the symbol rather than the word now: **512 B**, not *512 bytes*. Every one of these ends up inside a sentence that is translated around it, and a German finding reading *512 B von EXIF* is right where *512 bytes von EXIF* is half English.

compress-image solves the same problem the other way, with `size.bytes`/`size.kb`/`size.mb` phrases. That is the better answer where a size stands alone as a label; here it never does.

## The tests

They assert keys now. `buildFindings` takes a resolver, so the tests hand it one that answers with the key — which is exactly what `phrase()` does with a key the page does not define, and it makes each assertion name the finding it is about.

## Checks

- `python build.py --out _plain --clean --no-minify` — clean
- `python -m unittest discover -t . -s tests/python` — 484 pass
- `node --test "tests/js/*.test.js"` — 1935 pass
- Driven for real in the built German page: a canvas JPEG with a hand-built EXIF block carrying `Make = Canon` produced **Das Gerät, aus dem es kam / Canon. Für sich genommen harmlos; zum Erkennungsmerkmal wird es, wenn jedes Foto, das Sie veröffentlichen, dasselbe trägt.** A JPEG with no metadata produced the clean state, also in German. Singular and plural, the altitude variant and the nested identifier label were read back through the page's own `phrase()`.
- `python zh-tw-sync.py --check` reports one file, and it is not this branch's: `locales/zh-TW/locale.toml`, where #228's hand-written 尋找工具 / 沒有符合的工具 differs from what the conversion produces. Same note as #229 — it wants the `MAINTAINED` list or a register rule, deliberately.

Baseline: exif-editor 78 → 63. What is left in this tool is the block list and the tag editor in `main.js`, and the tag dictionary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
