### PR TITLE
Tell a tool when a file is coming back rather than arriving

### DIFF
--- a/shared/lang-keep.js
+++ b/shared/lang-keep.js
@@ -341,7 +341,21 @@
     for (var i = 0; i < files.length; i += 1) carrier.items.add(files[i]);
     input.files = carrier.files;
     restoring = true;
+    /* Said on the input as well as kept here, because the tool has to be able
+       to see it. A tool that places a file by looking at what is already on
+       the page - compare-text puts a single file into whichever box is empty,
+       which is the only thing a drop could sensibly mean - gets that judgement
+       wrong during a restore: it reads the file asynchronously, the settings
+       below land while it is still reading, and by the time it looks the box
+       it came out of is full again. It then files the text as a second
+       document and reports the two as identical.
+
+       The flag is readable for exactly as long as this dispatch runs, which is
+       long enough: a handler starts synchronously and can take a copy before
+       its first await. */
+    input.dataset.langRestore = '1';
     input.dispatchEvent(new Event('change', { bubbles: true }));
+    delete input.dataset.langRestore;
     restoring = false;
   }
 

--- a/tests/js/lang-keep.test.js
+++ b/tests/js/lang-keep.test.js
@@ -141,6 +141,13 @@ function el(selectors = [], attrs = {}) {
     attrs,
     parentNode: null,
     fired: [],
+    // Every element has one, and the source now writes to it: deliver() marks
+    // the file input for the length of its dispatch so a tool can tell a file
+    // coming back from a file arriving. A stub without it made that line throw
+    // and the dispatch never happened, which is a fault in the stub rather
+    // than in the page - and exactly the kind this file exists to catch, since
+    // a real input would have carried it without comment.
+    dataset: {},
     getAttribute: (name) => (name in attrs ? attrs[name] : null),
     setAttribute: (name, value) => { attrs[name] = value; },
     closest(query) {
@@ -614,6 +621,41 @@ test('the far side of a switch hands the work back', async () => {
   assert.deepEqual(page.input.fired, ['change'], 'as if it had been chosen');
   assert.equal(width.value, '640');
   assert.deepEqual(width.fired, ['input', 'change'], 'and the tool is told, or it would ignore it');
+});
+
+test('a file coming back says so, for exactly as long as it takes to say it', async () => {
+  // A tool that places a file by looking at what is already on the page needs
+  // to know the difference between a file arriving and a file coming back.
+  // compare-text puts a single dropped file into whichever box is empty, which
+  // is right for a drop and wrong for a restore: it reads the file
+  // asynchronously, the settings land while it is still reading, and by the
+  // time it looks the box the file came out of is full again - so it files the
+  // text as a second document and calls the two identical.
+  //
+  // The mark is readable for the length of the dispatch and gone afterwards.
+  // Both halves matter: a handler takes its copy synchronously before its
+  // first await, and a mark left behind would make every later drop look like
+  // a restore.
+  const page = run({
+    lang: 'de',
+    ready: 'complete',
+    parked: {
+      lang: 'en', time: Date.now(), files: [file('holiday.jpg')], values: [],
+    },
+  });
+
+  let saidDuring = null;
+  const dispatch = page.input.dispatchEvent;
+  page.input.dispatchEvent = (event) => {
+    if (event.type === 'change') saidDuring = page.input.dataset.langRestore;
+    return dispatch(event);
+  };
+
+  await page.settle();
+
+  assert.equal(saidDuring, '1', 'the tool was not told the file was coming back');
+  assert.equal(page.input.dataset.langRestore, undefined,
+    'the mark was left on the input, so the next real drop would look like a restore');
 });
 
 test('it waits for load, so the tool is listening before it is told anything', async () => {

--- a/tools/compare-text/src/main.js
+++ b/tools/compare-text/src/main.js
@@ -62,6 +62,10 @@ const picker = wireFilePicker({
 });
 
 async function loadFiles(files) {
+  // Taken before the first await, while the flag is still on the input:
+  // shared/lang-keep.js sets it for the length of its dispatch, and this
+  // handler starts synchronously inside that.
+  const restoring = el.fileInput?.dataset.langRestore === '1';
   picker.busy(readingLabel(files.length));
   try {
     // Read as text, here, by the browser. There is no other step: the strings
@@ -70,9 +74,15 @@ async function loadFiles(files) {
     if (texts.length > 1) {
       el.input.value = texts[0];
       el.inputB.value = texts[1];
-    } else if (el.input.value.trim() && !el.inputB.value.trim()) {
+    } else if (!restoring && el.input.value.trim() && !el.inputB.value.trim()) {
       // One file dropped onto a comparison that already has an original fills
       // the empty side, which is the only thing it could sensibly mean.
+      //
+      // Only when somebody dropped it. A file handed back by a language
+      // switch is the same file that was in the first box, and the text
+      // already restored into that box is what it was read from - so the
+      // empty side is not where it belongs, and putting it there turns one
+      // document into two identical ones.
       el.inputB.value = texts[0];
     } else {
       el.input.value = texts[0];


### PR DESCRIPTION
Load a file into the comparer, switch language, and **both boxes came back holding the same text** — so a comparison between a document and nothing reported *"identical, byte for byte."* The wrong answer, from the one tool whose only unforgivable failure is calling two different things the same.

## It's a race, and no ordering fixes it

`lang-keep` hands the carried file back through the file input and *then* restores the saved settings — the right way round, and it says so. But the tool reads the file **asynchronously**, so the settings land while it's still reading. By the time the read finishes, the box the file came out of is full again.

compare-text, seeing one box full and one empty, files the text as a second document. That judgement is correct **for a drop**:

> One file dropped onto a comparison that already has an original fills the empty side, which is the only thing it could sensibly mean.

It's wrong for a **restore**, because the "original" it's looking at is the same file, put there half a millisecond earlier by the restore itself.

## The change

The restore now says what it is. `lang-keep` already kept a private flag for the length of its dispatch; it says the same thing on the input where a tool can see it, and compare-text takes a copy **before its first `await`** — a handler starts synchronously, which is why this needs no timer.

Two lines and three. No heuristics, and it covers the cases that defeat the alternatives: two files restored together, or a file with text typed beside it afterwards.

**This is general, not a compare-text quirk.** Any picker that places a file by inspecting what's already on the page will fail the same way under restore. compare-text is just the only one that does today.

## Verified both directions

| | box A | box B | verdict |
|---|---|---|---|
| before the switch | the document | empty | *1 added, 3 removed* |
| after | the document | **empty** | the same, in Arabic |

And a real drop still fills the empty side. 34 tests across the language-switch and compare-text specs.

Closes the last of the QA suite's open findings (qa#29).

🤖 Generated with [Claude Code](https://claude.com/claude-code)