### PR TITLE
Let a card that is waiting say what it is waiting for

### DIFF
--- a/config/site.toml
+++ b/config/site.toml
@@ -662,6 +662,16 @@ related_heading = "Also in the box"
 handoff_lead = "Carry the result straight into:"
 privacy_heading = "How the privacy claim is verifiable"
 
+# What a step says while it is still waiting. Every tool's last card is on the
+# page from the start and dimmed, so the whole job can be read before anything
+# is handed over - but a dimmed heading over a dimmed button says only that
+# something is unavailable, not what would make it available. This says it.
+#
+# One sentence rather than one per card, because `inert` comes off in exactly
+# one place - the moment files arrive, in shared/js/file-picker.js - so it is
+# the same answer on all of them.
+card_waiting = "This opens as soon as you choose a file above."
+
 # The headline claim. The noun in the middle is this tool's own - "files",
 # "pictures", "clips" - and the sentence is written round it rather than in two
 # pieces either side of it, so a language that puts the verb last can.

--- a/locales/ar/locale.toml
+++ b/locales/ar/locale.toml
@@ -427,6 +427,7 @@ related_heading = "أيضا في الصندوق"
 handoff_lead = "احمل الناتج مباشرة إلى:"
 privacy_heading = "كيف يمكن التحقق من وعد الخصوصية"
 
+card_waiting = "يُفتح هذا بمجرّد أن تختار ملفاً في الأعلى."
 pledge_line = """
     {{ tool.words.plural }} لا تُرفع <strong>أبدا</strong>. لا يوجد خادم."""
 

--- a/locales/de/locale.toml
+++ b/locales/de/locale.toml
@@ -450,6 +450,7 @@ related_heading = "Auch im Werkzeugkasten"
 handoff_lead = "Das Ergebnis direkt weiterreichen an:"
 privacy_heading = "So lässt sich das Datenschutzversprechen nachprüfen"
 
+card_waiting = "Öffnet sich, sobald Sie oben eine Datei auswählen."
 # Das Substantiv steht mitten im Satz, und das Verb am Ende - genau der Grund,
 # warum dieser Satz als Ganzes übersetzt wird und nicht in zwei Hälften.
 pledge_line = """

--- a/locales/es/locale.toml
+++ b/locales/es/locale.toml
@@ -396,6 +396,7 @@ related_heading = "También en la caja"
 handoff_lead = "Lleva el resultado directamente a:"
 privacy_heading = "Cómo se comprueba la promesa de privacidad"
 
+card_waiting = "Se abre en cuanto eliges un archivo arriba."
 pledge_line = """
     Tus {{ tool.words.plural }} <strong>nunca se suben</strong>. No hay ningún servidor."""
 

--- a/locales/fr/locale.toml
+++ b/locales/fr/locale.toml
@@ -414,6 +414,7 @@ related_heading = "Aussi dans la boîte"
 handoff_lead = "Poursuivre avec le résultat dans&nbsp;:"
 privacy_heading = "Comment cette promesse se vérifie"
 
+card_waiting = "S'ouvre dès que vous choisissez un fichier ci-dessus."
 # Tournée à l'actif : le participe passé s'accorderait avec
 # {{ tool.words.plural }}, qui est tantôt masculin ("documents") tantôt féminin
 # ("images"), et aucune forme écrite ici ne pourrait convenir aux deux.

--- a/locales/hi/locale.toml
+++ b/locales/hi/locale.toml
@@ -306,6 +306,7 @@ related_heading = "बॉक्स में और भी टूल"
 handoff_lead = "नतीजा सीधे यहाँ ले जाइए:"
 privacy_heading = "प्राइवेसी का यह दावा कैसे जाँचा जा सकता है"
 
+card_waiting = "ऊपर फ़ाइल चुनते ही यह खुल जाएगा।"
 pledge_line = """
     यह टूल {{ tool.words.plural }} <strong>कभी अपलोड नहीं करता</strong>। यहाँ कोई सर्वर है ही नहीं।"""
 

--- a/locales/id/locale.toml
+++ b/locales/id/locale.toml
@@ -422,6 +422,7 @@ related_heading = "Juga ada di dalam kotak"
 handoff_lead = "Bawa hasilnya langsung ke:"
 privacy_heading = "Cara memverifikasi klaim privasi ini"
 
+card_waiting = "Terbuka begitu Anda memilih berkas di atas."
 pledge_line = """
     {{ tool.words.plural }} Anda <strong>tidak pernah diunggah</strong>.
     Tidak ada server."""

--- a/locales/it/locale.toml
+++ b/locales/it/locale.toml
@@ -391,6 +391,7 @@ related_heading = "Anche nella cassetta"
 handoff_lead = "Porta il risultato dritto in:"
 privacy_heading = "Come si verifica quello che promette"
 
+card_waiting = "Si apre appena scegli un file qui sopra."
 # Il nome che sta in mezzo cambia genere da uno strumento all'altro - le
 # immagini, i documenti, i video - e un participio concordato sarebbe
 # sbagliato su metà del sito. Il "si" impersonale con il plurale nudo li regge

--- a/locales/ja/locale.toml
+++ b/locales/ja/locale.toml
@@ -290,6 +290,7 @@ related_heading = "箱の中のほかのツール"
 handoff_lead = "結果をそのまま次へ："
 privacy_heading = "この主張を確かめる方法"
 
+card_waiting = "上でファイルを選ぶとすぐに開きます。"
 pledge_line = """
     {{ tool.words.plural }}が<strong>アップロードされることはありません</strong>。サーバーが存在しないからです。"""
 

--- a/locales/ko/locale.toml
+++ b/locales/ko/locale.toml
@@ -427,6 +427,7 @@ related_heading = "상자 속 다른 도구"
 handoff_lead = "결과를 곧바로 이어서:"
 privacy_heading = "이 약속을 직접 확인하는 방법"
 
+card_waiting = "위에서 파일을 고르면 바로 열립니다."
 pledge_line = """
     {{ tool.words.plural }} <strong>절대 업로드되지 않습니다</strong>. 서버가 아예 없으니까요."""
 

--- a/locales/nl/locale.toml
+++ b/locales/nl/locale.toml
@@ -400,6 +400,7 @@ related_heading = "Ook in de gereedschapskist"
 handoff_lead = "Neem het resultaat rechtstreeks mee naar:"
 privacy_heading = "Hoe je de privacybelofte controleert"
 
+card_waiting = "Gaat open zodra je hierboven een bestand kiest."
 pledge_line = """
     Je {{ tool.words.plural }} worden <strong>nooit geüpload</strong>. Er is geen server."""
 

--- a/locales/pt/locale.toml
+++ b/locales/pt/locale.toml
@@ -391,6 +391,7 @@ related_heading = "Também na caixa"
 handoff_lead = "Leve o resultado direto para:"
 privacy_heading = "Como dá para conferir a promessa de privacidade"
 
+card_waiting = "Abre assim que você escolher um arquivo acima."
 # O inglês escreve "Your {{ plural }} are never uploaded", e o particípio
 # concorda em gênero: "enviadas" para imagens e fotos, "enviados" para vídeos
 # e documentos. Como o substantivo vem de cada ferramenta, nenhuma das duas

--- a/locales/tr/locale.toml
+++ b/locales/tr/locale.toml
@@ -412,6 +412,7 @@ related_heading = "Kutuda ayrıca"
 handoff_lead = "Sonucu doğrudan şuraya taşıyın:"
 privacy_heading = "Gizlilik iddiası nasıl doğrulanabilir"
 
+card_waiting = "Yukarıdan bir dosya seçtiğinizde açılır."
 pledge_line = """
     {{ tool.words.plural }} <strong>asla yüklenmez</strong>. Sunucu yoktur."""
 

--- a/locales/zh-TW/locale.toml
+++ b/locales/zh-TW/locale.toml
@@ -268,6 +268,7 @@ related_heading = "工具箱裡還有"
 handoff_lead = "把結果直接帶到："
 privacy_heading = "這條隱私承諾怎麼核實"
 
+card_waiting = "在上方選擇檔案後就會開啟。"
 pledge_line = """
     你的{{ tool.words.plural }}<strong>不會上傳</strong>。這裡根本沒有伺服器。"""
 

--- a/locales/zh/locale.toml
+++ b/locales/zh/locale.toml
@@ -289,6 +289,7 @@ related_heading = "工具箱里还有"
 handoff_lead = "把结果直接带到："
 privacy_heading = "这条隐私承诺怎么核实"
 
+card_waiting = "在上方选择文件后就会打开。"
 pledge_line = """
     你的{{ tool.words.plural }}<strong>不会上传</strong>。这里根本没有服务器。"""
 

--- a/shared/css/tool-frame.css
+++ b/shared/css/tool-frame.css
@@ -432,6 +432,14 @@ main, .topbar, .crumbs, .privacy, .pledge, .faq, .tool-next, footer {
    the attribute had gone. Instant is also the honest reading - the step
    becomes usable the moment the file lands, and a fade would say it was still
    thinking. */
+/* What the dimmed card is waiting for, in the place a lede would be. It is
+   removed the moment the card wakes, so it never sits beside live controls. */
+.card-waiting {
+  margin: 0.15rem 0 0;
+  color: var(--text-dim);
+  font-size: 0.95rem;
+}
+
 .card[inert] {
   opacity: 0.55;
   pointer-events: none;

--- a/shared/js/file-picker.js
+++ b/shared/js/file-picker.js
@@ -46,6 +46,33 @@ export function wireFilePicker({ input, dropzone, onFiles, idleTitle }) {
   const titleEl = dropzone.querySelector('.dropzone-title');
   const idle = idleTitle ?? titleEl?.textContent ?? '';
 
+  /**
+   * Say what a dimmed card is waiting for.
+   *
+   * The last step of a tool is on the page from the start and dimmed, so the
+   * whole job can be read before anything is handed over. What that left on
+   * eleven tools was a heading and a disabled button and nothing else - "3
+   * Compress", "4 Your stills", "2 What it says" - which tells a reader that
+   * the step exists and not what would open it.
+   *
+   * One sentence, from the frame, because `inert` comes off in exactly one
+   * place: the moment files arrive, below. So it is the same answer on every
+   * card that carries it.
+   */
+  const sayWaiting = () => {
+    for (const card of document.querySelectorAll('main .card[inert]')) {
+      if (card.querySelector('.card-waiting')) continue;
+      const line = document.createElement('p');
+      line.className = 'card-waiting';
+      line.textContent = phrase('card.waiting');
+      // Where a lede would be, rather than at the end under the controls it
+      // is explaining.
+      const heading = card.querySelector('h2');
+      if (heading) heading.after(line);
+      else card.prepend(line);
+    }
+  };
+
   const hand = (files) => {
     const picked = Array.from(files ?? []);
     if (!picked.length) return;
@@ -58,8 +85,12 @@ export function wireFilePicker({ input, dropzone, onFiles, idleTitle }) {
     for (const card of document.querySelectorAll('main .card[inert]')) {
       card.removeAttribute('inert');
     }
+    // The card is not waiting any more, so it stops saying so.
+    for (const line of document.querySelectorAll('main .card .card-waiting')) line.remove();
     onFiles(picked);
   };
+
+  sayWaiting();
 
   input.addEventListener('change', () => {
     // `input.files` is a live list and resetting `value` empties it, so take a

--- a/templates/tool.html
+++ b/templates/tool.html
@@ -165,6 +165,7 @@
   #phrases block of its own body.html, which is looked up first.
 -->
 <div id="frame-phrases" hidden aria-hidden="true">
+  <span data-phrase="card.waiting">{{ ui.tool.card_waiting }}</span>
   <span data-phrase="offline.ready">{{ ui.tool.offline_ready }}</span>
   <span data-phrase="offline.none">{{ ui.tool.offline_none }}</span>
   <span data-phrase="offline.insecure">{{ ui.tool.offline_insecure }}</span>


### PR DESCRIPTION
The last step of a tool is on the page from the start and dimmed, so the whole job can be read before anything is handed over — the decision #208 made. On **eleven tools** what that leaves is a heading and a disabled button and nothing else:

> **3 Compress** · **4 Your stills** · **2 What it says** · **3 Read what changed** · *(and seven more)*

A reader is told the step exists, and not what would open it — which is the half of the decision that was worth showing.

## The change

One sentence, from the frame, in the place a lede would go:

> This opens as soon as you choose a file above.

**One rather than eleven**, because `inert` comes off in exactly one place — the moment files arrive, in `shared/js/file-picker.js` — so it's the same answer on every card that carries it. A per-card version would be eleven ways of saying the same thing and 165 strings to translate. It's added at load and removed when the card wakes, so it never sits beside live controls.

## Translations

Mine in thirteen languages, and **generated for zh-TW by `zh-tw-sync.py`**, which turned the Simplified into 在上方選擇檔案後就會開啟。— `檔案` and `開啟` rather than the mainland words, which is the whole reason that script exists. The thirteen deserve a native reading.

## How it was found

By measuring rather than looking: a pass over every tool page counting cards visible with no content and fewer than a dozen words in them. Eleven came back, and compress-pdf came back twice.

Verified on a local build: the line appears on the dimmed card, and is gone once a file is chosen. Build clean, 1,939 JavaScript tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)