### PR TITLE
Say whether the photograph will pass in the reader's own language

### DIFF
--- a/locales/ar/tools/id-photo.html
+++ b/locales/ar/tools/id-photo.html
@@ -210,6 +210,81 @@
     JavaScript, and a semicolon is not the mark half these languages join with.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="facts.print">مقاس الطباعة</span>
+    <span data-phrase="facts.head">الرأس، من الذقن إلى القمة</span>
+    <span data-phrase="facts.eye">خط العينين، من الأسفل</span>
+    <span data-phrase="facts.background">الخلفية</span>
+    <span data-phrase="band.range">من {min} إلى {max}</span>
+    <span data-phrase="band.mm">{range} ({min}&ndash;{max} مم)</span>
+    <span data-phrase="band.guidance">{band} (إرشاد)</span>
+    <span data-phrase="measured.mm">{percent} ({mm} مم)</span>
+    <span data-phrase="verdict.head.ok">ارتفاع الرأس {measured}. والقاعدة تطلب {wanted}.</span>
+    <span data-phrase="verdict.head.low">ارتفاع الرأس {measured}، وهو أصغر مما ينبغي. والقاعدة تطلب {wanted}. صغِّر الإطار.</span>
+    <span data-phrase="verdict.head.high">ارتفاع الرأس {measured}، وهو أكبر مما ينبغي. والقاعدة تطلب {wanted}. كبِّر الإطار.</span>
+    <span data-phrase="verdict.eye.ok">خط العينين عند {measured}. والقاعدة تطلب {wanted}.</span>
+    <span data-phrase="verdict.eye.low">خط العينين عند {measured}، وهو أخفض مما ينبغي في الكادر. والقاعدة تطلب {wanted}.
+      أنزِل الإطار.</span>
+    <span data-phrase="verdict.eye.high">خط العينين عند {measured}، وهو أعلى مما ينبغي في الكادر. والقاعدة تطلب {wanted}.
+      ارفع الإطار.</span>
+    <span data-phrase="tilt.level">خط العينين مستوٍ.</span>
+    <span data-phrase="tilt.ok.left">الرأس مائل {degrees} درجة إلى اليسار، وهذا في حدود الدرجات القليلة التي لا يلحظها
+      الفاحص.</span>
+    <span data-phrase="tilt.ok.right">الرأس مائل {degrees} درجة إلى اليمين، وهذا في حدود الدرجات القليلة التي لا يلحظها
+      الفاحص.</span>
+    <span data-phrase="tilt.bad.left">الرأس مائل {degrees} درجة إلى اليسار، وهذا يُلحَظ. أعِد التقاط الصورة والكاميرا
+      مستوية، أو قوِّم الصورة أولاً.</span>
+    <span data-phrase="tilt.bad.right">الرأس مائل {degrees} درجة إلى اليمين، وهذا يُلحَظ. أعِد التقاط الصورة والكاميرا
+      مستوية، أو قوِّم الصورة أولاً.</span>
+    <span data-phrase="centre.ok">الوجه في وسط الكادر.</span>
+    <span data-phrase="centre.left">الوجه يقع على بُعد {size} من عرض الكادر يسار الوسط. اسحب الإطار إلى الجهة الأخرى، أو
+      اضغط &laquo;اضبط&raquo; مرة أخرى.</span>
+    <span data-phrase="centre.right">الوجه يقع على بُعد {size} من عرض الكادر يمين الوسط. اسحب الإطار إلى الجهة الأخرى، أو
+      اضغط &laquo;اضبط&raquo; مرة أخرى.</span>
+    <span data-phrase="resample.enough">القصّة {have} بكسل والمخرَج {need}، فلا شيء يحتاج إلى اختلاق.</span>
+    <span data-phrase="resample.slight">القصّة {have} بكسل لا غير، والمخرَج {need}. ستُكبَّر قليلاً، وهذا يكلّف شيئاً يسيراً
+      من الحدّة ولا شيء غيره.</span>
+    <span data-phrase="resample.severe">القصّة {have} بكسل لا غير، والمخرَج {need}. وهذا نقص كبير: سيخرج الناتج طرياً، وعلى
+      الورق سيبدو كلقطة شاشة. ولا علاج إلا صورة أُخذت من مسافة أقرب أو بدقّة أعلى.</span>
+    <span data-phrase="ready.geometry">الأبعاد لا تفي بالقاعدة بعد. ويمكنك حفظ الملفات على كل حال &mdash; فما هنا شيء يمنعك
+      صورتك &mdash; لكن الأرقام أعلاه هي ما سيقيسه النموذج.</span>
+    <span data-phrase="ready.background">الأبعاد تفي بالقاعدة. أما الخلفية فلا، وهي السبب الأشيع في ردّ الصورة.</span>
+    <span data-phrase="ready.good">الأبعاد تفي بالقاعدة، والخلفية مقبولة.</span>
+    <span data-phrase="bg.white.label">أبيض سادة</span>
+    <span data-phrase="bg.white.inline">أبيض سادة</span>
+    <span data-phrase="bg.white.note">الحائط الأبيض يخرج في الصورة رمادياً فاتحاً. والمطلوب خلفية سادة، مضاءة بانتظام وبلا
+      ظل، لا لون طلاء بعينه.</span>
+    <span data-phrase="bg.off-white.label">أبيض أو مائل إلى البياض</span>
+    <span data-phrase="bg.off-white.inline">أبيض أو مائل إلى البياض</span>
+    <span data-phrase="bg.off-white.note">كلاهما مقبول، وهذا يعني عملياً كل ما كان سادة فاتحاً: لا نقش، ولا أثاث، ولا ظل خلف
+      الرأس.</span>
+    <span data-phrase="bg.light-grey.label">رمادي فاتح سادة</span>
+    <span data-phrase="bg.light-grey.inline">رمادي فاتح سادة</span>
+    <span data-phrase="bg.light-grey.note">الرمادي الفاتح هو ما تفضّله الإيكاو لأنه يفصل الوجه الفاتح عن الخلفية، ويفصل الشعر
+      الداكن عنها كذلك. أما الأبيض الناصع فلا يفعل هذا ولا ذاك.</span>
+    <span data-phrase="bg.cream.label">رمادي فاتح أو كريمي</span>
+    <span data-phrase="bg.cream.inline">رمادي فاتح أو كريمي</span>
+    <span data-phrase="bg.cream.note">هذه صياغة المملكة المتحدة. والكريمي يُقرأ بياضاً دافئاً؛ ومقصد القاعدة أن تكون
+      الخلفية سادة منتظمة، لا أن تكون درجة بعينها.</span>
+    <span data-phrase="bg.colour.bad">الخلفية تُقاس {hex}، وهذا بعيد جداً عن {wanted}.</span>
+    <span data-phrase="bg.colour.warn">الخلفية تُقاس {hex} &mdash; قريبة من {wanted} ولكن ليست هي تماماً.</span>
+    <span data-phrase="bg.colour.good">الخلفية تُقاس {hex}، وهي تمرّ بوصفها {wanted}.</span>
+    <span data-phrase="bg.uniform.bad">ليست لوناً واحداً مستوياً &mdash; فخلفك ظل أو نقش أو شيء ما.</span>
+    <span data-phrase="bg.uniform.warn">غير مستوية قليلاً. والوقوف على بُعد نصف متر آخر من الحائط هو الحل كله في الغالب.</span>
+    <span data-phrase="bg.uniform.good">مضاءة بانتظام، ولا ظل خلف الرأس.</span>
+    <span data-phrase="bg.sides.bad">أحد جانبي الخلفية أدكن من الآخر بكثير، وهذا يُقرأ إضاءةً جانبية.</span>
+    <span data-phrase="bg.sides.warn">أحد الجانبين أدكن قليلاً من الآخر.</span>
+    <span data-phrase="bg.note">{colour} ولن تستبدل هذه الأداة خلفية: فقصّ شخص من صورة يحتاج نموذج تجزئة، والرديء
+      منها يأكل شعر الناس الذين تُرَدّ صورهم أكثر من غيرهم أصلاً. والوقوف على بُعد نصف متر
+      آخر من الحائط يعالج من هذا أكثر مما يعالجه أي مرشِّح.</span>
+    <span data-phrase="bg.signature.note">لا شيء هنا يغيّر توقيعك. يُقاس ويُعرَض عليك، والقصّة بيدك تحرّكها كما تشاء.</span>
+    <span data-phrase="sig.ink.bad">لا حبر يُذكر في القصّة. فإما أن الإطار خارج التوقيع، وإما أن القلم كان أفتح من أن
+      يظهر في التصوير.</span>
+    <span data-phrase="sig.ink.warn">بكسلات داكنة كثيرة جداً &mdash; تحقّق أن القصّة لم تلتقط سطراً مسطَّراً أو حافة
+      الورقة.</span>
+    <span data-phrase="sig.ink.good">الحبر يغطّي {coverage}% من القصّة، وهذا يُقرأ توقيعاً.</span>
+    <span data-phrase="sig.paper.bad">الورق يخرج رمادياً لا أبيض. زِد الضوء على الورقة، أو امسحها ضوئياً بدل تصويرها.</span>
+    <span data-phrase="sig.paper.warn">الورق باهت قليلاً. ومعظم النماذج تريد صفحة بيضاء نظيفة خلف التوقيع.</span>
+    <span data-phrase="sig.paper.good">الورق نظيف وأبيض.</span>
     <span data-phrase="marks.measured">قِيست الأربع كلها من الصورة &mdash;
       التاج من الخطّ الخارجي لرأسك، والبؤبؤان من دكنتهما، والذقن من حيث يجري
       الفكّ إلى العنق. تحقّق منها رغم ذلك، واسحب ما حطّ منها في غير موضعه:

--- a/locales/de/tools/id-photo.html
+++ b/locales/de/tools/id-photo.html
@@ -215,6 +215,96 @@
     a semicolon; nothing else is substituted.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="facts.print">Druckgröße</span>
+    <span data-phrase="facts.head">Kopf, Kinn bis Scheitel</span>
+    <span data-phrase="facts.eye">Augenlinie, von unten</span>
+    <span data-phrase="facts.background">Hintergrund</span>
+    <span data-phrase="band.range">{min} bis {max}</span>
+    <span data-phrase="band.mm">{range} ({min}&ndash;{max} mm)</span>
+    <span data-phrase="band.guidance">{band} (Empfehlung)</span>
+    <span data-phrase="measured.mm">{percent} ({mm} mm)</span>
+    <span data-phrase="verdict.head.ok">Die Kopfhöhe beträgt {measured}. Die Vorschrift verlangt {wanted}.</span>
+    <span data-phrase="verdict.head.low">Die Kopfhöhe beträgt {measured} und ist damit zu klein. Die Vorschrift verlangt
+      {wanted}. Machen Sie den Rahmen kleiner.</span>
+    <span data-phrase="verdict.head.high">Die Kopfhöhe beträgt {measured} und ist damit zu groß. Die Vorschrift verlangt
+      {wanted}. Machen Sie den Rahmen größer.</span>
+    <span data-phrase="verdict.eye.ok">Die Augenlinie liegt bei {measured}. Die Vorschrift verlangt {wanted}.</span>
+    <span data-phrase="verdict.eye.low">Die Augenlinie liegt bei {measured} und damit zu tief im Bild. Die Vorschrift
+      verlangt {wanted}. Schieben Sie den Rahmen nach unten.</span>
+    <span data-phrase="verdict.eye.high">Die Augenlinie liegt bei {measured} und damit zu hoch im Bild. Die Vorschrift
+      verlangt {wanted}. Schieben Sie den Rahmen nach oben.</span>
+    <span data-phrase="tilt.level">Die Augenlinie ist waagerecht.</span>
+    <span data-phrase="tilt.ok.left">Der Kopf neigt sich um {degrees} Grad nach links, und das liegt in den paar Grad,
+      die einem Prüfer nicht auffallen.</span>
+    <span data-phrase="tilt.ok.right">Der Kopf neigt sich um {degrees} Grad nach rechts, und das liegt in den paar Grad,
+      die einem Prüfer nicht auffallen.</span>
+    <span data-phrase="tilt.bad.left">Der Kopf neigt sich um {degrees} Grad nach links, und das fällt auf. Nehmen Sie das
+      Foto mit gerader Kamera neu auf, oder richten Sie das Bild vorher gerade.</span>
+    <span data-phrase="tilt.bad.right">Der Kopf neigt sich um {degrees} Grad nach rechts, und das fällt auf. Nehmen Sie das
+      Foto mit gerader Kamera neu auf, oder richten Sie das Bild vorher gerade.</span>
+    <span data-phrase="centre.ok">Das Gesicht sitzt mittig im Bild.</span>
+    <span data-phrase="centre.left">Das Gesicht sitzt {size} der Bildbreite links der Mitte. Ziehen Sie den Rahmen in
+      die andere Richtung, oder drücken Sie noch einmal &bdquo;Einpassen&ldquo;.</span>
+    <span data-phrase="centre.right">Das Gesicht sitzt {size} der Bildbreite rechts der Mitte. Ziehen Sie den Rahmen in
+      die andere Richtung, oder drücken Sie noch einmal &bdquo;Einpassen&ldquo;.</span>
+    <span data-phrase="resample.enough">Der Ausschnitt ist {have} Pixel groß und die Ausgabe {need}, es muss also nichts
+      erfunden werden.</span>
+    <span data-phrase="resample.slight">Der Ausschnitt ist nur {have} Pixel groß und die Ausgabe {need}. Er wird leicht
+      vergrößert, was ein wenig Schärfe kostet und sonst nichts.</span>
+    <span data-phrase="resample.severe">Der Ausschnitt ist nur {have} Pixel groß und die Ausgabe {need}. Das ist weit
+      daneben: das Ergebnis wird weich, und auf Papier sieht es aus wie ein
+      Bildschirmfoto. Nur ein Foto aus geringerer Entfernung oder mit höherer Auflösung
+      hilft.</span>
+    <span data-phrase="ready.geometry">Die Maße erfüllen die Vorschrift noch nicht. Sie können die Dateien trotzdem
+      speichern &mdash; hier verweigert Ihnen niemand Ihr eigenes Foto &mdash;, aber die
+      Zahlen oben sind das, woran das Formular messen wird.</span>
+    <span data-phrase="ready.background">Die Maße erfüllen die Vorschrift. Der Hintergrund nicht, und das ist der häufigere
+      Grund, aus dem ein Foto zurückkommt.</span>
+    <span data-phrase="ready.good">Die Maße erfüllen die Vorschrift, und der Hintergrund geht durch.</span>
+    <span data-phrase="bg.white.label">Reines Weiß</span>
+    <span data-phrase="bg.white.inline">reines Weiß</span>
+    <span data-phrase="bg.white.note">Eine weiße Wand fotografiert sich hellgrau. Verlangt wird ein schlichter,
+      gleichmäßig ausgeleuchteter, schattenfreier Hintergrund, keine Wandfarbe.</span>
+    <span data-phrase="bg.off-white.label">Weiß oder gebrochenes Weiß</span>
+    <span data-phrase="bg.off-white.inline">Weiß oder gebrochenes Weiß</span>
+    <span data-phrase="bg.off-white.note">Beides wird akzeptiert, was in der Praxis alles Schlichte und Helle meint: kein
+      Muster, keine Möbel und kein Schatten hinter dem Kopf.</span>
+    <span data-phrase="bg.light-grey.label">Schlichtes Hellgrau</span>
+    <span data-phrase="bg.light-grey.inline">schlichtes Hellgrau</span>
+    <span data-phrase="bg.light-grey.note">Hellgrau ist die Vorgabe der ICAO, weil es ein helles Gesicht vom Hintergrund trennt
+      und dunkles Haar ebenso. Reines Weiß tut beides nicht.</span>
+    <span data-phrase="bg.cream.label">Hellgrau oder Creme</span>
+    <span data-phrase="bg.cream.inline">Hellgrau oder Creme</span>
+    <span data-phrase="bg.cream.note">So formuliert es das Vereinigte Königreich. Creme wirkt wie ein warmes gebrochenes
+      Weiß; der Sinn der Vorschrift ist, dass der Hintergrund schlicht und gleichmäßig
+      ist, nicht dass er einen bestimmten Ton hat.</span>
+    <span data-phrase="bg.colour.bad">Der Hintergrund misst sich als {hex}, und das ist weit von {wanted} entfernt.</span>
+    <span data-phrase="bg.colour.warn">Der Hintergrund misst sich als {hex} &mdash; nah an {wanted}, aber nicht ganz.</span>
+    <span data-phrase="bg.colour.good">Der Hintergrund misst sich als {hex} und geht als {wanted} durch.</span>
+    <span data-phrase="bg.uniform.bad">Er ist nicht eine einzige Fläche &mdash; da ist ein Schatten, ein Muster oder ein
+      Gegenstand hinter Ihnen.</span>
+    <span data-phrase="bg.uniform.warn">Leicht ungleichmäßig. Einen halben Meter weiter weg von der Wand zu stehen ist meist
+      die ganze Lösung.</span>
+    <span data-phrase="bg.uniform.good">Gleichmäßig ausgeleuchtet, ohne Schatten hinter dem Kopf.</span>
+    <span data-phrase="bg.sides.bad">Die eine Seite des Hintergrunds ist deutlich dunkler als die andere, was wie
+      Seitenlicht aussieht.</span>
+    <span data-phrase="bg.sides.warn">Die eine Seite ist ein wenig dunkler als die andere.</span>
+    <span data-phrase="bg.note">{colour} Dieses Werkzeug ersetzt keinen Hintergrund: einen Menschen aus einem Foto
+      freizustellen braucht ein Segmentierungsmodell, und ein schlechtes frisst genau den
+      Leuten die Haare weg, deren Fotos ohnehin am häufigsten abgelehnt werden. Einen
+      halben Meter weiter weg von der Wand zu stehen behebt mehr davon als jeder Filter.</span>
+    <span data-phrase="bg.signature.note">Hier wird an Ihrer Unterschrift nichts verändert. Sie wird gemessen und beschrieben,
+      und der Ausschnitt gehört Ihnen.</span>
+    <span data-phrase="sig.ink.bad">Fast keine Tinte im Ausschnitt. Entweder liegt der Rahmen neben der Unterschrift,
+      oder der Stift war zu hell zum Fotografieren.</span>
+    <span data-phrase="sig.ink.warn">Sehr viele dunkle Pixel &mdash; prüfen Sie, ob der Ausschnitt eine Linie oder den
+      Rand des Blattes erwischt hat.</span>
+    <span data-phrase="sig.ink.good">Tinte bedeckt {coverage}% des Ausschnitts, und das liest sich wie eine Unterschrift.</span>
+    <span data-phrase="sig.paper.bad">Das Papier kommt grau statt weiß heraus. Mehr Licht auf das Blatt, oder ein Scan
+      statt eines Fotos.</span>
+    <span data-phrase="sig.paper.warn">Das Papier ist ein wenig stumpf. Die meisten Formulare wollen eine saubere weiße
+      Seite hinter der Unterschrift.</span>
+    <span data-phrase="sig.paper.good">Das Papier ist sauber und weiß.</span>
     <span data-phrase="marks.measured">Alle vier wurden am Foto gemessen &mdash; der Scheitel an
       der Kontur Ihres Kopfes, die Pupillen an ihrer Dunkelheit, das Kinn dort, wo der
       Kiefer in den Hals übergeht. Prüfen Sie sie trotzdem und ziehen Sie zurecht, was

--- a/locales/es/tools/id-photo.html
+++ b/locales/es/tools/id-photo.html
@@ -213,6 +213,92 @@
     a semicolon; nothing else is substituted.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="facts.print">Tamaño de impresión</span>
+    <span data-phrase="facts.head">Cabeza, de la barbilla a la coronilla</span>
+    <span data-phrase="facts.eye">Línea de los ojos, desde abajo</span>
+    <span data-phrase="facts.background">Fondo</span>
+    <span data-phrase="band.range">de {min} a {max}</span>
+    <span data-phrase="band.mm">{range} ({min}&ndash;{max} mm)</span>
+    <span data-phrase="band.guidance">{band} (orientativo)</span>
+    <span data-phrase="measured.mm">{percent} ({mm} mm)</span>
+    <span data-phrase="verdict.head.ok">La altura de la cabeza es {measured}. La norma pide {wanted}.</span>
+    <span data-phrase="verdict.head.low">La altura de la cabeza es {measured}, que es demasiado pequeña. La norma pide
+      {wanted}. Haz el recuadro más pequeño.</span>
+    <span data-phrase="verdict.head.high">La altura de la cabeza es {measured}, que es demasiado grande. La norma pide
+      {wanted}. Haz el recuadro más grande.</span>
+    <span data-phrase="verdict.eye.ok">La línea de los ojos está a {measured}. La norma pide {wanted}.</span>
+    <span data-phrase="verdict.eye.low">La línea de los ojos está a {measured}, demasiado baja en el encuadre. La norma pide
+      {wanted}. Baja el recuadro.</span>
+    <span data-phrase="verdict.eye.high">La línea de los ojos está a {measured}, demasiado alta en el encuadre. La norma pide
+      {wanted}. Sube el recuadro.</span>
+    <span data-phrase="tilt.level">La línea de los ojos está nivelada.</span>
+    <span data-phrase="tilt.ok.left">La cabeza se inclina {degrees} grados a la izquierda, que está dentro del par de
+      grados que un examinador no va a notar.</span>
+    <span data-phrase="tilt.ok.right">La cabeza se inclina {degrees} grados a la derecha, que está dentro del par de
+      grados que un examinador no va a notar.</span>
+    <span data-phrase="tilt.bad.left">La cabeza se inclina {degrees} grados a la izquierda, y eso se nota. Repite la foto
+      con la cámara nivelada, o endereza antes la imagen.</span>
+    <span data-phrase="tilt.bad.right">La cabeza se inclina {degrees} grados a la derecha, y eso se nota. Repite la foto
+      con la cámara nivelada, o endereza antes la imagen.</span>
+    <span data-phrase="centre.ok">La cara está centrada en el encuadre.</span>
+    <span data-phrase="centre.left">La cara queda {size} del ancho del encuadre a la izquierda del centro. Arrastra el
+      recuadro al otro lado, o vuelve a pulsar «Ajustar».</span>
+    <span data-phrase="centre.right">La cara queda {size} del ancho del encuadre a la derecha del centro. Arrastra el
+      recuadro al otro lado, o vuelve a pulsar «Ajustar».</span>
+    <span data-phrase="resample.enough">El recorte es de {have} píxeles y la salida de {need}, así que no hay que inventarse
+      nada.</span>
+    <span data-phrase="resample.slight">El recorte es de solo {have} píxeles y la salida de {need}. Se ampliará un poco, lo
+      que cuesta algo de nitidez y nada más.</span>
+    <span data-phrase="resample.severe">El recorte es de solo {have} píxeles y la salida de {need}. Se queda muy corto: el
+      resultado se verá blando, y en papel parecerá una captura de pantalla. Solo lo
+      arregla una foto hecha más de cerca, o a más resolución.</span>
+    <span data-phrase="ready.geometry">El encuadre todavía no cumple la norma. Puedes guardar los archivos igual &mdash;
+      aquí nadie te niega tu propia fotografía &mdash;, pero las cifras de arriba son lo
+      que el formulario va a medir.</span>
+    <span data-phrase="ready.background">El encuadre cumple la norma. El fondo no, y ese es el motivo más común por el que
+      devuelven una foto.</span>
+    <span data-phrase="ready.good">El encuadre cumple la norma y el fondo se lee como aceptable.</span>
+    <span data-phrase="bg.white.label">Blanco liso</span>
+    <span data-phrase="bg.white.inline">blanco liso</span>
+    <span data-phrase="bg.white.note">Una pared blanca sale gris claro en la foto. Lo que se pide es un fondo liso,
+      iluminado por igual y sin sombras, no un color de pintura.</span>
+    <span data-phrase="bg.off-white.label">Blanco o blanco roto</span>
+    <span data-phrase="bg.off-white.inline">blanco o blanco roto</span>
+    <span data-phrase="bg.off-white.note">Se aceptan los dos, lo que en la práctica quiere decir cualquier cosa lisa y clara:
+      sin dibujo, sin muebles y sin sombra detrás de la cabeza.</span>
+    <span data-phrase="bg.light-grey.label">Gris claro liso</span>
+    <span data-phrase="bg.light-grey.inline">gris claro liso</span>
+    <span data-phrase="bg.light-grey.note">El gris claro es lo que prefiere la OACI porque separa del fondo una cara clara, y
+      también el pelo oscuro. El blanco puro no hace ninguna de las dos cosas.</span>
+    <span data-phrase="bg.cream.label">Gris claro o crema</span>
+    <span data-phrase="bg.cream.inline">gris claro o crema</span>
+    <span data-phrase="bg.cream.note">Así lo redacta el Reino Unido. El crema se lee como un blanco roto cálido; lo que
+      persigue la norma es que el fondo sea liso y uniforme, no que sea un tono concreto.</span>
+    <span data-phrase="bg.colour.bad">El fondo mide {hex}, que queda muy lejos de {wanted}.</span>
+    <span data-phrase="bg.colour.warn">El fondo mide {hex} &mdash; cerca de {wanted}, pero no del todo.</span>
+    <span data-phrase="bg.colour.good">El fondo mide {hex}, que pasa como {wanted}.</span>
+    <span data-phrase="bg.uniform.bad">No es un solo color liso &mdash; hay una sombra, un dibujo o un objeto detrás de ti.</span>
+    <span data-phrase="bg.uniform.warn">Un poco desigual. Ponerte medio metro más lejos de la pared suele ser todo el
+      arreglo.</span>
+    <span data-phrase="bg.uniform.good">Iluminado por igual, sin sombra detrás de la cabeza.</span>
+    <span data-phrase="bg.sides.bad">Un lado del fondo está bastante más oscuro que el otro, lo que se lee como luz
+      lateral.</span>
+    <span data-phrase="bg.sides.warn">Un lado está un poco más oscuro que el otro.</span>
+    <span data-phrase="bg.note">{colour} Esta herramienta no va a sustituir un fondo: recortar a una persona de una
+      foto necesita un modelo de segmentación, y uno malo se come el pelo justo de las
+      personas a las que ya les rechazan más las fotos. Ponerte medio metro más lejos de
+      la pared arregla más casos que cualquier filtro.</span>
+    <span data-phrase="bg.signature.note">Aquí no se toca tu firma. Se mide y se describe, y el recorte es tuyo.</span>
+    <span data-phrase="sig.ink.bad">Casi no hay tinta en el recorte. O el recuadro está fuera de la firma, o el
+      bolígrafo era demasiado claro para salir en la foto.</span>
+    <span data-phrase="sig.ink.warn">Muchísimos píxeles oscuros &mdash; comprueba que el recorte no haya cogido una raya
+      del papel o el borde de la hoja.</span>
+    <span data-phrase="sig.ink.good">La tinta cubre el {coverage}% del recorte, que se lee como una firma.</span>
+    <span data-phrase="sig.paper.bad">El papel está saliendo gris en vez de blanco. Más luz sobre la hoja, o un escaneo en
+      vez de una foto.</span>
+    <span data-phrase="sig.paper.warn">El papel queda un poco apagado. Casi todos los formularios quieren una hoja blanca y
+      limpia detrás de la firma.</span>
+    <span data-phrase="sig.paper.good">El papel está limpio y blanco.</span>
     <span data-phrase="marks.measured">Los cuatro se midieron sobre la foto: la coronilla por el
       contorno de tu cabeza, las pupilas por lo oscuras que son, la barbilla por donde
       la mandíbula se mete en el cuello. Compruébalos igualmente y arrastra el que haya

--- a/locales/fr/tools/id-photo.html
+++ b/locales/fr/tools/id-photo.html
@@ -217,6 +217,100 @@
     a semicolon; nothing else is substituted.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="facts.print">Taille d&rsquo;impression</span>
+    <span data-phrase="facts.head">Tête, du menton au sommet du crâne</span>
+    <span data-phrase="facts.eye">Ligne des yeux, depuis le bas</span>
+    <span data-phrase="facts.background">Fond</span>
+    <span data-phrase="band.range">de {min} à {max}</span>
+    <span data-phrase="band.mm">{range} ({min}&ndash;{max} mm)</span>
+    <span data-phrase="band.guidance">{band} (indicatif)</span>
+    <span data-phrase="measured.mm">{percent} ({mm} mm)</span>
+    <span data-phrase="verdict.head.ok">La hauteur de tête est de {measured}. La règle demande {wanted}.</span>
+    <span data-phrase="verdict.head.low">La hauteur de tête est de {measured}, ce qui est trop petit. La règle demande
+      {wanted}. Réduisez le cadre.</span>
+    <span data-phrase="verdict.head.high">La hauteur de tête est de {measured}, ce qui est trop grand. La règle demande
+      {wanted}. Agrandissez le cadre.</span>
+    <span data-phrase="verdict.eye.ok">La ligne des yeux est à {measured}. La règle demande {wanted}.</span>
+    <span data-phrase="verdict.eye.low">La ligne des yeux est à {measured}, ce qui est trop bas dans le cadre. La règle
+      demande {wanted}. Descendez le cadre.</span>
+    <span data-phrase="verdict.eye.high">La ligne des yeux est à {measured}, ce qui est trop haut dans le cadre. La règle
+      demande {wanted}. Remontez le cadre.</span>
+    <span data-phrase="tilt.level">La ligne des yeux est horizontale.</span>
+    <span data-phrase="tilt.ok.left">La tête penche de {degrees} degrés vers la gauche, ce qui reste dans les quelques
+      degrés qu&rsquo;un examinateur ne remarquera pas.</span>
+    <span data-phrase="tilt.ok.right">La tête penche de {degrees} degrés vers la droite, ce qui reste dans les quelques
+      degrés qu&rsquo;un examinateur ne remarquera pas.</span>
+    <span data-phrase="tilt.bad.left">La tête penche de {degrees} degrés vers la gauche, et cela se voit. Refaites la
+      photo avec l&rsquo;appareil d&rsquo;aplomb, ou redressez l&rsquo;image
+      d&rsquo;abord.</span>
+    <span data-phrase="tilt.bad.right">La tête penche de {degrees} degrés vers la droite, et cela se voit. Refaites la
+      photo avec l&rsquo;appareil d&rsquo;aplomb, ou redressez l&rsquo;image
+      d&rsquo;abord.</span>
+    <span data-phrase="centre.ok">Le visage est centré dans le cadre.</span>
+    <span data-phrase="centre.left">Le visage est décalé de {size} de la largeur du cadre vers la gauche. Tirez le cadre
+      dans l&rsquo;autre sens, ou appuyez de nouveau sur
+      &laquo;&nbsp;Ajuster&nbsp;&raquo;.</span>
+    <span data-phrase="centre.right">Le visage est décalé de {size} de la largeur du cadre vers la droite. Tirez le cadre
+      dans l&rsquo;autre sens, ou appuyez de nouveau sur
+      &laquo;&nbsp;Ajuster&nbsp;&raquo;.</span>
+    <span data-phrase="resample.enough">Le recadrage fait {have} pixels et la sortie {need}&nbsp;: rien n&rsquo;a à être
+      inventé.</span>
+    <span data-phrase="resample.slight">Le recadrage ne fait que {have} pixels et la sortie {need}. Il sera légèrement
+      agrandi, ce qui coûte un peu de netteté et rien d&rsquo;autre.</span>
+    <span data-phrase="resample.severe">Le recadrage ne fait que {have} pixels et la sortie {need}. C&rsquo;est très loin du
+      compte&nbsp;: le résultat paraîtra mou, et sur papier il aura l&rsquo;air
+      d&rsquo;une capture d&rsquo;écran. Seule une photo prise de plus près, ou à une
+      résolution plus haute, y remédie.</span>
+    <span data-phrase="ready.geometry">Le cadrage ne satisfait pas encore la règle. Vous pouvez tout de même enregistrer
+      les fichiers &mdash; rien ici ne vous refuse votre propre photographie &mdash; mais
+      ce sont les chiffres ci-dessus que le formulaire mesurera.</span>
+    <span data-phrase="ready.background">Le cadrage satisfait la règle. Le fond non, et c&rsquo;est la raison la plus
+      fréquente pour laquelle une photo revient.</span>
+    <span data-phrase="ready.good">Le cadrage satisfait la règle et le fond passe.</span>
+    <span data-phrase="bg.white.label">Blanc uni</span>
+    <span data-phrase="bg.white.inline">blanc uni</span>
+    <span data-phrase="bg.white.note">Un mur blanc se photographie en gris clair. Ce qui est demandé, c&rsquo;est un fond
+      uni, éclairé uniformément et sans ombre, pas une couleur de peinture.</span>
+    <span data-phrase="bg.off-white.label">Blanc ou blanc cassé</span>
+    <span data-phrase="bg.off-white.inline">blanc ou blanc cassé</span>
+    <span data-phrase="bg.off-white.note">Les deux sont acceptés, ce qui en pratique veut dire tout ce qui est uni et
+      clair&nbsp;: pas de motif, pas de meuble et pas d&rsquo;ombre derrière la tête.</span>
+    <span data-phrase="bg.light-grey.label">Gris clair uni</span>
+    <span data-phrase="bg.light-grey.inline">gris clair uni</span>
+    <span data-phrase="bg.light-grey.note">Le gris clair est la préférence de l&rsquo;OACI parce qu&rsquo;il détache un visage
+      clair du fond, et les cheveux foncés aussi. Le blanc pur ne fait ni l&rsquo;un ni
+      l&rsquo;autre.</span>
+    <span data-phrase="bg.cream.label">Gris clair ou crème</span>
+    <span data-phrase="bg.cream.inline">gris clair ou crème</span>
+    <span data-phrase="bg.cream.note">La formulation employée par le Royaume-Uni. Le crème se lit comme un blanc cassé
+      chaud&nbsp;; ce que veut la règle, c&rsquo;est que le fond soit uni et uniforme, pas
+      qu&rsquo;il soit d&rsquo;une teinte précise.</span>
+    <span data-phrase="bg.colour.bad">Le fond se mesure à {hex}, ce qui est très loin de {wanted}.</span>
+    <span data-phrase="bg.colour.warn">Le fond se mesure à {hex} &mdash; proche de {wanted}, mais pas tout à fait.</span>
+    <span data-phrase="bg.colour.good">Le fond se mesure à {hex}, ce qui passe pour du {wanted}.</span>
+    <span data-phrase="bg.uniform.bad">Ce n&rsquo;est pas une seule couleur unie &mdash; il y a une ombre, un motif ou un
+      objet derrière vous.</span>
+    <span data-phrase="bg.uniform.warn">Légèrement inégal. Se tenir un demi-mètre plus loin du mur suffit presque toujours.</span>
+    <span data-phrase="bg.uniform.good">Éclairé uniformément, sans ombre derrière la tête.</span>
+    <span data-phrase="bg.sides.bad">Un côté du fond est bien plus sombre que l&rsquo;autre, ce qui se lit comme un
+      éclairage latéral.</span>
+    <span data-phrase="bg.sides.warn">Un côté est un peu plus sombre que l&rsquo;autre.</span>
+    <span data-phrase="bg.note">{colour} Cet outil ne remplacera pas un fond&nbsp;: détourer une personne demande un
+      modèle de segmentation, et un mauvais mange les cheveux de précisément ceux dont les
+      photos sont déjà refusées le plus souvent. Se tenir un demi-mètre plus loin du mur
+      en corrige davantage que n&rsquo;importe quel filtre.</span>
+    <span data-phrase="bg.signature.note">Rien ici ne modifie votre signature. Elle est mesurée et décrite, et le cadre est à
+      vous.</span>
+    <span data-phrase="sig.ink.bad">Presque pas d&rsquo;encre dans le cadre. Ou bien le cadre est à côté de la
+      signature, ou bien le stylo était trop clair pour être photographié.</span>
+    <span data-phrase="sig.ink.warn">Énormément de pixels sombres &mdash; vérifiez que le cadre n&rsquo;a pas attrapé une
+      ligne réglée ou le bord de la page.</span>
+    <span data-phrase="sig.ink.good">L&rsquo;encre couvre {coverage}&nbsp;% du cadre, ce qui se lit comme une signature.</span>
+    <span data-phrase="sig.paper.bad">Le papier ressort gris plutôt que blanc. Plus de lumière sur la page, ou un scan
+      plutôt qu&rsquo;une photo.</span>
+    <span data-phrase="sig.paper.warn">Le papier est un peu terne. La plupart des formulaires veulent une page blanche et
+      propre derrière la signature.</span>
+    <span data-phrase="sig.paper.good">Le papier est propre et blanc.</span>
     <span data-phrase="marks.measured">Les quatre ont été mesurés sur la photo&nbsp;: le sommet
       du crâne d&rsquo;après le contour de votre tête, les pupilles d&rsquo;après ce
       qu&rsquo;elles ont de sombre, le menton là où la mâchoire rejoint le cou.

--- a/locales/hi/tools/id-photo.html
+++ b/locales/hi/tools/id-photo.html
@@ -215,6 +215,91 @@
     a semicolon; nothing else is substituted.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="facts.print">छपाई का आकार</span>
+    <span data-phrase="facts.head">सिर, ठोड़ी से चोटी तक</span>
+    <span data-phrase="facts.eye">आँखों की रेखा, नीचे से</span>
+    <span data-phrase="facts.background">पृष्ठभूमि</span>
+    <span data-phrase="band.range">{min} से {max}</span>
+    <span data-phrase="band.mm">{range} ({min}&ndash;{max} मिमी)</span>
+    <span data-phrase="band.guidance">{band} (मार्गदर्शन)</span>
+    <span data-phrase="measured.mm">{percent} ({mm} मिमी)</span>
+    <span data-phrase="verdict.head.ok">सिर की ऊँचाई {measured} है। नियम {wanted} माँगता है।</span>
+    <span data-phrase="verdict.head.low">सिर की ऊँचाई {measured} है, जो बहुत कम है। नियम {wanted} माँगता है। बॉक्स को छोटा
+      कीजिए।</span>
+    <span data-phrase="verdict.head.high">सिर की ऊँचाई {measured} है, जो बहुत ज़्यादा है। नियम {wanted} माँगता है। बॉक्स को
+      बड़ा कीजिए।</span>
+    <span data-phrase="verdict.eye.ok">आँखों की रेखा {measured} पर है। नियम {wanted} माँगता है।</span>
+    <span data-phrase="verdict.eye.low">आँखों की रेखा {measured} पर है, यानी फ़्रेम में बहुत नीचे। नियम {wanted} माँगता है।
+      बॉक्स को नीचे सरकाइए।</span>
+    <span data-phrase="verdict.eye.high">आँखों की रेखा {measured} पर है, यानी फ़्रेम में बहुत ऊपर। नियम {wanted} माँगता है।
+      बॉक्स को ऊपर सरकाइए।</span>
+    <span data-phrase="tilt.level">आँखों की रेखा सीधी है।</span>
+    <span data-phrase="tilt.ok.left">सिर {degrees} डिग्री बाईं ओर झुका है, और यह उन दो-एक डिग्री के भीतर है जिन्हें कोई
+      जाँचने वाला पकड़ता नहीं।</span>
+    <span data-phrase="tilt.ok.right">सिर {degrees} डिग्री दाईं ओर झुका है, और यह उन दो-एक डिग्री के भीतर है जिन्हें कोई
+      जाँचने वाला पकड़ता नहीं।</span>
+    <span data-phrase="tilt.bad.left">सिर {degrees} डिग्री बाईं ओर झुका है, और यह दिख जाता है। कैमरा सीधा रखकर दोबारा
+      खींचिए, या पहले तस्वीर को सीधा कर लीजिए।</span>
+    <span data-phrase="tilt.bad.right">सिर {degrees} डिग्री दाईं ओर झुका है, और यह दिख जाता है। कैमरा सीधा रखकर दोबारा
+      खींचिए, या पहले तस्वीर को सीधा कर लीजिए।</span>
+    <span data-phrase="centre.ok">चेहरा फ़्रेम के बीचोंबीच है।</span>
+    <span data-phrase="centre.left">चेहरा फ़्रेम की चौड़ाई का {size} बीच से बाईं ओर बैठा है। बॉक्स को दूसरी ओर खींचिए,
+      या &ldquo;फ़िट&rdquo; दोबारा दबाइए।</span>
+    <span data-phrase="centre.right">चेहरा फ़्रेम की चौड़ाई का {size} बीच से दाईं ओर बैठा है। बॉक्स को दूसरी ओर खींचिए,
+      या &ldquo;फ़िट&rdquo; दोबारा दबाइए।</span>
+    <span data-phrase="resample.enough">कटा हुआ हिस्सा {have} पिक्सल का है और निकलेगा {need} का, इसलिए कुछ गढ़ना नहीं
+      पड़ेगा।</span>
+    <span data-phrase="resample.slight">कटा हुआ हिस्सा सिर्फ़ {have} पिक्सल का है और निकलेगा {need} का। इसे थोड़ा बड़ा किया
+      जाएगा, जिसमें ज़रा-सी सफ़ाई जाती है और कुछ नहीं।</span>
+    <span data-phrase="resample.severe">कटा हुआ हिस्सा सिर्फ़ {have} पिक्सल का है और निकलेगा {need} का। यह बहुत कम है: नतीजा
+      धुँधला लगेगा, और काग़ज़ पर स्क्रीनशॉट जैसा दिखेगा। इसका एक ही इलाज है, पास से या
+      ज़्यादा रेज़ोल्यूशन पर खींची गई तस्वीर।</span>
+    <span data-phrase="ready.geometry">नाप-जोख अभी नियम पर नहीं उतरती। फ़ाइलें फिर भी सहेजी जा सकती हैं &mdash; यहाँ कोई
+      आपकी अपनी तस्वीर देने से इनकार नहीं करता &mdash; पर फ़ॉर्म जो नापेगा वह ऊपर के यही
+      आँकड़े हैं।</span>
+    <span data-phrase="ready.background">नाप-जोख नियम पर उतरती है। पृष्ठभूमि नहीं, और तस्वीर लौटने की ज़्यादा आम वजह यही होती
+      है।</span>
+    <span data-phrase="ready.good">नाप-जोख नियम पर उतरती है और पृष्ठभूमि भी ठीक पढ़ी जा रही है।</span>
+    <span data-phrase="bg.white.label">सादा सफ़ेद</span>
+    <span data-phrase="bg.white.inline">सादा सफ़ेद</span>
+    <span data-phrase="bg.white.note">सफ़ेद दीवार तस्वीर में हल्की भूरी आती है। माँगा यह जाता है कि पृष्ठभूमि सादी हो,
+      रोशनी बराबर हो और परछाईं न हो &mdash; कोई ख़ास रंग का पेंट नहीं।</span>
+    <span data-phrase="bg.off-white.label">सफ़ेद या हल्का मटमैला सफ़ेद</span>
+    <span data-phrase="bg.off-white.inline">सफ़ेद या हल्का मटमैला सफ़ेद</span>
+    <span data-phrase="bg.off-white.note">दोनों चल जाते हैं, यानी असल में कुछ भी सादा और हल्का: न कोई छपाई, न फ़र्नीचर, न सिर
+      के पीछे परछाईं।</span>
+    <span data-phrase="bg.light-grey.label">सादा हल्का भूरा</span>
+    <span data-phrase="bg.light-grey.inline">सादा हल्का भूरा</span>
+    <span data-phrase="bg.light-grey.note">हल्का भूरा ICAO की पसंद है, क्योंकि यह गोरे चेहरे को पृष्ठभूमि से अलग करता है और
+      गहरे बालों को भी। शुद्ध सफ़ेद दोनों में से कुछ नहीं करता।</span>
+    <span data-phrase="bg.cream.label">हल्का भूरा या क्रीम</span>
+    <span data-phrase="bg.cream.inline">हल्का भूरा या क्रीम</span>
+    <span data-phrase="bg.cream.note">यह शब्द ब्रिटेन इस्तेमाल करता है। क्रीम गरम मटमैले सफ़ेद जैसा पढ़ा जाता है; नियम का
+      मतलब यह है कि पृष्ठभूमि सादी और एकसार हो, न कि कोई एक ख़ास रंगत।</span>
+    <span data-phrase="bg.colour.bad">पृष्ठभूमि {hex} नापी गई है, जो {wanted} से बहुत दूर है।</span>
+    <span data-phrase="bg.colour.warn">पृष्ठभूमि {hex} नापी गई है &mdash; {wanted} के पास, पर बिलकुल वही नहीं।</span>
+    <span data-phrase="bg.colour.good">पृष्ठभूमि {hex} नापी गई है, जो {wanted} के तौर पर चल जाती है।</span>
+    <span data-phrase="bg.uniform.bad">यह एक ही सपाट रंग नहीं है &mdash; आपके पीछे कोई परछाईं, कोई छपाई या कोई चीज़ है।</span>
+    <span data-phrase="bg.uniform.warn">थोड़ी असमान है। दीवार से आधा मीटर और दूर खड़े हो जाना अक्सर पूरा इलाज है।</span>
+    <span data-phrase="bg.uniform.good">रोशनी बराबर है, सिर के पीछे कोई परछाईं नहीं।</span>
+    <span data-phrase="bg.sides.bad">पृष्ठभूमि की एक तरफ़ दूसरी से कहीं ज़्यादा गहरी है, जो बगल से आती रोशनी जैसी पढ़ी
+      जाती है।</span>
+    <span data-phrase="bg.sides.warn">एक तरफ़ दूसरी से ज़रा गहरी है।</span>
+    <span data-phrase="bg.note">{colour} यह औज़ार पृष्ठभूमि बदलेगा नहीं: तस्वीर में से किसी इंसान को काटकर निकालने
+      के लिए सेगमेंटेशन मॉडल चाहिए, और ख़राब मॉडल ठीक उन्हीं लोगों के बाल चर जाता है जिनकी
+      तस्वीरें पहले से सबसे ज़्यादा लौटाई जाती हैं। दीवार से आधा मीटर और दूर खड़े होना
+      किसी भी फ़िल्टर से ज़्यादा मामले सुलझा देता है।</span>
+    <span data-phrase="bg.signature.note">यहाँ आपके दस्तख़त में कोई फेरबदल नहीं होता। उन्हें नापा जाता है और आपको बता दिया
+      जाता है, और कटाई का दायरा आपके ही हाथ में है।</span>
+    <span data-phrase="sig.ink.bad">कटे हुए हिस्से में स्याही है ही नहीं। या तो बॉक्स दस्तख़त से हटकर है, या फिर क़लम
+      इतनी हल्की थी कि तस्वीर में आई नहीं।</span>
+    <span data-phrase="sig.ink.warn">गहरे पिक्सल बहुत ज़्यादा हैं &mdash; देख लीजिए कि कटाई में काग़ज़ की कोई लकीर या
+      पन्ने का किनारा तो नहीं आ गया।</span>
+    <span data-phrase="sig.ink.good">स्याही कटे हुए हिस्से का {coverage}% ढके हुए है, जो दस्तख़त जैसा पढ़ा जाता है।</span>
+    <span data-phrase="sig.paper.bad">काग़ज़ सफ़ेद के बजाय भूरा आ रहा है। पन्ने पर और रोशनी डालिए, या तस्वीर के बजाय स्कैन
+      कीजिए।</span>
+    <span data-phrase="sig.paper.warn">काग़ज़ थोड़ा फीका है। ज़्यादातर फ़ॉर्म दस्तख़त के पीछे साफ़ सफ़ेद पन्ना चाहते हैं।</span>
+    <span data-phrase="sig.paper.good">काग़ज़ साफ़ और सफ़ेद है।</span>
     <span data-phrase="marks.measured">चारों फ़ोटो पर नापकर रखे गए हैं &mdash; शिखर आपके सिर की
       बाहरी रेखा से, पुतलियाँ उनके गहरेपन से, और ठुड्डी वहाँ से जहाँ जबड़ा गर्दन में
       उतरता है। फिर भी इन्हें देख लीजिए और जो गलत जगह गिरा हो उसे खींच दीजिए: क्रॉप

--- a/locales/id/tools/id-photo.html
+++ b/locales/id/tools/id-photo.html
@@ -224,6 +224,94 @@
     JavaScript, and a semicolon is not the mark half these languages join with.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="facts.print">Ukuran cetak</span>
+    <span data-phrase="facts.head">Kepala, dagu sampai ubun-ubun</span>
+    <span data-phrase="facts.eye">Garis mata, dari bawah</span>
+    <span data-phrase="facts.background">Latar</span>
+    <span data-phrase="band.range">{min} sampai {max}</span>
+    <span data-phrase="band.mm">{range} ({min}&ndash;{max} mm)</span>
+    <span data-phrase="band.guidance">{band} (anjuran)</span>
+    <span data-phrase="measured.mm">{percent} ({mm} mm)</span>
+    <span data-phrase="verdict.head.ok">Tinggi kepala {measured}. Aturannya minta {wanted}.</span>
+    <span data-phrase="verdict.head.low">Tinggi kepala {measured}, dan itu terlalu kecil. Aturannya minta {wanted}. Kecilkan
+      kotaknya.</span>
+    <span data-phrase="verdict.head.high">Tinggi kepala {measured}, dan itu terlalu besar. Aturannya minta {wanted}. Besarkan
+      kotaknya.</span>
+    <span data-phrase="verdict.eye.ok">Garis matanya di {measured}. Aturannya minta {wanted}.</span>
+    <span data-phrase="verdict.eye.low">Garis matanya di {measured}, terlalu rendah di dalam bingkai. Aturannya minta
+      {wanted}. Turunkan kotaknya.</span>
+    <span data-phrase="verdict.eye.high">Garis matanya di {measured}, terlalu tinggi di dalam bingkai. Aturannya minta
+      {wanted}. Naikkan kotaknya.</span>
+    <span data-phrase="tilt.level">Garis matanya rata.</span>
+    <span data-phrase="tilt.ok.left">Kepalanya miring {degrees} derajat ke kiri, dan itu masih di dalam dua tiga derajat
+      yang tidak akan disadari pemeriksa.</span>
+    <span data-phrase="tilt.ok.right">Kepalanya miring {degrees} derajat ke kanan, dan itu masih di dalam dua tiga derajat
+      yang tidak akan disadari pemeriksa.</span>
+    <span data-phrase="tilt.bad.left">Kepalanya miring {degrees} derajat ke kiri, dan itu kelihatan. Foto ulang dengan
+      kamera yang rata, atau luruskan dulu gambarnya.</span>
+    <span data-phrase="tilt.bad.right">Kepalanya miring {degrees} derajat ke kanan, dan itu kelihatan. Foto ulang dengan
+      kamera yang rata, atau luruskan dulu gambarnya.</span>
+    <span data-phrase="centre.ok">Wajahnya di tengah bingkai.</span>
+    <span data-phrase="centre.left">Wajahnya {size} dari lebar bingkai di sebelah kiri titik tengah. Geser kotaknya ke
+      arah sebaliknya, atau tekan &ldquo;Paskan&rdquo; lagi.</span>
+    <span data-phrase="centre.right">Wajahnya {size} dari lebar bingkai di sebelah kanan titik tengah. Geser kotaknya ke
+      arah sebaliknya, atau tekan &ldquo;Paskan&rdquo; lagi.</span>
+    <span data-phrase="resample.enough">Potongannya {have} piksel dan keluarannya {need}, jadi tidak ada yang perlu
+      dikarang.</span>
+    <span data-phrase="resample.slight">Potongannya cuma {have} piksel dan keluarannya {need}. Ia akan sedikit diperbesar,
+      dan itu cuma memakan sedikit ketajaman.</span>
+    <span data-phrase="resample.severe">Potongannya cuma {have} piksel dan keluarannya {need}. Itu jauh kurang: hasilnya
+      akan lembek, dan di atas kertas akan kelihatan seperti tangkapan layar. Satu-satunya
+      jalan adalah foto yang diambil lebih dekat atau dengan resolusi lebih tinggi.</span>
+    <span data-phrase="ready.geometry">Ukurannya belum memenuhi aturan. Anda tetap bisa menyimpan berkasnya &mdash; tidak
+      ada apa pun di sini yang menolak memberikan foto Anda sendiri &mdash; tapi
+      angka-angka di atas itulah yang akan diukur formulirnya.</span>
+    <span data-phrase="ready.background">Ukurannya memenuhi aturan. Latarnya tidak, dan itu alasan yang lebih sering membuat
+      sebuah foto dikembalikan.</span>
+    <span data-phrase="ready.good">Ukurannya memenuhi aturan dan latarnya terbaca cukup baik.</span>
+    <span data-phrase="bg.white.label">Putih polos</span>
+    <span data-phrase="bg.white.inline">putih polos</span>
+    <span data-phrase="bg.white.note">Tembok putih terfoto jadi abu-abu muda. Yang diminta adalah latar yang polos,
+      cahayanya rata dan tanpa bayangan, bukan warna cat.</span>
+    <span data-phrase="bg.off-white.label">Putih atau putih gading</span>
+    <span data-phrase="bg.off-white.inline">putih atau putih gading</span>
+    <span data-phrase="bg.off-white.note">Dua-duanya diterima, yang dalam praktiknya berarti apa saja yang polos dan terang:
+      tanpa motif, tanpa perabot dan tanpa bayangan di belakang kepala.</span>
+    <span data-phrase="bg.light-grey.label">Abu-abu muda polos</span>
+    <span data-phrase="bg.light-grey.inline">abu-abu muda polos</span>
+    <span data-phrase="bg.light-grey.note">Abu-abu muda adalah yang disukai ICAO karena ia memisahkan wajah yang terang dari
+      latarnya, dan rambut gelap juga. Putih murni tidak melakukan keduanya.</span>
+    <span data-phrase="bg.cream.label">Abu-abu muda atau krem</span>
+    <span data-phrase="bg.cream.inline">abu-abu muda atau krem</span>
+    <span data-phrase="bg.cream.note">Begitulah Britania Raya menuliskannya. Krem terbaca sebagai putih gading yang
+      hangat; yang dikejar aturannya adalah latar yang polos dan rata, bukan satu rona
+      tertentu.</span>
+    <span data-phrase="bg.colour.bad">Latarnya terbaca {hex}, dan itu jauh sekali dari {wanted}.</span>
+    <span data-phrase="bg.colour.warn">Latarnya terbaca {hex} &mdash; dekat ke {wanted}, tapi belum pas.</span>
+    <span data-phrase="bg.colour.good">Latarnya terbaca {hex}, dan itu lolos sebagai {wanted}.</span>
+    <span data-phrase="bg.uniform.bad">Bukan satu warna rata &mdash; ada bayangan, motif atau benda di belakang Anda.</span>
+    <span data-phrase="bg.uniform.warn">Sedikit tidak rata. Berdiri setengah meter lebih jauh dari tembok biasanya sudah
+      menyelesaikan semuanya.</span>
+    <span data-phrase="bg.uniform.good">Cahayanya rata, tidak ada bayangan di belakang kepala.</span>
+    <span data-phrase="bg.sides.bad">Satu sisi latarnya jauh lebih gelap daripada sisi lain, dan itu terbaca sebagai
+      cahaya dari samping.</span>
+    <span data-phrase="bg.sides.warn">Satu sisinya sedikit lebih gelap daripada sisi lain.</span>
+    <span data-phrase="bg.note">{colour} Alat ini tidak akan mengganti latar: memotong orang keluar dari sebuah foto
+      butuh model segmentasi, dan model yang buruk memakan rambut justru orang yang
+      fotonya memang paling sering ditolak. Berdiri setengah meter lebih jauh dari tembok
+      menyelesaikan lebih banyak daripada filter mana pun.</span>
+    <span data-phrase="bg.signature.note">Tidak ada yang mengubah tanda tangan Anda di sini. Ia diukur dan dilaporkan, dan
+      potongannya milik Anda untuk digeser.</span>
+    <span data-phrase="sig.ink.bad">Nyaris tidak ada tinta di potongan itu. Entah kotaknya meleset dari tanda tangannya,
+      entah penanya terlalu tipis untuk terfoto.</span>
+    <span data-phrase="sig.ink.warn">Piksel gelapnya banyak sekali &mdash; periksa apakah potongannya ikut mengambil
+      garis kertas atau tepi halaman.</span>
+    <span data-phrase="sig.ink.good">Tinta menutupi {coverage}% potongan, dan itu terbaca sebagai tanda tangan.</span>
+    <span data-phrase="sig.paper.bad">Kertasnya keluar abu-abu, bukan putih. Tambah cahaya di halamannya, atau pindai saja
+      alih-alih difoto.</span>
+    <span data-phrase="sig.paper.warn">Kertasnya agak kusam. Kebanyakan formulir mau halaman putih bersih di belakang tanda
+      tangan.</span>
+    <span data-phrase="sig.paper.good">Kertasnya bersih dan putih.</span>
     <span data-phrase="marks.measured">Keempatnya diukur dari fotonya &mdash;
       puncak kepala dari siluet kepala Anda, pupilnya dari gelapnya, dagunya dari
       tempat rahang bertemu leher. Periksa juga, dan seret yang mendarat keliru:

--- a/locales/it/tools/id-photo.html
+++ b/locales/it/tools/id-photo.html
@@ -214,6 +214,96 @@
     a semicolon; nothing else is substituted.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="facts.print">Dimensione di stampa</span>
+    <span data-phrase="facts.head">Testa, dal mento alla sommità</span>
+    <span data-phrase="facts.eye">Linea degli occhi, dal basso</span>
+    <span data-phrase="facts.background">Sfondo</span>
+    <span data-phrase="band.range">da {min} a {max}</span>
+    <span data-phrase="band.mm">{range} ({min}&ndash;{max} mm)</span>
+    <span data-phrase="band.guidance">{band} (indicativo)</span>
+    <span data-phrase="measured.mm">{percent} ({mm} mm)</span>
+    <span data-phrase="verdict.head.ok">L&rsquo;altezza della testa è {measured}. La regola chiede {wanted}.</span>
+    <span data-phrase="verdict.head.low">L&rsquo;altezza della testa è {measured}, ed è troppo poco. La regola chiede
+      {wanted}. Rimpicciolisci il riquadro.</span>
+    <span data-phrase="verdict.head.high">L&rsquo;altezza della testa è {measured}, ed è troppo. La regola chiede {wanted}.
+      Allarga il riquadro.</span>
+    <span data-phrase="verdict.eye.ok">La linea degli occhi è a {measured}. La regola chiede {wanted}.</span>
+    <span data-phrase="verdict.eye.low">La linea degli occhi è a {measured}, troppo in basso nell&rsquo;inquadratura. La
+      regola chiede {wanted}. Sposta il riquadro in giù.</span>
+    <span data-phrase="verdict.eye.high">La linea degli occhi è a {measured}, troppo in alto nell&rsquo;inquadratura. La
+      regola chiede {wanted}. Sposta il riquadro in su.</span>
+    <span data-phrase="tilt.level">La linea degli occhi è in piano.</span>
+    <span data-phrase="tilt.ok.left">La testa pende di {degrees} gradi a sinistra, e sta dentro i due gradi che un
+      esaminatore non nota.</span>
+    <span data-phrase="tilt.ok.right">La testa pende di {degrees} gradi a destra, e sta dentro i due gradi che un
+      esaminatore non nota.</span>
+    <span data-phrase="tilt.bad.left">La testa pende di {degrees} gradi a sinistra, e si vede. Rifai la foto con la
+      macchina in piano, oppure raddrizza prima l&rsquo;immagine.</span>
+    <span data-phrase="tilt.bad.right">La testa pende di {degrees} gradi a destra, e si vede. Rifai la foto con la macchina
+      in piano, oppure raddrizza prima l&rsquo;immagine.</span>
+    <span data-phrase="centre.ok">Il viso è al centro dell&rsquo;inquadratura.</span>
+    <span data-phrase="centre.left">Il viso sta {size} della larghezza a sinistra del centro. Tira il riquadro
+      dall&rsquo;altra parte, oppure premi di nuovo &laquo;Adatta&raquo;.</span>
+    <span data-phrase="centre.right">Il viso sta {size} della larghezza a destra del centro. Tira il riquadro
+      dall&rsquo;altra parte, oppure premi di nuovo &laquo;Adatta&raquo;.</span>
+    <span data-phrase="resample.enough">Il ritaglio è di {have} pixel e l&rsquo;uscita di {need}, quindi non c&rsquo;è
+      niente da inventare.</span>
+    <span data-phrase="resample.slight">Il ritaglio è solo di {have} pixel e l&rsquo;uscita di {need}. Verrà ingrandito un
+      poco, e questo costa un filo di nitidezza e nient&rsquo;altro.</span>
+    <span data-phrase="resample.severe">Il ritaglio è solo di {have} pixel e l&rsquo;uscita di {need}. Manca parecchio: il
+      risultato verrà molle, e su carta sembrerà una schermata. L&rsquo;unico rimedio è
+      una foto scattata più da vicino, o a risoluzione più alta.</span>
+    <span data-phrase="ready.geometry">L&rsquo;inquadratura non rispetta ancora la regola. Puoi salvare i file lo stesso
+      &mdash; qui nessuno ti nega la tua fotografia &mdash; ma i numeri qui sopra sono
+      quelli che il modulo andrà a misurare.</span>
+    <span data-phrase="ready.background">L&rsquo;inquadratura rispetta la regola. Lo sfondo no, ed è il motivo più frequente
+      per cui una foto torna indietro.</span>
+    <span data-phrase="ready.good">L&rsquo;inquadratura rispetta la regola e lo sfondo passa.</span>
+    <span data-phrase="bg.white.label">Bianco pieno</span>
+    <span data-phrase="bg.white.inline">bianco pieno</span>
+    <span data-phrase="bg.white.note">Un muro bianco viene fotografato grigio chiaro. Quello che si chiede è uno sfondo
+      pieno, illuminato in modo uniforme e senza ombre, non un colore di pittura.</span>
+    <span data-phrase="bg.off-white.label">Bianco o bianco sporco</span>
+    <span data-phrase="bg.off-white.inline">bianco o bianco sporco</span>
+    <span data-phrase="bg.off-white.note">Vanno bene entrambi, che in pratica vuol dire qualunque cosa piena e chiara: niente
+      fantasie, niente mobili e niente ombre dietro la testa.</span>
+    <span data-phrase="bg.light-grey.label">Grigio chiaro pieno</span>
+    <span data-phrase="bg.light-grey.inline">grigio chiaro pieno</span>
+    <span data-phrase="bg.light-grey.note">Il grigio chiaro è la preferenza dell&rsquo;ICAO perché stacca dallo sfondo un viso
+      chiaro, e anche i capelli scuri. Il bianco puro non fa né l&rsquo;una né
+      l&rsquo;altra cosa.</span>
+    <span data-phrase="bg.cream.label">Grigio chiaro o crema</span>
+    <span data-phrase="bg.cream.inline">grigio chiaro o crema</span>
+    <span data-phrase="bg.cream.note">È la formula usata dal Regno Unito. Il crema si legge come un bianco sporco caldo;
+      quello che la regola vuole è che lo sfondo sia pieno e uniforme, non che sia una
+      tinta precisa.</span>
+    <span data-phrase="bg.colour.bad">Lo sfondo misura {hex}, ed è lontanissimo da {wanted}.</span>
+    <span data-phrase="bg.colour.warn">Lo sfondo misura {hex} &mdash; vicino a {wanted}, ma non ci siamo del tutto.</span>
+    <span data-phrase="bg.colour.good">Lo sfondo misura {hex}, e passa come {wanted}.</span>
+    <span data-phrase="bg.uniform.bad">Non è un colore solo &mdash; c&rsquo;è un&rsquo;ombra, una fantasia o un oggetto
+      dietro di te.</span>
+    <span data-phrase="bg.uniform.warn">Leggermente disomogeneo. Mettersi mezzo metro più lontano dal muro di solito risolve
+      tutto.</span>
+    <span data-phrase="bg.uniform.good">Illuminato in modo uniforme, senza ombre dietro la testa.</span>
+    <span data-phrase="bg.sides.bad">Un lato dello sfondo è molto più scuro dell&rsquo;altro, e si legge come luce
+      laterale.</span>
+    <span data-phrase="bg.sides.warn">Un lato è un po&rsquo; più scuro dell&rsquo;altro.</span>
+    <span data-phrase="bg.note">{colour} Questo strumento non sostituisce lo sfondo: ritagliare una persona da una
+      fotografia richiede un modello di segmentazione, e uno fatto male mangia i capelli
+      proprio a quelle persone a cui le foto vengono già rifiutate più spesso. Mettersi
+      mezzo metro più lontano dal muro ne risolve più di qualsiasi filtro.</span>
+    <span data-phrase="bg.signature.note">Qui non si tocca la tua firma. Viene misurata e descritta, e il ritaglio è tuo.</span>
+    <span data-phrase="sig.ink.bad">Quasi nessun inchiostro nel ritaglio. O il riquadro è fuori dalla firma, o la penna
+      era troppo chiara per essere fotografata.</span>
+    <span data-phrase="sig.ink.warn">Moltissimi pixel scuri &mdash; controlla che il ritaglio non abbia preso una riga
+      del foglio o il bordo della pagina.</span>
+    <span data-phrase="sig.ink.good">L&rsquo;inchiostro copre il {coverage}% del ritaglio, e questo si legge come una
+      firma.</span>
+    <span data-phrase="sig.paper.bad">La carta viene fuori grigia invece che bianca. Più luce sul foglio, oppure una
+      scansione al posto della foto.</span>
+    <span data-phrase="sig.paper.warn">La carta è un po&rsquo; spenta. Quasi tutti i moduli vogliono un foglio bianco e
+      pulito dietro la firma.</span>
+    <span data-phrase="sig.paper.good">La carta è pulita e bianca.</span>
     <span data-phrase="marks.measured">Tutti e quattro sono stati misurati sulla foto: la
       sommità del capo dal contorno della testa, le pupille da quanto sono scure, il
       mento da dove la mascella entra nel collo. Controllali lo stesso e trascina

--- a/locales/ja/tools/id-photo.html
+++ b/locales/ja/tools/id-photo.html
@@ -197,6 +197,62 @@
     a semicolon; nothing else is substituted.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="facts.print">印刷サイズ</span>
+    <span data-phrase="facts.head">頭、あごから頭頂まで</span>
+    <span data-phrase="facts.eye">目の高さ、下から</span>
+    <span data-phrase="facts.background">背景</span>
+    <span data-phrase="band.range">{min}から{max}</span>
+    <span data-phrase="band.mm">{range}（{min}〜{max}mm）</span>
+    <span data-phrase="band.guidance">{band}（目安）</span>
+    <span data-phrase="measured.mm">{percent}（{mm}mm）</span>
+    <span data-phrase="verdict.head.ok">頭の高さは{measured}です。規定は{wanted}を求めています。</span>
+    <span data-phrase="verdict.head.low">頭の高さは{measured}で、小さすぎます。規定は{wanted}を求めています。枠を小さくしてください。</span>
+    <span data-phrase="verdict.head.high">頭の高さは{measured}で、大きすぎます。規定は{wanted}を求めています。枠を大きくしてください。</span>
+    <span data-phrase="verdict.eye.ok">目の高さは{measured}です。規定は{wanted}を求めています。</span>
+    <span data-phrase="verdict.eye.low">目の高さは{measured}で、画面の中で低すぎます。規定は{wanted}を求めています。枠を下げてください。</span>
+    <span data-phrase="verdict.eye.high">目の高さは{measured}で、画面の中で高すぎます。規定は{wanted}を求めています。枠を上げてください。</span>
+    <span data-phrase="tilt.level">目の高さは水平です。</span>
+    <span data-phrase="tilt.ok.left">頭が左に{degrees}度傾いていますが、審査で気づかれない数度の範囲に収まっています。</span>
+    <span data-phrase="tilt.ok.right">頭が右に{degrees}度傾いていますが、審査で気づかれない数度の範囲に収まっています。</span>
+    <span data-phrase="tilt.bad.left">頭が左に{degrees}度傾いていて、これは目につきます。カメラを水平にして撮り直すか、先に画像を回して起こしてください。</span>
+    <span data-phrase="tilt.bad.right">頭が右に{degrees}度傾いていて、これは目につきます。カメラを水平にして撮り直すか、先に画像を回して起こしてください。</span>
+    <span data-phrase="centre.ok">顔は画面の中央にあります。</span>
+    <span data-phrase="centre.left">顔が画面の幅の{size}だけ中央より左にあります。枠を反対側へ動かすか、もう一度「合わせる」を押してください。</span>
+    <span data-phrase="centre.right">顔が画面の幅の{size}だけ中央より右にあります。枠を反対側へ動かすか、もう一度「合わせる」を押してください。</span>
+    <span data-phrase="resample.enough">切り抜きは{have}ピクセル、書き出しは{need}なので、作り足すものはありません。</span>
+    <span data-phrase="resample.slight">切り抜きは{have}ピクセルしかなく、書き出しは{need}です。少し拡大され、失うのはわずかな解像感だけです。</span>
+    <span data-phrase="resample.severe">切り抜きは{have}ピクセルしかなく、書き出しは{need}です。まるで足りません。結果は眠くなり、紙にすると画面写真のように見えます。もっと近づいて、あるいはもっと高い解像度で撮り直すほかありません。</span>
+    <span data-phrase="ready.geometry">寸法はまだ規定に届いていません。それでもファイルは保存できます。ここにはあなたの写真を渡さない仕組みはありません。ただ、窓口が測るのは上の数字です。</span>
+    <span data-phrase="ready.background">寸法は規定どおりです。背景はそうではありません。写真が返される理由としてはこちらのほうが多いです。</span>
+    <span data-phrase="ready.good">寸法は規定どおりで、背景も差し支えありません。</span>
+    <span data-phrase="bg.white.label">白一色</span>
+    <span data-phrase="bg.white.inline">白一色</span>
+    <span data-phrase="bg.white.note">白い壁は写真では薄いグレーに写ります。求められているのは、無地で、むらなく明るく、影のない背景であって、塗料の色ではありません。</span>
+    <span data-phrase="bg.off-white.label">白またはオフホワイト</span>
+    <span data-phrase="bg.off-white.inline">白またはオフホワイト</span>
+    <span data-phrase="bg.off-white.note">どちらでもかまいません。実際には、無地で明るければよいということです。柄がなく、家具が写らず、頭の後ろに影がないこと。</span>
+    <span data-phrase="bg.light-grey.label">薄いグレー一色</span>
+    <span data-phrase="bg.light-grey.inline">薄いグレー一色</span>
+    <span data-phrase="bg.light-grey.note">薄いグレーはICAOが勧める色です。色白の顔を背景から切り離し、黒い髪も切り離してくれるからです。真っ白はどちらもしてくれません。</span>
+    <span data-phrase="bg.cream.label">薄いグレーまたはクリーム</span>
+    <span data-phrase="bg.cream.inline">薄いグレーまたはクリーム</span>
+    <span data-phrase="bg.cream.note">イギリスの言い回しです。クリームは暖かいオフホワイトに見えます。規定が求めているのは背景が無地でむらのないことであって、特定の色味ではありません。</span>
+    <span data-phrase="bg.colour.bad">背景は{hex}と測れました。{wanted}からはかなり離れています。</span>
+    <span data-phrase="bg.colour.warn">背景は{hex}と測れました。{wanted}に近いのですが、そのものではありません。</span>
+    <span data-phrase="bg.colour.good">背景は{hex}と測れました。{wanted}として通ります。</span>
+    <span data-phrase="bg.uniform.bad">一色ではありません。うしろに影か、柄か、物があります。</span>
+    <span data-phrase="bg.uniform.warn">わずかにむらがあります。壁から半歩離れて立つだけで、たいていは片づきます。</span>
+    <span data-phrase="bg.uniform.good">むらなく明るく、頭の後ろに影もありません。</span>
+    <span data-phrase="bg.sides.bad">背景の片側がもう一方よりずっと暗く、横からの光のように見えます。</span>
+    <span data-phrase="bg.sides.warn">片側がもう一方より少し暗くなっています。</span>
+    <span data-phrase="bg.note">{colour} この道具は背景を差し替えません。写真から人を切り抜くにはセグメンテーションモデルが要り、出来の悪いものは、ただでさえ写真をはねられることの多い人の髪を食べてしまいます。壁から半歩離れて立つほうが、どんなフィルターよりも多くを解決します。</span>
+    <span data-phrase="bg.signature.note">ここで署名に手は加えません。測って報告するだけで、切り抜く位置はご自分で動かせます。</span>
+    <span data-phrase="sig.ink.bad">切り抜きの中にインクがほとんどありません。枠が署名から外れているか、ペンが薄すぎて写らなかったかのどちらかです。</span>
+    <span data-phrase="sig.ink.warn">暗い画素が非常に多いです。切り抜きが罫線や紙の端を巻き込んでいないか確かめてください。</span>
+    <span data-phrase="sig.ink.good">インクが切り抜きの{coverage}%を覆っていて、署名として読み取れます。</span>
+    <span data-phrase="sig.paper.bad">紙が白ではなく灰色に出ています。紙にもっと光を当てるか、写真ではなくスキャンにしてください。</span>
+    <span data-phrase="sig.paper.warn">紙が少しくすんでいます。多くの書式は、署名の後ろにきれいな白い紙を求めます。</span>
+    <span data-phrase="sig.paper.good">紙はきれいな白です。</span>
     <span data-phrase="marks.measured">4点とも写真から測りました&mdash;頭頂は頭の輪郭から、瞳はその暗さから、あごは下顎が首に入るところから。それでも確かめて、ずれている点はドラッグしてください。切り抜きは4点が最終的にある場所から取られます。</span><span data-phrase="marks.rough">置きましたが、すべてを測れたわけではありません。枠を合わせる前に4点とも確かめてください。</span><span data-phrase="marks.none">この写真からは何も測れませんでした。点は代わりに初期位置にあります。頭頂、あご、左右の瞳へドラッグしてください。</span>
     <span data-phrase="marks.manual">4つの点はあなたのもので、何も動かしません。それぞれを頭頂、あご、瞳へドラッグしてください。</span><span data-phrase="marks.edited">点を動かしたので、4つともあなたのものになりました。「探してもらう」を選ぶと写真をもう一度測ります。</span>
 

--- a/locales/ko/tools/id-photo.html
+++ b/locales/ko/tools/id-photo.html
@@ -210,6 +210,65 @@
     a semicolon; nothing else is substituted.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="facts.print">인쇄 크기</span>
+    <span data-phrase="facts.head">머리, 턱에서 정수리까지</span>
+    <span data-phrase="facts.eye">눈높이, 아래에서부터</span>
+    <span data-phrase="facts.background">배경</span>
+    <span data-phrase="band.range">{min}에서 {max}까지</span>
+    <span data-phrase="band.mm">{range} ({min}&ndash;{max} mm)</span>
+    <span data-phrase="band.guidance">{band} (권고)</span>
+    <span data-phrase="measured.mm">{percent} ({mm} mm)</span>
+    <span data-phrase="verdict.head.ok">머리 높이가 {measured}입니다. 규정은 {wanted}를 요구합니다.</span>
+    <span data-phrase="verdict.head.low">머리 높이가 {measured}로 너무 작습니다. 규정은 {wanted}를 요구합니다. 상자를 더 작게 만드세요.</span>
+    <span data-phrase="verdict.head.high">머리 높이가 {measured}로 너무 큽니다. 규정은 {wanted}를 요구합니다. 상자를 더 크게 만드세요.</span>
+    <span data-phrase="verdict.eye.ok">눈높이가 {measured}입니다. 규정은 {wanted}를 요구합니다.</span>
+    <span data-phrase="verdict.eye.low">눈높이가 {measured}로, 화면에서 너무 아래입니다. 규정은 {wanted}를 요구합니다. 상자를 아래로 옮기세요.</span>
+    <span data-phrase="verdict.eye.high">눈높이가 {measured}로, 화면에서 너무 위입니다. 규정은 {wanted}를 요구합니다. 상자를 위로 옮기세요.</span>
+    <span data-phrase="tilt.level">눈높이가 수평입니다.</span>
+    <span data-phrase="tilt.ok.left">머리가 왼쪽으로 {degrees}도 기울었는데, 심사관이 알아채지 못하는 몇 도 안에 듭니다.</span>
+    <span data-phrase="tilt.ok.right">머리가 오른쪽으로 {degrees}도 기울었는데, 심사관이 알아채지 못하는 몇 도 안에 듭니다.</span>
+    <span data-phrase="tilt.bad.left">머리가 왼쪽으로 {degrees}도 기울었고, 이 정도면 눈에 띕니다. 카메라를 수평으로 두고 다시 찍거나, 사진을 먼저 바로 세우세요.</span>
+    <span data-phrase="tilt.bad.right">머리가 오른쪽으로 {degrees}도 기울었고, 이 정도면 눈에 띕니다. 카메라를 수평으로 두고 다시 찍거나, 사진을 먼저 바로 세우세요.</span>
+    <span data-phrase="centre.ok">얼굴이 화면 가운데에 있습니다.</span>
+    <span data-phrase="centre.left">얼굴이 화면 너비의 {size}만큼 가운데에서 왼쪽에 있습니다. 상자를 반대쪽으로 끌거나 &lsquo;맞추기&rsquo;를 다시 누르세요.</span>
+    <span data-phrase="centre.right">얼굴이 화면 너비의 {size}만큼 가운데에서 오른쪽에 있습니다. 상자를 반대쪽으로 끌거나 &lsquo;맞추기&rsquo;를 다시 누르세요.</span>
+    <span data-phrase="resample.enough">자른 영역은 {have}픽셀이고 결과물은 {need}이므로, 없는 것을 지어낼 일이 없습니다.</span>
+    <span data-phrase="resample.slight">자른 영역이 {have}픽셀뿐인데 결과물은 {need}입니다. 조금 확대되고, 그 대가는 약간의 선명함뿐입니다.</span>
+    <span data-phrase="resample.severe">자른 영역이 {have}픽셀뿐인데 결과물은 {need}입니다. 많이 모자랍니다. 결과가 흐릿해지고, 인쇄하면 화면 캡처처럼 보입니다. 더 가까이서
+      찍거나 더 높은 해상도로 찍은 사진 말고는 방법이 없습니다.</span>
+    <span data-phrase="ready.geometry">치수가 아직 규정에 맞지 않습니다. 그래도 파일은 저장할 수 있습니다. 여기서 당신 사진을 못 준다고 하는 것은 없습니다. 다만 위의 숫자가 서식에서
+      잴 값입니다.</span>
+    <span data-phrase="ready.background">치수는 규정에 맞습니다. 배경은 아닙니다. 사진이 반려되는 더 흔한 이유가 배경입니다.</span>
+    <span data-phrase="ready.good">치수도 규정에 맞고 배경도 무난합니다.</span>
+    <span data-phrase="bg.white.label">순백</span>
+    <span data-phrase="bg.white.inline">순백</span>
+    <span data-phrase="bg.white.note">흰 벽은 사진에서 밝은 회색으로 나옵니다. 요구하는 것은 무늬 없이 고르게 밝고 그림자 없는 배경이지, 특정 페인트 색이 아닙니다.</span>
+    <span data-phrase="bg.off-white.label">흰색 또는 아이보리</span>
+    <span data-phrase="bg.off-white.inline">흰색 또는 아이보리</span>
+    <span data-phrase="bg.off-white.note">둘 다 받아 줍니다. 실제로는 무늬 없고 밝기만 하면 됩니다. 무늬도, 가구도, 머리 뒤 그림자도 없어야 합니다.</span>
+    <span data-phrase="bg.light-grey.label">밝은 회색</span>
+    <span data-phrase="bg.light-grey.inline">밝은 회색</span>
+    <span data-phrase="bg.light-grey.note">밝은 회색은 ICAO가 선호하는 색입니다. 밝은 얼굴을 배경에서 떼어 놓고, 어두운 머리카락도 떼어 놓기 때문입니다. 순백은 둘 다 하지 못합니다.</span>
+    <span data-phrase="bg.cream.label">밝은 회색 또는 크림색</span>
+    <span data-phrase="bg.cream.inline">밝은 회색 또는 크림색</span>
+    <span data-phrase="bg.cream.note">영국이 쓰는 표현입니다. 크림색은 따뜻한 아이보리처럼 보입니다. 규정이 노리는 것은 배경이 단순하고 고르다는 점이지, 특정 색조가 아닙니다.</span>
+    <span data-phrase="bg.colour.bad">배경이 {hex}로 측정되는데, {wanted}와는 거리가 멉니다.</span>
+    <span data-phrase="bg.colour.warn">배경이 {hex}로 측정됩니다. {wanted}에 가깝지만 딱 그것은 아닙니다.</span>
+    <span data-phrase="bg.colour.good">배경이 {hex}로 측정되고, {wanted}로 통과합니다.</span>
+    <span data-phrase="bg.uniform.bad">한 가지 색이 아닙니다. 뒤에 그림자나 무늬, 아니면 물건이 있습니다.</span>
+    <span data-phrase="bg.uniform.warn">조금 고르지 않습니다. 벽에서 반 걸음 더 떨어져 서는 것으로 대개 다 해결됩니다.</span>
+    <span data-phrase="bg.uniform.good">고르게 밝고, 머리 뒤에 그림자가 없습니다.</span>
+    <span data-phrase="bg.sides.bad">배경 한쪽이 반대쪽보다 훨씬 어둡습니다. 옆에서 빛이 든 것으로 보입니다.</span>
+    <span data-phrase="bg.sides.warn">한쪽이 반대쪽보다 조금 어둡습니다.</span>
+    <span data-phrase="bg.note">{colour} 이 도구는 배경을 바꿔 주지 않습니다. 사진에서 사람을 오려 내려면 분할 모델이 필요하고, 성능이 나쁜 모델은 하필 사진이 가장 자주
+      반려되는 사람들의 머리카락을 먹습니다. 벽에서 반 걸음 더 떨어져 서는 편이 어떤 필터보다 많은 경우를 해결합니다.</span>
+    <span data-phrase="bg.signature.note">여기서 서명을 손대지 않습니다. 재서 알려 드릴 뿐이고, 자르는 위치는 직접 옮기시면 됩니다.</span>
+    <span data-phrase="sig.ink.bad">자른 영역에 잉크가 거의 없습니다. 상자가 서명에서 벗어났거나, 펜이 사진에 담기기에 너무 흐렸습니다.</span>
+    <span data-phrase="sig.ink.warn">어두운 픽셀이 아주 많습니다. 자른 영역이 밑줄이나 종이 가장자리를 물지 않았는지 확인하세요.</span>
+    <span data-phrase="sig.ink.good">잉크가 자른 영역의 {coverage}%를 덮고 있어서 서명으로 읽힙니다.</span>
+    <span data-phrase="sig.paper.bad">종이가 흰색이 아니라 회색으로 나옵니다. 종이에 빛을 더 주거나, 사진 대신 스캔을 쓰세요.</span>
+    <span data-phrase="sig.paper.warn">종이가 조금 칙칙합니다. 대부분의 서식은 서명 뒤에 깨끗한 흰 종이를 원합니다.</span>
+    <span data-phrase="sig.paper.good">종이가 깨끗하고 하얗습니다.</span>
     <span data-phrase="marks.measured">네 점 모두 사진에서 재어 놓았습니다. 정수리는 머리의 윤곽에서, 눈동자는 그 어두움에서, 턱 끝은 턱이 목으로 들어가는 자리에서요. 그래도 한 번 확인하시고 잘못 떨어진 점은 끌어다 놓으세요. 잘라내기는 점이 최종적으로 놓인 자리에서 만들어집니다.</span>
     <span data-phrase="marks.rough">놓기는 했지만 전부 잰 것은 아닙니다. 상자를 맞추기 전에 네 점을 모두 확인하세요.</span>
     <span data-phrase="marks.none">이 사진에서는 아무것도 잴 수 없었습니다. 점은 대신 처음 자리에 있습니다. 정수리와 턱 끝, 양쪽 눈동자로 끌어다 놓으세요.</span>

--- a/locales/nl/tools/id-photo.html
+++ b/locales/nl/tools/id-photo.html
@@ -214,6 +214,95 @@
     a semicolon; nothing else is substituted.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="facts.print">Afdrukformaat</span>
+    <span data-phrase="facts.head">Hoofd, kin tot kruin</span>
+    <span data-phrase="facts.eye">Ooglijn, vanaf onderen</span>
+    <span data-phrase="facts.background">Achtergrond</span>
+    <span data-phrase="band.range">{min} tot {max}</span>
+    <span data-phrase="band.mm">{range} ({min}&ndash;{max} mm)</span>
+    <span data-phrase="band.guidance">{band} (richtlijn)</span>
+    <span data-phrase="measured.mm">{percent} ({mm} mm)</span>
+    <span data-phrase="verdict.head.ok">De hoofdhoogte is {measured}. De regel vraagt {wanted}.</span>
+    <span data-phrase="verdict.head.low">De hoofdhoogte is {measured}, en dat is te klein. De regel vraagt {wanted}. Maak het
+      kader kleiner.</span>
+    <span data-phrase="verdict.head.high">De hoofdhoogte is {measured}, en dat is te groot. De regel vraagt {wanted}. Maak het
+      kader groter.</span>
+    <span data-phrase="verdict.eye.ok">De ooglijn zit op {measured}. De regel vraagt {wanted}.</span>
+    <span data-phrase="verdict.eye.low">De ooglijn zit op {measured}, en dat is te laag in het beeld. De regel vraagt
+      {wanted}. Schuif het kader omlaag.</span>
+    <span data-phrase="verdict.eye.high">De ooglijn zit op {measured}, en dat is te hoog in het beeld. De regel vraagt
+      {wanted}. Schuif het kader omhoog.</span>
+    <span data-phrase="tilt.level">De ooglijn ligt waterpas.</span>
+    <span data-phrase="tilt.ok.left">Het hoofd helt {degrees} graden naar links, en dat blijft binnen de paar graden die
+      een beoordelaar niet opmerkt.</span>
+    <span data-phrase="tilt.ok.right">Het hoofd helt {degrees} graden naar rechts, en dat blijft binnen de paar graden die
+      een beoordelaar niet opmerkt.</span>
+    <span data-phrase="tilt.bad.left">Het hoofd helt {degrees} graden naar links, en dat valt op. Maak de foto opnieuw met
+      de camera recht, of zet het beeld eerst recht.</span>
+    <span data-phrase="tilt.bad.right">Het hoofd helt {degrees} graden naar rechts, en dat valt op. Maak de foto opnieuw
+      met de camera recht, of zet het beeld eerst recht.</span>
+    <span data-phrase="centre.ok">Het gezicht staat midden in beeld.</span>
+    <span data-phrase="centre.left">Het gezicht zit {size} van de breedte links van het midden. Trek het kader de andere
+      kant op, of druk nog eens op &lsquo;Passend maken&rsquo;.</span>
+    <span data-phrase="centre.right">Het gezicht zit {size} van de breedte rechts van het midden. Trek het kader de
+      andere kant op, of druk nog eens op &lsquo;Passend maken&rsquo;.</span>
+    <span data-phrase="resample.enough">De uitsnede is {have} pixels en de uitvoer {need}, dus er hoeft niets verzonnen te
+      worden.</span>
+    <span data-phrase="resample.slight">De uitsnede is maar {have} pixels en de uitvoer {need}. Hij wordt licht vergroot,
+      wat een beetje scherpte kost en verder niets.</span>
+    <span data-phrase="resample.severe">De uitsnede is maar {have} pixels en de uitvoer {need}. Dat scheelt een heel eind:
+      het resultaat wordt zacht, en op papier ziet het eruit als een schermafdruk. Alleen
+      een foto van dichterbij, of met een hogere resolutie, helpt.</span>
+    <span data-phrase="ready.geometry">De maatvoering haalt de regel nog niet. Je kunt de bestanden toch opslaan &mdash;
+      niets hier weigert je je eigen foto &mdash; maar de cijfers hierboven zijn waar het
+      formulier op meet.</span>
+    <span data-phrase="ready.background">De maatvoering haalt de regel. De achtergrond niet, en dat is de meest voorkomende
+      reden dat een foto terugkomt.</span>
+    <span data-phrase="ready.good">De maatvoering haalt de regel en de achtergrond komt door.</span>
+    <span data-phrase="bg.white.label">Effen wit</span>
+    <span data-phrase="bg.white.inline">effen wit</span>
+    <span data-phrase="bg.white.note">Een witte muur fotografeert lichtgrijs. Wat gevraagd wordt is een effen, gelijkmatig
+      belichte achtergrond zonder schaduw, geen verfkleur.</span>
+    <span data-phrase="bg.off-white.label">Wit of gebroken wit</span>
+    <span data-phrase="bg.off-white.inline">wit of gebroken wit</span>
+    <span data-phrase="bg.off-white.note">Allebei goed, wat in de praktijk alles betekent wat effen en licht is: geen patroon,
+      geen meubels en geen schaduw achter het hoofd.</span>
+    <span data-phrase="bg.light-grey.label">Effen lichtgrijs</span>
+    <span data-phrase="bg.light-grey.inline">effen lichtgrijs</span>
+    <span data-phrase="bg.light-grey.note">Lichtgrijs heeft de voorkeur van de ICAO omdat het een licht gezicht van de
+      achtergrond scheidt, en donker haar ook. Zuiver wit doet geen van beide.</span>
+    <span data-phrase="bg.cream.label">Lichtgrijs of crème</span>
+    <span data-phrase="bg.cream.inline">lichtgrijs of crème</span>
+    <span data-phrase="bg.cream.note">Zo verwoordt het Verenigd Koninkrijk het. Crème leest als een warm gebroken wit; het
+      gaat de regel erom dat de achtergrond effen en gelijkmatig is, niet dat hij één
+      bepaalde tint heeft.</span>
+    <span data-phrase="bg.colour.bad">De achtergrond meet {hex}, en dat is ver van {wanted}.</span>
+    <span data-phrase="bg.colour.warn">De achtergrond meet {hex} &mdash; dicht bij {wanted}, maar net niet.</span>
+    <span data-phrase="bg.colour.good">De achtergrond meet {hex}, en dat gaat door voor {wanted}.</span>
+    <span data-phrase="bg.uniform.bad">Het is niet één effen kleur &mdash; er zit een schaduw, een patroon of een voorwerp
+      achter je.</span>
+    <span data-phrase="bg.uniform.warn">Licht ongelijk. Een halve meter verder van de muur gaan staan is meestal de hele
+      oplossing.</span>
+    <span data-phrase="bg.uniform.good">Gelijkmatig belicht, zonder schaduw achter het hoofd.</span>
+    <span data-phrase="bg.sides.bad">De ene kant van de achtergrond is een stuk donkerder dan de andere, wat leest als
+      zijlicht.</span>
+    <span data-phrase="bg.sides.warn">De ene kant is iets donkerder dan de andere.</span>
+    <span data-phrase="bg.note">{colour} Deze tool vervangt geen achtergrond: iemand uit een foto knippen vraagt een
+      segmentatiemodel, en een slecht model vreet het haar op van precies die mensen wier
+      foto&rsquo;s toch al het vaakst worden afgekeurd. Een halve meter verder van de muur
+      gaan staan lost er meer op dan welk filter ook.</span>
+    <span data-phrase="bg.signature.note">Hier verandert niets aan je handtekening. Ze wordt gemeten en beschreven, en de
+      uitsnede is van jou.</span>
+    <span data-phrase="sig.ink.bad">Bijna geen inkt in de uitsnede. Of het kader staat naast de handtekening, of de pen
+      was te licht om te fotograferen.</span>
+    <span data-phrase="sig.ink.warn">Heel veel donkere pixels &mdash; kijk of de uitsnede geen lijntje of de rand van het
+      blad heeft meegenomen.</span>
+    <span data-phrase="sig.ink.good">Inkt bedekt {coverage}% van de uitsnede, en dat leest als een handtekening.</span>
+    <span data-phrase="sig.paper.bad">Het papier komt grijs uit in plaats van wit. Meer licht op het blad, of een scan in
+      plaats van een foto.</span>
+    <span data-phrase="sig.paper.warn">Het papier is wat dof. De meeste formulieren willen een schoon wit blad achter de
+      handtekening.</span>
+    <span data-phrase="sig.paper.good">Het papier is schoon en wit.</span>
     <span data-phrase="marks.measured">Alle vier zijn op de foto gemeten: de kruin aan de omtrek
       van je hoofd, de pupillen aan hoe donker ze zijn, de kin waar de kaak in de nek
       overgaat. Controleer ze toch, en sleep wat verkeerd is geland: de uitsnede wordt

--- a/locales/pt/tools/id-photo.html
+++ b/locales/pt/tools/id-photo.html
@@ -212,6 +212,90 @@
     a semicolon; nothing else is substituted.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="facts.print">Tamanho de impressão</span>
+    <span data-phrase="facts.head">Cabeça, do queixo ao topo</span>
+    <span data-phrase="facts.eye">Linha dos olhos, a partir de baixo</span>
+    <span data-phrase="facts.background">Fundo</span>
+    <span data-phrase="band.range">de {min} a {max}</span>
+    <span data-phrase="band.mm">{range} ({min}&ndash;{max} mm)</span>
+    <span data-phrase="band.guidance">{band} (orientação)</span>
+    <span data-phrase="measured.mm">{percent} ({mm} mm)</span>
+    <span data-phrase="verdict.head.ok">A altura da cabeça é {measured}. A regra pede {wanted}.</span>
+    <span data-phrase="verdict.head.low">A altura da cabeça é {measured}, e isso é pequeno demais. A regra pede {wanted}.
+      Deixe o quadro menor.</span>
+    <span data-phrase="verdict.head.high">A altura da cabeça é {measured}, e isso é grande demais. A regra pede {wanted}.
+      Deixe o quadro maior.</span>
+    <span data-phrase="verdict.eye.ok">A linha dos olhos está em {measured}. A regra pede {wanted}.</span>
+    <span data-phrase="verdict.eye.low">A linha dos olhos está em {measured}, baixa demais no enquadramento. A regra pede
+      {wanted}. Desça o quadro.</span>
+    <span data-phrase="verdict.eye.high">A linha dos olhos está em {measured}, alta demais no enquadramento. A regra pede
+      {wanted}. Suba o quadro.</span>
+    <span data-phrase="tilt.level">A linha dos olhos está no nível.</span>
+    <span data-phrase="tilt.ok.left">A cabeça pende {degrees} graus para a esquerda, o que fica dentro dos dois graus que
+      um examinador não repara.</span>
+    <span data-phrase="tilt.ok.right">A cabeça pende {degrees} graus para a direita, o que fica dentro dos dois graus que
+      um examinador não repara.</span>
+    <span data-phrase="tilt.bad.left">A cabeça pende {degrees} graus para a esquerda, e isso dá para ver. Tire a foto de
+      novo com a câmera no nível, ou endireite a imagem antes.</span>
+    <span data-phrase="tilt.bad.right">A cabeça pende {degrees} graus para a direita, e isso dá para ver. Tire a foto de
+      novo com a câmera no nível, ou endireite a imagem antes.</span>
+    <span data-phrase="centre.ok">O rosto está centralizado no enquadramento.</span>
+    <span data-phrase="centre.left">O rosto está {size} da largura à esquerda do centro. Arraste o quadro para o outro
+      lado, ou aperte &ldquo;Ajustar&rdquo; de novo.</span>
+    <span data-phrase="centre.right">O rosto está {size} da largura à direita do centro. Arraste o quadro para o outro
+      lado, ou aperte &ldquo;Ajustar&rdquo; de novo.</span>
+    <span data-phrase="resample.enough">O recorte tem {have} pixels e a saída tem {need}, então não há nada para inventar.</span>
+    <span data-phrase="resample.slight">O recorte tem só {have} pixels e a saída tem {need}. Ele vai ser ampliado um pouco,
+      o que custa um tiquinho de nitidez e mais nada.</span>
+    <span data-phrase="resample.severe">O recorte tem só {have} pixels e a saída tem {need}. Falta muito: o resultado vai
+      sair mole, e no papel vai parecer uma captura de tela. Só resolve uma foto tirada
+      mais perto, ou com resolução maior.</span>
+    <span data-phrase="ready.geometry">O enquadramento ainda não atende à regra. Você pode salvar os arquivos mesmo assim
+      &mdash; aqui ninguém nega a você a sua própria fotografia &mdash;, mas os números
+      acima são o que o formulário vai medir.</span>
+    <span data-phrase="ready.background">O enquadramento atende à regra. O fundo não, e esse é o motivo mais comum de uma
+      foto voltar.</span>
+    <span data-phrase="ready.good">O enquadramento atende à regra e o fundo passa.</span>
+    <span data-phrase="bg.white.label">Branco liso</span>
+    <span data-phrase="bg.white.inline">branco liso</span>
+    <span data-phrase="bg.white.note">Uma parede branca sai cinza-claro na foto. O que se pede é um fundo liso, com luz
+      por igual e sem sombra, não uma cor de tinta.</span>
+    <span data-phrase="bg.off-white.label">Branco ou quase branco</span>
+    <span data-phrase="bg.off-white.inline">branco ou quase branco</span>
+    <span data-phrase="bg.off-white.note">Os dois são aceitos, o que na prática quer dizer qualquer coisa lisa e clara: sem
+      estampa, sem móvel e sem sombra atrás da cabeça.</span>
+    <span data-phrase="bg.light-grey.label">Cinza-claro liso</span>
+    <span data-phrase="bg.light-grey.inline">cinza-claro liso</span>
+    <span data-phrase="bg.light-grey.note">O cinza-claro é a preferência da OACI porque separa do fundo um rosto claro, e
+      cabelo escuro também. O branco puro não faz nem uma coisa nem outra.</span>
+    <span data-phrase="bg.cream.label">Cinza-claro ou creme</span>
+    <span data-phrase="bg.cream.inline">cinza-claro ou creme</span>
+    <span data-phrase="bg.cream.note">É como o Reino Unido escreve. O creme lê como um quase branco quente; o que a regra
+      quer é que o fundo seja liso e uniforme, não que seja um tom específico.</span>
+    <span data-phrase="bg.colour.bad">O fundo mede {hex}, o que está bem longe de {wanted}.</span>
+    <span data-phrase="bg.colour.warn">O fundo mede {hex} &mdash; perto de {wanted}, mas não bem isso.</span>
+    <span data-phrase="bg.colour.good">O fundo mede {hex}, o que passa como {wanted}.</span>
+    <span data-phrase="bg.uniform.bad">Não é uma cor só &mdash; tem uma sombra, uma estampa ou um objeto atrás de você.</span>
+    <span data-phrase="bg.uniform.warn">Um pouco desigual. Ficar meio metro mais longe da parede costuma ser a solução
+      inteira.</span>
+    <span data-phrase="bg.uniform.good">Luz por igual, sem sombra atrás da cabeça.</span>
+    <span data-phrase="bg.sides.bad">Um lado do fundo está bem mais escuro que o outro, o que lê como luz lateral.</span>
+    <span data-phrase="bg.sides.warn">Um lado está um pouco mais escuro que o outro.</span>
+    <span data-phrase="bg.note">{colour} Esta ferramenta não vai trocar o fundo: recortar uma pessoa de uma foto
+      precisa de um modelo de segmentação, e um ruim come o cabelo justamente de quem já
+      tem foto recusada com mais frequência. Ficar meio metro mais longe da parede resolve
+      mais casos do que qualquer filtro.</span>
+    <span data-phrase="bg.signature.note">Aqui nada mexe na sua assinatura. Ela é medida e descrita, e o recorte é seu.</span>
+    <span data-phrase="sig.ink.bad">Quase nenhuma tinta no recorte. Ou o quadro está fora da assinatura, ou a caneta era
+      clara demais para aparecer na foto.</span>
+    <span data-phrase="sig.ink.warn">Muitíssimo pixel escuro &mdash; verifique se o recorte não pegou uma linha do papel
+      ou a borda da página.</span>
+    <span data-phrase="sig.ink.good">A tinta cobre {coverage}% do recorte, o que lê como uma assinatura.</span>
+    <span data-phrase="sig.paper.bad">O papel está saindo cinza em vez de branco. Mais luz na folha, ou um escaneamento em
+      vez de foto.</span>
+    <span data-phrase="sig.paper.warn">O papel está meio apagado. A maioria dos formulários quer uma folha branca e limpa
+      atrás da assinatura.</span>
+    <span data-phrase="sig.paper.good">O papel está limpo e branco.</span>
     <span data-phrase="marks.measured">Os quatro foram medidos na foto: o topo da cabeça pelo
       contorno dela, as pupilas pelo escuro que têm, o queixo por onde a mandíbula
       entra no pescoço. Confira mesmo assim e arraste o que caiu errado: o corte sai de

--- a/locales/tr/tools/id-photo.html
+++ b/locales/tr/tools/id-photo.html
@@ -221,6 +221,87 @@
     JavaScript, and a semicolon is not the mark half these languages join with.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="facts.print">Baskı boyutu</span>
+    <span data-phrase="facts.head">Baş, çeneden tepeye</span>
+    <span data-phrase="facts.eye">Göz hizası, alttan</span>
+    <span data-phrase="facts.background">Arka plan</span>
+    <span data-phrase="band.range">{min} ile {max} arası</span>
+    <span data-phrase="band.mm">{range} ({min}&ndash;{max} mm)</span>
+    <span data-phrase="band.guidance">{band} (tavsiye)</span>
+    <span data-phrase="measured.mm">{percent} ({mm} mm)</span>
+    <span data-phrase="verdict.head.ok">Baş yüksekliği {measured}. Kural {wanted} istiyor.</span>
+    <span data-phrase="verdict.head.low">Baş yüksekliği {measured}, yani fazla küçük. Kural {wanted} istiyor. Kutuyu
+      küçültün.</span>
+    <span data-phrase="verdict.head.high">Baş yüksekliği {measured}, yani fazla büyük. Kural {wanted} istiyor. Kutuyu büyütün.</span>
+    <span data-phrase="verdict.eye.ok">Göz hizası {measured}. Kural {wanted} istiyor.</span>
+    <span data-phrase="verdict.eye.low">Göz hizası {measured}, yani karede fazla aşağıda. Kural {wanted} istiyor. Kutuyu
+      aşağı kaydırın.</span>
+    <span data-phrase="verdict.eye.high">Göz hizası {measured}, yani karede fazla yukarıda. Kural {wanted} istiyor. Kutuyu
+      yukarı kaydırın.</span>
+    <span data-phrase="tilt.level">Göz hizası düz.</span>
+    <span data-phrase="tilt.ok.left">Baş {degrees} derece sola yatık; bu, bir memurun fark etmeyeceği birkaç derecenin
+      içinde kalıyor.</span>
+    <span data-phrase="tilt.ok.right">Baş {degrees} derece sağa yatık; bu, bir memurun fark etmeyeceği birkaç derecenin
+      içinde kalıyor.</span>
+    <span data-phrase="tilt.bad.left">Baş {degrees} derece sola yatık ve bu fark edilir. Fotoğrafı kamerayı düz tutarak
+      yeniden çekin ya da önce görüntüyü düzeltin.</span>
+    <span data-phrase="tilt.bad.right">Baş {degrees} derece sağa yatık ve bu fark edilir. Fotoğrafı kamerayı düz tutarak
+      yeniden çekin ya da önce görüntüyü düzeltin.</span>
+    <span data-phrase="centre.ok">Yüz karenin ortasında.</span>
+    <span data-phrase="centre.left">Yüz, karenin genişliğinin {size} kadarı ortanın solunda. Kutuyu öbür yana çekin ya
+      da yeniden &ldquo;Oturt&rdquo;a basın.</span>
+    <span data-phrase="centre.right">Yüz, karenin genişliğinin {size} kadarı ortanın sağında. Kutuyu öbür yana çekin ya
+      da yeniden &ldquo;Oturt&rdquo;a basın.</span>
+    <span data-phrase="resample.enough">Kırpma {have} piksel, çıktı ise {need}; yani uydurulacak bir şey yok.</span>
+    <span data-phrase="resample.slight">Kırpma yalnızca {have} piksel, çıktı ise {need}. Biraz büyütülecek; bu da azıcık
+      keskinliğe mal olur, başka bir şeye değil.</span>
+    <span data-phrase="resample.severe">Kırpma yalnızca {have} piksel, çıktı ise {need}. Bu çok yetersiz: sonuç yumuşak
+      çıkar, kâğıtta ise ekran görüntüsü gibi durur. Tek çözüm, daha yakından ya da daha
+      yüksek çözünürlükte çekilmiş bir fotoğraf.</span>
+    <span data-phrase="ready.geometry">Ölçüler kuralı henüz tutturmuyor. Dosyaları yine de kaydedebilirsiniz &mdash; burada
+      kimse size kendi fotoğrafınızı vermemezlik etmez &mdash; ama formun ölçeceği şey
+      yukarıdaki rakamlardır.</span>
+    <span data-phrase="ready.background">Ölçüler kuralı tutturuyor. Arka plan tutturmuyor ve bir fotoğrafın geri gelmesinin
+      daha sık görülen sebebi budur.</span>
+    <span data-phrase="ready.good">Ölçüler kuralı tutturuyor, arka plan da kabul edilebilir görünüyor.</span>
+    <span data-phrase="bg.white.label">Düz beyaz</span>
+    <span data-phrase="bg.white.inline">düz beyaz</span>
+    <span data-phrase="bg.white.note">Beyaz bir duvar fotoğrafta açık gri çıkar. İstenen şey düz, her yeri eşit
+      aydınlatılmış, gölgesiz bir arka plandır; bir boya rengi değil.</span>
+    <span data-phrase="bg.off-white.label">Beyaz ya da kırık beyaz</span>
+    <span data-phrase="bg.off-white.inline">beyaz ya da kırık beyaz</span>
+    <span data-phrase="bg.off-white.note">İkisi de kabul edilir; bu da pratikte düz ve açık olan her şey demek: desen yok,
+      mobilya yok, başın arkasında gölge yok.</span>
+    <span data-phrase="bg.light-grey.label">Düz açık gri</span>
+    <span data-phrase="bg.light-grey.inline">düz açık gri</span>
+    <span data-phrase="bg.light-grey.note">Açık gri, ICAO&rsquo;nun tercihidir; çünkü açık tenli bir yüzü arka plandan ayırır,
+      koyu saçı da öyle. Saf beyaz ikisini de yapmaz.</span>
+    <span data-phrase="bg.cream.label">Açık gri ya da krem</span>
+    <span data-phrase="bg.cream.inline">açık gri ya da krem</span>
+    <span data-phrase="bg.cream.note">Birleşik Krallık&rsquo;ın kullandığı ifade. Krem, sıcak bir kırık beyaz gibi okunur;
+      kuralın derdi arka planın düz ve tekdüze olması, belli bir ton olması değil.</span>
+    <span data-phrase="bg.colour.bad">Arka plan {hex} ölçülüyor ve bu, {wanted} olmaktan çok uzak.</span>
+    <span data-phrase="bg.colour.warn">Arka plan {hex} ölçülüyor &mdash; {wanted} rengine yakın ama tam o değil.</span>
+    <span data-phrase="bg.colour.good">Arka plan {hex} ölçülüyor ve {wanted} olarak geçer.</span>
+    <span data-phrase="bg.uniform.bad">Tek bir düz renk değil &mdash; arkanızda bir gölge, bir desen ya da bir nesne var.</span>
+    <span data-phrase="bg.uniform.warn">Hafifçe dalgalı. Duvardan yarım metre daha uzakta durmak çoğu zaman çözümün
+      tamamıdır.</span>
+    <span data-phrase="bg.uniform.good">Her yeri eşit aydınlatılmış, başın arkasında gölge yok.</span>
+    <span data-phrase="bg.sides.bad">Arka planın bir yanı öbüründen epeyce koyu; bu da yandan ışık gibi okunuyor.</span>
+    <span data-phrase="bg.sides.warn">Bir yan öbüründen biraz daha koyu.</span>
+    <span data-phrase="bg.note">{colour} Bu araç arka planı değiştirmez: bir insanı fotoğraftan kesip çıkarmak bir
+      bölütleme modeli ister ve kötüsü, fotoğrafları zaten en çok reddedilen kişilerin
+      saçını yer. Duvardan yarım metre daha uzakta durmak, bunların herhangi bir filtreden
+      daha fazlasını çözer.</span>
+    <span data-phrase="bg.signature.note">Burada imzanıza dokunulmuyor. Ölçülüp size bildiriliyor, kırpma da sizin elinizde.</span>
+    <span data-phrase="sig.ink.bad">Kırpmada neredeyse hiç mürekkep yok. Ya kutu imzanın dışında kalmış ya da kalem
+      fotoğrafa çıkamayacak kadar açıkmış.</span>
+    <span data-phrase="sig.ink.warn">Çok fazla koyu piksel &mdash; kırpmanın çizgili bir satırı ya da sayfanın kenarını
+      almadığından emin olun.</span>
+    <span data-phrase="sig.ink.good">Mürekkep kırpmanın %{coverage} kadarını kaplıyor; bu da imza gibi okunuyor.</span>
+    <span data-phrase="sig.paper.bad">Kâğıt beyaz yerine gri çıkıyor. Sayfaya daha çok ışık, ya da fotoğraf yerine tarama.</span>
+    <span data-phrase="sig.paper.warn">Kâğıt biraz sönük. Çoğu form, imzanın arkasında temiz ve beyaz bir sayfa ister.</span>
+    <span data-phrase="sig.paper.good">Kâğıt temiz ve beyaz.</span>
     <span data-phrase="marks.measured">Dördü de fotoğraftan ölçüldü &mdash; tepe
       kafanızın dış hattından, bebekler kendi koyuluklarından, çene ise çene
       hattının boyuna karıştığı yerden. Yine de denetleyin ve yanlış düşenleri

--- a/locales/zh-TW/tools/id-photo.html
+++ b/locales/zh-TW/tools/id-photo.html
@@ -197,6 +197,62 @@
     a semicolon; nothing else is substituted.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="facts.print">列印尺寸</span>
+    <span data-phrase="facts.head">頭部，下巴到頭頂</span>
+    <span data-phrase="facts.eye">眼睛高度，從底部量</span>
+    <span data-phrase="facts.background">背景</span>
+    <span data-phrase="band.range">{min} 到 {max}</span>
+    <span data-phrase="band.mm">{range}（{min}–{max} mm）</span>
+    <span data-phrase="band.guidance">{band}（參考）</span>
+    <span data-phrase="measured.mm">{percent}（{mm} mm）</span>
+    <span data-phrase="verdict.head.ok">頭高是 {measured}。規矩要的是 {wanted}。</span>
+    <span data-phrase="verdict.head.low">頭高是 {measured}，偏小了。規矩要的是 {wanted}。把框縮小一點。</span>
+    <span data-phrase="verdict.head.high">頭高是 {measured}，偏大了。規矩要的是 {wanted}。把框放大一點。</span>
+    <span data-phrase="verdict.eye.ok">眼睛高度是 {measured}。規矩要的是 {wanted}。</span>
+    <span data-phrase="verdict.eye.low">眼睛高度是 {measured}，在畫面裡偏低。規矩要的是 {wanted}。把框往下挪。</span>
+    <span data-phrase="verdict.eye.high">眼睛高度是 {measured}，在畫面裡偏高。規矩要的是 {wanted}。把框往上挪。</span>
+    <span data-phrase="tilt.level">兩眼是平的。</span>
+    <span data-phrase="tilt.ok.left">頭往左偏了 {degrees} 度，還在稽核的人不會注意到的那幾度以內。</span>
+    <span data-phrase="tilt.ok.right">頭往右偏了 {degrees} 度，還在稽核的人不會注意到的那幾度以內。</span>
+    <span data-phrase="tilt.bad.left">頭往左偏了 {degrees} 度，這個是看得出來的。把相機端平重拍，或者先把照片擺正。</span>
+    <span data-phrase="tilt.bad.right">頭往右偏了 {degrees} 度，這個是看得出來的。把相機端平重拍，或者先把照片擺正。</span>
+    <span data-phrase="centre.ok">臉在畫面正中間。</span>
+    <span data-phrase="centre.left">臉偏在中線左邊，差了畫面寬度的 {size}。把框往反方向拖，或者再按一次「適配」。</span>
+    <span data-phrase="centre.right">臉偏在中線右邊，差了畫面寬度的 {size}。把框往反方向拖，或者再按一次「適配」。</span>
+    <span data-phrase="resample.enough">裁下來的是 {have} 畫素，要輸出的是 {need}，所以不用憑空造畫素。</span>
+    <span data-phrase="resample.slight">裁下來的只有 {have} 畫素，要輸出的是 {need}。會稍微放大一點，代價只是損失一點銳度，別的沒有。</span>
+    <span data-phrase="resample.severe">裁下來的只有 {have} 畫素，要輸出的是 {need}。差得太多了：結果會發糊，列印出來像截圖。只有走近一點重拍，或者用更高的解析度拍，才治得了。</span>
+    <span data-phrase="ready.geometry">幾何尺寸還不合規矩。檔案照樣能存下來——這裡沒有哪一處會不給你你自己的照片——只是上面那些數字才是表單要量的。</span>
+    <span data-phrase="ready.background">幾何尺寸合規矩了，背景不合。照片被退回來，更常見的原因是背景。</span>
+    <span data-phrase="ready.good">幾何尺寸合規矩，背景也過得去。</span>
+    <span data-phrase="bg.white.label">純白</span>
+    <span data-phrase="bg.white.inline">純白</span>
+    <span data-phrase="bg.white.note">白牆拍出來是淺灰的。人家要的是一塊乾淨、光照均勻、沒有影子的背景，不是一種塗料的顏色。</span>
+    <span data-phrase="bg.off-white.label">白或米白</span>
+    <span data-phrase="bg.off-white.inline">白或米白</span>
+    <span data-phrase="bg.off-white.note">兩種都收，實際上就是隻要素淨又淺就行：沒有花紋，沒有傢俱，頭後面沒有影子。</span>
+    <span data-phrase="bg.light-grey.label">純淺灰</span>
+    <span data-phrase="bg.light-grey.inline">純淺灰</span>
+    <span data-phrase="bg.light-grey.note">淺灰是國際民航組織偏好的顏色，因為它既把淺色的臉和背景分開，也把深色頭髮和背景分開。純白兩樣都做不到。</span>
+    <span data-phrase="bg.cream.label">淺灰或奶油色</span>
+    <span data-phrase="bg.cream.inline">淺灰或奶油色</span>
+    <span data-phrase="bg.cream.note">這是英國的說法。奶油色看起來像偏暖的米白；規矩要的是背景素淨均勻，不是非得哪一個色號。</span>
+    <span data-phrase="bg.colour.bad">背景量出來是 {hex}，離 {wanted} 差得很遠。</span>
+    <span data-phrase="bg.colour.warn">背景量出來是 {hex}——離 {wanted} 挺近，但還不是。</span>
+    <span data-phrase="bg.colour.good">背景量出來是 {hex}，能算作 {wanted}。</span>
+    <span data-phrase="bg.uniform.bad">它不是一塊乾淨的單色——你身後有影子、花紋或者別的東西。</span>
+    <span data-phrase="bg.uniform.warn">有點不勻。往前站半米離牆遠一些，通常就全解決了。</span>
+    <span data-phrase="bg.uniform.good">光照均勻，頭後面沒有影子。</span>
+    <span data-phrase="bg.sides.bad">背景一邊比另一邊暗不少，看起來像是側面來的光。</span>
+    <span data-phrase="bg.sides.warn">一邊比另一邊稍微暗一點。</span>
+    <span data-phrase="bg.note">{colour} 這個工具不會替你換背景：把人從照片裡裁出來要用分割模型，而差的模型專挑那些照片本來就最常被退回的人，把頭髮啃掉一塊。往前站半米離牆遠一些，比任何濾鏡都管用。</span>
+    <span data-phrase="bg.signature.note">這裡不會動你的簽名。只是量一量、報給你看，裁剪框你自己挪。</span>
+    <span data-phrase="sig.ink.bad">裁下來的這塊裡幾乎沒有墨。要麼框沒框住簽名，要麼筆太淡，拍不出來。</span>
+    <span data-phrase="sig.ink.warn">深色畫素太多了——看看裁剪是不是把一條橫線或者紙邊也框進去了。</span>
+    <span data-phrase="sig.ink.good">墨覆蓋了這塊的 {coverage}%，看起來像是一個簽名。</span>
+    <span data-phrase="sig.paper.bad">紙拍出來是灰的，不是白的。給紙多點光，或者別拍照，直接掃描。</span>
+    <span data-phrase="sig.paper.warn">紙有點發暗。多數表單要簽名後面是一張乾淨的白紙。</span>
+    <span data-phrase="sig.paper.good">紙乾淨又白。</span>
     <span data-phrase="marks.measured">四個點都是從照片上量出來的：頭頂取自你頭部的輪廓，瞳孔取自它們的暗，下巴取自下頜收進脖子的地方。還是看一眼，哪個落偏了就拖回來：裁切框取自它們最後停在哪裡。</span><span data-phrase="marks.rough">放好了，但不是每一處都量得出來。套用裁切框之前，請把四個點都看一遍。</span><span data-phrase="marks.none">這張照片上什麼也量不出來。四個點改為停在起始位置上&mdash;&mdash;請把它們拖到頭頂、下巴和左右瞳孔上。</span><span data-phrase="marks.manual">這四個點歸你，什麼都不會去動它們。請把每一個拖到頭頂、下巴和瞳孔上。</span><span data-phrase="marks.edited">你動過一個點，所以四個點現在都歸你了。選「替我找」會重新量一遍這張照片。</span>
 
     <span data-phrase="marks.why.background">你背後那面牆不夠乾淨，襯不出一個頭的輪廓。</span><span data-phrase="marks.why.top">頭從照片上方出了框，沒有頭頂可找。</span><span data-phrase="marks.why.eyes">眼睛認不出來，於是兩隻都放在這麼大的頭通常長眼睛的位置。</span><span data-phrase="marks.why.chin">下巴來自頭的一般比例，而不是這個頭的輪廓。</span>

--- a/locales/zh/tools/id-photo.html
+++ b/locales/zh/tools/id-photo.html
@@ -197,6 +197,62 @@
     a semicolon; nothing else is substituted.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="facts.print">打印尺寸</span>
+    <span data-phrase="facts.head">头部，下巴到头顶</span>
+    <span data-phrase="facts.eye">眼睛高度，从底部量</span>
+    <span data-phrase="facts.background">背景</span>
+    <span data-phrase="band.range">{min} 到 {max}</span>
+    <span data-phrase="band.mm">{range}（{min}–{max} mm）</span>
+    <span data-phrase="band.guidance">{band}（参考）</span>
+    <span data-phrase="measured.mm">{percent}（{mm} mm）</span>
+    <span data-phrase="verdict.head.ok">头高是 {measured}。规矩要的是 {wanted}。</span>
+    <span data-phrase="verdict.head.low">头高是 {measured}，偏小了。规矩要的是 {wanted}。把框缩小一点。</span>
+    <span data-phrase="verdict.head.high">头高是 {measured}，偏大了。规矩要的是 {wanted}。把框放大一点。</span>
+    <span data-phrase="verdict.eye.ok">眼睛高度是 {measured}。规矩要的是 {wanted}。</span>
+    <span data-phrase="verdict.eye.low">眼睛高度是 {measured}，在画面里偏低。规矩要的是 {wanted}。把框往下挪。</span>
+    <span data-phrase="verdict.eye.high">眼睛高度是 {measured}，在画面里偏高。规矩要的是 {wanted}。把框往上挪。</span>
+    <span data-phrase="tilt.level">两眼是平的。</span>
+    <span data-phrase="tilt.ok.left">头往左偏了 {degrees} 度，还在审核的人不会注意到的那几度以内。</span>
+    <span data-phrase="tilt.ok.right">头往右偏了 {degrees} 度，还在审核的人不会注意到的那几度以内。</span>
+    <span data-phrase="tilt.bad.left">头往左偏了 {degrees} 度，这个是看得出来的。把相机端平重拍，或者先把照片摆正。</span>
+    <span data-phrase="tilt.bad.right">头往右偏了 {degrees} 度，这个是看得出来的。把相机端平重拍，或者先把照片摆正。</span>
+    <span data-phrase="centre.ok">脸在画面正中间。</span>
+    <span data-phrase="centre.left">脸偏在中线左边，差了画面宽度的 {size}。把框往反方向拖，或者再按一次「适配」。</span>
+    <span data-phrase="centre.right">脸偏在中线右边，差了画面宽度的 {size}。把框往反方向拖，或者再按一次「适配」。</span>
+    <span data-phrase="resample.enough">裁下来的是 {have} 像素，要输出的是 {need}，所以不用凭空造像素。</span>
+    <span data-phrase="resample.slight">裁下来的只有 {have} 像素，要输出的是 {need}。会稍微放大一点，代价只是损失一点锐度，别的没有。</span>
+    <span data-phrase="resample.severe">裁下来的只有 {have} 像素，要输出的是 {need}。差得太多了：结果会发糊，打印出来像截图。只有走近一点重拍，或者用更高的分辨率拍，才治得了。</span>
+    <span data-phrase="ready.geometry">几何尺寸还不合规矩。文件照样能存下来——这儿没有哪一处会不给你你自己的照片——只是上面那些数字才是表单要量的。</span>
+    <span data-phrase="ready.background">几何尺寸合规矩了，背景不合。照片被退回来，更常见的原因是背景。</span>
+    <span data-phrase="ready.good">几何尺寸合规矩，背景也过得去。</span>
+    <span data-phrase="bg.white.label">纯白</span>
+    <span data-phrase="bg.white.inline">纯白</span>
+    <span data-phrase="bg.white.note">白墙拍出来是浅灰的。人家要的是一块干净、光照均匀、没有影子的背景，不是一种涂料的颜色。</span>
+    <span data-phrase="bg.off-white.label">白或米白</span>
+    <span data-phrase="bg.off-white.inline">白或米白</span>
+    <span data-phrase="bg.off-white.note">两种都收，实际上就是只要素净又浅就行：没有花纹，没有家具，头后面没有影子。</span>
+    <span data-phrase="bg.light-grey.label">纯浅灰</span>
+    <span data-phrase="bg.light-grey.inline">纯浅灰</span>
+    <span data-phrase="bg.light-grey.note">浅灰是国际民航组织偏好的颜色，因为它既把浅色的脸和背景分开，也把深色头发和背景分开。纯白两样都做不到。</span>
+    <span data-phrase="bg.cream.label">浅灰或奶油色</span>
+    <span data-phrase="bg.cream.inline">浅灰或奶油色</span>
+    <span data-phrase="bg.cream.note">这是英国的说法。奶油色看着像偏暖的米白；规矩要的是背景素净均匀，不是非得哪一个色号。</span>
+    <span data-phrase="bg.colour.bad">背景量出来是 {hex}，离 {wanted} 差得很远。</span>
+    <span data-phrase="bg.colour.warn">背景量出来是 {hex}——离 {wanted} 挺近，但还不是。</span>
+    <span data-phrase="bg.colour.good">背景量出来是 {hex}，能算作 {wanted}。</span>
+    <span data-phrase="bg.uniform.bad">它不是一块干净的单色——你身后有影子、花纹或者别的东西。</span>
+    <span data-phrase="bg.uniform.warn">有点不匀。往前站半米离墙远一些，通常就全解决了。</span>
+    <span data-phrase="bg.uniform.good">光照均匀，头后面没有影子。</span>
+    <span data-phrase="bg.sides.bad">背景一边比另一边暗不少，看着像是侧面来的光。</span>
+    <span data-phrase="bg.sides.warn">一边比另一边稍微暗一点。</span>
+    <span data-phrase="bg.note">{colour} 这个工具不会替你换背景：把人从照片里抠出来要用分割模型，而差的模型专挑那些照片本来就最常被退回的人，把头发啃掉一块。往前站半米离墙远一些，比任何滤镜都管用。</span>
+    <span data-phrase="bg.signature.note">这儿不会动你的签名。只是量一量、报给你看，裁剪框你自己挪。</span>
+    <span data-phrase="sig.ink.bad">裁下来的这块里几乎没有墨。要么框没框住签名，要么笔太淡，拍不出来。</span>
+    <span data-phrase="sig.ink.warn">深色像素太多了——看看裁剪是不是把一条横线或者纸边也框进去了。</span>
+    <span data-phrase="sig.ink.good">墨覆盖了这块的 {coverage}%，看着像是一个签名。</span>
+    <span data-phrase="sig.paper.bad">纸拍出来是灰的，不是白的。给纸多点光，或者别拍照，直接扫描。</span>
+    <span data-phrase="sig.paper.warn">纸有点发暗。多数表单要签名后面是一张干净的白纸。</span>
+    <span data-phrase="sig.paper.good">纸干净又白。</span>
     <span data-phrase="marks.measured">四个点都是从照片上量出来的：头顶取自你头部的轮廓，瞳孔取自它们的暗，下巴取自下颌收进脖子的地方。还是看一眼，哪个落偏了就拖回来：裁切框取自它们最后停在哪里。</span><span data-phrase="marks.rough">放好了，但不是每一处都量得出来。套用裁切框之前，请把四个点都看一遍。</span><span data-phrase="marks.none">这张照片上什么也量不出来。四个点改为停在起始位置上&mdash;&mdash;请把它们拖到头顶、下巴和左右瞳孔上。</span><span data-phrase="marks.manual">这四个点归你，什么都不会去动它们。请把每一个拖到头顶、下巴和瞳孔上。</span><span data-phrase="marks.edited">你动过一个点，所以四个点现在都归你了。选「替我找」会重新量一遍这张照片。</span>
 
     <span data-phrase="marks.why.background">你背后那面墙不够干净，衬不出一个头的轮廓。</span><span data-phrase="marks.why.top">头从照片上方出了框，没有头顶可找。</span><span data-phrase="marks.why.eyes">眼睛认不出来，于是两只都放在这么大的头通常长眼睛的位置。</span><span data-phrase="marks.why.chin">下巴来自头的一般比例，而不是这个头的轮廓。</span>

--- a/tests/js/id-photo.test.js
+++ b/tests/js/id-photo.test.js
@@ -52,6 +52,11 @@ import { JFIF_SEGMENT, ascii, concat, jpeg, segment } from './helpers.js';
 
 /* ================================================================ the rules */
 
+// The sentences live in body.html now, so these functions take a resolver.
+// This one answers with the key and whatever values were handed to it, which
+// is what lets an assertion name the sentence that was chosen.
+const say = (key, values = {}) => [key, ...Object.values(values)].join(' ');
+
 test('specs: every entry can be cropped to and is describable', () => {
   for (const spec of SPECS) {
     assert.ok(spec.print || spec.digital, `${spec.id} has neither a print size nor a pixel size`);
@@ -156,7 +161,7 @@ test('withCustom: a head band typed backwards is read the right way round', () =
 
 test('backgroundOf: every named colour parses to a real one', () => {
   for (const spec of SPECS) {
-    const background = backgroundOf(spec);
+    const background = backgroundOf(spec, say);
     assert.match(background.hex, /^#[0-9a-f]{6}$/);
     assert.ok(background.tolerance > 0);
   }
@@ -458,7 +463,7 @@ test('readBackground: an empty picture is not guessed at', () => {
 });
 
 test('checkBackground: the right colour passes and a wrong one does not', () => {
-  const grey = backgroundOf(specById('schengen'));
+  const grey = backgroundOf(specById('schengen'), say);
   const good = checkBackground(readBackground(flatImage([220, 220, 220]), { stride: 1 }), grey);
   assert.equal(good.status, 'good');
 
@@ -468,7 +473,7 @@ test('checkBackground: the right colour passes and a wrong one does not', () => 
 });
 
 test('checkBackground: a shadow down one side is reported separately from the colour', () => {
-  const white = BACKGROUNDS.white;
+  const white = backgroundOf({ background: 'white' }, say);
   const reading = readBackground(flatImage([252, 252, 252], { shade: [170, 170, 170] }), { stride: 1 });
   const verdict = checkBackground(reading, white);
   assert.equal(verdict.status, 'bad');
@@ -477,7 +482,7 @@ test('checkBackground: a shadow down one side is reported separately from the co
 });
 
 test('checkBackground: nothing to read is "unknown", not a pass', () => {
-  assert.equal(checkBackground(null, BACKGROUNDS.white).status, 'unknown');
+  assert.equal(checkBackground(null, backgroundOf({ background: 'white' }, say)).status, 'unknown');
 });
 
 test('readSignature: ink on white paper, and a page with nothing on it', () => {
@@ -596,24 +601,28 @@ test('outName: a name with nothing usable in it still produces a filename', () =
 });
 
 test('bandText: the published millimetres are shown, not recomputed ones', () => {
-  assert.match(bandText(specById('uk-passport').head, 45), /29-34 mm/);
-  assert.match(bandText(specById('icao').head, 45), /31\.5-36 mm/);
+  // The published millimetres are handed to the phrase as values; the dash and
+  // the unit between them belong to body.html.
+  assert.match(bandText(specById('uk-passport').head, 45, say), /band\.mm .* 29 34$/);
+  assert.match(bandText(specById('icao').head, 45, say), /band\.mm .* 31\.5 36$/);
   assert.equal(percent(0.732), '73.2%');
   assert.equal(trim(16.933333), '16.9');
 });
 
-test('verdictText: says which way to drag, and never for a passing check', () => {
+test('verdictText: names the sentence for the subject and the direction', () => {
   const spec = specById('uk-passport');
-  const low = verdictText({ value: 0.5, mm: 22.5, status: 'low', min: 0.64, max: 0.76 }, 'Head height', 45);
-  assert.match(low, /too small/);
-  assert.match(low, /Make the box smaller/);
+  // A whole sentence per way of being wrong, so the key says which one: the
+  // words that tell somebody which way to drag are in body.html, translated.
+  const low = verdictText({ value: 0.5, mm: 22.5, status: 'low', min: 0.64, max: 0.76 }, 'head', 45, say);
+  assert.match(low, /^verdict\.head\.low/);
+  // The measurement is carried as a value; the word "mm" belongs to the phrase.
+  assert.match(low, /22\.5/);
 
-  const eye = verdictText({ value: 0.4, mm: 18, status: 'low', min: 0.5, max: 0.6 }, 'Eye line', 45);
-  assert.match(eye, /too low in the frame/);
-  assert.match(eye, /Move the box down/);
+  const eye = verdictText({ value: 0.4, mm: 18, status: 'low', min: 0.5, max: 0.6 }, 'eye', 45, say);
+  assert.match(eye, /^verdict\.eye\.low/);
 
-  const ok = verdictText({ value: 0.7, mm: 31.5, status: 'ok', min: 0.64, max: 0.76 }, 'Head height', 45);
-  assert.ok(!/Make the box/.test(ok));
+  const ok = verdictText({ value: 0.7, mm: 31.5, status: 'ok', min: 0.64, max: 0.76 }, 'head', 45, say);
+  assert.match(ok, /^verdict\.head\.ok/);
   assert.ok(spec.head.minMm);
 });
 
@@ -623,13 +632,16 @@ test('statusClass: an advisory band never paints a failure red', () => {
   assert.equal(statusClass('high', true), 'warn');
 });
 
-test('tiltText, centreText, resamplingText, readyText: all say something', () => {
-  assert.match(tiltText({ degrees: 0.1, status: 'ok' }), /level/);
-  assert.match(tiltText({ degrees: -4.2, status: 'high' }), /4\.2 degrees to the left/);
-  assert.match(centreText({ offset: 0, status: 'ok' }), /centred/);
-  assert.match(centreText({ offset: -0.08, status: 'low' }), /left of centre/);
-  assert.match(resamplingText(resampling({ width: 120, height: 150 }, { width: 600, height: 750 })), /soft/);
-  assert.match(readyText(false, 'good'), /does not meet the rule yet/);
-  assert.match(readyText(true, 'bad'), /background does not/);
-  assert.match(readyText(true, 'good'), /meets the rule/);
+test('tiltText, centreText, resamplingText, readyText: each picks its sentence', () => {
+  assert.equal(tiltText({ degrees: 0.1, status: 'ok' }, say), 'tilt.level');
+  assert.match(tiltText({ degrees: -4.2, status: 'high' }, say), /^tilt\.bad\.left 4\.2/);
+  assert.equal(centreText({ offset: 0, status: 'ok' }, say), 'centre.ok');
+  assert.match(centreText({ offset: -0.08, status: 'low' }, say), /^centre\.left/);
+  assert.match(
+    resamplingText(resampling({ width: 120, height: 150 }, { width: 600, height: 750 }), say),
+    /^resample\.severe/,
+  );
+  assert.equal(readyText(false, 'good', say), 'ready.geometry');
+  assert.equal(readyText(true, 'bad', say), 'ready.background');
+  assert.equal(readyText(true, 'good', say), 'ready.good');
 });

--- a/tests/python/test_english_in_js.py
+++ b/tests/python/test_english_in_js.py
@@ -72,7 +72,7 @@ BASELINE = {
     'grab-frame': 22,
     'hash-checksum': 10,
     'heic-to-jpg': 35,
-    'id-photo': 106,
+    'id-photo': 71,
     'image-to-data-uri': 20,
     'image-to-ico': 71,
     'images-to-pdf': 26,

--- a/tools/id-photo/body.html
+++ b/tools/id-photo/body.html
@@ -215,6 +215,91 @@
     JavaScript, and a semicolon is not the mark half these languages join with.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="facts.print">Print size</span>
+    <span data-phrase="facts.head">Head, chin to crown</span>
+    <span data-phrase="facts.eye">Eye line, from the bottom</span>
+    <span data-phrase="facts.background">Background</span>
+    <span data-phrase="band.range">{min} to {max}</span>
+    <span data-phrase="band.mm">{range} ({min}&ndash;{max} mm)</span>
+    <span data-phrase="band.guidance">{band} (guidance)</span>
+    <span data-phrase="measured.mm">{percent} ({mm} mm)</span>
+    <span data-phrase="verdict.head.ok">Head height is {measured}. The rule asks for {wanted}.</span>
+    <span data-phrase="verdict.head.low">Head height is {measured}, which is too small. The rule asks for {wanted}. Make the
+      box smaller.</span>
+    <span data-phrase="verdict.head.high">Head height is {measured}, which is too large. The rule asks for {wanted}. Make the
+      box larger.</span>
+    <span data-phrase="verdict.eye.ok">The eye line is {measured}. The rule asks for {wanted}.</span>
+    <span data-phrase="verdict.eye.low">The eye line is {measured}, which is too low in the frame. The rule asks for
+      {wanted}. Move the box down.</span>
+    <span data-phrase="verdict.eye.high">The eye line is {measured}, which is too high in the frame. The rule asks for
+      {wanted}. Move the box up.</span>
+    <span data-phrase="tilt.level">The eye line is level.</span>
+    <span data-phrase="tilt.ok.left">The head leans {degrees} degrees to the left, which is within the couple of degrees
+      an examiner will not notice.</span>
+    <span data-phrase="tilt.ok.right">The head leans {degrees} degrees to the right, which is within the couple of degrees
+      an examiner will not notice.</span>
+    <span data-phrase="tilt.bad.left">The head leans {degrees} degrees to the left, which is enough to be noticed. Retake
+      it with the camera level, or straighten the picture first.</span>
+    <span data-phrase="tilt.bad.right">The head leans {degrees} degrees to the right, which is enough to be noticed. Retake
+      it with the camera level, or straighten the picture first.</span>
+    <span data-phrase="centre.ok">The face is centred in the frame.</span>
+    <span data-phrase="centre.left">The face sits {size} of the frame&rsquo;s width to the left of centre. Drag the box
+      the other way, or press Fit again.</span>
+    <span data-phrase="centre.right">The face sits {size} of the frame&rsquo;s width to the right of centre. Drag the box
+      the other way, or press Fit again.</span>
+    <span data-phrase="resample.enough">The crop is {have} pixels and the output is {need}, so nothing has to be invented.</span>
+    <span data-phrase="resample.slight">The crop is only {have} pixels and the output is {need}. It will be enlarged
+      slightly, which costs a little sharpness and nothing else.</span>
+    <span data-phrase="resample.severe">The crop is only {have} pixels and the output is {need}. That is a long way short:
+      the result will look soft, and on paper it will look like a screenshot. A photograph
+      taken closer, or at a higher resolution, is the only fix.</span>
+    <span data-phrase="ready.geometry">The geometry does not meet the rule yet. You can still save the files &mdash;
+      nothing here refuses to give you your own photograph &mdash; but the figures above
+      are what the form will be measuring.</span>
+    <span data-phrase="ready.background">The geometry meets the rule. The background does not, and that is the more common
+      reason a photograph comes back.</span>
+    <span data-phrase="ready.good">The geometry meets the rule and the background reads as acceptable.</span>
+    <span data-phrase="bg.white.label">Plain white</span>
+    <span data-phrase="bg.white.inline">plain white</span>
+    <span data-phrase="bg.white.note">A white wall photographs light grey. What is being asked for is a plain, evenly lit,
+      shadow-free background, not a paint colour.</span>
+    <span data-phrase="bg.off-white.label">White or off-white</span>
+    <span data-phrase="bg.off-white.inline">white or off-white</span>
+    <span data-phrase="bg.off-white.note">Either is accepted, which in practice means anything plain and light with no
+      pattern, no furniture and no shadow behind the head.</span>
+    <span data-phrase="bg.light-grey.label">Plain light grey</span>
+    <span data-phrase="bg.light-grey.inline">plain light grey</span>
+    <span data-phrase="bg.light-grey.note">Light grey is the ICAO preference because it separates a fair face from the
+      background and dark hair from it as well. Pure white does neither.</span>
+    <span data-phrase="bg.cream.label">Light grey or cream</span>
+    <span data-phrase="bg.cream.inline">light grey or cream</span>
+    <span data-phrase="bg.cream.note">The wording used by the UK. Cream reads as a warm off-white; the point of the rule
+      is that it is plain and uniform, not that it is any one shade.</span>
+    <span data-phrase="bg.colour.bad">The background reads {hex}, which is a long way from {wanted}.</span>
+    <span data-phrase="bg.colour.warn">The background reads {hex} &mdash; close to {wanted}, but not quite it.</span>
+    <span data-phrase="bg.colour.good">The background reads {hex}, which passes as {wanted}.</span>
+    <span data-phrase="bg.uniform.bad">It is not one flat colour &mdash; there is a shadow, a pattern or an object behind
+      you.</span>
+    <span data-phrase="bg.uniform.warn">Slightly uneven. Standing a foot further from the wall is usually the whole fix.</span>
+    <span data-phrase="bg.uniform.good">Evenly lit, with no shadow behind the head.</span>
+    <span data-phrase="bg.sides.bad">One side of the background is much darker than the other, which reads as side
+      lighting.</span>
+    <span data-phrase="bg.sides.warn">One side is a little darker than the other.</span>
+    <span data-phrase="bg.note">{colour} This tool will not replace a background: cutting a person out of a
+      photograph needs a segmentation model, and a bad one eats the hair of exactly the
+      people whose photographs already get rejected most often. Standing a foot further
+      from the wall fixes more of these than any filter would.</span>
+    <span data-phrase="bg.signature.note">Nothing here changes your signature. It is measured and reported, and the crop is
+      yours to move.</span>
+    <span data-phrase="sig.ink.bad">Almost no ink in the crop. Either the box is off the signature, or the pen was too
+      light to photograph.</span>
+    <span data-phrase="sig.ink.warn">A great deal of dark pixels &mdash; check the crop has not taken in a ruled line or
+      the edge of the page.</span>
+    <span data-phrase="sig.ink.good">Ink covers {coverage}% of the crop, which reads as a signature.</span>
+    <span data-phrase="sig.paper.bad">The paper is coming out grey rather than white. More light on the page, or a scan
+      rather than a photo.</span>
+    <span data-phrase="sig.paper.warn">The paper is a little dull. Most forms want a clean white page behind the signature.</span>
+    <span data-phrase="sig.paper.good">The paper is clean and white.</span>
     <span data-phrase="marks.measured">All four were measured off the photograph
       &mdash; the crown from the outline of your head, the pupils from the dark of
       them, the chin from where the jaw runs into the neck. Check them anyway, and

--- a/tools/id-photo/src/background.js
+++ b/tools/id-photo/src/background.js
@@ -202,7 +202,11 @@ const SIDE_LIMIT = 5;
  * is the light being on one side of you.
  *
  * @param {Reading|null} reading
- * @param {{hex: string, tolerance: number, label: string}} required
+ * A finding carries a phrase key and the values its sentence needs rather than
+ * the sentence: this module is copied byte for byte into fifteen languages, so
+ * the words live in the tool's body.html and main.js resolves them.
+ *
+ * @param {{hex: string, tolerance: number, label: string, inline: string}} required
  */
 export function checkBackground(reading, required) {
   if (!reading) {
@@ -218,19 +222,22 @@ export function checkBackground(reading, required) {
     findings.push({
       key: 'colour',
       status: 'bad',
-      text: `The background reads ${reading.hex}, which is a long way from ${required.label.toLowerCase()}.`,
+      phrase: 'bg.colour.bad',
+      values: { hex: reading.hex, wanted: required.inline },
     });
   } else if (distance > required.tolerance) {
     findings.push({
       key: 'colour',
       status: 'warn',
-      text: `The background reads ${reading.hex} - close to ${required.label.toLowerCase()}, but not quite it.`,
+      phrase: 'bg.colour.warn',
+      values: { hex: reading.hex, wanted: required.inline },
     });
   } else {
     findings.push({
       key: 'colour',
       status: 'good',
-      text: `The background reads ${reading.hex}, which passes as ${required.label.toLowerCase()}.`,
+      phrase: 'bg.colour.good',
+      values: { hex: reading.hex, wanted: required.inline },
     });
   }
 
@@ -238,19 +245,19 @@ export function checkBackground(reading, required) {
     findings.push({
       key: 'uniform',
       status: 'bad',
-      text: 'It is not one flat colour - there is a shadow, a pattern or an object behind you.',
+      phrase: 'bg.uniform.bad',
     });
   } else if (reading.spread > SPREAD_LIMIT) {
     findings.push({
       key: 'uniform',
       status: 'warn',
-      text: 'Slightly uneven. Standing a foot further from the wall is usually the whole fix.',
+      phrase: 'bg.uniform.warn',
     });
   } else {
     findings.push({
       key: 'uniform',
       status: 'good',
-      text: 'Evenly lit, with no shadow behind the head.',
+      phrase: 'bg.uniform.good',
     });
   }
 
@@ -258,13 +265,13 @@ export function checkBackground(reading, required) {
     findings.push({
       key: 'sides',
       status: 'bad',
-      text: 'One side of the background is much darker than the other, which reads as side lighting.',
+      phrase: 'bg.sides.bad',
     });
   } else if (reading.lightRange > SIDE_LIMIT) {
     findings.push({
       key: 'sides',
       status: 'warn',
-      text: 'One side is a little darker than the other.',
+      phrase: 'bg.sides.warn',
     });
   }
 
@@ -330,19 +337,20 @@ export function checkSignature(reading) {
     findings.push({
       key: 'ink',
       status: 'bad',
-      text: 'Almost no ink in the crop. Either the box is off the signature, or the pen was too light to photograph.',
+      phrase: 'sig.ink.bad',
     });
   } else if (reading.coverage > 0.35) {
     findings.push({
       key: 'ink',
       status: 'warn',
-      text: 'A great deal of dark pixels - check the crop has not taken in a ruled line or the edge of the page.',
+      phrase: 'sig.ink.warn',
     });
   } else {
     findings.push({
       key: 'ink',
       status: 'good',
-      text: `Ink covers ${(reading.coverage * 100).toFixed(1)}% of the crop, which reads as a signature.`,
+      phrase: 'sig.ink.good',
+      values: { coverage: (reading.coverage * 100).toFixed(1) },
     });
   }
 
@@ -350,16 +358,16 @@ export function checkSignature(reading) {
     findings.push({
       key: 'paper',
       status: 'bad',
-      text: 'The paper is coming out grey rather than white. More light on the page, or a scan rather than a photo.',
+      phrase: 'sig.paper.bad',
     });
   } else if (reading.paperLightness < 88) {
     findings.push({
       key: 'paper',
       status: 'warn',
-      text: 'The paper is a little dull. Most forms want a clean white page behind the signature.',
+      phrase: 'sig.paper.warn',
     });
   } else {
-    findings.push({ key: 'paper', status: 'good', text: 'The paper is clean and white.' });
+    findings.push({ key: 'paper', status: 'good', phrase: 'sig.paper.good' });
   }
 
   const status = findings.some((one) => one.status === 'bad')

--- a/tools/id-photo/src/files.js
+++ b/tools/id-photo/src/files.js
@@ -42,13 +42,17 @@ export function outName(stem, spec, kind, detail = {}) {
 export const percent = (value) => `${(value * 100).toFixed(1)}%`;
 
 /** A band, as it reads on the page: "70.0% to 80.0% (31.5-36.0 mm)". */
-export function bandText(band, heightMm) {
-  const fractions = `${percent(band.min)} to ${percent(band.max)}`;
+export function bandText(band, heightMm, t) {
+  const fractions = t('band.range', { min: percent(band.min), max: percent(band.max) });
   if (band.minMm !== undefined && band.maxMm !== undefined) {
-    return `${fractions} (${trim(band.minMm)}-${trim(band.maxMm)} mm)`;
+    return t('band.mm', { range: fractions, min: trim(band.minMm), max: trim(band.maxMm) });
   }
   if (heightMm) {
-    return `${fractions} (${trim(band.min * heightMm)}-${trim(band.max * heightMm)} mm)`;
+    return t('band.mm', {
+      range: fractions,
+      min: trim(band.min * heightMm),
+      max: trim(band.max * heightMm),
+    });
   }
   return fractions;
 }
@@ -56,25 +60,22 @@ export function bandText(band, heightMm) {
 /**
  * One measurement, as a sentence that says what to do about it.
  *
- * "Too small" on its own makes somebody guess which way to drag; every line
- * here names the direction. The advisory flag changes the wording rather than
- * the maths: a band nobody published is still worth showing, and is not worth
- * calling a failure.
+ * "Too small" on its own makes somebody guess which way to drag, so there is a
+ * whole sentence for each way a measurement can be wrong, named by the subject
+ * and the status: verdict.head.low says the head is too small AND which way to
+ * drag the box. Assembling one from a subject, a direction and a fix is English
+ * word order, and this file is copied into fifteen languages.
+ *
+ * `subject` is 'head' or 'eye'; `t` resolves a phrase key against the page.
  */
-export function verdictText(check, subject, heightMm) {
+export function verdictText(check, subject, heightMm, t) {
   const measured = check.mm !== null && check.mm !== undefined
-    ? `${percent(check.value)} (${trim(check.mm)} mm)`
+    ? t('measured.mm', { percent: percent(check.value), mm: trim(check.mm) })
     : percent(check.value);
-  const wanted = bandText(check, heightMm);
-
-  if (check.status === 'ok') return `${subject} is ${measured}. The rule asks for ${wanted}.`;
-  const direction = check.status === 'low'
-    ? (subject === 'Eye line' ? 'too low in the frame' : 'too small')
-    : (subject === 'Eye line' ? 'too high in the frame' : 'too large');
-  const fix = subject === 'Eye line'
-    ? (check.status === 'low' ? 'Move the box down.' : 'Move the box up.')
-    : (check.status === 'low' ? 'Make the box smaller.' : 'Make the box larger.');
-  return `${subject} is ${measured}, which is ${direction}. The rule asks for ${wanted}. ${fix}`;
+  return t(`verdict.${subject}.${check.status}`, {
+    measured,
+    wanted: bandText(check, heightMm, t),
+  });
 }
 
 /** 'ok' | 'low' | 'high' -> the class the page paints the row with. */
@@ -84,23 +85,19 @@ export const statusClass = (status, advisory = false) => {
 };
 
 /** "4.2 degrees to the left" - the tilt line, which has no band, only a limit. */
-export function tiltText(tilt) {
+export function tiltText(tilt, t) {
   const size = Math.abs(tilt.degrees);
-  if (size < 0.5) return 'The eye line is level.';
+  if (size < 0.5) return t('tilt.level');
   const side = tilt.degrees > 0 ? 'right' : 'left';
-  const tail = tilt.status === 'ok'
-    ? 'which is within the couple of degrees an examiner will not notice.'
-    : 'which is enough to be noticed. Retake it with the camera level, or straighten the picture first.';
-  return `The head leans ${size.toFixed(1)} degrees to the ${side}, ${tail}`;
+  return t(`tilt.${tilt.status === 'ok' ? 'ok' : 'bad'}.${side}`, { degrees: size.toFixed(1) });
 }
 
 /** The centring line. The offset is a fraction of the frame's width. */
-export function centreText(centre) {
+export function centreText(centre, t) {
   const size = Math.abs(centre.offset);
-  if (centre.status === 'ok') return 'The face is centred in the frame.';
+  if (centre.status === 'ok') return t('centre.ok');
   const side = centre.offset > 0 ? 'right' : 'left';
-  return `The face sits ${percent(size)} of the frame's width to the ${side} of centre. `
-    + 'Drag the box the other way, or press Fit again.';
+  return t(`centre.${side}`, { size: percent(size) });
 }
 
 /**
@@ -108,29 +105,17 @@ export function centreText(centre) {
  *
  * @param {ReturnType<import('./geometry.js').resampling>} check
  */
-export function resamplingText(check) {
-  if (!check.enlarging) {
-    return `The crop is ${check.have.width} x ${check.have.height} pixels and the output is `
-      + `${check.need.width} x ${check.need.height}, so nothing has to be invented.`;
-  }
-  const short = `The crop is only ${check.have.width} x ${check.have.height} pixels and the output `
-    + `is ${check.need.width} x ${check.need.height}.`;
-  return check.severe
-    ? `${short} That is a long way short: the result will look soft, and on paper it will look `
-      + 'like a screenshot. A photograph taken closer, or at a higher resolution, is the only fix.'
-    : `${short} It will be enlarged slightly, which costs a little sharpness and nothing else.`;
+export function resamplingText(check, t) {
+  const sizes = {
+    have: `${check.have.width} x ${check.have.height}`,
+    need: `${check.need.width} x ${check.need.height}`,
+  };
+  if (!check.enlarging) return t('resample.enough', sizes);
+  return t(check.severe ? 'resample.severe' : 'resample.slight', sizes);
 }
 
 /** The one-line summary above the download buttons. */
-export function readyText(passing, backgroundStatus) {
-  if (!passing) {
-    return 'The geometry does not meet the rule yet. You can still save the files - '
-      + 'nothing here refuses to give you your own photograph - but the figures above '
-      + 'are what the form will be measuring.';
-  }
-  if (backgroundStatus === 'bad') {
-    return 'The geometry meets the rule. The background does not, and that is the more '
-      + 'common reason a photograph comes back.';
-  }
-  return 'The geometry meets the rule and the background reads as acceptable.';
+export function readyText(passing, backgroundStatus, t) {
+  if (!passing) return t('ready.geometry');
+  return t(backgroundStatus === 'bad' ? 'ready.background' : 'ready.good');
 }

--- a/tools/id-photo/src/main.js
+++ b/tools/id-photo/src/main.js
@@ -198,23 +198,26 @@ function buildPaperSelect() {
   }
 }
 
+/** A band, with the note that nobody published it as a requirement. */
+const guidance = (text, advisory) => (advisory ? phrase('band.guidance', { band: text }) : text);
+
 /** The table of figures under the chooser. */
 function renderSpec() {
   const spec = currentSpec();
-  const background = backgroundOf(spec);
+  const background = backgroundOf(spec, phrase);
   const heightMm = spec.print?.heightMm ?? null;
 
-  const facts = [['Print size', printLabel(spec)]];
+  const facts = [[phrase('facts.print'), printLabel(spec)]];
 
   // A signature has no head and no eye line, and showing it "0% to 100%" for
   // both would be the panel filling a row rather than stating a rule.
   if (spec.kind !== 'signature') {
     facts.push(
-      ['Head, chin to crown', bandText(spec.head, heightMm) + (spec.head.advisory ? ' (guidance)' : '')],
-      ['Eye line, from the bottom', bandText(spec.eye, heightMm) + (spec.eye.advisory ? ' (guidance)' : '')],
+      [phrase('facts.head'), guidance(bandText(spec.head, heightMm, phrase), spec.head.advisory)],
+      [phrase('facts.eye'), guidance(bandText(spec.eye, heightMm, phrase), spec.eye.advisory)],
     );
   }
-  facts.push(['Background', background.label]);
+  facts.push([phrase('facts.background'), background.label]);
 
   if (spec.digital) {
     const bytes = portalBytes(spec);
@@ -544,10 +547,10 @@ function refreshFrame() {
 
   const heightMm = spec.print?.heightMm ?? null;
   const rows = [
-    [metrics.head, verdictText(metrics.head, 'Head height', heightMm)],
-    [metrics.eye, verdictText(metrics.eye, 'Eye line', heightMm)],
-    [metrics.centre, centreText(metrics.centre)],
-    [metrics.tilt, tiltText(metrics.tilt)],
+    [metrics.head, verdictText(metrics.head, 'head', heightMm, phrase)],
+    [metrics.eye, verdictText(metrics.eye, 'eye', heightMm, phrase)],
+    [metrics.centre, centreText(metrics.centre, phrase)],
+    [metrics.tilt, tiltText(metrics.tilt, phrase)],
   ];
 
   el.geometryChecks.replaceChildren(...rows.map(([check, text]) => checkRow(
@@ -579,13 +582,14 @@ function renderResample(spec, rect) {
     return;
   }
   const largest = outputs.reduce((a, b) => (a.height >= b.height ? a : b));
-  el.resampleNote.textContent = resamplingText(resampling(rect, largest));
+  el.resampleNote.textContent = resamplingText(resampling(rect, largest), phrase);
 }
 
 function renderReady() {
   el.readyLine.textContent = readyText(
     lastMetrics ? passes(lastMetrics) : true,
     reading?.status ?? 'unknown',
+    phrase,
   );
 }
 
@@ -626,7 +630,7 @@ function readBackgroundNow() {
     reading.found = null;
   } else {
     const read = readBackground(pixels);
-    reading = checkBackground(read, backgroundOf(spec));
+    reading = checkBackground(read, backgroundOf(spec, phrase));
     reading.found = read;
   }
 
@@ -636,7 +640,7 @@ function readBackgroundNow() {
 
 function renderBackground() {
   const spec = currentSpec();
-  const wanted = backgroundOf(spec);
+  const wanted = backgroundOf(spec, phrase);
 
   if (!reading) {
     el.swatches.hidden = true;
@@ -654,16 +658,12 @@ function renderBackground() {
   }
 
   el.backgroundChecks.replaceChildren(...reading.findings.map(
-    (finding) => checkRow(finding.status, finding.text),
+    (finding) => checkRow(finding.status, phrase(finding.phrase, finding.values)),
   ));
 
   el.backgroundNote.textContent = spec.kind === 'signature'
-    ? 'Nothing here changes your signature. It is measured and reported, and the crop '
-      + 'is yours to move.'
-    : `${wanted.note} This tool will not replace a background: cutting a person out of a `
-      + 'photograph needs a segmentation model, and a bad one eats the hair of exactly '
-      + 'the people whose photographs already get rejected most often. Standing a foot '
-      + 'further from the wall fixes more of these than any filter would.';
+    ? phrase('bg.signature.note')
+    : phrase('bg.note', { colour: wanted.note });
 }
 
 /* --------------------------------------------------------------- the files */

--- a/tools/id-photo/src/specs.js
+++ b/tools/id-photo/src/specs.js
@@ -44,38 +44,10 @@
  * grey is not a stationer's grey.
  */
 export const BACKGROUNDS = {
-  white: {
-    id: 'white',
-    label: 'Plain white',
-    hex: '#ffffff',
-    tolerance: 14,
-    note: 'A white wall photographs light grey. What is being asked for is a plain, '
-      + 'evenly lit, shadow-free background, not a paint colour.',
-  },
-  'off-white': {
-    id: 'off-white',
-    label: 'White or off-white',
-    hex: '#f6f4f0',
-    tolerance: 18,
-    note: 'Either is accepted, which in practice means anything plain and light '
-      + 'with no pattern, no furniture and no shadow behind the head.',
-  },
-  'light-grey': {
-    id: 'light-grey',
-    label: 'Plain light grey',
-    hex: '#dcdcdc',
-    tolerance: 20,
-    note: 'Light grey is the ICAO preference because it separates a fair face from '
-      + 'the background and dark hair from it as well. Pure white does neither.',
-  },
-  cream: {
-    id: 'cream',
-    label: 'Light grey or cream',
-    hex: '#ebe4d7',
-    tolerance: 22,
-    note: 'The wording used by the UK. Cream reads as a warm off-white; the point '
-      + 'of the rule is that it is plain and uniform, not that it is any one shade.',
-  },
+  white: { id: 'white', hex: '#ffffff', tolerance: 14 },
+  'off-white': { id: 'off-white', hex: '#f6f4f0', tolerance: 18 },
+  'light-grey': { id: 'light-grey', hex: '#dcdcdc', tolerance: 20 },
+  cream: { id: 'cream', hex: '#ebe4d7', tolerance: 22 },
 };
 
 /* -------------------------------------------------------------- geometries */
@@ -578,7 +550,23 @@ export function specsByCountry() {
   return groups;
 }
 
-export const backgroundOf = (spec) => BACKGROUNDS[spec.background] ?? BACKGROUNDS.white;
+/**
+ * The background a rule asks for, in the reader's language.
+ *
+ * Three phrases rather than two: `label` is what the swatch says, `inline` is
+ * the same words where a sentence carries them ("...which passes as plain
+ * white"), and the second is not the first lowercased - German capitalises its
+ * nouns and would be wrong either way round.
+ */
+export function backgroundOf(spec, t) {
+  const found = BACKGROUNDS[spec.background] ?? BACKGROUNDS.white;
+  return {
+    ...found,
+    label: t(`bg.${found.id}.label`),
+    inline: t(`bg.${found.id}.inline`),
+    note: t(`bg.${found.id}.note`),
+  };
+}
 
 /**
  * The pixel size a portal file should be written at.


### PR DESCRIPTION
id-photo measures a photograph against a published rule and says what is wrong with it: the head is too small, the eye line sits too low, one side of the background is darker than the other. That verdict *is* the tool. All of it was English on a page translated into fifteen languages, because it lived in `src/background.js` and `src/files.js`.

## Most of these sentences were assembled, and assembly does not translate

`verdictText` took a subject, chose a direction and a fix, and concatenated the three:

> Head height is 50%, **which is too small**. The rule asks for 64% to 76%. **Make the box smaller.**

Six whole sentences now, named by subject and status, so a language can put the fix where it puts fixes. The tilt line spliced a side into the middle of a clause and is four sentences; centring is three; the resampling note is three; the ready line is three.

## The background colour was being lowercased into a sentence

`required.label.toLowerCase()` is English orthography. German capitalises its nouns and comes out wrong whichever way you do it. Each of the four colours now carries a label for the swatch and *the same words again* as they read inside a sentence — `bg.light-grey.label` is **Schlichtes Hellgrau** and `bg.light-grey.inline` is the same, so the finished German sentence reads *…und geht als schlichtes Hellgrau durch.*

The fourteen locales already had the labels: they are in the manual-entry table on every one of those pages. This uses those exact words rather than inventing a second set, so the swatch and the dropdown agree.

## The tests

They hand in a resolver that answers with the key and its values — what `phrase()` does with a key the page does not define — and assert which sentence was chosen rather than the words in it.

## Checks

- `python build.py --out _plain --clean --no-minify` — clean
- `python -m unittest discover -t . -s tests/python` — 484 pass
- `node --test "tests/js/*.test.js"` — 1935 pass, id-photo's own 64 among them
- `python zh-tw-sync.py --check` — `0 of 0 files differ`
- Driven in the built German page: the spec table reads **Druckgröße / Kopf, Kinn bis Scheitel / 70.0% bis 80.0% (31.5–36 mm) / Hintergrund: Schlichtes Hellgrau**, and the verdicts compose through the page's own `phrase()` — the nested band inside the head sentence, the inline colour inside the background sentence.

## One thing I did not fix

Numbers are not localised anywhere in this codebase: `percent()` writes `50.0%` with a full stop, while the hand-written German markup elsewhere on the site writes `0,25×` with a comma. That is a different mechanism from phrases — it wants `Intl.NumberFormat` and a locale the JavaScript would have to read off `document.documentElement.lang` — and it would touch every tool. Worth its own change; flagging it rather than half-doing it here.

Baseline: id-photo 106 → 71. What is left is the country rulebook in `specs.js`, the encoder's messages, and the rest of `main.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
