### PR TITLE
Stop offering to carry a result that does not exist yet

### DIFF
--- a/shared/css/tool-frame.css
+++ b/shared/css/tool-frame.css
@@ -1409,12 +1409,10 @@ ins.adsbygoogle[data-ad-status="unfilled"] { display: none !important; }
   borrows the feedback panel's register: an aside in the flow of the page, on
   --surface-2, never a second call to action shouting over the first. The
   links are the other tools' names, which is all they need to be.
-*/
-/* Greyed while there is nothing to carry, the same way a step that cannot act
-   yet is greyed. It is readable throughout - the point of showing it early is
-   that somebody can see where this tool leads before they commit a file. */
-.handoff[inert] { opacity: 0.55; pointer-events: none; }
 
+  It is drawn only once there is something to carry - handoff.js reveals it
+  beside the finished result - so nothing here has a disabled state to style.
+*/
 .handoff {
   margin-top: 0.8rem;
   padding: 0.6rem 0.9rem;

--- a/shared/handoff.js
+++ b/shared/handoff.js
@@ -41,8 +41,8 @@
  * Like shared/feedback.js beside it, this is a frame script rather than a
  * shared module: no tool imports it, no tool.toml asks for it, and the only
  * markup it touches is its own - templates/partials/handoff.html, rendered
- * hidden on pages that declare targets and moved next to the download link
- * when there is a result to carry.
+ * hidden on pages that declare targets, then moved next to the download link
+ * and revealed when there is a result to carry.
  */
 (function () {
   'use strict';
@@ -194,8 +194,10 @@
     // re-runs this function, which sets it again - a microtask loop that
     // freezes the tab. Writing only on change is what breaks the cycle.
     if (!anchor) {
-      // No result yet. The row stays where the markup put it, saying what this
-      // tool feeds; whether it is still inert is file-picker.js's business.
+      // No result yet, so the row stays hidden. An offer to carry a result
+      // is a false one until there is a result: the strip used to sit under
+      // the last card, greyed, promising to pass on something the page had
+      // not made.
       return;
     }
     // Under the result the download belongs to. A tool laid out in a way this
@@ -207,10 +209,11 @@
     } else if (anchor.parentNode && anchor.nextElementSibling !== nav) {
       anchor.insertAdjacentElement('afterend', nav);
     }
-    if (nav.hidden) nav.hidden = false;
     // A result is the strongest possible sign there is something to carry, so
-    // the row is live from here whatever the picker did.
-    if (nav.hasAttribute('inert')) nav.removeAttribute('inert');
+    // this is the one place the row is revealed. Guarded by a read for the
+    // reason above: the observer watches `hidden`, and writing it unchanged
+    // would re-enter this function forever.
+    if (nav.hidden) nav.hidden = false;
   }
 
   // Tools reveal the link by unhiding it and swapping its href for each new

--- a/templates/partials/handoff.html
+++ b/templates/partials/handoff.html
@@ -6,11 +6,13 @@
   IndexedDB for the next page. See that file for why nothing in the journey
   touches the network.
 
-  Rendered inert rather than hidden: the row says which tools this one feeds,
-  and that is worth reading before you have handed anything over - it is half
-  of what the page is for. shared/js/file-picker.js takes the attribute off
-  when a file arrives, and handoff.js moves the row under the result once
-  there is one.
+  It used to render inert instead - present but dimmed and unclickable - on the
+  argument that the row says which tools this one feeds, and that is worth
+  reading before you have handed anything over. What that produced was an
+  offer, in a box, under a disabled button, to carry a result that did not
+  exist. A control that cannot do anything yet is better absent than present
+  and greyed, and the tools this one feeds are named in "Also in the box"
+  further down every one of these pages whether or not anything has been made.
 
   Rendered rather than built in JavaScript for the same reason the feedback
   panel is: the lead line is translated in every locale's [ui.tool], and each
@@ -22,7 +24,7 @@
   each name is drawn in CSS, where Arabic can turn it around; written here it
   would point out of the page in the one language that reads the other way.
 -->
-<nav class="handoff" id="handoff" aria-labelledby="handoff-lead" inert>
+<nav class="handoff" id="handoff" aria-labelledby="handoff-lead" hidden>
   <p class="handoff-lead" id="handoff-lead">{{ ui.tool.handoff_lead }}</p>
   <ul class="handoff-targets">
 {% for other in handoff %}    <li>

--- a/tools/crop-video/tool.toml
+++ b/tools/crop-video/tool.toml
@@ -33,7 +33,7 @@ js_parts = ["file-picker"]
 # tools whose picker takes what this page produces; checked against the tools
 # that exist by the build.
 handoff = ["trim-video", "video-to-gif"]
-lastmod = "2026-08-27"
+lastmod = "2026-08-28"
 
 # --- what search engines and chat apps are told ------------------------------
 

--- a/tools/document-scanner/tool.toml
+++ b/tools/document-scanner/tool.toml
@@ -29,7 +29,7 @@ js_parts = ["file-picker", "zip", "crc32"]
 # tools whose picker takes what this page produces; checked against the tools
 # that exist by the build.
 handoff = ["merge-pdf", "compress-pdf"]
-lastmod = "2026-08-27"
+lastmod = "2026-08-28"
 
 # --- what search engines and chat apps are told ------------------------------
 

--- a/tools/edit-audio/tool.toml
+++ b/tools/edit-audio/tool.toml
@@ -33,7 +33,7 @@ js_parts = ["file-picker"]
 # tools whose picker takes what this page produces; checked against the tools
 # that exist by the build.
 handoff = ["trim-audio"]
-lastmod = "2026-08-27"
+lastmod = "2026-08-28"
 
 # --- what search engines and chat apps are told ------------------------------
 

--- a/tools/gif-maker/tool.toml
+++ b/tools/gif-maker/tool.toml
@@ -33,7 +33,7 @@ js_parts = ["file-picker"]
 # tools whose picker takes what this page produces; checked against the tools
 # that exist by the build.
 handoff = ["gif-analyzer"]
-lastmod = "2026-08-27"
+lastmod = "2026-08-28"
 
 # --- what search engines and chat apps are told ------------------------------
 

--- a/tools/images-to-pdf/tool.toml
+++ b/tools/images-to-pdf/tool.toml
@@ -33,7 +33,7 @@ js_parts = ["file-picker"]
 # tools whose picker takes what this page produces; checked against the tools
 # that exist by the build.
 handoff = ["merge-pdf", "compress-pdf"]
-lastmod = "2026-08-27"
+lastmod = "2026-08-28"
 
 # --- what search engines and chat apps are told ------------------------------
 

--- a/tools/merge-pdf/tool.toml
+++ b/tools/merge-pdf/tool.toml
@@ -30,7 +30,7 @@ js_parts = ["file-picker"]
 # tools whose picker takes what this page produces; checked against the tools
 # that exist by the build.
 handoff = ["compress-pdf"]
-lastmod = "2026-08-27"
+lastmod = "2026-08-28"
 
 # --- what search engines and chat apps are told ------------------------------
 

--- a/tools/reverse-video/tool.toml
+++ b/tools/reverse-video/tool.toml
@@ -33,7 +33,7 @@ js_parts = ["file-picker"]
 # tools whose picker takes what this page produces; checked against the tools
 # that exist by the build.
 handoff = ["trim-video", "video-to-gif"]
-lastmod = "2026-08-27"
+lastmod = "2026-08-28"
 
 # --- what search engines and chat apps are told ------------------------------
 

--- a/tools/stack-images/tool.toml
+++ b/tools/stack-images/tool.toml
@@ -33,7 +33,7 @@ js_parts = ["file-picker"]
 # tools whose picker takes what this page produces; checked against the tools
 # that exist by the build.
 handoff = ["compress-image", "resize-image"]
-lastmod = "2026-08-27"
+lastmod = "2026-08-28"
 
 # --- what search engines and chat apps are told ------------------------------
 

--- a/tools/timelapse-video/tool.toml
+++ b/tools/timelapse-video/tool.toml
@@ -33,7 +33,7 @@ js_parts = ["file-picker"]
 # tools whose picker takes what this page produces; checked against the tools
 # that exist by the build.
 handoff = ["video-to-gif"]
-lastmod = "2026-08-27"
+lastmod = "2026-08-28"
 
 # --- what search engines and chat apps are told ------------------------------
 

--- a/tools/trim-audio/tool.toml
+++ b/tools/trim-audio/tool.toml
@@ -41,7 +41,7 @@ js_parts = ["file-picker"]
 # tools whose picker takes what this page produces; checked against the tools
 # that exist by the build.
 handoff = ["edit-audio"]
-lastmod = "2026-08-27"
+lastmod = "2026-08-28"
 
 # --- what search engines and chat apps are told ------------------------------
 

--- a/tools/trim-video/tool.toml
+++ b/tools/trim-video/tool.toml
@@ -34,7 +34,7 @@ js_parts = ["file-picker"]
 # tools whose picker takes what this page produces; checked against the tools
 # that exist by the build.
 handoff = ["video-to-gif", "reverse-video"]
-lastmod = "2026-08-27"
+lastmod = "2026-08-28"
 
 # --- what search engines and chat apps are told ------------------------------
 

--- a/tools/video-to-gif/tool.toml
+++ b/tools/video-to-gif/tool.toml
@@ -33,7 +33,7 @@ js_parts = ["file-picker"]
 # tools whose picker takes what this page produces; checked against the tools
 # that exist by the build.
 handoff = ["gif-analyzer", "split-gif"]
-lastmod = "2026-08-27"
+lastmod = "2026-08-28"
 
 # --- what search engines and chat apps are told ------------------------------
 


### PR DESCRIPTION
Twelve tools end with a "Carry the result straight into:" strip — the row that
hands a finished file to the next tool without a download and a re-upload. It
was rendered `inert` rather than hidden, on the argument that the row says
where this tool leads and that is worth reading before you have committed a
file to anything.

What that argument produced, on a page where nothing had been made yet, was an
offer to carry a result that did not exist: a bordered box sitting under a
greyed-out **Make GIF** button, itself greyed, promising to pass on a file the
page had not produced. A control that cannot do anything yet reads better
absent than present and dimmed — and the thing it was there to say is said
anyway, in *Also in the box* further down every one of these pages, which
names GIF Analyzer whether or not a GIF has been made.

So the strip is now rendered `hidden`, and `shared/handoff.js` reveals it where
it already moved it: under the finished result, next to the download link.

## What changed

- `templates/partials/handoff.html` — `inert` → `hidden` on the `<nav>`, and
  the comment that argued for the old choice now records why it was dropped.
- `shared/handoff.js` — the reveal is unchanged code; only the comments moved.
  The no-result branch says the row stays hidden, and the header no longer
  claims `file-picker.js` un-inerts the nav, which it never did: that function
  only reaches `main .card[inert]`, and this nav sits outside `<main>`.
- `shared/css/tool-frame.css` — `.handoff[inert]` deleted. Nothing sets the
  attribute any more, so the rule and the paragraph explaining the dimming were
  both describing a state that can no longer occur.
- `lastmod` bumped on the twelve tools that render the strip: crop-video,
  document-scanner, edit-audio, gif-maker, images-to-pdf, merge-pdf,
  reverse-video, stack-images, timelapse-video, trim-audio, trim-video,
  video-to-gif.

## Checked

All twelve of those tools carry `id="download"`, which is what `result()` looks
for, so the reveal path is the same in each.

Verified on the built site by making a real GIF in the page — three drawn
frames handed to the picker as a drop, then Export — rather than by faking a
result: the strip is absent on load and appears under **Download GIF** once
there is a 240×160, 3-frame, 2 KB file to carry.

## Before / after

| | |
|---|---|
| Before, nothing made yet | `handoff-before.png` |
| After, nothing made yet | `handoff-after.png` |
| After, once a GIF exists | `handoff-after-result.png` |

*(Images to be dropped in — GitHub has no API for PR attachments.)*
