### PR TITLE
Let the last card go back to waiting when the file is turned away

### DIFF
--- a/shared/js/file-picker.js
+++ b/shared/js/file-picker.js
@@ -56,6 +56,9 @@ export function wireFilePicker({ input, dropzone, onFiles, idleTitle }) {
     // has to remember to do it. `inert` is used for nothing else on these
     // pages; see .card[inert] in tool-frame.css.
     for (const card of document.querySelectorAll('main .card[inert]')) {
+      // Remembered, so a tool that turns the file away can put the card back
+      // the way it found it. See waiting() below.
+      card.dataset.waited = 'yes';
       card.removeAttribute('inert');
     }
     onFiles(picked);
@@ -101,6 +104,25 @@ export function wireFilePicker({ input, dropzone, onFiles, idleTitle }) {
     done() {
       dropzone.classList.remove('busy');
       if (titleEl) titleEl.textContent = idle;
+    },
+    /**
+     * Put the last step back to waiting.
+     *
+     * `inert` comes off the moment files are handed over, which is right for
+     * a file the tool can read and wrong for one it cannot: a refused file
+     * left split-gif's frames card live and empty, its Select all and Start
+     * again buttons offering to act on nothing, under a line saying the file
+     * was not a GIF at all.
+     *
+     * Called by a tool from the place it already knows the answer - its own
+     * failure path - because that is the only place the answer exists. The
+     * hand-over cannot wait for it: onFiles is fire and forget, and several
+     * tools read their files asynchronously.
+     */
+    waiting() {
+      for (const card of document.querySelectorAll('main .card')) {
+        if (card.dataset.waited === 'yes') card.setAttribute('inert', '');
+      }
     },
   };
 }

--- a/tools/split-gif/src/main.js
+++ b/tools/split-gif/src/main.js
@@ -108,6 +108,11 @@ async function loadFile(picked) {
     // reasons throws a sentence, and phrase() hands back what it does not know.
     if (error instanceof GifFormatError) showError(phrase(error.message, error.values));
     else showError(phrase('read.failed', { why: phrase(error.message) }));
+    // Nothing was read, so the frames card has nothing to act on. Without
+    // this it stays live and empty - Select all, Select none and Start again
+    // all offering to work on no frames, under a line saying the file was not
+    // a GIF at all.
+    picker.waiting();
   } finally {
     picker.done();
   }


### PR DESCRIPTION
`inert` comes off the last step the moment files are handed over, so the whole job can be read before anything is committed. That's right for a file the tool **can** read.

For one it cannot, the card was left **live and empty** — Select all, Select none and Start again all offering to act on no frames, underneath a line saying the file was not a GIF at all.

## Why the picker can't simply wait

`onFiles` is fire-and-forget, and several tools read their files asynchronously — the hand-over has no way to know the answer. So the picker gains a `waiting()` that puts back what it took off, and split-gif calls it from the place that already knows: its own failure path.

Only cards the picker actually woke are put back, so a tool that reveals a card for reasons of its own is left alone. Any tool with the same shape can use it; split-gif is where it shows, because its last card carries three buttons that all read as offers.

## Verified both directions

| given | frames card | rows |
|---|---|---|
| rubbish | **inert** | 0 |
| a real GIF | awake | 3 |

The second row is the half that matters — a card that never woke would pass the first test and break the tool for every file it can read. Both are now in the QA suite.

Found while proposing UI improvements from the test suite's own measurements. 1,939 JavaScript tests pass; build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)