### PR TITLE
Do not blame the picture when the browser is the problem

### DIFF
--- a/tools/stack-images/src/main.js
+++ b/tools/stack-images/src/main.js
@@ -141,10 +141,30 @@ function stopWork() {
 
 /* ------------------------------------------------------------------- files */
 
+/**
+ * Set when the browser cannot do the drawing this tool is made of. Checked
+ * before a file is looked at, not only before the run button is pressed.
+ */
+let unsupported = false;
+
 const picker = wireFilePicker({
   input: el.fileInput,
   dropzone: el.dropzone,
-  onFiles(chosen) { addFiles(chosen); },
+  onFiles(chosen) {
+    // Without OffscreenCanvas every frame fails to survey, and the survey
+    // says so in the only words it has: "that could not be opened as a
+    // picture and was left out". Which is a lie about the picture. It
+    // replaced the accurate message this page put up on load, so a visitor
+    // whose browser is too old was told their file was broken instead.
+    //
+    // So the files are not looked at at all. The message that was already
+    // right stays on the page.
+    if (unsupported) {
+      showUnsupported();
+      return;
+    }
+    addFiles(chosen);
+  },
 });
 
 let batch = 0;
@@ -685,12 +705,18 @@ window.addEventListener('unhandledrejection', (event) => {
   showError(phrase('error.broke', { detail: event.reason?.message ?? event.reason }));
 });
 
+/** The one thing this tool cannot work around, said the same way every time. */
+function showUnsupported() {
+  showError('This browser has no OffscreenCanvas, which this tool does all of its '
+    + 'drawing on. Chrome, Edge, Firefox 105 or Safari 16.4 and newer have it.');
+}
+
 if (typeof OffscreenCanvas !== 'function') {
   // There is no fallback for this one. Every surface in the pipeline is an
   // OffscreenCanvas, because the work happens off the main thread and a
   // document canvas cannot go there.
-  showError('This browser has no OffscreenCanvas, which this tool does all of its '
-    + 'drawing on. Chrome, Edge, Firefox 105 or Safari 16.4 and newer have it.');
+  unsupported = true;
+  showUnsupported();
   el.run.disabled = true;
 }
 


### PR DESCRIPTION
The image stacker draws every surface on an `OffscreenCanvas` and has no fallback, which it says plainly on load where the browser has none:

> This browser has no OffscreenCanvas, which this tool does all of its drawing on.

Then a file is chosen, the survey fails on every frame the only way it knows how, and that accurate message is **replaced**:

> f0.png could not be opened as a picture and was left out.

The visitor is told their **file** is broken. It isn't — their browser can't do the work, which the page knew before they picked anything.

## The change

The files aren't looked at at all when the tool already knows it can't use them, and the message that was right stays on the page. One flag, one guard in `onFiles`, and the capability sentence moved into a function so both places say it identically.

## Worth being precise: this is not a Safari bug

Found by running the QA suite in WebKit for the first time. Playwright's WebKit build has **no OffscreenCanvas at all**, while **Safari 16.4+ does** — the message on this page says exactly that and is correct. So the stacker is probably fine in your actual Safari.

What the engine exposed is a **wrong message on any browser that lacks it**, whichever browser that turns out to be. That's engine-independent and worth fixing on its own.

Verified: 1,939 JavaScript tests pass, build clean, and on a local build the honest message now survives a file being chosen in WebKit while Chrome is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)