### PR TITLE
Say what the site licenses rather than what it reserves

### DIFF
--- a/config/site.toml
+++ b/config/site.toml
@@ -811,6 +811,31 @@ blurb = """
         nothing to upload, no account to make."""
 base = "Every claim on this site is meant to be checked, not believed."
 
+# What the site licenses, rather than what it reserves. The conventional footer
+# line is a copyright notice, and here that would be a false one: LICENSE puts
+# the code under MIT and LICENSE-CONTENT puts every sentence a visitor reads
+# under CC BY 4.0, so "all rights reserved" would deny, on the page itself, the
+# thing those two files grant. Copyright attaches on creation under the Berne
+# Convention and a notice has not been required since 1989, so the notice was
+# never buying anything a licence line does not buy better.
+#
+# The <a> sits inside the translated string for the reason given above
+# `guarantees_note`: which words carry the link is a translator's decision. The
+# two URLs are written out rather than built from `source_url`, because strings
+# under [footer] are substituted into the template and not themselves rendered -
+# a {{ }} here ships to the visitor verbatim. pages/terms/body.html spells the
+# same repository out for the same reason.
+#
+# The year is deliberately absent. A year computed at build time would rewrite
+# twelve hundred pages every 1 January, which `--check` would report as the
+# whole site changing and the deploy would then submit wholesale to IndexNow.
+licence = """
+    Text under
+    <a href="https://github.com/A-Box-of-Tools/website/blob/main/LICENSE-CONTENT" target="_blank" rel="noopener noreferrer">CC BY 4.0</a>,
+    code under
+    <a href="https://github.com/A-Box-of-Tools/website/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">MIT</a>.
+    Reuse it, credit it."""
+
 #
 # ---------------------------------------------------------------------------
 # /llms.txt - the same site, said once in plain text, for a machine.

--- a/locales/ar/locale.toml
+++ b/locales/ar/locale.toml
@@ -353,6 +353,12 @@ blurb = """
         أدوات لا تلامس خادما أبدا. ملفاتك تبقى على جهازك &mdash; لا
         شيء تحتاج إلى رفعه، ولا حساب عليك إنشاؤه."""
 base = "كل ادعاء في هذا الموقع مُعَدّ ليُتحقَّق منه، لا ليُصدَّق."
+licence = """
+    النصوص بترخيص
+    <a href="https://github.com/A-Box-of-Tools/website/blob/main/LICENSE-CONTENT" target="_blank" rel="noopener noreferrer">CC BY 4.0</a>،
+    والشيفرة بترخيص
+    <a href="https://github.com/A-Box-of-Tools/website/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">MIT</a>.
+    أعد استخدامها مع ذكر المصدر."""
 
 #
 # ---------------------------------------------------------------------------

--- a/locales/de/locale.toml
+++ b/locales/de/locale.toml
@@ -374,6 +374,12 @@ blurb = """
         Werkzeuge, die ohne Server auskommen. Ihre Dateien bleiben auf Ihrem
         Gerät. Sie laden nichts hoch und legen kein Konto an."""
 base = "Jede Behauptung auf dieser Seite ist zum Nachprüfen gedacht, nicht zum Glauben."
+licence = """
+    Texte unter
+    <a href="https://github.com/A-Box-of-Tools/website/blob/main/LICENSE-CONTENT" target="_blank" rel="noopener noreferrer">CC BY 4.0</a>,
+    Code unter
+    <a href="https://github.com/A-Box-of-Tools/website/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">MIT</a>.
+    Gern weiterverwenden, mit Quellenangabe."""
 
 #
 # ---------------------------------------------------------------------------

--- a/locales/es/locale.toml
+++ b/locales/es/locale.toml
@@ -327,6 +327,12 @@ blurb = """
         Herramientas que no pasan por ningún servidor. Tus archivos se quedan
         en tu dispositivo, sin nada que subir y sin ninguna cuenta que crear."""
 base = "Cada afirmación de este sitio está hecha para comprobarla, no para creértela."
+licence = """
+    Los textos, con licencia
+    <a href="https://github.com/A-Box-of-Tools/website/blob/main/LICENSE-CONTENT" target="_blank" rel="noopener noreferrer">CC BY 4.0</a>;
+    el código, con
+    <a href="https://github.com/A-Box-of-Tools/website/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">MIT</a>.
+    Reutilízalo citando la fuente."""
 
 #
 # ---------------------------------------------------------------------------

--- a/locales/fr/locale.toml
+++ b/locales/fr/locale.toml
@@ -344,6 +344,12 @@ blurb = """
         Des outils qui ne passent jamais par un serveur. Vos fichiers restent
         sur votre machine, sans rien à envoyer ni compte à créer."""
 base = "Chaque affirmation de ce site est faite pour être vérifiée, pas pour être crue."
+licence = """
+    Les textes sont sous
+    <a href="https://github.com/A-Box-of-Tools/website/blob/main/LICENSE-CONTENT" target="_blank" rel="noopener noreferrer">CC BY 4.0</a>,
+    le code sous
+    <a href="https://github.com/A-Box-of-Tools/website/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">MIT</a>.
+    Réutilisez-les en citant la source."""
 
 #
 # ---------------------------------------------------------------------------

--- a/locales/hi/locale.toml
+++ b/locales/hi/locale.toml
@@ -227,6 +227,12 @@ blurb = """
         ऐसे टूल जो किसी सर्वर से बात ही नहीं करते। आपकी फ़ाइलें आपके डिवाइस
         पर ही रहती हैं। न कुछ अपलोड करना, न कोई खाता बनाना।"""
 base = "इस साइट का हर दावा जाँचने के लिए लिखा गया है, मान लेने के लिए नहीं।"
+licence = """
+    यहाँ का लेखन
+    <a href="https://github.com/A-Box-of-Tools/website/blob/main/LICENSE-CONTENT" target="_blank" rel="noopener noreferrer">CC BY 4.0</a>
+    के तहत है और कोड
+    <a href="https://github.com/A-Box-of-Tools/website/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">MIT</a>
+    के तहत। स्रोत बताकर दोनों का इस्तेमाल कीजिए।"""
 
 #
 # ---------------------------------------------------------------------------

--- a/locales/id/locale.toml
+++ b/locales/id/locale.toml
@@ -347,6 +347,12 @@ blurb = """
         perangkat Anda &mdash; tidak ada yang perlu diunggah, tidak perlu
         membuat akun."""
 base = "Setiap klaim di situs ini dimaksudkan untuk diperiksa, bukan dipercaya begitu saja."
+licence = """
+    Teks di sini berlisensi
+    <a href="https://github.com/A-Box-of-Tools/website/blob/main/LICENSE-CONTENT" target="_blank" rel="noopener noreferrer">CC BY 4.0</a>,
+    kodenya
+    <a href="https://github.com/A-Box-of-Tools/website/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">MIT</a>.
+    Silakan pakai ulang, cukup cantumkan sumbernya."""
 
 #
 # ---------------------------------------------------------------------------

--- a/locales/it/locale.toml
+++ b/locales/it/locale.toml
@@ -322,6 +322,12 @@ blurb = """
         Strumenti che non passano da nessun server. I tuoi file restano dove
         sono &mdash; niente da caricare, nessun account da creare."""
 base = "Ogni affermazione di questo sito è fatta per essere verificata, non per essere creduta."
+licence = """
+    I testi sono sotto
+    <a href="https://github.com/A-Box-of-Tools/website/blob/main/LICENSE-CONTENT" target="_blank" rel="noopener noreferrer">CC BY 4.0</a>,
+    il codice sotto
+    <a href="https://github.com/A-Box-of-Tools/website/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">MIT</a>.
+    Riusali pure, citando la fonte."""
 
 #
 # ---------------------------------------------------------------------------

--- a/locales/ja/locale.toml
+++ b/locales/ja/locale.toml
@@ -223,6 +223,7 @@ blurb = """
         サーバーに触れない道具。ファイルは手元の端末に置いたままです。\
         アップロードするものも、作るアカウントもありません。"""
 base = "このサイトの主張はどれも、信じてもらうためではなく、確かめてもらうために書いてあります。"
+licence = """文章は<a href="https://github.com/A-Box-of-Tools/website/blob/main/LICENSE-CONTENT" target="_blank" rel="noopener noreferrer">CC BY 4.0</a>、コードは<a href="https://github.com/A-Box-of-Tools/website/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">MIT</a>です。出典を示せば自由に使えます。"""
 
 #
 # ---------------------------------------------------------------------------

--- a/locales/ko/locale.toml
+++ b/locales/ko/locale.toml
@@ -346,6 +346,12 @@ blurb = """
         서버를 거치지 않는 도구들. 파일은 내 기기에 그대로 남습니다. 올릴 것도,
         만들 계정도 없습니다."""
 base = "이 사이트에 적힌 주장은 믿으라고 쓴 것이 아니라 확인해 보라고 쓴 것입니다."
+licence = """
+    글은
+    <a href="https://github.com/A-Box-of-Tools/website/blob/main/LICENSE-CONTENT" target="_blank" rel="noopener noreferrer">CC BY 4.0</a>,
+    코드는
+    <a href="https://github.com/A-Box-of-Tools/website/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">MIT</a>
+    라이선스입니다. 출처만 밝히면 마음껏 가져다 쓰세요."""
 
 #
 # ---------------------------------------------------------------------------

--- a/locales/nl/locale.toml
+++ b/locales/nl/locale.toml
@@ -328,6 +328,12 @@ blurb = """
         je eigen apparaat, want er valt niets te uploaden en je hoeft geen
         account te maken."""
 base = "Elke bewering op deze site is bedoeld om na te trekken, niet om te geloven."
+licence = """
+    De teksten staan onder
+    <a href="https://github.com/A-Box-of-Tools/website/blob/main/LICENSE-CONTENT" target="_blank" rel="noopener noreferrer">CC BY 4.0</a>,
+    de code onder
+    <a href="https://github.com/A-Box-of-Tools/website/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">MIT</a>.
+    Hergebruik het gerust, met bronvermelding."""
 
 #
 # ---------------------------------------------------------------------------

--- a/locales/pt/locale.toml
+++ b/locales/pt/locale.toml
@@ -322,6 +322,12 @@ blurb = """
         Ferramentas que não passam por servidor nenhum. Seus arquivos ficam no
         seu computador, sem nada para enviar e sem conta para criar."""
 base = "Toda afirmação deste site é para ser conferida, não para ser aceita na fé."
+licence = """
+    Os textos estão sob
+    <a href="https://github.com/A-Box-of-Tools/website/blob/main/LICENSE-CONTENT" target="_blank" rel="noopener noreferrer">CC BY 4.0</a>
+    e o código sob
+    <a href="https://github.com/A-Box-of-Tools/website/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">MIT</a>.
+    Reutilize à vontade, citando a fonte."""
 
 #
 # ---------------------------------------------------------------------------

--- a/locales/tr/locale.toml
+++ b/locales/tr/locale.toml
@@ -337,6 +337,12 @@ blurb = """
         Sunucuya hiç dokunmayan araçlar. Dosyalarınız cihazınızda kalır
         &mdash; yükleyecek bir şey yok, oluşturulacak bir hesap yok."""
 base = "Bu sitedeki her iddia inanılmak için değil, doğrulanmak için var."
+licence = """
+    Metinler
+    <a href="https://github.com/A-Box-of-Tools/website/blob/main/LICENSE-CONTENT" target="_blank" rel="noopener noreferrer">CC BY 4.0</a>,
+    kod ise
+    <a href="https://github.com/A-Box-of-Tools/website/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">MIT</a>
+    lisanslıdır. Kaynak göstererek dilediğiniz gibi kullanın."""
 
 #
 # ---------------------------------------------------------------------------

--- a/locales/zh-TW/locale.toml
+++ b/locales/zh-TW/locale.toml
@@ -205,6 +205,7 @@ blurb = """
         不走伺服器的工具。檔案留在你自己的機器上，沒有東西要傳，也不用註冊\
         帳號。"""
 base = "本站說的每一句話，都是寫來給你核對的，不是寫來讓你信的。"
+licence = """本站文字採用<a href="https://github.com/A-Box-of-Tools/website/blob/main/LICENSE-CONTENT" target="_blank" rel="noopener noreferrer">CC BY 4.0</a>，程式碼採用<a href="https://github.com/A-Box-of-Tools/website/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">MIT</a>。歡迎取用，註明出處即可。"""
 
 #
 # ---------------------------------------------------------------------------

--- a/locales/zh/locale.toml
+++ b/locales/zh/locale.toml
@@ -226,6 +226,7 @@ blurb = """
         不走服务器的工具。文件留在你自己的机器上，没有东西要传，也不用注册\
         账号。"""
 base = "本站说的每一句话，都是写来给你核对的，不是写来让你信的。"
+licence = """本站文字采用<a href="https://github.com/A-Box-of-Tools/website/blob/main/LICENSE-CONTENT" target="_blank" rel="noopener noreferrer">CC BY 4.0</a>，代码采用<a href="https://github.com/A-Box-of-Tools/website/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">MIT</a>。欢迎取用，注明出处即可。"""
 
 #
 # ---------------------------------------------------------------------------

--- a/shared/css/tool-frame.css
+++ b/shared/css/tool-frame.css
@@ -1115,6 +1115,15 @@ footer a:hover { text-decoration: underline; }
   text-align: center;
 }
 
+/* The licence, directly under the closing line and quieter than it. It shares
+   that line's rule about the border - there is only one, above the pair, so the
+   two read as one closing block rather than as two footers. */
+.footer-licence {
+  margin: 0.4rem 0 0;
+  font-size: 0.75rem;
+  text-align: center;
+}
+
 /* The language switcher, across the foot of the page above the closing line.
 
    A row of plain links and nothing else: no JavaScript, no cookie, no

--- a/shared/site.css
+++ b/shared/site.css
@@ -743,6 +743,15 @@ footer a:hover { text-decoration: underline; }
   text-align: center;
 }
 
+/* The licence, directly under the closing line and quieter than it. It shares
+   that line's rule about the border - there is only one, above the pair, so the
+   two read as one closing block rather than as two footers. */
+.footer-licence {
+  margin: 0.4rem 0 0;
+  font-size: 0.75rem;
+  text-align: center;
+}
+
 /* The language switcher, across the foot of the page above the closing line.
 
    A row of plain links and nothing else: no JavaScript, no cookie, no

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -74,4 +74,8 @@
   <p class="footer-base">
 {{ site.footer.base }}
   </p>
+
+  <p class="footer-licence">
+{{ site.footer.licence }}
+  </p>
 </footer>


### PR DESCRIPTION
The footer had no closing legal line. The conventional one to reach for is a
copyright notice, and here that would be a false one: [`LICENSE`](../blob/main/LICENSE)
puts the code under MIT and [`LICENSE-CONTENT`](../blob/main/LICENSE-CONTENT)
puts every sentence a visitor reads under CC BY 4.0, so "all rights reserved"
would deny, on the page itself, the thing those two files grant.

Copyright attaches on creation under the Berne Convention and a notice has not
been required anywhere since 1989, so the notice was never buying anything a
licence line does not buy better — and the licence line is the one a reader
reusing a guide actually needs.

## Before / after

The English footer, and the two languages most likely to break — Japanese for
the CJK wrap, Arabic for bidi.

| | |
|---|---|
| Before | `footer-before-en.png` |
| After | `footer-after-en.png` |
| Japanese | `lic-ja.png` |
| Arabic | `lic-ar.png` |

## Decisions worth reviewing

**No year.** A year computed at build time would rewrite twelve hundred pages
every 1 January — `--check` would report the whole site as changed and the
deploy would submit it wholesale to IndexNow. A hard-coded year is a line
somebody has to remember to move.

**Literal URLs, not `{{ site.source_url }}`.** Strings under `[footer]` are
substituted into the template and not themselves rendered, so a `{{ }}` here
reaches the visitor verbatim. `pages/terms/body.html` spells the same
repository out for the same reason.

**`lastmod` left alone everywhere** — the one to push back on if you disagree.
Every page's footer moved, so the letter of the rule asks for a bump on all of
them; but that is the case the rule exists to prevent. Submitting all 1,245
URLs spends the host's standing with IndexNow to announce boilerplate no
crawler came for.

**All fifteen locales, not optional.** `[footer]` is a translatable frame path,
so a locale missing the key goes into frame debt and drops out of the sitemap,
the hreflang sets and the switcher. `ja`, `zh` and `zh-TW` stay on one line —
no spaces between words there, and a wrapped value ships a visible hole
mid-sentence.

## Verification

Full `python build.py --out _plain --clean --no-minify`: exit 0, no warnings,
no translation debt. Sitemap holds 1,245 URLs with all fifteen languages still
at 83 pages each, so nothing lost its place. Checked in a real browser at
desktop and mobile width in en, ja, zh-TW, ko, hi and ar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
