### PR TITLE
Let the hyphen go the way of the accent

### DIFF
--- a/locales/ar/tools/crop-video.html
+++ b/locales/ar/tools/crop-video.html
@@ -128,8 +128,8 @@
       <button type="button" id="cancel" class="ghost" hidden>ألغِ</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/ar/tools/edit-audio.html
+++ b/locales/ar/tools/edit-audio.html
@@ -150,8 +150,8 @@
       <button type="button" id="cancel" class="ghost" hidden>ألغِ</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/ar/tools/gif-maker.html
+++ b/locales/ar/tools/gif-maker.html
@@ -156,8 +156,8 @@
       <button type="button" id="cancel" class="ghost" hidden>ألغِ</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/ar/tools/grab-frame.html
+++ b/locales/ar/tools/grab-frame.html
@@ -107,8 +107,8 @@
       <button type="button" id="cancel" class="ghost" hidden>ألغِ</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/ar/tools/hash-checksum.html
+++ b/locales/ar/tools/hash-checksum.html
@@ -68,7 +68,7 @@
     <div class="progress" id="progress" hidden>
       <div class="progress-track" role="progressbar" id="progress-track"
            aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
-        <span class="progress-fill" id="progress-fill"></span>
+        <span class="progress-bar" id="progress-bar"></span>
       </div>
       <p class="progress-line">
         <span id="progress-text" role="status" aria-live="polite"></span>

--- a/locales/ar/tools/images-to-pdf.html
+++ b/locales/ar/tools/images-to-pdf.html
@@ -211,8 +211,8 @@
       <button type="button" id="cancel" class="ghost" hidden>ألغِ</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/ar/tools/images-to-video.html
+++ b/locales/ar/tools/images-to-video.html
@@ -148,8 +148,8 @@
       <button type="button" id="cancel" class="ghost" hidden>ألغِ</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/ar/tools/reverse-video.html
+++ b/locales/ar/tools/reverse-video.html
@@ -70,8 +70,8 @@
       <button type="button" id="cancel" class="ghost" hidden>ألغِ</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/ar/tools/split-gif.html
+++ b/locales/ar/tools/split-gif.html
@@ -81,8 +81,8 @@
       <button type="button" id="cancel" class="ghost" hidden>ألغِ</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
   </section>

--- a/locales/ar/tools/stack-images.html
+++ b/locales/ar/tools/stack-images.html
@@ -149,8 +149,8 @@
       <button type="button" id="cancel" class="ghost" hidden>إلغاء</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/ar/tools/timelapse-video.html
+++ b/locales/ar/tools/timelapse-video.html
@@ -134,8 +134,8 @@
       <button type="button" id="cancel" class="ghost" hidden>ألغِ</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/ar/tools/trim-audio.html
+++ b/locales/ar/tools/trim-audio.html
@@ -179,8 +179,8 @@
       <button type="button" id="cancel" class="ghost" hidden>ألغِ</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/ar/tools/trim-video.html
+++ b/locales/ar/tools/trim-video.html
@@ -204,8 +204,8 @@
       <button type="button" id="cancel" class="ghost" hidden>ألغِ</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/ar/tools/video-to-gif.html
+++ b/locales/ar/tools/video-to-gif.html
@@ -149,8 +149,8 @@
       <button type="button" id="cancel" class="ghost" hidden>ألغِ</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/de/tools/crop-video.html
+++ b/locales/de/tools/crop-video.html
@@ -129,8 +129,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Abbrechen</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/de/tools/edit-audio.html
+++ b/locales/de/tools/edit-audio.html
@@ -151,8 +151,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Abbrechen</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/de/tools/gif-maker.html
+++ b/locales/de/tools/gif-maker.html
@@ -157,8 +157,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Abbrechen</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/de/tools/grab-frame.html
+++ b/locales/de/tools/grab-frame.html
@@ -109,8 +109,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Abbrechen</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/de/tools/hash-checksum.html
+++ b/locales/de/tools/hash-checksum.html
@@ -70,7 +70,7 @@
     <div class="progress" id="progress" hidden>
       <div class="progress-track" role="progressbar" id="progress-track"
            aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
-        <span class="progress-fill" id="progress-fill"></span>
+        <span class="progress-bar" id="progress-bar"></span>
       </div>
       <p class="progress-line">
         <span id="progress-text" role="status" aria-live="polite"></span>

--- a/locales/de/tools/images-to-pdf.html
+++ b/locales/de/tools/images-to-pdf.html
@@ -213,8 +213,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Abbrechen</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/de/tools/images-to-video.html
+++ b/locales/de/tools/images-to-video.html
@@ -149,8 +149,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Abbrechen</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/de/tools/reverse-video.html
+++ b/locales/de/tools/reverse-video.html
@@ -71,8 +71,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Abbrechen</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/de/tools/split-gif.html
+++ b/locales/de/tools/split-gif.html
@@ -82,8 +82,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Abbrechen</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
   </section>

--- a/locales/de/tools/stack-images.html
+++ b/locales/de/tools/stack-images.html
@@ -151,8 +151,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Abbrechen</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/de/tools/timelapse-video.html
+++ b/locales/de/tools/timelapse-video.html
@@ -136,8 +136,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Abbrechen</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/de/tools/trim-audio.html
+++ b/locales/de/tools/trim-audio.html
@@ -183,8 +183,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Abbrechen</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/de/tools/trim-video.html
+++ b/locales/de/tools/trim-video.html
@@ -207,8 +207,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Abbrechen</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/de/tools/video-to-gif.html
+++ b/locales/de/tools/video-to-gif.html
@@ -152,8 +152,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Abbrechen</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/es/tools/crop-video.html
+++ b/locales/es/tools/crop-video.html
@@ -128,8 +128,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/es/tools/edit-audio.html
+++ b/locales/es/tools/edit-audio.html
@@ -151,8 +151,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/es/tools/gif-maker.html
+++ b/locales/es/tools/gif-maker.html
@@ -157,8 +157,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/es/tools/grab-frame.html
+++ b/locales/es/tools/grab-frame.html
@@ -109,8 +109,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/es/tools/hash-checksum.html
+++ b/locales/es/tools/hash-checksum.html
@@ -69,7 +69,7 @@
     <div class="progress" id="progress" hidden>
       <div class="progress-track" role="progressbar" id="progress-track"
            aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
-        <span class="progress-fill" id="progress-fill"></span>
+        <span class="progress-bar" id="progress-bar"></span>
       </div>
       <p class="progress-line">
         <span id="progress-text" role="status" aria-live="polite"></span>

--- a/locales/es/tools/images-to-pdf.html
+++ b/locales/es/tools/images-to-pdf.html
@@ -213,8 +213,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/es/tools/images-to-video.html
+++ b/locales/es/tools/images-to-video.html
@@ -148,8 +148,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/es/tools/reverse-video.html
+++ b/locales/es/tools/reverse-video.html
@@ -71,8 +71,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/es/tools/split-gif.html
+++ b/locales/es/tools/split-gif.html
@@ -82,8 +82,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
   </section>

--- a/locales/es/tools/stack-images.html
+++ b/locales/es/tools/stack-images.html
@@ -150,8 +150,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/es/tools/timelapse-video.html
+++ b/locales/es/tools/timelapse-video.html
@@ -136,8 +136,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/es/tools/trim-audio.html
+++ b/locales/es/tools/trim-audio.html
@@ -181,8 +181,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/es/tools/trim-video.html
+++ b/locales/es/tools/trim-video.html
@@ -207,8 +207,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/es/tools/video-to-gif.html
+++ b/locales/es/tools/video-to-gif.html
@@ -152,8 +152,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/fr/tools/crop-video.html
+++ b/locales/fr/tools/crop-video.html
@@ -129,8 +129,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Annuler</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/fr/tools/edit-audio.html
+++ b/locales/fr/tools/edit-audio.html
@@ -152,8 +152,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Annuler</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/fr/tools/gif-maker.html
+++ b/locales/fr/tools/gif-maker.html
@@ -157,8 +157,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Annuler</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/fr/tools/grab-frame.html
+++ b/locales/fr/tools/grab-frame.html
@@ -109,8 +109,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Annuler</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/fr/tools/hash-checksum.html
+++ b/locales/fr/tools/hash-checksum.html
@@ -70,7 +70,7 @@
     <div class="progress" id="progress" hidden>
       <div class="progress-track" role="progressbar" id="progress-track"
            aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
-        <span class="progress-fill" id="progress-fill"></span>
+        <span class="progress-bar" id="progress-bar"></span>
       </div>
       <p class="progress-line">
         <span id="progress-text" role="status" aria-live="polite"></span>

--- a/locales/fr/tools/images-to-pdf.html
+++ b/locales/fr/tools/images-to-pdf.html
@@ -213,8 +213,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Annuler</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/fr/tools/images-to-video.html
+++ b/locales/fr/tools/images-to-video.html
@@ -148,8 +148,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Annuler</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/fr/tools/reverse-video.html
+++ b/locales/fr/tools/reverse-video.html
@@ -71,8 +71,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Annuler</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/fr/tools/split-gif.html
+++ b/locales/fr/tools/split-gif.html
@@ -82,8 +82,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Annuler</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
   </section>

--- a/locales/fr/tools/stack-images.html
+++ b/locales/fr/tools/stack-images.html
@@ -151,8 +151,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Annuler</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/fr/tools/timelapse-video.html
+++ b/locales/fr/tools/timelapse-video.html
@@ -137,8 +137,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Annuler</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/fr/tools/trim-audio.html
+++ b/locales/fr/tools/trim-audio.html
@@ -182,8 +182,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Annuler</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/fr/tools/trim-video.html
+++ b/locales/fr/tools/trim-video.html
@@ -207,8 +207,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Annuler</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/fr/tools/video-to-gif.html
+++ b/locales/fr/tools/video-to-gif.html
@@ -152,8 +152,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Annuler</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/hi/tools/crop-video.html
+++ b/locales/hi/tools/crop-video.html
@@ -128,8 +128,8 @@
       <button type="button" id="cancel" class="ghost" hidden>रद्द कीजिए</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/hi/tools/edit-audio.html
+++ b/locales/hi/tools/edit-audio.html
@@ -152,8 +152,8 @@
       <button type="button" id="cancel" class="ghost" hidden>रद्द कीजिए</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/hi/tools/gif-maker.html
+++ b/locales/hi/tools/gif-maker.html
@@ -157,8 +157,8 @@
       <button type="button" id="cancel" class="ghost" hidden>रद्द कीजिए</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/hi/tools/grab-frame.html
+++ b/locales/hi/tools/grab-frame.html
@@ -109,8 +109,8 @@
       <button type="button" id="cancel" class="ghost" hidden>रद्द कीजिए</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/hi/tools/hash-checksum.html
+++ b/locales/hi/tools/hash-checksum.html
@@ -68,7 +68,7 @@
     <div class="progress" id="progress" hidden>
       <div class="progress-track" role="progressbar" id="progress-track"
            aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
-        <span class="progress-fill" id="progress-fill"></span>
+        <span class="progress-bar" id="progress-bar"></span>
       </div>
       <p class="progress-line">
         <span id="progress-text" role="status" aria-live="polite"></span>

--- a/locales/hi/tools/images-to-pdf.html
+++ b/locales/hi/tools/images-to-pdf.html
@@ -213,8 +213,8 @@
       <button type="button" id="cancel" class="ghost" hidden>रद्द कीजिए</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/hi/tools/images-to-video.html
+++ b/locales/hi/tools/images-to-video.html
@@ -149,8 +149,8 @@
       <button type="button" id="cancel" class="ghost" hidden>रद्द कीजिए</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/hi/tools/reverse-video.html
+++ b/locales/hi/tools/reverse-video.html
@@ -71,8 +71,8 @@
       <button type="button" id="cancel" class="ghost" hidden>रद्द कीजिए</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/hi/tools/split-gif.html
+++ b/locales/hi/tools/split-gif.html
@@ -82,8 +82,8 @@
       <button type="button" id="cancel" class="ghost" hidden>रद्द कीजिए</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
   </section>

--- a/locales/hi/tools/stack-images.html
+++ b/locales/hi/tools/stack-images.html
@@ -151,8 +151,8 @@
       <button type="button" id="cancel" class="ghost" hidden>रद्द करें</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/hi/tools/timelapse-video.html
+++ b/locales/hi/tools/timelapse-video.html
@@ -135,8 +135,8 @@
       <button type="button" id="cancel" class="ghost" hidden>रद्द करें</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/hi/tools/trim-audio.html
+++ b/locales/hi/tools/trim-audio.html
@@ -180,8 +180,8 @@
       <button type="button" id="cancel" class="ghost" hidden>रद्द कीजिए</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/hi/tools/trim-video.html
+++ b/locales/hi/tools/trim-video.html
@@ -207,8 +207,8 @@
       <button type="button" id="cancel" class="ghost" hidden>रद्द कीजिए</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/hi/tools/video-to-gif.html
+++ b/locales/hi/tools/video-to-gif.html
@@ -151,8 +151,8 @@
       <button type="button" id="cancel" class="ghost" hidden>रद्द कीजिए</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/id/tools/crop-video.html
+++ b/locales/id/tools/crop-video.html
@@ -135,8 +135,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Batalkan</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/id/tools/edit-audio.html
+++ b/locales/id/tools/edit-audio.html
@@ -157,8 +157,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Batalkan</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/id/tools/gif-maker.html
+++ b/locales/id/tools/gif-maker.html
@@ -163,8 +163,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Batalkan</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/id/tools/grab-frame.html
+++ b/locales/id/tools/grab-frame.html
@@ -115,8 +115,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Batalkan</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/id/tools/hash-checksum.html
+++ b/locales/id/tools/hash-checksum.html
@@ -76,7 +76,7 @@
     <div class="progress" id="progress" hidden>
       <div class="progress-track" role="progressbar" id="progress-track"
            aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
-        <span class="progress-fill" id="progress-fill"></span>
+        <span class="progress-bar" id="progress-bar"></span>
       </div>
       <p class="progress-line">
         <span id="progress-text" role="status" aria-live="polite"></span>

--- a/locales/id/tools/images-to-pdf.html
+++ b/locales/id/tools/images-to-pdf.html
@@ -219,8 +219,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Batalkan</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/id/tools/images-to-video.html
+++ b/locales/id/tools/images-to-video.html
@@ -155,8 +155,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Batalkan</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/id/tools/reverse-video.html
+++ b/locales/id/tools/reverse-video.html
@@ -77,8 +77,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Batalkan</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/id/tools/split-gif.html
+++ b/locales/id/tools/split-gif.html
@@ -88,8 +88,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Batalkan</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
   </section>

--- a/locales/id/tools/stack-images.html
+++ b/locales/id/tools/stack-images.html
@@ -151,8 +151,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Batalkan</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/id/tools/timelapse-video.html
+++ b/locales/id/tools/timelapse-video.html
@@ -144,8 +144,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Batalkan</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/id/tools/trim-audio.html
+++ b/locales/id/tools/trim-audio.html
@@ -188,8 +188,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Batalkan</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/id/tools/trim-video.html
+++ b/locales/id/tools/trim-video.html
@@ -214,8 +214,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Batalkan</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/id/tools/video-to-gif.html
+++ b/locales/id/tools/video-to-gif.html
@@ -157,8 +157,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Batalkan</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/it/tools/crop-video.html
+++ b/locales/it/tools/crop-video.html
@@ -128,8 +128,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Annulla</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/it/tools/edit-audio.html
+++ b/locales/it/tools/edit-audio.html
@@ -151,8 +151,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Annulla</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/it/tools/gif-maker.html
+++ b/locales/it/tools/gif-maker.html
@@ -157,8 +157,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Annulla</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/it/tools/grab-frame.html
+++ b/locales/it/tools/grab-frame.html
@@ -109,8 +109,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Annulla</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/it/tools/hash-checksum.html
+++ b/locales/it/tools/hash-checksum.html
@@ -69,7 +69,7 @@
     <div class="progress" id="progress" hidden>
       <div class="progress-track" role="progressbar" id="progress-track"
            aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
-        <span class="progress-fill" id="progress-fill"></span>
+        <span class="progress-bar" id="progress-bar"></span>
       </div>
       <p class="progress-line">
         <span id="progress-text" role="status" aria-live="polite"></span>

--- a/locales/it/tools/images-to-pdf.html
+++ b/locales/it/tools/images-to-pdf.html
@@ -213,8 +213,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Annulla</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/it/tools/images-to-video.html
+++ b/locales/it/tools/images-to-video.html
@@ -149,8 +149,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Annulla</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/it/tools/reverse-video.html
+++ b/locales/it/tools/reverse-video.html
@@ -71,8 +71,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Annulla</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/it/tools/split-gif.html
+++ b/locales/it/tools/split-gif.html
@@ -82,8 +82,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Annulla</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
   </section>

--- a/locales/it/tools/stack-images.html
+++ b/locales/it/tools/stack-images.html
@@ -151,8 +151,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Annulla</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/it/tools/timelapse-video.html
+++ b/locales/it/tools/timelapse-video.html
@@ -136,8 +136,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Annulla</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/it/tools/trim-audio.html
+++ b/locales/it/tools/trim-audio.html
@@ -180,8 +180,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Annulla</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/it/tools/trim-video.html
+++ b/locales/it/tools/trim-video.html
@@ -206,8 +206,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Annulla</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/it/tools/video-to-gif.html
+++ b/locales/it/tools/video-to-gif.html
@@ -151,8 +151,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Annulla</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/ja/tools/crop-video.html
+++ b/locales/ja/tools/crop-video.html
@@ -123,8 +123,8 @@
       <button type="button" id="cancel" class="ghost" hidden>中止</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/ja/tools/edit-audio.html
+++ b/locales/ja/tools/edit-audio.html
@@ -144,8 +144,8 @@
       <button type="button" id="cancel" class="ghost" hidden>中止</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/ja/tools/gif-maker.html
+++ b/locales/ja/tools/gif-maker.html
@@ -155,8 +155,8 @@
       <button type="button" id="cancel" class="ghost" hidden>中止</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/ja/tools/grab-frame.html
+++ b/locales/ja/tools/grab-frame.html
@@ -104,8 +104,8 @@
       <button type="button" id="cancel" class="ghost" hidden>中止</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/ja/tools/hash-checksum.html
+++ b/locales/ja/tools/hash-checksum.html
@@ -65,7 +65,7 @@
     <div class="progress" id="progress" hidden>
       <div class="progress-track" role="progressbar" id="progress-track"
            aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
-        <span class="progress-fill" id="progress-fill"></span>
+        <span class="progress-bar" id="progress-bar"></span>
       </div>
       <p class="progress-line">
         <span id="progress-text" role="status" aria-live="polite"></span>

--- a/locales/ja/tools/images-to-pdf.html
+++ b/locales/ja/tools/images-to-pdf.html
@@ -206,8 +206,8 @@
       <button type="button" id="cancel" class="ghost" hidden>中止</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/ja/tools/images-to-video.html
+++ b/locales/ja/tools/images-to-video.html
@@ -147,8 +147,8 @@
       <button type="button" id="cancel" class="ghost" hidden>中止</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/ja/tools/reverse-video.html
+++ b/locales/ja/tools/reverse-video.html
@@ -68,8 +68,8 @@
       <button type="button" id="cancel" class="ghost" hidden>中止</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/ja/tools/split-gif.html
+++ b/locales/ja/tools/split-gif.html
@@ -80,8 +80,8 @@
       <button type="button" id="cancel" class="ghost" hidden>中止</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
   </section>

--- a/locales/ja/tools/stack-images.html
+++ b/locales/ja/tools/stack-images.html
@@ -144,8 +144,8 @@
       <button type="button" id="cancel" class="ghost" hidden>中止</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/ja/tools/timelapse-video.html
+++ b/locales/ja/tools/timelapse-video.html
@@ -129,8 +129,8 @@
       <button type="button" id="cancel" class="ghost" hidden>中止</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/ja/tools/trim-audio.html
+++ b/locales/ja/tools/trim-audio.html
@@ -168,8 +168,8 @@
       <button type="button" id="cancel" class="ghost" hidden>中止</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/ja/tools/trim-video.html
+++ b/locales/ja/tools/trim-video.html
@@ -194,8 +194,8 @@
       <button type="button" id="cancel" class="ghost" hidden>中止</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/ja/tools/video-to-gif.html
+++ b/locales/ja/tools/video-to-gif.html
@@ -145,8 +145,8 @@
       <button type="button" id="cancel" class="ghost" hidden>中止</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/ko/tools/crop-video.html
+++ b/locales/ko/tools/crop-video.html
@@ -128,8 +128,8 @@
       <button type="button" id="cancel" class="ghost" hidden>취소</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/ko/tools/edit-audio.html
+++ b/locales/ko/tools/edit-audio.html
@@ -150,8 +150,8 @@
       <button type="button" id="cancel" class="ghost" hidden>취소</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/ko/tools/gif-maker.html
+++ b/locales/ko/tools/gif-maker.html
@@ -156,8 +156,8 @@
       <button type="button" id="cancel" class="ghost" hidden>취소</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/ko/tools/grab-frame.html
+++ b/locales/ko/tools/grab-frame.html
@@ -109,8 +109,8 @@
       <button type="button" id="cancel" class="ghost" hidden>취소</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/ko/tools/hash-checksum.html
+++ b/locales/ko/tools/hash-checksum.html
@@ -67,7 +67,7 @@
     <div class="progress" id="progress" hidden>
       <div class="progress-track" role="progressbar" id="progress-track"
            aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
-        <span class="progress-fill" id="progress-fill"></span>
+        <span class="progress-bar" id="progress-bar"></span>
       </div>
       <p class="progress-line">
         <span id="progress-text" role="status" aria-live="polite"></span>

--- a/locales/ko/tools/images-to-pdf.html
+++ b/locales/ko/tools/images-to-pdf.html
@@ -212,8 +212,8 @@
       <button type="button" id="cancel" class="ghost" hidden>취소</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/ko/tools/images-to-video.html
+++ b/locales/ko/tools/images-to-video.html
@@ -148,8 +148,8 @@
       <button type="button" id="cancel" class="ghost" hidden>취소</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/ko/tools/reverse-video.html
+++ b/locales/ko/tools/reverse-video.html
@@ -70,8 +70,8 @@
       <button type="button" id="cancel" class="ghost" hidden>취소</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/ko/tools/split-gif.html
+++ b/locales/ko/tools/split-gif.html
@@ -82,8 +82,8 @@
       <button type="button" id="cancel" class="ghost" hidden>취소</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
   </section>

--- a/locales/ko/tools/stack-images.html
+++ b/locales/ko/tools/stack-images.html
@@ -149,8 +149,8 @@
       <button type="button" id="cancel" class="ghost" hidden>취소</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/ko/tools/timelapse-video.html
+++ b/locales/ko/tools/timelapse-video.html
@@ -134,8 +134,8 @@
       <button type="button" id="cancel" class="ghost" hidden>취소</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/ko/tools/trim-audio.html
+++ b/locales/ko/tools/trim-audio.html
@@ -178,8 +178,8 @@
       <button type="button" id="cancel" class="ghost" hidden>취소</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/ko/tools/trim-video.html
+++ b/locales/ko/tools/trim-video.html
@@ -205,8 +205,8 @@
       <button type="button" id="cancel" class="ghost" hidden>취소</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/ko/tools/video-to-gif.html
+++ b/locales/ko/tools/video-to-gif.html
@@ -151,8 +151,8 @@
       <button type="button" id="cancel" class="ghost" hidden>취소</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/nl/tools/crop-video.html
+++ b/locales/nl/tools/crop-video.html
@@ -128,8 +128,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Annuleren</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/nl/tools/edit-audio.html
+++ b/locales/nl/tools/edit-audio.html
@@ -152,8 +152,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Annuleren</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/nl/tools/gif-maker.html
+++ b/locales/nl/tools/gif-maker.html
@@ -157,8 +157,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Annuleren</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/nl/tools/grab-frame.html
+++ b/locales/nl/tools/grab-frame.html
@@ -109,8 +109,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Annuleren</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/nl/tools/hash-checksum.html
+++ b/locales/nl/tools/hash-checksum.html
@@ -70,7 +70,7 @@
     <div class="progress" id="progress" hidden>
       <div class="progress-track" role="progressbar" id="progress-track"
            aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
-        <span class="progress-fill" id="progress-fill"></span>
+        <span class="progress-bar" id="progress-bar"></span>
       </div>
       <p class="progress-line">
         <span id="progress-text" role="status" aria-live="polite"></span>

--- a/locales/nl/tools/images-to-pdf.html
+++ b/locales/nl/tools/images-to-pdf.html
@@ -213,8 +213,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Annuleren</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/nl/tools/images-to-video.html
+++ b/locales/nl/tools/images-to-video.html
@@ -148,8 +148,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Annuleren</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/nl/tools/reverse-video.html
+++ b/locales/nl/tools/reverse-video.html
@@ -71,8 +71,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Annuleren</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/nl/tools/split-gif.html
+++ b/locales/nl/tools/split-gif.html
@@ -82,8 +82,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Annuleren</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
   </section>

--- a/locales/nl/tools/stack-images.html
+++ b/locales/nl/tools/stack-images.html
@@ -151,8 +151,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Annuleren</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/nl/tools/timelapse-video.html
+++ b/locales/nl/tools/timelapse-video.html
@@ -136,8 +136,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Annuleren</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/nl/tools/trim-audio.html
+++ b/locales/nl/tools/trim-audio.html
@@ -181,8 +181,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Annuleren</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/nl/tools/trim-video.html
+++ b/locales/nl/tools/trim-video.html
@@ -207,8 +207,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Annuleren</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/nl/tools/video-to-gif.html
+++ b/locales/nl/tools/video-to-gif.html
@@ -151,8 +151,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Annuleren</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/pt/tools/crop-video.html
+++ b/locales/pt/tools/crop-video.html
@@ -128,8 +128,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/pt/tools/edit-audio.html
+++ b/locales/pt/tools/edit-audio.html
@@ -151,8 +151,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/pt/tools/gif-maker.html
+++ b/locales/pt/tools/gif-maker.html
@@ -157,8 +157,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/pt/tools/grab-frame.html
+++ b/locales/pt/tools/grab-frame.html
@@ -108,8 +108,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/pt/tools/hash-checksum.html
+++ b/locales/pt/tools/hash-checksum.html
@@ -68,7 +68,7 @@
     <div class="progress" id="progress" hidden>
       <div class="progress-track" role="progressbar" id="progress-track"
            aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
-        <span class="progress-fill" id="progress-fill"></span>
+        <span class="progress-bar" id="progress-bar"></span>
       </div>
       <p class="progress-line">
         <span id="progress-text" role="status" aria-live="polite"></span>

--- a/locales/pt/tools/images-to-pdf.html
+++ b/locales/pt/tools/images-to-pdf.html
@@ -213,8 +213,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/pt/tools/images-to-video.html
+++ b/locales/pt/tools/images-to-video.html
@@ -148,8 +148,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/pt/tools/reverse-video.html
+++ b/locales/pt/tools/reverse-video.html
@@ -70,8 +70,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/pt/tools/split-gif.html
+++ b/locales/pt/tools/split-gif.html
@@ -82,8 +82,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
   </section>

--- a/locales/pt/tools/stack-images.html
+++ b/locales/pt/tools/stack-images.html
@@ -150,8 +150,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/pt/tools/timelapse-video.html
+++ b/locales/pt/tools/timelapse-video.html
@@ -135,8 +135,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/pt/tools/trim-audio.html
+++ b/locales/pt/tools/trim-audio.html
@@ -180,8 +180,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/pt/tools/trim-video.html
+++ b/locales/pt/tools/trim-video.html
@@ -206,8 +206,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/pt/tools/video-to-gif.html
+++ b/locales/pt/tools/video-to-gif.html
@@ -151,8 +151,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/tr/tools/crop-video.html
+++ b/locales/tr/tools/crop-video.html
@@ -134,8 +134,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Vazgeç</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/tr/tools/edit-audio.html
+++ b/locales/tr/tools/edit-audio.html
@@ -156,8 +156,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Vazgeç</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/tr/tools/gif-maker.html
+++ b/locales/tr/tools/gif-maker.html
@@ -164,8 +164,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Vazgeç</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/tr/tools/grab-frame.html
+++ b/locales/tr/tools/grab-frame.html
@@ -115,8 +115,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Vazgeç</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/tr/tools/hash-checksum.html
+++ b/locales/tr/tools/hash-checksum.html
@@ -76,7 +76,7 @@
     <div class="progress" id="progress" hidden>
       <div class="progress-track" role="progressbar" id="progress-track"
            aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
-        <span class="progress-fill" id="progress-fill"></span>
+        <span class="progress-bar" id="progress-bar"></span>
       </div>
       <p class="progress-line">
         <span id="progress-text" role="status" aria-live="polite"></span>

--- a/locales/tr/tools/images-to-pdf.html
+++ b/locales/tr/tools/images-to-pdf.html
@@ -218,8 +218,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Vazgeç</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/tr/tools/images-to-video.html
+++ b/locales/tr/tools/images-to-video.html
@@ -155,8 +155,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Vazgeç</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/tr/tools/reverse-video.html
+++ b/locales/tr/tools/reverse-video.html
@@ -77,8 +77,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Vazgeç</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/tr/tools/split-gif.html
+++ b/locales/tr/tools/split-gif.html
@@ -88,8 +88,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Vazgeç</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
   </section>

--- a/locales/tr/tools/stack-images.html
+++ b/locales/tr/tools/stack-images.html
@@ -150,8 +150,8 @@
       <button type="button" id="cancel" class="ghost" hidden>İptal</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/tr/tools/timelapse-video.html
+++ b/locales/tr/tools/timelapse-video.html
@@ -143,8 +143,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Vazgeç</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/tr/tools/trim-audio.html
+++ b/locales/tr/tools/trim-audio.html
@@ -187,8 +187,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Vazgeç</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/tr/tools/trim-video.html
+++ b/locales/tr/tools/trim-video.html
@@ -212,8 +212,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Vazgeç</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/tr/tools/video-to-gif.html
+++ b/locales/tr/tools/video-to-gif.html
@@ -157,8 +157,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Vazgeç</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/zh-TW/tools/crop-video.html
+++ b/locales/zh-TW/tools/crop-video.html
@@ -130,8 +130,8 @@
       <button type="button" id="cancel" class="ghost" hidden>取消</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/zh-TW/tools/edit-audio.html
+++ b/locales/zh-TW/tools/edit-audio.html
@@ -151,8 +151,8 @@
       <button type="button" id="cancel" class="ghost" hidden>取消</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/zh-TW/tools/gif-maker.html
+++ b/locales/zh-TW/tools/gif-maker.html
@@ -155,8 +155,8 @@
       <button type="button" id="cancel" class="ghost" hidden>取消</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/zh-TW/tools/grab-frame.html
+++ b/locales/zh-TW/tools/grab-frame.html
@@ -105,8 +105,8 @@
       <button type="button" id="cancel" class="ghost" hidden>取消</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/zh-TW/tools/hash-checksum.html
+++ b/locales/zh-TW/tools/hash-checksum.html
@@ -63,7 +63,7 @@
     <div class="progress" id="progress" hidden>
       <div class="progress-track" role="progressbar" id="progress-track"
            aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
-        <span class="progress-fill" id="progress-fill"></span>
+        <span class="progress-bar" id="progress-bar"></span>
       </div>
       <p class="progress-line">
         <span id="progress-text" role="status" aria-live="polite"></span>

--- a/locales/zh-TW/tools/images-to-pdf.html
+++ b/locales/zh-TW/tools/images-to-pdf.html
@@ -213,8 +213,8 @@
       <button type="button" id="cancel" class="ghost" hidden>取消</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/zh-TW/tools/images-to-video.html
+++ b/locales/zh-TW/tools/images-to-video.html
@@ -154,8 +154,8 @@
       <button type="button" id="cancel" class="ghost" hidden>取消</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/zh-TW/tools/reverse-video.html
+++ b/locales/zh-TW/tools/reverse-video.html
@@ -68,8 +68,8 @@
       <button type="button" id="cancel" class="ghost" hidden>取消</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/zh-TW/tools/split-gif.html
+++ b/locales/zh-TW/tools/split-gif.html
@@ -80,8 +80,8 @@
       <button type="button" id="cancel" class="ghost" hidden>取消</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
   </section>

--- a/locales/zh-TW/tools/stack-images.html
+++ b/locales/zh-TW/tools/stack-images.html
@@ -146,8 +146,8 @@
       <button type="button" id="cancel" class="ghost" hidden>取消</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/zh-TW/tools/timelapse-video.html
+++ b/locales/zh-TW/tools/timelapse-video.html
@@ -129,8 +129,8 @@
       <button type="button" id="cancel" class="ghost" hidden>取消</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/zh-TW/tools/trim-audio.html
+++ b/locales/zh-TW/tools/trim-audio.html
@@ -169,8 +169,8 @@
       <button type="button" id="cancel" class="ghost" hidden>取消</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/zh-TW/tools/trim-video.html
+++ b/locales/zh-TW/tools/trim-video.html
@@ -201,8 +201,8 @@
       <button type="button" id="cancel" class="ghost" hidden>取消</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/zh-TW/tools/video-to-gif.html
+++ b/locales/zh-TW/tools/video-to-gif.html
@@ -152,8 +152,8 @@
       <button type="button" id="cancel" class="ghost" hidden>取消</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/zh/tools/crop-video.html
+++ b/locales/zh/tools/crop-video.html
@@ -130,8 +130,8 @@
       <button type="button" id="cancel" class="ghost" hidden>取消</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/zh/tools/edit-audio.html
+++ b/locales/zh/tools/edit-audio.html
@@ -151,8 +151,8 @@
       <button type="button" id="cancel" class="ghost" hidden>取消</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/zh/tools/gif-maker.html
+++ b/locales/zh/tools/gif-maker.html
@@ -155,8 +155,8 @@
       <button type="button" id="cancel" class="ghost" hidden>取消</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/zh/tools/grab-frame.html
+++ b/locales/zh/tools/grab-frame.html
@@ -105,8 +105,8 @@
       <button type="button" id="cancel" class="ghost" hidden>取消</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/zh/tools/hash-checksum.html
+++ b/locales/zh/tools/hash-checksum.html
@@ -63,7 +63,7 @@
     <div class="progress" id="progress" hidden>
       <div class="progress-track" role="progressbar" id="progress-track"
            aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
-        <span class="progress-fill" id="progress-fill"></span>
+        <span class="progress-bar" id="progress-bar"></span>
       </div>
       <p class="progress-line">
         <span id="progress-text" role="status" aria-live="polite"></span>

--- a/locales/zh/tools/images-to-pdf.html
+++ b/locales/zh/tools/images-to-pdf.html
@@ -213,8 +213,8 @@
       <button type="button" id="cancel" class="ghost" hidden>取消</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/zh/tools/images-to-video.html
+++ b/locales/zh/tools/images-to-video.html
@@ -154,8 +154,8 @@
       <button type="button" id="cancel" class="ghost" hidden>取消</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/zh/tools/reverse-video.html
+++ b/locales/zh/tools/reverse-video.html
@@ -68,8 +68,8 @@
       <button type="button" id="cancel" class="ghost" hidden>取消</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/zh/tools/split-gif.html
+++ b/locales/zh/tools/split-gif.html
@@ -80,8 +80,8 @@
       <button type="button" id="cancel" class="ghost" hidden>取消</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
   </section>

--- a/locales/zh/tools/stack-images.html
+++ b/locales/zh/tools/stack-images.html
@@ -146,8 +146,8 @@
       <button type="button" id="cancel" class="ghost" hidden>取消</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/zh/tools/timelapse-video.html
+++ b/locales/zh/tools/timelapse-video.html
@@ -129,8 +129,8 @@
       <button type="button" id="cancel" class="ghost" hidden>取消</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/zh/tools/trim-audio.html
+++ b/locales/zh/tools/trim-audio.html
@@ -169,8 +169,8 @@
       <button type="button" id="cancel" class="ghost" hidden>取消</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/zh/tools/trim-video.html
+++ b/locales/zh/tools/trim-video.html
@@ -201,8 +201,8 @@
       <button type="button" id="cancel" class="ghost" hidden>取消</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/locales/zh/tools/video-to-gif.html
+++ b/locales/zh/tools/video-to-gif.html
@@ -152,8 +152,8 @@
       <button type="button" id="cancel" class="ghost" hidden>取消</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/shared/hub-filter.js
+++ b/shared/hub-filter.js
@@ -48,9 +48,17 @@
   if (!box || !input || !empty) return;
 
   /* Diacritics off both sides, so "compresion" finds "Compresión" and a German
-     reader is not stopped by an umlaut they did not type. */
+     reader is not stopped by an umlaut they did not type.
+
+     Hyphens go the same way, for the same reason. The time-lapse tool is
+     called "Time-Lapse Maker" and nobody types it that way - they type
+     timelapse, which is what its own address says - and until this line that
+     search found nothing at all. A reader should not have to guess where a
+     name keeps its punctuation any more than where it keeps its accents. */
   function fold(text) {
-    return text.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+    return text.toLowerCase().normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .replace(/[-\u2010-\u2015\u2212]/g, '');
   }
 
   /* Every card, with the text it can be found by worked out once. Reading this


### PR DESCRIPTION
The filter folds diacritics off both sides so `compresion` finds **Compresión**. It didn't fold hyphens — and the time-lapse tool is called **"Time-Lapse Maker"**.

So typing `timelapse` — how most people write it, and what the tool's own address says — **found nothing at all**. Not a near miss or a poor ranking. Nothing.

A reader shouldn't have to guess where a name keeps its punctuation any more than where it keeps its accents, so the same fold now takes the hyphen and its four typographic relatives (‐ ‑ ‒ – — −).

Found by the QA suite's new hub-filter spec, which searches for every tool by a word from its own slug and reports the ones that come back empty. One did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)