### PR TITLE
Announce the pages whose words moved, not the ones whose date did

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -262,12 +262,14 @@ jobs:
             git -C .publish checkout --orphan dist
           fi
 
-          # The sitemap as it is deployed right now, saved before the line
-          # below deletes it. It is the baseline the IndexNow step diffs
-          # against to work out which pages actually changed, and this is the
-          # last moment it exists.
+          # A fingerprint of every deployed page's <main>, taken before
+          # the line below deletes the tree. It is the baseline the
+          # IndexNow step diffs against to work out which pages actually
+          # changed, and this is the last moment the deployed tree exists
+          # to be measured.
           if [ -f .publish/sitemap.xml ]; then
-            cp .publish/sitemap.xml "$RUNNER_TEMP/deployed-sitemap.xml"
+            python indexnow.py --tree .publish \
+              --write-hashes "$RUNNER_TEMP/deployed-hashes.json"
           fi
 
           # Replace the tree wholesale rather than copying over it: a page that
@@ -400,8 +402,8 @@ jobs:
 
           status=0
           python indexnow.py \
-            --old "$RUNNER_TEMP/deployed-sitemap.xml" \
-            --new _site/sitemap.xml \
+            --tree _site \
+            --old-hashes "$RUNNER_TEMP/deployed-hashes.json" \
             --out "$RUNNER_TEMP/submitted.txt" \
             --submit || status=$?
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,14 +145,29 @@ of them but one. Put it in the markup - `#phrases` in the tool's `body.html`, or
 it asks. A module too deep to reach the DOM returns a *key* and lets the caller
 resolve it. See "The strings in the JavaScript" in [README.md](README.md).
 
-**`lastmod` now decides who hears about a change.** It used to be a hint in
-`sitemap.xml`; since `indexnow.py` joined the deploy it is also the signal that
-tells Bing which pages to refetch. Change the wording on a page and leave its
-`lastmod` alone and the deploy announces nothing — the change is live and no
-crawler is told. The reverse is worse: bumping every date to be safe submits
-the whole site and spends the host's standing with the protocol. Bump the dates
-that moved. See "Telling the search engines a page changed" in
-[docs/deploying.md](docs/deploying.md).
+**Nothing you write decides who hears about a change.** `indexnow.py` runs
+after the deploy and tells Bing, Yandex, Seznam, Naver and Yep which pages to
+refetch, and it works the answer out by comparing the bytes inside `<main>` on
+the tree about to ship against the tree already deployed. The frame is outside
+`<main>`, so shipping a tool or moving a colour announces nothing however many
+pages it rewrites, and changing a sentence announces exactly the pages that
+sentence is on. There is no field to remember and no way to get it wrong.
+
+It used to be `lastmod`, hand-written per page, and that is why the rule here
+used to say "bump the dates that moved". A date cannot express a second change
+to a page on the day it already names, so on 27 August — thirty-seven deploys —
+sixteen changed words a visitor reads and announced nothing at all. The signal
+was unfollowable and it failed silently, which is the worst way for a signal to
+fail. `lastmod` is still in `sitemap.xml` doing its own job for Google; nothing
+reads it to decide what to submit. See "Telling the search engines a page
+changed" in [docs/deploying.md](docs/deploying.md).
+
+**Every page in the sitemap must have exactly one `<main>`.** That is what the
+paragraph above compares, so a page with none would raise on every deploy and a
+page with two would compare half of itself. `tests/python/test_build.py` hands
+the real build to the real reader rather than trusting it. Redirect stubs have
+no `<main>` and that is fine — they are `noindex` and out of the sitemap, so
+nothing announces them.
 
 **The roadmap is kept out of search, in two files that must agree.**
 `templates/roadmap.html` carries `noindex, follow` and `buildlib/catalogue.py`

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -181,36 +181,52 @@ to the frame or the stylesheet rewrites them without moving a word anybody
 reads. Submitting URLs that did not change is how a host stops being trusted
 with the protocol, which would cost the site the one lever it has here.
 
-What does track real change is already in the repository. `lastmod` in
-`sitemap.xml` is one date per page, written by hand in `tool.toml` and
-`config/site.toml`, and moved only when the wording on that page moves — see
-the comment in [`templates/sitemap.xml`](../templates/sitemap.xml). So
-[`indexnow.py`](../indexnow.py) compares the sitemap about to be deployed
-against the one already deployed, and submits the entries that are new or whose
-date moved:
+What tracks real change is the page's own content. Every template wraps what a
+page actually says in a single `<main>`; the crumbs, the header, the language
+switcher and the footer all sit outside it. So
+[`indexnow.py`](../indexnow.py) hashes the bytes inside `<main>` for every page
+the sitemap lists, and submits the ones whose hash is new or has moved:
 
 | What changed | What is submitted |
 |---|---|
-| A tool's wording, with its `lastmod` bumped | that tool, in all fifteen languages |
-| A new tool | its pages, and the hubs, if their dates moved |
-| The footer, the CSS, the build | nothing |
+| A sentence on a tool page | that tool, in the languages the sentence changed in |
+| A new tool | its pages, and the hubs that now list it |
+| The footer, the CSS, an icon, the build | nothing |
 
-Because the list comes from the sitemap rather than from the output directory,
-it inherits every rule the sitemap already applies: an untranslated page is not
-in it, a locale still being translated is not in it, and the redirect stub left
-behind by a renamed tool is not in it either.
+Because the *set* of pages still comes from the sitemap rather than from the
+output directory, it inherits every rule the sitemap already applies: an
+untranslated page is not in it, a locale still being translated is not in it,
+the roadmap is not in it, and the redirect stub left behind by a renamed tool
+is not in it either.
 
-The [Build workflow](../.github/workflows/build.yml) saves the deployed
-`sitemap.xml` before it replaces the `dist` tree, and submits after the push —
-announcing a URL a minute before it exists gets it fetched, found stale, and
-believed. The step cannot fail the build: by the time it runs the deploy has
-happened, and a refused submission does not undo it. It writes what it sent to
-the run summary instead.
+This used to read `lastmod` instead — one date per page, written by hand and
+moved when the wording moved. The idea was right and the signal was not,
+because a date has no room for a second change on the day it already names. On
+27 August thirty-seven deploys went out; sixteen of them changed words a
+visitor reads and submitted nothing, because every page they touched already
+said `2026-08-27`. Nobody had forgotten anything — there was no value left to
+bump it to, and the failure was invisible, because a deploy that announces
+nothing looks exactly like a deploy with nothing to announce. `lastmod` is
+still in the sitemap doing its own job for Google. Nothing reads it to decide
+what to submit, and there is now no field an author has to remember.
+
+The [Build workflow](../.github/workflows/build.yml) fingerprints the deployed
+tree before it replaces it — that is the last moment the old pages exist — and
+submits after the push, because announcing a URL a minute before it exists gets
+it fetched, found stale, and believed. The step cannot fail the build: by the
+time it runs the deploy has happened, and a refused submission does not undo
+it. It writes what it sent to the run summary instead.
 
 To see what a deploy would submit, without submitting it:
 
 ```bash
-python indexnow.py --old deployed-sitemap.xml --new _site/sitemap.xml
+python indexnow.py --tree _site --old-hashes deployed-hashes.json
+```
+
+and to take the fingerprints that file holds, from a tree before it is replaced:
+
+```bash
+python indexnow.py --tree dist --write-hashes deployed-hashes.json
 ```
 
 ### The key file

--- a/indexnow.py
+++ b/indexnow.py
@@ -9,32 +9,56 @@ postings and livestreams, and a tool page submitted there is discarded - so
 Google is still reached the slow way, through the sitemap, and nothing here
 changes that.
 
-The only real question is which URLs to send, and this repository already
-answers it. A byte diff of the deployed tree is the obvious idea and it is
-wrong: the footer lists every tool, so shipping one rewrites all six hundred
-pages, and a change to the frame rewrites them without moving a word anybody
-reads. What does track real change is `lastmod` in sitemap.xml - one date per
-page, written by hand, moved only when that page's wording moves, for the
-reasons set out in templates/sitemap.xml. So this compares the sitemap about
-to be deployed against the one already deployed, and sends the entries that
-are new or whose date moved. A frame change sends nothing, which is correct.
+The only real question is which URLs to send. A byte diff of the deployed tree
+is the obvious idea and it is wrong: the footer lists every tool and the frame
+wraps every page, so a change to either rewrites all twelve hundred without
+moving a word anybody reads - #221 changed one CSS property and rewrote 468.
+
+This used to answer that with `lastmod` from sitemap.xml: one date per page,
+written by hand, moved only when that page's wording moved. The reasoning was
+sound and the signal was not, because a date cannot express two changes on one
+day. On 27 August thirty-seven deploys went out; sixteen of them changed words
+a visitor reads and announced nothing, because the page's `lastmod` already
+said 2026-08-27 and there was no value left to bump it to. That is not an
+author forgetting - the rule was unfollowable, and it failed silently, which
+is the worst way for a signal to fail.
+
+So the comparison is now of the thing itself: the bytes inside <main>, which is
+where a page's own content lives and where the frame does not reach. The nav,
+the header, the footer and the language switcher are all outside it, so the
+whole class of false positives that made a byte diff useless is excluded by
+construction rather than by discipline. `lastmod` stays exactly as it was and
+goes on doing its own job in the sitemap; nothing here reads it any more.
+
+The set of URLs still comes from the sitemap, because that is what already
+knows which pages are indexable - the roadmap is deliberately absent, and a
+language that has not translated a page does not list it.
 
 Sending more than that is not free. Pushing URLs that did not change is how a
 host stops being trusted with the protocol, and that trust is the only lever
 the site has here.
 
-Two sitemaps in, the list of URLs out:
+Two runs, because the deployed tree stops existing the moment it is replaced.
+Before the publish, take its fingerprints:
 
-    python indexnow.py --old deployed/sitemap.xml --new _site/sitemap.xml
+    python indexnow.py --tree .publish --sitemap .publish/sitemap.xml \
+        --write-hashes deployed-hashes.json
 
-Add --submit to actually send them. The key is deliberately not a secret: it
-is served at the site root, because being able to fetch it there is how the
-protocol proves the sender owns the host.
+After it, compare the new tree against them:
+
+    python indexnow.py --tree _site --sitemap _site/sitemap.xml \
+        --old-hashes deployed-hashes.json --submit
+
+Add --submit to actually send them; without it the list is only printed. The
+key is deliberately not a secret: it is served at the site root, because being
+able to fetch it there is how the protocol proves the sender owns the host.
 """
 
 import argparse
+import hashlib
 import json
 import pathlib
+import re
 import sys
 import urllib.error
 import urllib.request
@@ -80,8 +104,70 @@ def read_sitemap(path):
     return pages
 
 
+# A comment, and the page's own content within what is left.
+#
+# Stripping the comments first is not tidiness. templates/tool.html explains
+# itself in a comment that contains the characters "<main>", and on an
+# unminified build a reader that did not strip it would start its match there -
+# swallowing the header, the crumbs and the pledge banner into what it calls
+# the page's content, which is the entire class of false positive this exists
+# to avoid. The deployed pages are minified and carry no comments at all, so
+# the bug would never have shown up in production; it would have shown up as a
+# deploy that submitted twelve hundred URLs the first time somebody turned
+# minifying off. Excluding comments is also right on its own terms: nobody
+# reads them, so a change to one is not a change worth announcing.
+COMMENT = re.compile(rb'<!--.*?-->', re.S)
+MAIN = re.compile(rb'<main[\s/>].*?</main>', re.S)
+
+
+def content_of(path):
+    """The bytes inside <main>, or an error naming the page that has none.
+
+    Refusing rather than falling back to the whole file is deliberate. A
+    fallback would quietly restore the byte diff this script exists to avoid -
+    one page hashing its frame is one page submitted on every unrelated deploy
+    forever, and nothing would ever say so.
+    """
+    html = COMMENT.sub(b'', pathlib.Path(path).read_bytes())
+    found = MAIN.search(html)
+    if not found:
+        raise ValueError(f'{path} has no <main> to compare')
+    return found.group(0)
+
+
+def page_path(tree, url):
+    """Where a sitemap loc lands in a built tree.
+
+    The sitemap carries translated slugs as the characters themselves, and the
+    build writes directories under exactly those names, so the path needs no
+    decoding - only the percent-encoding in as_uri() below happens, and it
+    happens later and to a copy.
+    """
+    path = urlsplit(url).path.strip('/')
+    if not path:
+        return pathlib.Path(tree, 'index.html')
+    return pathlib.Path(tree, path, 'index.html')
+
+
+def hashes(tree, sitemap):
+    """{url: digest of its <main>} for every page the sitemap lists.
+
+    A URL the sitemap names and the tree does not hold is a build that
+    disagrees with itself, so it is raised rather than skipped: silently
+    dropping the page would mean never announcing it again.
+    """
+    out = {}
+    for url in read_sitemap(sitemap):
+        path = page_path(tree, url)
+        if not path.is_file():
+            raise ValueError(
+                f'{url} is in the sitemap but {path} is not there')
+        out[url] = hashlib.sha256(content_of(path)).hexdigest()
+    return out
+
+
 def changed(old, new):
-    """The URLs worth submitting: the new ones, and the ones whose date moved.
+    """The URLs worth submitting: new pages, and ones whose <main> moved.
 
     A URL that has left the sitemap is not returned. IndexNow does accept a
     removed page - it gets fetched, found to be gone, and dropped - but a tool
@@ -90,8 +176,8 @@ def changed(old, new):
     do not resolve is also a quick way to spend the host's standing with the
     protocol.
     """
-    return [url for url, lastmod in new.items()
-            if url not in old or old[url] != lastmod]
+    return [url for url, digest in new.items()
+            if url not in old or old[url] != digest]
 
 
 def host_of(urls):
@@ -166,25 +252,42 @@ def main(argv=None):
             stream.reconfigure(encoding='utf-8')
 
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
-    parser.add_argument('--new', required=True,
-                        help='the sitemap about to be deployed')
-    parser.add_argument('--old',
-                        help='the sitemap already deployed; leaving it out, '
-                             'or naming a file that is not there, means there '
-                             'is no baseline and nothing is sent')
+    parser.add_argument('--tree', required=True,
+                        help='the built site the sitemap describes')
+    parser.add_argument('--sitemap',
+                        help='its sitemap; defaults to sitemap.xml inside '
+                             '--tree')
+    parser.add_argument('--old-hashes',
+                        help='fingerprints of the tree already deployed, from '
+                             'an earlier --write-hashes; leaving it out, or '
+                             'naming a file that is not there, means there is '
+                             'no baseline and nothing is sent')
+    parser.add_argument('--write-hashes',
+                        help="write this tree's fingerprints here and stop. "
+                             'Run before the deploy replaces the tree, which '
+                             'is the last moment it can be measured')
     parser.add_argument('--all', action='store_true',
-                        help='every URL in --new, whatever --old says; for a '
-                             'deliberate resubmission, not for a deploy')
+                        help='every URL in the sitemap, whatever the baseline '
+                             'says; for a deliberate resubmission, not for a '
+                             'deploy')
     parser.add_argument('--submit', action='store_true',
                         help='send them. Without it the list is only printed')
     parser.add_argument('--out', help='also write the list to this file')
     args = parser.parse_args(argv)
 
-    new = read_sitemap(args.new)
+    sitemap = args.sitemap or str(pathlib.Path(args.tree, 'sitemap.xml'))
+    new = hashes(args.tree, sitemap)
+
+    if args.write_hashes:
+        pathlib.Path(args.write_hashes).write_bytes(
+            json.dumps(new, ensure_ascii=False, indent=1).encode('utf-8'))
+        return 0
+
     if args.all:
         urls = list(new)
-    elif args.old and pathlib.Path(args.old).exists():
-        urls = changed(read_sitemap(args.old), new)
+    elif args.old_hashes and pathlib.Path(args.old_hashes).exists():
+        old = json.loads(pathlib.Path(args.old_hashes).read_bytes())
+        urls = changed(old, new)
     else:
         # No baseline: the first run after this was added, or a dist branch
         # being created from scratch. Submitting the whole site is precisely
@@ -192,7 +295,7 @@ def main(argv=None):
         # nothing the sitemap does not already tell them - so send nothing and
         # let the next deploy have something to compare against. --all is
         # there for when somebody really does mean the whole site.
-        print('no previous sitemap to compare against; nothing to submit',
+        print('no fingerprints to compare against; nothing to submit',
               file=sys.stderr)
         urls = []
 

--- a/tests/python/test_build.py
+++ b/tests/python/test_build.py
@@ -23,6 +23,7 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import build as buildmod
+import indexnow
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -323,6 +324,26 @@ class BuildTheSite(unittest.TestCase):
         found = [f'{locale["prefix"]}index.html' for locale in self.locales]
         self.assertTrue(all(name in self.written for name in found))
         return found
+
+    def test_indexnow_can_fingerprint_every_page_it_would_announce(self):
+        """indexnow.py compares the bytes inside <main> to decide which pages a
+        deploy announces. A page in the sitemap with no <main> would raise on
+        every deploy, and one with two would compare whichever the regex
+        reached first - both silent, and neither visible in the rendered page.
+        So the real build is handed to the real reader here.
+
+        The set is the sitemap's, not everything written: a redirect stub is a
+        bare meta-refresh with no frame and no <main>, and it is deliberately
+        noindex and out of the sitemap, so it is not a page anybody announces.
+        """
+        urls = indexnow.read_sitemap(self.out / 'sitemap.xml')
+        # Raises on a page with no <main>, and on a URL the tree does not
+        # hold. Both are the failures worth catching here; that two pages
+        # could share a digest is not one of them, because a locale falling
+        # back to English is entitled to serve the same words twice.
+        digests = indexnow.hashes(self.out, self.out / 'sitemap.xml')
+        self.assertEqual(sorted(digests), sorted(urls))
+        self.assertTrue(digests)
 
     def test_it_reports_what_it_wrote(self):
         self.assertIn('index.html', self.written)

--- a/tests/python/test_indexnow.py
+++ b/tests/python/test_indexnow.py
@@ -6,7 +6,11 @@ selection rule, because getting it wrong is invisible: submitting too few
 means the protocol quietly does nothing for the site, and submitting every
 page on every deploy means the host stops being trusted and the protocol
 quietly does nothing for the site. Neither shows up anywhere but in a Bing
-Webmaster Tools chart weeks later.
+Webmaster Tools chart weeks later. The rule used to read `lastmod` and it
+failed the first way, silently, for sixteen deploys in one day: a date cannot
+express a second change to a page on the day it already names. So what is
+compared now is the bytes inside <main>, and what is tested is that the frame
+around it cannot leak in.
 
 The second is that the key in the script and the key file served at the site
 root have to be the same string. A mismatch is not an error either: the
@@ -72,39 +76,133 @@ class ReadingASitemap(unittest.TestCase):
 class ChoosingWhatToSubmit(unittest.TestCase):
 
     def test_a_new_page_is_submitted(self):
-        old = {'https://abox.tools/': '2026-08-01'}
-        new = {'https://abox.tools/': '2026-08-01',
-               'https://abox.tools/split-pdf/': '2026-08-26'}
+        old = {'https://abox.tools/': 'aaaa'}
+        new = {'https://abox.tools/': 'aaaa',
+               'https://abox.tools/split-pdf/': 'bbbb'}
         self.assertEqual(indexnow.changed(old, new),
                          ['https://abox.tools/split-pdf/'])
 
-    def test_a_moved_lastmod_is_submitted(self):
-        old = {'https://abox.tools/crop-video/': '2026-07-02'}
-        new = {'https://abox.tools/crop-video/': '2026-08-26'}
+    def test_a_moved_digest_is_submitted(self):
+        old = {'https://abox.tools/crop-video/': 'aaaa'}
+        new = {'https://abox.tools/crop-video/': 'bbbb'}
         self.assertEqual(indexnow.changed(old, new),
                          ['https://abox.tools/crop-video/'])
 
-    def test_a_frame_change_submits_nothing(self):
-        """The case this whole design exists for. Changing the footer or the
-        stylesheet rewrites the bytes of every page on the site and moves no
-        lastmod, because lastmod is written by hand and says when the wording
-        changed. A byte diff of dist would submit six hundred URLs here."""
-        pages = {'https://abox.tools/': '2026-08-01',
-                 'https://abox.tools/crop-video/': '2026-07-02',
-                 'https://abox.tools/de/': '2026-08-01'}
+    def test_an_unchanged_site_submits_nothing(self):
+        pages = {'https://abox.tools/': 'aaaa',
+                 'https://abox.tools/crop-video/': 'bbbb',
+                 'https://abox.tools/de/': 'cccc'}
         self.assertEqual(indexnow.changed(pages, dict(pages)), [])
 
     def test_a_page_that_left_the_sitemap_is_not_submitted(self):
         """A retired tool becomes a redirect stub, so its address goes on
         answering 200 and there is nothing to tell anyone about."""
-        old = {'https://abox.tools/text-tools/': '2026-07-02'}
+        old = {'https://abox.tools/text-tools/': 'aaaa'}
         self.assertEqual(indexnow.changed(old, {}), [])
 
     def test_the_submitted_order_follows_the_new_sitemap(self):
         old = {}
-        new = {'https://abox.tools/': '2026-08-26',
-               'https://abox.tools/split-pdf/': '2026-08-26'}
+        new = {'https://abox.tools/': 'aaaa',
+               'https://abox.tools/split-pdf/': 'bbbb'}
         self.assertEqual(indexnow.changed(old, new), list(new))
+
+
+PAGE = ('<!doctype html><html lang="en"><head><title>{title}</title></head>'
+        '<body><nav class="crumbs">{crumbs}</nav>'
+        '<header class="topbar">{header}</header>'
+        '<main id="main">{main}</main>'
+        '<footer>{footer}</footer></body></html>')
+
+
+def page(main='the tool', crumbs='Home', header='abox.tools',
+         footer='every tool', title='A tool'):
+    return PAGE.format(main=main, crumbs=crumbs, header=header,
+                       footer=footer, title=title)
+
+
+class ComparingWhatThePageSays(unittest.TestCase):
+    """The signal itself: <main> and nothing around it."""
+
+    def digest(self, html):
+        path = pathlib.Path(
+            self.enterContext(tempfile.TemporaryDirectory())) / 'index.html'
+        path.write_bytes(html.encode('utf-8'))
+        return indexnow.content_of(path)
+
+    def test_the_frame_around_it_is_not_compared(self):
+        """The case this whole design exists for, and the one a byte diff gets
+        wrong. The footer names every tool, the header carries the language
+        switcher, the crumbs carry the section - shipping a tool or moving a
+        colour rewrites all three on all twelve hundred pages. #221 changed one
+        CSS property and rewrote 468 of them while moving nobody's words."""
+        self.assertEqual(
+            self.digest(page(crumbs='Home', header='a', footer='b',
+                             title='A tool')),
+            self.digest(page(crumbs='Home / Tools', header='z', footer='y',
+                             title='A different title')))
+
+    def test_a_word_inside_it_is_compared(self):
+        self.assertNotEqual(self.digest(page(main='已不再分享')),
+                            self.digest(page(main='已不再共享')))
+
+    def test_a_comment_that_mentions_main_does_not_start_the_match(self):
+        """templates/tool.html explains itself in a comment containing the
+        characters "<main>". A reader that did not strip comments first starts
+        its match there and swallows the header, the crumbs and the pledge
+        banner - so every frame change would submit every page, which is the
+        one thing this must never do. Minified pages carry no comments, so
+        production would have looked fine until somebody built with
+        --no-minify."""
+        commented = PAGE.replace(
+            '<body>',
+            '<body><!-- the skip link lands on the <main> below -->')
+        plain = self.digest(page(header='a'))
+        with_comment = self.digest(
+            commented.format(main='the tool', crumbs='Home', header='a',
+                             footer='every tool', title='A tool'))
+        self.assertEqual(plain, with_comment)
+
+    def test_a_page_with_no_main_is_refused_rather_than_guessed_at(self):
+        """Falling back to the whole file would quietly restore the byte diff
+        for that one page: submitted on every unrelated deploy, forever, with
+        nothing to say so."""
+        with self.assertRaises(ValueError):
+            self.digest('<!doctype html><html><body><p>no main</p></body>'
+                        '</html>')
+
+    def test_the_opening_tag_may_carry_attributes(self):
+        """The build emits <main id="main"> for the skip link to land on."""
+        self.assertIn(b'the tool', self.digest(page()))
+
+
+class FindingAPageInTheTree(unittest.TestCase):
+
+    def test_a_slug_becomes_its_directory_index(self):
+        self.assertEqual(
+            indexnow.page_path('_site', 'https://abox.tools/crop-video/'),
+            pathlib.Path('_site', 'crop-video', 'index.html'))
+
+    def test_the_root_is_the_top_index(self):
+        self.assertEqual(indexnow.page_path('_site', 'https://abox.tools/'),
+                         pathlib.Path('_site', 'index.html'))
+
+    def test_a_translated_slug_is_not_decoded_on_the_way_in(self):
+        """The sitemap carries these as the characters themselves and the build
+        writes directories under exactly those names, so nothing is unquoted
+        here. The percent-encoding happens later, in as_uri, and to a copy."""
+        self.assertEqual(
+            indexnow.page_path('_site', 'https://abox.tools/ar/ضغط-الصور/'),
+            pathlib.Path('_site', 'ar', 'ضغط-الصور', 'index.html'))
+
+    def test_a_sitemap_url_the_tree_does_not_hold_is_refused(self):
+        """A build that disagrees with its own sitemap. Skipping the page would
+        mean never announcing it again, and never saying why."""
+        tmp = pathlib.Path(self.enterContext(tempfile.TemporaryDirectory()))
+        (tmp / 'sitemap.xml').write_bytes(
+            sitemap(
+                ('https://abox.tools/gone/', '2026-08-01')).encode('utf-8'))
+        with self.assertRaises(ValueError):
+            indexnow.hashes(tmp, tmp / 'sitemap.xml')
 
 
 class TheHostInTheSubmission(unittest.TestCase):


### PR DESCRIPTION
`indexnow.py` is not broken — its last real submission was 285 URLs, HTTP 200, and the key file validates. The signal feeding it is what failed.

## What was happening

It chose what to submit by diffing `lastmod` between the deployed sitemap and the one about to ship. The reasoning was right — a byte diff of the tree is useless, because the footer names every tool and the frame wraps every page. But the signal is a **date**, and a date has no room for a second change on the day it already names.

On 27 August, **37 deploys** went out. **31 announced nothing**, and **16 of those changed words a visitor reads**:

```
b7b133c   61 word-files  Say it in four more tools, where the same reader is carried (#231)
e461490   49 word-files  Let the MP4 reader say why in the reader's own language (#229)
86cfdaa   37 word-files  One progress bar, in one file, under one set of names (#222)
d73595a   30 word-files  Take the two loudest tools' sentences out of their JavaScript (#181)
…12 more
```

Nobody had forgotten anything. Every affected page already read `lastmod = "2026-08-27"` *before* the PR and still did after:

```
exif-editor        before=2026-08-27  after=2026-08-27
crop-video         before=2026-08-27  after=2026-08-27
compress-image     before=2026-08-27  after=2026-08-27
password-generator before=2026-08-27  after=2026-08-27
```

There was no value left to bump it to. And it failed **silently** — a deploy that announces nothing looks exactly like a deploy with nothing to announce, and the step is green either way.

## What this does

Compares the thing itself: the bytes inside `<main>`. Every template wraps what a page says in one `<main>`, and the crumbs, header, language switcher and footer are all outside it — so the whole class of false positive is excluded by construction rather than by discipline.

The *set* of URLs still comes from the sitemap, which already knows what is indexable: the roadmap is out, an untranslated page is out, a redirect stub is out. `lastmod` stays where it is, doing its own job for Google. Nothing reads it to decide what to submit, and **there is now no field an author has to remember.**

## Replayed over the window it got wrong

Every deploy since 27 Aug, re-run through the new reader:

```
[ 0] f08b342e  files changed= 468   <main> moved=   0   submitted=   0   correctly silent
[ 1] 10e5352f  files changed=  13   <main> moved=  13   submitted=   0   MISSED
[ 2] c53cafe5  files changed= 606   <main> moved= 537   submitted= 450
[ 8] c25d5f4e  files changed= 468   <main> moved=  13   submitted=   0   MISSED
[ 9] 58a1d9c0  files changed=1068   <main> moved=   0   submitted=   0   correctly silent
[10] b48b0878  files changed=  26   <main> moved=  26   submitted=   0   MISSED
```

The two extremes are the proof: #221 changed one CSS property, rewrote 468 pages, and moves **zero** `<main>`. The phrases deploys that submitted nothing move 13, 26 and 35.

End-to-end against two real deployed trees (#229's deploy): **39 URLs**, every one a page that genuinely changed — `reverse-video` and `trim-video` in every language, plus the eight `zh-TW` pages that same commit re-synced. **Zero false positives.**

## Two traps found while building it

**A page with no `<main>` is refused, not fallen back on.** A fallback would quietly hash the frame for that one page and submit it on every unrelated deploy forever, with nothing to say so. The redirect stubs (`text-tools` in 15 languages) have no `<main>` — they are `noindex` and out of the sitemap, so nothing reaches them.

**Comments are stripped before the match.** `templates/tool.html` explains itself in a comment containing the characters `<main>`. Unstripped, an unminified build starts its match *there* and swallows the header, crumbs and pledge banner — every frame change would then submit every page. Production minifies comments away, so this would have waited to bite until someone built with `--no-minify`. Both have tests.

## Verified

- `python -m unittest tests.python.test_indexnow` — 24 tests, pass
- `python build.py --out _plain --clean --no-minify` — 1278 pages, links checked
- the real reader against that clean unminified build — 1245 sitemap URLs, 1245 fingerprinted, sets equal
- simulated deploy: an edit inside `<main>` submits the page, an edit outside it submits nothing
- every touched file is LF

`tests/python/test_build.py` now hands the real build to the real reader, so a template that loses or doubles its `<main>` fails CI instead of failing a deploy in silence.

## One question for you

`indexnow.py` runs *after* the deploy and cannot change any page, but it is not in `INVISIBLE_FILES` in `buildlib/version.py`, so this tags a patch (`1.0.2 → 1.0.3`). Adding it there would be correct and is one line — I left it out because it changes versioning behaviour and that is your call.

Nothing a visitor sees changes, so there are no before/after pictures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
