### PR TITLE
Say the rasterised size in the reader's language, not only in English

### DIFF
--- a/locales/ar/tools/svg-to-image.html
+++ b/locales/ar/tools/svg-to-image.html
@@ -210,6 +210,57 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.notsvg">{name}: هذه الأداة لا تقرأ إلا ملفات SVG. أما PNG أو
+      JPEG فهو بكسلات أصلاً؛ لذلك هناك أداة تغيير حجم الصور.</span>
+    <span data-phrase="read.nosvg.named">{name}: لا يوجد عنصر &lt;svg&gt; في هذا الملف.</span>
+    <span data-phrase="read.nosvg">لا يوجد عنصر &lt;svg&gt; في هذا الملف.</span>
+    <span data-phrase="file.failed">{name}: {why}</span>
+    <span data-phrase="draw.failed">لم يستطع هذا المتصفح رسم ملف SVG. ربما لم يكن XML
+      سليماً.</span>
+    <span data-phrase="encode.refused">رفض هذا المتصفح كتابة {format} بهذا المقاس.</span>
+    <span data-phrase="out.size">&larr; {size}</span>
+    <span data-phrase="out.toobig">&larr; أكبر من اللازم: {why}</span>
+    <span data-phrase="plan.none">أضف ملف SVG ليظهر هنا المقاس الذي سيخرج به.</span>
+    <span data-phrase="plan.from">يرسم الملف نفسه بمقاس {fromWidth} &times;
+      {fromHeight}؛ وهذا يخرج بمقاس {width} &times; {height}، أي {times} ذلك.</span>
+    <span data-phrase="plan.stretched">تُمدّ الصورة لتملأ الإطار، فيخرج الرسم مشوّهاً.</span>
+    <span data-phrase="plan.padded">تتوسط الإطار، وتظهر الخلفية على جانبيها.</span>
+    <span data-phrase="plan.density">{width} &times; {height} عند @{d}x</span>
+    <span data-phrase="plan.plus">وكذلك {list}.</span>
+    <span data-phrase="limit.side">{width} &times; {height} يتجاوز حد {max} بكسل الذي
+      للوحة الرسم في الضلع الواحد. لن يعود إلا صورة فارغة.</span>
+    <span data-phrase="limit.pixels">{size} أكثر مما يحتمله المتصفح &mdash; فهذا {mb}
+      ميغابايت من لوحة الرسم قبل ترميز أي شيء. يلزم مقاس أصغر.</span>
+    <span data-phrase="limit.safari">{size} فوق سقف {ceiling} ميغابكسل الذي لسفاري على
+      آيفون أو آيباد. سينجح على حاسوب مكتبي؛ أما على الهاتف فقد يعود فارغاً.</span>
+    <span data-phrase="unit.megapixels">{n} ميغابكسل</span>
+    <span data-phrase="format.png">بلا فقد، وهو الوحيد من الثلاثة الذي يقرأه كل برنامج.
+      الألوان المسطحة والحواف الحادة &mdash; وهي معظم ما يتكوّن منه الرسم &mdash; تُضغط
+      فيه جيداً، فالشعار المُنقَّط عادةً أصغر بصيغة PNG منه بصيغة JPEG على أي حال.</span>
+    <span data-phrase="format.jpeg">لا شفافية فيه، وفقده يظهر بأسوأ صورة في هذا النوع من
+      الصور تحديداً: هالة من النقط حول كل حافة حادة. يستحق العناء لرسم معظمه تدرّجات
+      شبيهة بالصور الفوتوغرافية، ونادراً غير ذلك.</span>
+    <span data-phrase="format.webp">شفافية كشفافية PNG، وملف أصغر من الاثنين الآخرين
+      بالجودة نفسها. تقرأه كل المتصفحات الحديثة؛ أما البرامج القديمة وبعض المطابع فلا
+      تفتحه بعد.</span>
+    <span data-phrase="format.webp.cannot">هذا المتصفح لا يكتب WebP، فسيخرج PNG بدلاً
+      منه. اختر أحد الاثنين الآخرين.</span>
+    <span data-phrase="bg.none">تبقى الأجزاء الشفافة من الرسم شفافة.</span>
+    <span data-phrase="bg.behind">تُرسم خلف الصورة كلها، فلا يبقى في الملف شيء شفاف.</span>
+    <span data-phrase="bg.needed">صيغة {format} لا تعرف الشفافية، فيُرسم هذا اللون خلف
+      الرسم. ولولاه لخرج كل ما كان شفافاً أسودَ.</span>
+    <span data-phrase="preview.actual">معروض بالمقاس الذي سيخرج به.</span>
+    <span data-phrase="preview.scaled">معروض بمقدار {times} من ملف {size}، أُعيد رسمه من
+      المتجه لا صُغِّر &mdash; فهكذا يبدو ذلك المقاس فعلاً.</span>
+    <span data-phrase="preview.checkerboard">رقعة الشطرنج هي المواضع التي سيكون فيها
+      الملف شفافاً.</span>
+    <span data-phrase="join.sentences">{a} {b}</span>
+    <span data-phrase="join.and">{a} و{b}</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="join.comma">{a}، {b}</span>
+    <span data-phrase="size.b">{n} بايت</span>
+    <span data-phrase="size.kb">{n} كيلوبايت</span>
+    <span data-phrase="size.mb">{n} ميغابايت</span>
     <span data-phrase="run.one">أنشئ الصورة</span>
     <span data-phrase="run.many">أنشئ الصور {count}</span>
     <span data-phrase="chosen.one">ملف واحد مختار</span>

--- a/locales/de/tools/svg-to-image.html
+++ b/locales/de/tools/svg-to-image.html
@@ -216,6 +216,69 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.notsvg">{name}: dieses Werkzeug liest nur SVG-Dateien. Ein
+      PNG oder ein JPEG besteht schon aus Pixeln; dafür ist der Bildskalierer da.</span>
+    <span data-phrase="read.nosvg.named">{name}: in dieser Datei gibt es kein
+      &lt;svg&gt;-Element.</span>
+    <span data-phrase="read.nosvg">In dieser Datei gibt es kein &lt;svg&gt;-Element.</span>
+    <span data-phrase="file.failed">{name}: {why}</span>
+    <span data-phrase="draw.failed">Dieser Browser konnte das SVG nicht zeichnen. Es ist
+      vielleicht kein gültiges XML.</span>
+    <span data-phrase="encode.refused">Dieser Browser wollte in dieser Größe kein
+      {format} schreiben.</span>
+    <span data-phrase="out.size">&rarr; {size}</span>
+    <span data-phrase="out.toobig">&rarr; zu groß: {why}</span>
+    <span data-phrase="plan.none">Fügen Sie ein SVG hinzu, dann steht hier, wie groß es
+      herauskommt.</span>
+    <span data-phrase="plan.from">Die Datei zeichnet sich selbst mit {fromWidth} &times;
+      {fromHeight}; heraus kommt {width} &times; {height}, das ist {times} so groß.</span>
+    <span data-phrase="plan.stretched">Die Form wird auf den Rahmen gedehnt, die
+      Zeichnung wird also verzerrt.</span>
+    <span data-phrase="plan.padded">Sie steht mittig im Rahmen, links und rechts schaut
+      der Hintergrund heraus.</span>
+    <span data-phrase="plan.density">{width} &times; {height} bei @{d}x</span>
+    <span data-phrase="plan.plus">Dazu {list}.</span>
+    <span data-phrase="limit.side">{width} &times; {height} liegt über der Grenze von
+      {max} Pixeln, die eine Canvas pro Seite hat. Zurück käme nur ein leeres Bild.</span>
+    <span data-phrase="limit.pixels">{size} ist mehr, als ein Browser fasst &mdash; das
+      sind {mb} MB Canvas, bevor überhaupt etwas kodiert wird. Eine kleinere Größe wäre
+      nötig.</span>
+    <span data-phrase="limit.safari">{size} liegt über der Grenze von {ceiling}
+      Megapixeln, die Safari auf einem iPhone oder iPad hat. Auf einem Desktop geht es;
+      auf einem Telefon kommt vielleicht ein leeres Bild zurück.</span>
+    <span data-phrase="unit.megapixels">{n} Megapixel</span>
+    <span data-phrase="format.png">Verlustfrei, und das einzige der drei, das jedes
+      Programm liest. Flächige Farben und harte Kanten &mdash; und daraus besteht eine
+      Zeichnung meistens &mdash; komprimieren sich darin gut, ein gerastertes Logo ist
+      als PNG also ohnehin meist kleiner als ein JPEG.</span>
+    <span data-phrase="format.jpeg">Keine Transparenz, und verlustbehaftet auf genau die
+      Art, die bei dieser Art Bild am meisten auffällt: ein Kranz aus Sprenkeln um jede
+      harte Kante. Für eine Zeichnung mit vorwiegend fotoartigen Verläufen lohnt es
+      sich, sonst selten.</span>
+    <span data-phrase="format.webp">Transparenz wie ein PNG, und bei gleicher Qualität
+      eine kleinere Datei als die beiden anderen. Jeder aktuelle Browser liest es;
+      ältere Programme und manche Druckereien öffnen es noch immer nicht.</span>
+    <span data-phrase="format.webp.cannot">Dieser Browser kann kein WebP schreiben, es
+      käme also ein PNG heraus. Nehmen Sie eines der beiden anderen.</span>
+    <span data-phrase="bg.none">Die transparenten Stellen der Zeichnung bleiben
+      transparent.</span>
+    <span data-phrase="bg.behind">Hinter das ganze Bild gelegt, in der Datei ist also
+      nichts transparent.</span>
+    <span data-phrase="bg.needed">{format} kennt keine Transparenz, diese Farbe wird
+      also hinter die Zeichnung gelegt. Ohne sie käme alles, was transparent war,
+      schwarz heraus.</span>
+    <span data-phrase="preview.actual">In der Größe gezeigt, in der es herauskommt.</span>
+    <span data-phrase="preview.scaled">Mit {times} der {size} großen Datei gezeigt, aus
+      dem Vektor neu gezeichnet statt verkleinert &mdash; so sieht diese Größe also aus.</span>
+    <span data-phrase="preview.checkerboard">Das Schachbrettmuster ist, wo die Datei
+      transparent sein wird.</span>
+    <span data-phrase="join.sentences">{a} {b}</span>
+    <span data-phrase="join.and">{a} und {b}</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="join.comma">{a}, {b}</span>
+    <span data-phrase="size.b">{n} B</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="run.one">Das Bild erstellen</span>
     <span data-phrase="run.many">Die {count} Bilder erstellen</span>
     <span data-phrase="chosen.one">Eine Datei gewählt</span>

--- a/locales/es/tools/svg-to-image.html
+++ b/locales/es/tools/svg-to-image.html
@@ -215,6 +215,67 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.notsvg">{name}: esta herramienta solo lee archivos SVG. Un
+      PNG o un JPEG ya son píxeles; para esos está el Redimensionador de imágenes.</span>
+    <span data-phrase="read.nosvg.named">{name}: en este archivo no hay ningún elemento
+      &lt;svg&gt;.</span>
+    <span data-phrase="read.nosvg">En este archivo no hay ningún elemento &lt;svg&gt;.</span>
+    <span data-phrase="file.failed">{name}: {why}</span>
+    <span data-phrase="draw.failed">Este navegador no ha podido dibujar el SVG. Puede
+      que no sea XML válido.</span>
+    <span data-phrase="encode.refused">Este navegador no ha querido escribir {format} a
+      ese tamaño.</span>
+    <span data-phrase="out.size">&rarr; {size}</span>
+    <span data-phrase="out.toobig">&rarr; demasiado grande: {why}</span>
+    <span data-phrase="plan.none">Añade un SVG y aquí pondrá a qué tamaño va a salir.</span>
+    <span data-phrase="plan.from">El archivo se dibuja a {fromWidth} &times;
+      {fromHeight}; esto sale a {width} &times; {height}, que es {times} eso.</span>
+    <span data-phrase="plan.stretched">La forma se estira para llenar la caja, así que
+      el dibujo sale deformado.</span>
+    <span data-phrase="plan.padded">Va centrado en la caja, con el fondo asomando a los
+      lados.</span>
+    <span data-phrase="plan.density">{width} &times; {height} a @{d}x</span>
+    <span data-phrase="plan.plus">Más {list}.</span>
+    <span data-phrase="limit.side">{width} &times; {height} pasa del límite de {max}
+      píxeles que tiene un lienzo por lado. No volvería más que una imagen en blanco.</span>
+    <span data-phrase="limit.pixels">{size} es más de lo que un navegador aguanta: son
+      {mb} MB de lienzo antes de codificar nada. Hace falta un tamaño más pequeño.</span>
+    <span data-phrase="limit.safari">{size} pasa del techo de {ceiling} megapíxeles que
+      tiene Safari en un iPhone o un iPad. En un ordenador irá; en un teléfono puede
+      volver en blanco.</span>
+    <span data-phrase="unit.megapixels">{n} megapíxeles</span>
+    <span data-phrase="format.png">Sin pérdida, y el único de los tres que lee cualquier
+      programa. Los colores planos y los bordes duros &mdash; que es de lo que está
+      hecho casi todo dibujo &mdash; comprimen bien en él, así que un logotipo
+      rasterizado suele ser más pequeño en PNG que en JPEG de todas formas.</span>
+    <span data-phrase="format.jpeg">Sin transparencia, y con la pérdida que peor se ve
+      justo en esta clase de imagen: un anillo de moteado alrededor de cada borde duro.
+      Merece la pena para un dibujo hecho sobre todo de degradados fotográficos, y pocas
+      veces más.</span>
+    <span data-phrase="format.webp">Transparencia como un PNG, y un archivo más pequeño
+      que los otros dos a la misma calidad. Lo lee cualquier navegador actual; los
+      programas antiguos y algunas imprentas siguen sin abrirlo.</span>
+    <span data-phrase="format.webp.cannot">Este navegador no sabe escribir WebP, así que
+      saldría un PNG. Elige uno de los otros dos.</span>
+    <span data-phrase="bg.none">Las partes transparentes del dibujo se quedan
+      transparentes.</span>
+    <span data-phrase="bg.behind">Pintado detrás de toda la imagen, así que en el
+      archivo no hay nada transparente.</span>
+    <span data-phrase="bg.needed">El {format} no tiene transparencia, así que este color
+      se pinta detrás del dibujo. Sin él, todo lo que era transparente saldría negro.</span>
+    <span data-phrase="preview.actual">Mostrado al tamaño que va a tener.</span>
+    <span data-phrase="preview.scaled">Mostrado a {times} del archivo de {size},
+      redibujado desde el vector en vez de encogido, así que esto es lo que se ve a ese
+      tamaño.</span>
+    <span data-phrase="preview.checkerboard">El damero es donde el archivo va a ser
+      transparente.</span>
+    <span data-phrase="join.sentences">{a} {b}</span>
+    <span data-phrase="join.and">{a} y {b}</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="join.comma">{a}, {b}</span>
+    <span data-phrase="size.b">{n} B</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="run.one">Crear la imagen</span>
     <span data-phrase="run.many">Crear las {count} imágenes</span>
     <span data-phrase="chosen.one">Un archivo elegido</span>

--- a/locales/fr/tools/svg-to-image.html
+++ b/locales/fr/tools/svg-to-image.html
@@ -217,6 +217,74 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.notsvg">{name}&nbsp;: cet outil ne lit que les fichiers SVG.
+      Un PNG ou un JPEG est déjà fait de pixels&nbsp;; c&rsquo;est le Redimensionneur
+      d&rsquo;images qu&rsquo;il faut pour ceux-là.</span>
+    <span data-phrase="read.nosvg.named">{name}&nbsp;: il n&rsquo;y a pas
+      d&rsquo;élément &lt;svg&gt; dans ce fichier.</span>
+    <span data-phrase="read.nosvg">Il n&rsquo;y a pas d&rsquo;élément &lt;svg&gt; dans
+      ce fichier.</span>
+    <span data-phrase="file.failed">{name}&nbsp;: {why}</span>
+    <span data-phrase="draw.failed">Ce navigateur n&rsquo;a pas pu dessiner le SVG. Ce
+      n&rsquo;est peut-être pas du XML valide.</span>
+    <span data-phrase="encode.refused">Ce navigateur a refusé d&rsquo;écrire du {format}
+      à cette taille.</span>
+    <span data-phrase="out.size">&rarr; {size}</span>
+    <span data-phrase="out.toobig">&rarr; trop grand&nbsp;: {why}</span>
+    <span data-phrase="plan.none">Ajoutez un SVG et cette ligne dira à quelle taille il
+      sortira.</span>
+    <span data-phrase="plan.from">Le fichier se dessine à {fromWidth} &times;
+      {fromHeight}&nbsp;; cela sort en {width} &times; {height}, soit {times} cela.</span>
+    <span data-phrase="plan.stretched">La forme est étirée pour remplir le cadre, le
+      dessin est donc déformé.</span>
+    <span data-phrase="plan.padded">Il est centré dans le cadre, avec le fond qui
+      dépasse de part et d&rsquo;autre.</span>
+    <span data-phrase="plan.density">{width} &times; {height} en @{d}x</span>
+    <span data-phrase="plan.plus">Plus {list}.</span>
+    <span data-phrase="limit.side">{width} &times; {height} dépasse la limite de {max}
+      pixels qu&rsquo;un canvas a par côté. Il n&rsquo;en reviendrait qu&rsquo;une image
+      vide.</span>
+    <span data-phrase="limit.pixels">{size}, c&rsquo;est plus qu&rsquo;un navigateur ne
+      peut tenir &mdash; cela fait {mb} Mo de canvas avant même le moindre encodage. Il
+      faut une taille plus petite.</span>
+    <span data-phrase="limit.safari">{size} dépasse le plafond de {ceiling} mégapixels
+      que Safari a sur un iPhone ou un iPad. Cela marchera sur un ordinateur&nbsp;; sur
+      un téléphone, l&rsquo;image peut revenir vide.</span>
+    <span data-phrase="unit.megapixels">{n} mégapixels</span>
+    <span data-phrase="format.png">Sans perte, et le seul des trois que tous les
+      logiciels lisent. Les aplats et les bords nets &mdash; c&rsquo;est-à-dire
+      l&rsquo;essentiel d&rsquo;un dessin &mdash; s&rsquo;y compressent bien, un logo
+      rastérisé est donc de toute façon plus petit en PNG qu&rsquo;en JPEG.</span>
+    <span data-phrase="format.jpeg">Pas de transparence, et une perte qui se voit le
+      plus sur exactement ce genre d&rsquo;image&nbsp;: une couronne de moucheture
+      autour de chaque bord net. Cela vaut le coup pour un dessin fait surtout de
+      dégradés photographiques, rarement autrement.</span>
+    <span data-phrase="format.webp">La transparence d&rsquo;un PNG, et un fichier plus
+      petit que les deux autres à qualité égale. Lu par tous les navigateurs
+      actuels&nbsp;; les logiciels anciens et certains imprimeurs n&rsquo;en ouvrent
+      toujours pas.</span>
+    <span data-phrase="format.webp.cannot">Ce navigateur ne sait pas écrire de WebP, il
+      sortirait donc un PNG. Choisissez l&rsquo;un des deux autres.</span>
+    <span data-phrase="bg.none">Les parties transparentes du dessin restent
+      transparentes.</span>
+    <span data-phrase="bg.behind">Peint derrière toute l&rsquo;image&nbsp;: rien
+      n&rsquo;est transparent dans le fichier.</span>
+    <span data-phrase="bg.needed">Le {format} n&rsquo;a pas de transparence, cette
+      couleur est donc peinte derrière le dessin. Sans elle, tout ce qui était
+      transparent sortirait noir.</span>
+    <span data-phrase="preview.actual">Montré à la taille qu&rsquo;il aura.</span>
+    <span data-phrase="preview.scaled">Montré à {times} du fichier de {size}, redessiné
+      depuis le vecteur plutôt que réduit &mdash; c&rsquo;est donc bien ce que donne
+      cette taille.</span>
+    <span data-phrase="preview.checkerboard">Le damier, c&rsquo;est là où le fichier
+      sera transparent.</span>
+    <span data-phrase="join.sentences">{a} {b}</span>
+    <span data-phrase="join.and">{a} et {b}</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="join.comma">{a}, {b}</span>
+    <span data-phrase="size.b">{n} o</span>
+    <span data-phrase="size.kb">{n} Ko</span>
+    <span data-phrase="size.mb">{n} Mo</span>
     <span data-phrase="run.one">Créer l&rsquo;image</span>
     <span data-phrase="run.many">Créer les {count} images</span>
     <span data-phrase="chosen.one">Un fichier choisi</span>

--- a/locales/hi/tools/svg-to-image.html
+++ b/locales/hi/tools/svg-to-image.html
@@ -215,6 +215,64 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.notsvg">{name}: यह औज़ार सिर्फ़ SVG फ़ाइलें पढ़ता है। PNG या
+      JPEG तो पहले से पिक्सेल ही है; उनके लिए इमेज रिसाइज़र है।</span>
+    <span data-phrase="read.nosvg.named">{name}: इस फ़ाइल में कोई &lt;svg&gt; एलिमेंट
+      नहीं है।</span>
+    <span data-phrase="read.nosvg">इस फ़ाइल में कोई &lt;svg&gt; एलिमेंट नहीं है।</span>
+    <span data-phrase="file.failed">{name}: {why}</span>
+    <span data-phrase="draw.failed">यह ब्राउज़र SVG नहीं बना सका। शायद यह वैध XML नहीं
+      है।</span>
+    <span data-phrase="encode.refused">इस ब्राउज़र ने उस आकार पर {format} लिखने से मना
+      कर दिया।</span>
+    <span data-phrase="out.size">&rarr; {size}</span>
+    <span data-phrase="out.toobig">&rarr; बहुत बड़ा: {why}</span>
+    <span data-phrase="plan.none">कोई SVG जोड़िए, यहाँ लिखा आएगा कि वह किस आकार में
+      निकलेगा।</span>
+    <span data-phrase="plan.from">फ़ाइल खुद को {fromWidth} &times; {fromHeight} पर बनाती
+      है; यह {width} &times; {height} निकलेगा, यानी उसका {times}।</span>
+    <span data-phrase="plan.stretched">आकृति बॉक्स भरने के लिए खींची जाती है, इसलिए
+      चित्र विकृत हो जाता है।</span>
+    <span data-phrase="plan.padded">यह बॉक्स के बीच में रहता है, दोनों ओर पृष्ठभूमि
+      दिखती है।</span>
+    <span data-phrase="plan.density">@{d}x पर {width} &times; {height}</span>
+    <span data-phrase="plan.plus">साथ में {list}।</span>
+    <span data-phrase="limit.side">{width} &times; {height} एक कैनवस की प्रति भुजा {max}
+      पिक्सेल की सीमा से बाहर है। खाली तस्वीर के सिवा कुछ वापस नहीं आएगा।</span>
+    <span data-phrase="limit.pixels">{size} उससे ज़्यादा है जितना ब्राउज़र सँभाल सके
+      &mdash; कुछ भी एनकोड होने से पहले ही यह {mb} MB कैनवस है। छोटा आकार चाहिए।</span>
+    <span data-phrase="limit.safari">{size} उस {ceiling} मेगापिक्सेल की छत से ऊपर है जो
+      iPhone या iPad पर Safari में है। डेस्कटॉप पर चलेगा; फ़ोन पर शायद खाली लौटे।</span>
+    <span data-phrase="unit.megapixels">{n} मेगापिक्सेल</span>
+    <span data-phrase="format.png">बिना नुक़सान वाला, और तीनों में अकेला जिसे हर
+      सॉफ़्टवेयर पढ़ता है। सपाट रंग और तीखे किनारे &mdash; चित्र ज़्यादातर इन्हीं से
+      बनता है &mdash; इसमें अच्छे दबते हैं, इसलिए रास्टर किया लोगो वैसे भी PNG में JPEG
+      से छोटा ही रहता है।</span>
+    <span data-phrase="format.jpeg">पारदर्शिता नहीं, और नुक़सान ठीक इसी तरह की तस्वीर पर
+      सबसे बुरा दिखता है: हर तीखे किनारे के चारों ओर धब्बों का छल्ला। ऐसे चित्र के लिए
+      सार्थक है जो ज़्यादातर तस्वीर जैसी छाया से बना हो, वरना कम ही।</span>
+    <span data-phrase="format.webp">PNG जैसी पारदर्शिता, और उसी गुणवत्ता पर बाक़ी दोनों
+      से छोटी फ़ाइल। हर मौजूदा ब्राउज़र पढ़ता है; पुराने सॉफ़्टवेयर और कुछ प्रिंट की
+      दुकानें अब भी नहीं खोलतीं।</span>
+    <span data-phrase="format.webp.cannot">यह ब्राउज़र WebP नहीं लिख सकता, इसलिए बदले
+      में PNG निकलेगा। बाक़ी दो में से एक चुनिए।</span>
+    <span data-phrase="bg.none">चित्र के पारदर्शी हिस्से पारदर्शी ही रहते हैं।</span>
+    <span data-phrase="bg.behind">पूरी तस्वीर के पीछे पोता गया, इसलिए फ़ाइल में कुछ भी
+      पारदर्शी नहीं है।</span>
+    <span data-phrase="bg.needed">{format} में पारदर्शिता होती ही नहीं, इसलिए यह रंग
+      चित्र के पीछे पोता जाता है। इसके बिना जो कुछ पारदर्शी था वह काला निकलता।</span>
+    <span data-phrase="preview.actual">उसी आकार में दिखाया गया जिसमें वह निकलेगा।</span>
+    <span data-phrase="preview.scaled">{size} वाली फ़ाइल के {times} पर दिखाया गया,
+      सिकोड़ा नहीं बल्कि वेक्टर से दोबारा बनाया गया &mdash; तो उस आकार पर ऐसा ही दिखेगा।</span>
+    <span data-phrase="preview.checkerboard">शतरंज जैसा ख़ाना वहाँ है जहाँ फ़ाइल
+      पारदर्शी होगी।</span>
+    <span data-phrase="join.sentences">{a} {b}</span>
+    <span data-phrase="join.and">{a} और {b}</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="join.comma">{a}, {b}</span>
+    <span data-phrase="size.b">{n} B</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="run.one">तस्वीर बनाइए</span>
     <span data-phrase="run.many">{count} तस्वीरें बनाइए</span>
     <span data-phrase="chosen.one">एक फ़ाइल चुनी गई</span>

--- a/locales/id/tools/svg-to-image.html
+++ b/locales/id/tools/svg-to-image.html
@@ -222,6 +222,70 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.notsvg">{name}: alat ini hanya membaca berkas SVG. PNG atau
+      JPEG sudah berupa piksel; untuk itu ada Pengubah Ukuran Gambar.</span>
+    <span data-phrase="read.nosvg.named">{name}: tidak ada elemen &lt;svg&gt; di berkas
+      ini.</span>
+    <span data-phrase="read.nosvg">Tidak ada elemen &lt;svg&gt; di berkas ini.</span>
+    <span data-phrase="file.failed">{name}: {why}</span>
+    <span data-phrase="draw.failed">Browser ini tidak bisa menggambar SVG-nya. Mungkin
+      XML-nya tidak sah.</span>
+    <span data-phrase="encode.refused">Browser ini tidak mau menulis {format} pada
+      ukuran itu.</span>
+    <span data-phrase="out.size">&rarr; {size}</span>
+    <span data-phrase="out.toobig">&rarr; terlalu besar: {why}</span>
+    <span data-phrase="plan.none">Tambahkan sebuah SVG, lalu di sini akan tertulis akan
+      keluar seberapa besar.</span>
+    <span data-phrase="plan.from">Berkasnya menggambar dirinya pada {fromWidth} &times;
+      {fromHeight}; ini keluar pada {width} &times; {height}, yaitu {times} dari itu.</span>
+    <span data-phrase="plan.stretched">Bentuknya ditarik untuk memenuhi kotaknya, jadi
+      gambarnya jadi melenceng.</span>
+    <span data-phrase="plan.padded">Ia di tengah kotak, dengan latarnya kelihatan di
+      kedua sisi.</span>
+    <span data-phrase="plan.density">{width} &times; {height} pada @{d}x</span>
+    <span data-phrase="plan.plus">Ditambah {list}.</span>
+    <span data-phrase="limit.side">{width} &times; {height} melewati batas {max} piksel
+      yang dipunyai sebuah kanvas per sisi. Tidak ada yang kembali selain gambar kosong.</span>
+    <span data-phrase="limit.pixels">{size} lebih dari yang sanggup ditampung browser
+      &mdash; itu {mb} MB kanvas sebelum apa pun dikodekan. Perlu ukuran yang lebih
+      kecil.</span>
+    <span data-phrase="limit.safari">{size} di atas langit-langit {ceiling} megapiksel
+      yang dipunyai Safari di iPhone atau iPad. Di komputer akan jalan; di ponsel bisa
+      kembali kosong.</span>
+    <span data-phrase="unit.megapixels">{n} megapiksel</span>
+    <span data-phrase="format.png">Tanpa kehilangan mutu, dan satu-satunya dari
+      ketiganya yang dibaca semua perangkat lunak. Warna rata dan tepi tegas &mdash;
+      yang merupakan sebagian besar isi sebuah gambar &mdash; termampatkan dengan baik
+      di dalamnya, jadi logo yang dirasterkan biasanya tetap lebih kecil sebagai PNG
+      daripada sebagai JPEG.</span>
+    <span data-phrase="format.jpeg">Tanpa transparansi, dan kehilangan mutunya paling
+      kelihatan justru pada gambar semacam ini: cincin bintik di sekeliling tiap tepi
+      tegas. Setimpal untuk gambar yang sebagian besar berupa gradasi mirip foto, dan
+      jarang selain itu.</span>
+    <span data-phrase="format.webp">Transparansi seperti PNG, dan berkasnya lebih kecil
+      daripada kedua yang lain pada mutu yang sama. Dibaca semua browser masa kini;
+      perangkat lunak lama dan sebagian percetakan masih tidak bisa membukanya.</span>
+    <span data-phrase="format.webp.cannot">Browser ini tidak bisa menulis WebP, jadi
+      yang keluar akan berupa PNG. Pilih salah satu dari dua yang lain.</span>
+    <span data-phrase="bg.none">Bagian gambar yang tembus pandang tetap tembus pandang.</span>
+    <span data-phrase="bg.behind">Dicat di belakang seluruh gambar, jadi tidak ada yang
+      tembus pandang di berkasnya.</span>
+    <span data-phrase="bg.needed">{format} tidak punya transparansi, jadi warna ini
+      dicat di belakang gambarnya. Tanpa itu, semua yang tadinya tembus pandang akan
+      keluar hitam.</span>
+    <span data-phrase="preview.actual">Ditampilkan pada ukuran yang akan jadi.</span>
+    <span data-phrase="preview.scaled">Ditampilkan pada {times} dari berkas {size},
+      digambar ulang dari vektornya dan bukan dikecilkan &mdash; jadi begitulah rupanya
+      pada ukuran itu.</span>
+    <span data-phrase="preview.checkerboard">Pola papan catur itu tempat berkasnya nanti
+      tembus pandang.</span>
+    <span data-phrase="join.sentences">{a} {b}</span>
+    <span data-phrase="join.and">{a} dan {b}</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="join.comma">{a}, {b}</span>
+    <span data-phrase="size.b">{n} B</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="run.one">Buat gambarnya</span>
     <span data-phrase="run.many">Buat {count} gambarnya</span>
     <span data-phrase="chosen.one">Satu berkas dipilih</span>

--- a/locales/it/tools/svg-to-image.html
+++ b/locales/it/tools/svg-to-image.html
@@ -216,6 +216,72 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.notsvg">{name}: questo strumento legge solo file SVG. Un PNG
+      o un JPEG è già fatto di pixel; per quelli c&rsquo;è il Ridimensionatore di
+      immagini.</span>
+    <span data-phrase="read.nosvg.named">{name}: in questo file non c&rsquo;è nessun
+      elemento &lt;svg&gt;.</span>
+    <span data-phrase="read.nosvg">In questo file non c&rsquo;è nessun elemento
+      &lt;svg&gt;.</span>
+    <span data-phrase="file.failed">{name}: {why}</span>
+    <span data-phrase="draw.failed">Questo browser non è riuscito a disegnare
+      l&rsquo;SVG. Forse non è XML valido.</span>
+    <span data-phrase="encode.refused">Questo browser non ha voluto scrivere {format} a
+      quella dimensione.</span>
+    <span data-phrase="out.size">&rarr; {size}</span>
+    <span data-phrase="out.toobig">&rarr; troppo grande: {why}</span>
+    <span data-phrase="plan.none">Aggiungi un SVG e qui comparirà a che dimensione
+      uscirà.</span>
+    <span data-phrase="plan.from">Il file si disegna a {fromWidth} &times; {fromHeight};
+      questo esce a {width} &times; {height}, cioè {times} tanto.</span>
+    <span data-phrase="plan.stretched">La forma viene tirata per riempire il riquadro,
+      quindi il disegno esce deformato.</span>
+    <span data-phrase="plan.padded">Sta al centro del riquadro, con lo sfondo che si
+      vede ai due lati.</span>
+    <span data-phrase="plan.density">{width} &times; {height} a @{d}x</span>
+    <span data-phrase="plan.plus">Più {list}.</span>
+    <span data-phrase="limit.side">{width} &times; {height} supera il limite di {max}
+      pixel che una canvas ha per lato. Non tornerebbe altro che un&rsquo;immagine
+      vuota.</span>
+    <span data-phrase="limit.pixels">{size} è più di quanto un browser regga: sono {mb}
+      MB di canvas prima ancora di codificare qualcosa. Serve una dimensione più
+      piccola.</span>
+    <span data-phrase="limit.safari">{size} supera il tetto di {ceiling} megapixel che
+      Safari ha su un iPhone o un iPad. Su un computer funziona; su un telefono può
+      tornare vuota.</span>
+    <span data-phrase="unit.megapixels">{n} megapixel</span>
+    <span data-phrase="format.png">Senza perdita, e l&rsquo;unico dei tre che ogni
+      programma legge. I colori piatti e i bordi netti &mdash; cioè quasi tutto ciò di
+      cui è fatto un disegno &mdash; ci si comprimono bene, quindi un logo rasterizzato
+      è comunque di solito più piccolo in PNG che in JPEG.</span>
+    <span data-phrase="format.jpeg">Nessuna trasparenza, e una perdita che si vede
+      peggio proprio su questo tipo di immagine: un alone di puntini attorno a ogni
+      bordo netto. Ne vale la pena per un disegno fatto soprattutto di sfumature
+      fotografiche, raramente altrimenti.</span>
+    <span data-phrase="format.webp">Trasparenza come un PNG, e un file più piccolo degli
+      altri due a parità di qualità. Lo legge ogni browser attuale; i programmi vecchi e
+      certe tipografie ancora non lo aprono.</span>
+    <span data-phrase="format.webp.cannot">Questo browser non sa scrivere WebP, quindi
+      uscirebbe un PNG. Scegli uno degli altri due.</span>
+    <span data-phrase="bg.none">Le parti trasparenti del disegno restano trasparenti.</span>
+    <span data-phrase="bg.behind">Dipinto dietro tutta l&rsquo;immagine, quindi nel file
+      non c&rsquo;è niente di trasparente.</span>
+    <span data-phrase="bg.needed">Il {format} non ha trasparenza, quindi questo colore
+      viene dipinto dietro il disegno. Senza, tutto quello che era trasparente uscirebbe
+      nero.</span>
+    <span data-phrase="preview.actual">Mostrato alla dimensione che avrà.</span>
+    <span data-phrase="preview.scaled">Mostrato a {times} del file da {size},
+      ridisegnato dal vettore invece che rimpicciolito &mdash; quindi è proprio così che
+      viene a quella dimensione.</span>
+    <span data-phrase="preview.checkerboard">La scacchiera è dove il file sarà
+      trasparente.</span>
+    <span data-phrase="join.sentences">{a} {b}</span>
+    <span data-phrase="join.and">{a} e {b}</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="join.comma">{a}, {b}</span>
+    <span data-phrase="size.b">{n} B</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="run.one">Crea l&rsquo;immagine</span>
     <span data-phrase="run.many">Crea le {count} immagini</span>
     <span data-phrase="chosen.one">Un file scelto</span>

--- a/locales/ja/tools/svg-to-image.html
+++ b/locales/ja/tools/svg-to-image.html
@@ -199,6 +199,41 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.notsvg">{name}：この道具はSVGファイルしか読みません。PNGやJPEGはすでにピクセルなので、それらには画像リサイズツールがあります。</span>
+    <span data-phrase="read.nosvg.named">{name}：このファイルには&lt;svg&gt;要素がありません。</span>
+    <span data-phrase="read.nosvg">このファイルには&lt;svg&gt;要素がありません。</span>
+    <span data-phrase="file.failed">{name}：{why}</span>
+    <span data-phrase="draw.failed">このブラウザーはSVGを描画できませんでした。正しいXMLではないのかもしれません。</span>
+    <span data-phrase="encode.refused">このブラウザーはそのサイズで{format}を書き出しませんでした。</span>
+    <span data-phrase="out.size">&rarr; {size}</span>
+    <span data-phrase="out.toobig">&rarr; 大きすぎます：{why}</span>
+    <span data-phrase="plan.none">SVGを追加すると、どのサイズで出るかがここに出ます。</span>
+    <span data-phrase="plan.from">このファイルは{fromWidth} &times; {fromHeight}で自分を描きます。出てくるのは{width} &times; {height}で、その{times}にあたります。</span>
+    <span data-phrase="plan.stretched">枠を埋めるように形が引き伸ばされるので、絵はゆがみます。</span>
+    <span data-phrase="plan.padded">枠の中央に置かれ、その両側に背景が見えます。</span>
+    <span data-phrase="plan.density">@{d}xで{width} &times; {height}</span>
+    <span data-phrase="plan.plus">ほかに{list}。</span>
+    <span data-phrase="limit.side">{width} &times; {height}は、キャンバスの1辺の上限{max}ピクセルを超えています。返ってくるのは空の画像だけです。</span>
+    <span data-phrase="limit.pixels">{size}はブラウザーが抱えられる量を超えています。何もエンコードしないうちからキャンバスだけで{mb} MBです。もっと小さいサイズにしてください。</span>
+    <span data-phrase="limit.safari">{size}は、iPhoneやiPadのSafariにある{ceiling}メガピクセルの上限を超えています。デスクトップなら動きますが、スマートフォンでは空で返ることがあります。</span>
+    <span data-phrase="unit.megapixels">{n}メガピクセル</span>
+    <span data-phrase="format.png">劣化がなく、3つのうちどのソフトでも読めるのはこれだけです。べた塗りと硬い輪郭&mdash;図はたいていそれでできています&mdash;はよく縮むので、ラスター化したロゴはどのみちJPEGよりPNGのほうが小さくなるのがふつうです。</span>
+    <span data-phrase="format.jpeg">透明を扱えず、しかも劣化がこの種の絵でいちばん目立ちます。硬い輪郭のまわりに点のにじみが出ます。写真のような階調が主体の図には向きますが、それ以外ではまれです。</span>
+    <span data-phrase="format.webp">PNGと同じ透明が使えて、同じ画質なら他の2つより小さくなります。今のブラウザーはどれも読めますが、古いソフトや一部の印刷所では今も開けません。</span>
+    <span data-phrase="format.webp.cannot">このブラウザーはWebPを書き出せないため、代わりにPNGが出ます。ほかの2つから選んでください。</span>
+    <span data-phrase="bg.none">図の透明な部分は透明のままです。</span>
+    <span data-phrase="bg.behind">絵全体の後ろに敷かれるので、ファイルの中に透明な部分は残りません。</span>
+    <span data-phrase="bg.needed">{format}に透明はないので、この色が図の後ろに敷かれます。これがないと、透明だった部分はすべて黒くなります。</span>
+    <span data-phrase="preview.actual">出てくるサイズのまま表示しています。</span>
+    <span data-phrase="preview.scaled">{size}のファイルの{times}で表示しています。縮小ではなくベクターから描き直しているので、そのサイズでの見え方そのものです。</span>
+    <span data-phrase="preview.checkerboard">市松模様のところが、ファイルで透明になる部分です。</span>
+    <span data-phrase="join.sentences">{a}{b}</span>
+    <span data-phrase="join.and">{a}と{b}</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="join.comma">{a}、{b}</span>
+    <span data-phrase="size.b">{n} B</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="run.one">画像を作る</span>
     <span data-phrase="run.many">{count}枚の画像を作る</span>
     <span data-phrase="chosen.one">ファイル1個を選択中</span>

--- a/locales/ko/tools/svg-to-image.html
+++ b/locales/ko/tools/svg-to-image.html
@@ -210,6 +210,53 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.notsvg">{name}: 이 도구는 SVG 파일만 읽습니다. PNG나 JPEG는 이미 픽셀이라, 그런
+      것에는 이미지 크기 조절이 있습니다.</span>
+    <span data-phrase="read.nosvg.named">{name}: 이 파일에는 &lt;svg&gt; 요소가 없습니다.</span>
+    <span data-phrase="read.nosvg">이 파일에는 &lt;svg&gt; 요소가 없습니다.</span>
+    <span data-phrase="file.failed">{name}: {why}</span>
+    <span data-phrase="draw.failed">이 브라우저는 SVG를 그리지 못했습니다. 올바른 XML이 아닐 수 있습니다.</span>
+    <span data-phrase="encode.refused">이 브라우저는 그 크기로 {format}을 쓰지 않았습니다.</span>
+    <span data-phrase="out.size">&rarr; {size}</span>
+    <span data-phrase="out.toobig">&rarr; 너무 큼: {why}</span>
+    <span data-phrase="plan.none">SVG를 넣으면 어떤 크기로 나오는지 여기에 적힙니다.</span>
+    <span data-phrase="plan.from">파일은 자신을 {fromWidth} &times; {fromHeight}로 그립니다. 이것은
+      {width} &times; {height}로 나오며, 그 {times}입니다.</span>
+    <span data-phrase="plan.stretched">상자를 채우도록 모양이 늘어나서 그림이 일그러집니다.</span>
+    <span data-phrase="plan.padded">상자 가운데에 놓이고, 양옆으로 배경이 보입니다.</span>
+    <span data-phrase="plan.density">@{d}x에서 {width} &times; {height}</span>
+    <span data-phrase="plan.plus">여기에 {list}.</span>
+    <span data-phrase="limit.side">{width} &times; {height}는 캔버스 한 변의 한계인 {max}픽셀을 넘습니다.
+      빈 이미지 말고는 아무것도 돌아오지 않습니다.</span>
+    <span data-phrase="limit.pixels">{size}는 브라우저가 감당하는 것보다 많습니다. 아무것도 인코딩하기 전에 캔버스만
+      {mb} MB입니다. 더 작은 크기가 필요합니다.</span>
+    <span data-phrase="limit.safari">{size}는 iPhone이나 iPad의 Safari에 있는 {ceiling}메가픽셀 상한을
+      넘습니다. 데스크톱에서는 되지만 휴대전화에서는 비어서 돌아올 수 있습니다.</span>
+    <span data-phrase="unit.megapixels">{n}메가픽셀</span>
+    <span data-phrase="format.png">손실이 없고, 셋 중에서 모든 소프트웨어가 읽는 유일한 형식입니다. 단색면과 또렷한
+      가장자리&mdash;그림은 대개 그것으로 이루어집니다&mdash;가 잘 압축되므로, 래스터로 바꾼 로고는 어차피 JPEG보다 PNG가 더 작은
+      편입니다.</span>
+    <span data-phrase="format.jpeg">투명을 담지 못하고, 손실이 하필 이런 그림에서 가장 심하게 드러납니다. 또렷한 가장자리마다
+      얼룩 고리가 생깁니다. 사진 같은 음영이 주를 이루는 그림에는 쓸 만하지만, 그 밖에는 드뭅니다.</span>
+    <span data-phrase="format.webp">PNG처럼 투명을 담고, 같은 품질이면 나머지 둘보다 파일이 작습니다. 요즘 브라우저는 모두
+      읽지만, 오래된 소프트웨어와 일부 인쇄소는 아직 열지 못합니다.</span>
+    <span data-phrase="format.webp.cannot">이 브라우저는 WebP를 쓰지 못해서 대신 PNG가 나옵니다. 나머지 둘 중
+      하나를 고르세요.</span>
+    <span data-phrase="bg.none">그림에서 투명한 부분은 투명한 채로 남습니다.</span>
+    <span data-phrase="bg.behind">그림 전체 뒤에 칠해지므로 파일 안에 투명한 곳은 없습니다.</span>
+    <span data-phrase="bg.needed">{format}에는 투명이 없어서 이 색이 그림 뒤에 칠해집니다. 그것이 없으면 투명하던 곳은
+      모두 검게 나옵니다.</span>
+    <span data-phrase="preview.actual">나올 크기 그대로 보여 줍니다.</span>
+    <span data-phrase="preview.scaled">{size} 파일의 {times}로 보여 줍니다. 줄인 것이 아니라 벡터에서 다시 그린
+      것이라, 그 크기에서 실제로 이렇게 보입니다.</span>
+    <span data-phrase="preview.checkerboard">바둑판 무늬는 파일에서 투명해질 자리입니다.</span>
+    <span data-phrase="join.sentences">{a} {b}</span>
+    <span data-phrase="join.and">{a}와 {b}</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="join.comma">{a}, {b}</span>
+    <span data-phrase="size.b">{n} B</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="run.one">이미지 만들기</span>
     <span data-phrase="run.many">이미지 {count}개 만들기</span>
     <span data-phrase="chosen.one">파일 한 개 선택됨</span>

--- a/locales/nl/tools/svg-to-image.html
+++ b/locales/nl/tools/svg-to-image.html
@@ -213,6 +213,72 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.notsvg">{name}: dit gereedschap leest alleen SVG-bestanden.
+      Een PNG of een JPEG bestaat al uit pixels; daarvoor is Afbeeldingsformaat
+      wijzigen.</span>
+    <span data-phrase="read.nosvg.named">{name}: er zit geen &lt;svg&gt;-element in dit
+      bestand.</span>
+    <span data-phrase="read.nosvg">Er zit geen &lt;svg&gt;-element in dit bestand.</span>
+    <span data-phrase="file.failed">{name}: {why}</span>
+    <span data-phrase="draw.failed">Deze browser kon de SVG niet tekenen. Het is
+      misschien geen geldige XML.</span>
+    <span data-phrase="encode.refused">Deze browser wilde op dat formaat geen {format}
+      schrijven.</span>
+    <span data-phrase="out.size">&rarr; {size}</span>
+    <span data-phrase="out.toobig">&rarr; te groot: {why}</span>
+    <span data-phrase="plan.none">Voeg een SVG toe, dan staat hier hoe groot hij eruit
+      komt.</span>
+    <span data-phrase="plan.from">Het bestand tekent zichzelf op {fromWidth} &times;
+      {fromHeight}; hier komt {width} &times; {height} uit, dat is {times} zoveel.</span>
+    <span data-phrase="plan.stretched">De vorm wordt uitgerekt om het kader te vullen,
+      dus de tekening wordt vervormd.</span>
+    <span data-phrase="plan.padded">Hij staat midden in het kader, met de achtergrond
+      aan weerszijden zichtbaar.</span>
+    <span data-phrase="plan.density">{width} &times; {height} op @{d}x</span>
+    <span data-phrase="plan.plus">Plus {list}.</span>
+    <span data-phrase="limit.side">{width} &times; {height} gaat over de grens van {max}
+      pixels heen die een canvas per zijde heeft. Er zou niets terugkomen dan een leeg
+      beeld.</span>
+    <span data-phrase="limit.pixels">{size} is meer dan een browser aankan &mdash; dat
+      is {mb} MB canvas nog voordat er iets gecodeerd is. Er is een kleiner formaat
+      nodig.</span>
+    <span data-phrase="limit.safari">{size} gaat over het plafond van {ceiling}
+      megapixel heen dat Safari op een iPhone of iPad heeft. Op een desktop werkt het;
+      op een telefoon komt het misschien leeg terug.</span>
+    <span data-phrase="unit.megapixels">{n} megapixel</span>
+    <span data-phrase="format.png">Verliesvrij, en de enige van de drie die elk
+      programma leest. Vlakke kleur en harde randen &mdash; en daar bestaat een tekening
+      grotendeels uit &mdash; comprimeren er goed in, dus een gerasterd logo is als PNG
+      meestal toch al kleiner dan als JPEG.</span>
+    <span data-phrase="format.jpeg">Geen transparantie, en verliesgevend op precies de
+      manier die bij dit soort plaatje het meest opvalt: een krans van spikkels rond
+      elke harde rand. De moeite waard voor een tekening die vooral uit fotoachtige
+      verlopen bestaat, en verder zelden.</span>
+    <span data-phrase="format.webp">Transparantie als een PNG, en bij gelijke kwaliteit
+      een kleiner bestand dan de andere twee. Elke huidige browser leest het; oudere
+      programma&rsquo;s en sommige drukkerijen openen er nog steeds geen.</span>
+    <span data-phrase="format.webp.cannot">Deze browser kan geen WebP schrijven, dus er
+      zou een PNG uitkomen. Kies een van de andere twee.</span>
+    <span data-phrase="bg.none">De transparante delen van de tekening blijven
+      transparant.</span>
+    <span data-phrase="bg.behind">Achter het hele beeld gelegd, dus in het bestand is
+      niets transparant.</span>
+    <span data-phrase="bg.needed">{format} kent geen transparantie, dus deze kleur wordt
+      achter de tekening gelegd. Zonder die kleur zou alles wat transparant was zwart
+      worden.</span>
+    <span data-phrase="preview.actual">Getoond op het formaat dat het krijgt.</span>
+    <span data-phrase="preview.scaled">Getoond op {times} van het bestand van {size},
+      opnieuw getekend uit de vector in plaats van verkleind &mdash; dus zo ziet dat
+      formaat eruit.</span>
+    <span data-phrase="preview.checkerboard">Het schaakbordpatroon is waar het bestand
+      transparant wordt.</span>
+    <span data-phrase="join.sentences">{a} {b}</span>
+    <span data-phrase="join.and">{a} en {b}</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="join.comma">{a}, {b}</span>
+    <span data-phrase="size.b">{n} B</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="run.one">De afbeelding maken</span>
     <span data-phrase="run.many">De {count} afbeeldingen maken</span>
     <span data-phrase="chosen.one">Eén bestand gekozen</span>

--- a/locales/pt/tools/svg-to-image.html
+++ b/locales/pt/tools/svg-to-image.html
@@ -215,6 +215,68 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.notsvg">{name}: esta ferramenta só lê arquivos SVG. Um PNG
+      ou um JPEG já é feito de pixels; para esses é o Redimensionador de imagens.</span>
+    <span data-phrase="read.nosvg.named">{name}: não há elemento &lt;svg&gt; nenhum
+      neste arquivo.</span>
+    <span data-phrase="read.nosvg">Não há elemento &lt;svg&gt; nenhum neste arquivo.</span>
+    <span data-phrase="file.failed">{name}: {why}</span>
+    <span data-phrase="draw.failed">Este navegador não conseguiu desenhar o SVG. Pode
+      não ser XML válido.</span>
+    <span data-phrase="encode.refused">Este navegador não quis escrever {format} nesse
+      tamanho.</span>
+    <span data-phrase="out.size">&rarr; {size}</span>
+    <span data-phrase="out.toobig">&rarr; grande demais: {why}</span>
+    <span data-phrase="plan.none">Adicione um SVG e aqui vai dizer em que tamanho ele
+      sai.</span>
+    <span data-phrase="plan.from">O arquivo se desenha a {fromWidth} &times;
+      {fromHeight}; isto sai a {width} &times; {height}, que é {times} isso.</span>
+    <span data-phrase="plan.stretched">A forma é esticada para preencher a caixa, então
+      o desenho sai distorcido.</span>
+    <span data-phrase="plan.padded">Fica centralizado na caixa, com o fundo aparecendo
+      dos dois lados.</span>
+    <span data-phrase="plan.density">{width} &times; {height} em @{d}x</span>
+    <span data-phrase="plan.plus">Mais {list}.</span>
+    <span data-phrase="limit.side">{width} &times; {height} passa do limite de {max}
+      pixels que um canvas tem por lado. Não voltaria nada além de uma imagem em branco.</span>
+    <span data-phrase="limit.pixels">{size} é mais do que um navegador aguenta: são {mb}
+      MB de canvas antes de codificar qualquer coisa. Precisa de um tamanho menor.</span>
+    <span data-phrase="limit.safari">{size} passa do teto de {ceiling} megapixels que o
+      Safari tem num iPhone ou num iPad. Num computador vai; num telefone pode voltar em
+      branco.</span>
+    <span data-phrase="unit.megapixels">{n} megapixels</span>
+    <span data-phrase="format.png">Sem perda, e o único dos três que todo programa lê.
+      Cores chapadas e bordas duras &mdash; que é quase tudo o que um desenho tem
+      &mdash; comprimem bem nele, então um logotipo rasterizado costuma sair menor em
+      PNG do que em JPEG de qualquer jeito.</span>
+    <span data-phrase="format.jpeg">Sem transparência, e com a perda que mais aparece
+      justo nesse tipo de imagem: um anel de chuvisco em volta de cada borda dura. Vale
+      a pena para um desenho feito sobretudo de degradês fotográficos, e raramente fora
+      disso.</span>
+    <span data-phrase="format.webp">Transparência como um PNG, e um arquivo menor que os
+      outros dois na mesma qualidade. Todo navegador atual lê; programas antigos e
+      algumas gráficas ainda não abrem.</span>
+    <span data-phrase="format.webp.cannot">Este navegador não sabe escrever WebP, então
+      sairia um PNG. Escolha um dos outros dois.</span>
+    <span data-phrase="bg.none">As partes transparentes do desenho continuam
+      transparentes.</span>
+    <span data-phrase="bg.behind">Pintado atrás da imagem inteira, então no arquivo não
+      há nada transparente.</span>
+    <span data-phrase="bg.needed">O {format} não tem transparência, então esta cor é
+      pintada atrás do desenho. Sem ela, tudo o que era transparente sairia preto.</span>
+    <span data-phrase="preview.actual">Mostrado no tamanho que vai ter.</span>
+    <span data-phrase="preview.scaled">Mostrado a {times} do arquivo de {size},
+      redesenhado a partir do vetor em vez de encolhido &mdash; então é assim mesmo que
+      fica nesse tamanho.</span>
+    <span data-phrase="preview.checkerboard">O xadrez é onde o arquivo vai ser
+      transparente.</span>
+    <span data-phrase="join.sentences">{a} {b}</span>
+    <span data-phrase="join.and">{a} e {b}</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="join.comma">{a}, {b}</span>
+    <span data-phrase="size.b">{n} B</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="run.one">Criar a imagem</span>
     <span data-phrase="run.many">Criar as {count} imagens</span>
     <span data-phrase="chosen.one">Um arquivo escolhido</span>

--- a/locales/tr/tools/svg-to-image.html
+++ b/locales/tr/tools/svg-to-image.html
@@ -219,6 +219,64 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.notsvg">{name}: bu araç yalnızca SVG dosyalarını okur. PNG
+      ya da JPEG zaten pikseldir; onlar için Görsel Boyutlandırıcı var.</span>
+    <span data-phrase="read.nosvg.named">{name}: bu dosyada &lt;svg&gt; ögesi yok.</span>
+    <span data-phrase="read.nosvg">Bu dosyada &lt;svg&gt; ögesi yok.</span>
+    <span data-phrase="file.failed">{name}: {why}</span>
+    <span data-phrase="draw.failed">Bu tarayıcı SVG&rsquo;yi çizemedi. Geçerli bir XML
+      olmayabilir.</span>
+    <span data-phrase="encode.refused">Bu tarayıcı o boyutta {format} yazmak istemedi.</span>
+    <span data-phrase="out.size">&rarr; {size}</span>
+    <span data-phrase="out.toobig">&rarr; fazla büyük: {why}</span>
+    <span data-phrase="plan.none">Bir SVG ekleyin, burada hangi boyutta çıkacağı yazsın.</span>
+    <span data-phrase="plan.from">Dosya kendini {fromWidth} &times; {fromHeight}
+      çiziyor; bu {width} &times; {height} olarak çıkıyor, yani onun {times} katı.</span>
+    <span data-phrase="plan.stretched">Biçim kutuyu dolduracak şekilde geriliyor,
+      dolayısıyla çizim bozuluyor.</span>
+    <span data-phrase="plan.padded">Kutunun ortasında duruyor, iki yanından arka plan
+      görünüyor.</span>
+    <span data-phrase="plan.density">@{d}x&rsquo;te {width} &times; {height}</span>
+    <span data-phrase="plan.plus">Ayrıca {list}.</span>
+    <span data-phrase="limit.side">{width} &times; {height}, bir tuvalin bir kenarda
+      sahip olduğu {max} piksel sınırını aşıyor. Boş bir görüntüden başka bir şey
+      dönmezdi.</span>
+    <span data-phrase="limit.pixels">{size}, bir tarayıcının tutabileceğinden fazla
+      &mdash; daha hiçbir şey kodlanmadan {mb} MB tuval eder. Daha küçük bir boyut
+      gerekiyor.</span>
+    <span data-phrase="limit.safari">{size}, Safari&rsquo;nin bir iPhone ya da
+      iPad&rsquo;de sahip olduğu {ceiling} megapiksel tavanının üstünde. Masaüstünde
+      çalışır; telefonda boş dönebilir.</span>
+    <span data-phrase="unit.megapixels">{n} megapiksel</span>
+    <span data-phrase="format.png">Kayıpsız ve üçünün içinde her yazılımın okuduğu tek
+      biçim. Düz renkler ve keskin kenarlar &mdash; bir çizim çoğunlukla bunlardan
+      oluşur &mdash; onda iyi sıkışır, bu yüzden rasterlenmiş bir logo zaten genellikle
+      PNG olarak JPEG&rsquo;ten küçüktür.</span>
+    <span data-phrase="format.jpeg">Saydamlık yok ve kaybı tam da bu tür resimlerde en
+      kötü görünen türden: her keskin kenarın çevresinde bir benek halkası. Çoğunlukla
+      fotoğraf gibi geçişlerden oluşan bir çizim için değer, başka türlü nadiren.</span>
+    <span data-phrase="format.webp">PNG gibi saydamlık ve aynı kalitede diğer ikisinden
+      küçük bir dosya. Güncel her tarayıcı okur; eski yazılımlar ve bazı matbaalar hâlâ
+      açmıyor.</span>
+    <span data-phrase="format.webp.cannot">Bu tarayıcı WebP yazamıyor, dolayısıyla PNG
+      çıkardı. Diğer ikisinden birini seçin.</span>
+    <span data-phrase="bg.none">Çizimin saydam yerleri saydam kalır.</span>
+    <span data-phrase="bg.behind">Resmin tamamının arkasına boyanır, dolayısıyla dosyada
+      saydam hiçbir şey kalmaz.</span>
+    <span data-phrase="bg.needed">{format} saydamlık tanımaz, bu yüzden bu renk çizimin
+      arkasına boyanır. Olmasa saydam olan her şey siyah çıkardı.</span>
+    <span data-phrase="preview.actual">Çıkacağı boyutta gösteriliyor.</span>
+    <span data-phrase="preview.scaled">{size} boyutundaki dosyanın {times} kadarı olarak
+      gösteriliyor; küçültülmedi, vektörden yeniden çizildi &mdash; yani o boyut böyle
+      görünüyor.</span>
+    <span data-phrase="preview.checkerboard">Damalı desen, dosyanın saydam olacağı yer.</span>
+    <span data-phrase="join.sentences">{a} {b}</span>
+    <span data-phrase="join.and">{a} ve {b}</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="join.comma">{a}, {b}</span>
+    <span data-phrase="size.b">{n} B</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="run.one">Görseli oluştur</span>
     <span data-phrase="run.many">{count} görseli oluştur</span>
     <span data-phrase="chosen.one">Bir dosya seçildi</span>

--- a/locales/zh-TW/tools/svg-to-image.html
+++ b/locales/zh-TW/tools/svg-to-image.html
@@ -206,6 +206,41 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.notsvg">{name}：這個工具只讀 SVG 檔案。PNG 或 JPEG 本來就是畫素，那種要用圖片縮放。</span>
+    <span data-phrase="read.nosvg.named">{name}：這個檔案裡沒有 &lt;svg&gt; 元素。</span>
+    <span data-phrase="read.nosvg">這個檔案裡沒有 &lt;svg&gt; 元素。</span>
+    <span data-phrase="file.failed">{name}：{why}</span>
+    <span data-phrase="draw.failed">這個瀏覽器畫不出這個 SVG。它可能不是合法的 XML。</span>
+    <span data-phrase="encode.refused">這個瀏覽器不肯在那個尺寸下寫 {format}。</span>
+    <span data-phrase="out.size">&rarr; {size}</span>
+    <span data-phrase="out.toobig">&rarr; 太大了：{why}</span>
+    <span data-phrase="plan.none">加一個 SVG，這裡就會寫出它會出多大。</span>
+    <span data-phrase="plan.from">檔案把自己畫成 {fromWidth} &times; {fromHeight}；這次出來是 {width} &times; {height}，是它的 {times}。</span>
+    <span data-phrase="plan.stretched">形狀被拉開填滿框子，所以圖會變形。</span>
+    <span data-phrase="plan.padded">它居中放在框子裡，兩邊露出背景。</span>
+    <span data-phrase="plan.density">@{d}x 下 {width} &times; {height}</span>
+    <span data-phrase="plan.plus">另外還有 {list}。</span>
+    <span data-phrase="limit.side">{width} &times; {height} 超過了畫布單邊 {max} 畫素的上限。除了一張空圖什麼都回不來。</span>
+    <span data-phrase="limit.pixels">{size} 超過了瀏覽器裝得下的量&mdash;什麼都還沒編碼，光畫布就有 {mb} MB。得換個小一點的尺寸。</span>
+    <span data-phrase="limit.safari">{size} 超過了 Safari 在 iPhone 或 iPad 上 {ceiling} 兆畫素的上限。在電腦上沒問題；在手機上可能回來一張空圖。</span>
+    <span data-phrase="unit.megapixels">{n} 兆畫素</span>
+    <span data-phrase="format.png">無損，也是三種裡唯一每個軟體都能讀的。平塗的顏色和硬邊&mdash;圖形基本就是這些&mdash;在它裡面壓得好，所以柵格化的標誌本來就通常是 PNG 比 JPEG 小。</span>
+    <span data-phrase="format.jpeg">不能透明，而且它那種損失恰好在這類圖上最難看：每條硬邊周圍一圈麻點。如果圖形主要是照片一樣的漸變還值得，別的時候很少。</span>
+    <span data-phrase="format.webp">像 PNG 一樣能透明，同樣畫質下比另外兩種都小。現在的瀏覽器都能讀；老軟體和有些印刷店還是打不開。</span>
+    <span data-phrase="format.webp.cannot">這個瀏覽器寫不了 WebP，出來的會是 PNG。請從另外兩種裡挑一個。</span>
+    <span data-phrase="bg.none">圖形裡透明的地方仍然透明。</span>
+    <span data-phrase="bg.behind">鋪在整張圖後面，所以檔案裡沒有透明的地方。</span>
+    <span data-phrase="bg.needed">{format} 沒有透明，所以這個顏色會鋪在圖形後面。沒有它，原本透明的地方都會變成黑色。</span>
+    <span data-phrase="preview.actual">按它將來的尺寸顯示。</span>
+    <span data-phrase="preview.scaled">按 {size} 那個檔案的 {times} 顯示，是從向量重畫的而不是縮小的&mdash;所以那個尺寸看起來就是這樣。</span>
+    <span data-phrase="preview.checkerboard">棋盤格的地方就是檔案裡將來透明的地方。</span>
+    <span data-phrase="join.sentences">{a}{b}</span>
+    <span data-phrase="join.and">{a} 和 {b}</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="join.comma">{a}，{b}</span>
+    <span data-phrase="size.b">{n} B</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="run.one">產生圖片</span>
     <span data-phrase="run.many">產生 {count} 張圖片</span>
     <span data-phrase="chosen.one">已選 1 個檔案</span>

--- a/locales/zh/tools/svg-to-image.html
+++ b/locales/zh/tools/svg-to-image.html
@@ -206,6 +206,41 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.notsvg">{name}：这个工具只读 SVG 文件。PNG 或 JPEG 本来就是像素，那种要用图片缩放。</span>
+    <span data-phrase="read.nosvg.named">{name}：这个文件里没有 &lt;svg&gt; 元素。</span>
+    <span data-phrase="read.nosvg">这个文件里没有 &lt;svg&gt; 元素。</span>
+    <span data-phrase="file.failed">{name}：{why}</span>
+    <span data-phrase="draw.failed">这个浏览器画不出这个 SVG。它可能不是合法的 XML。</span>
+    <span data-phrase="encode.refused">这个浏览器不肯在那个尺寸下写 {format}。</span>
+    <span data-phrase="out.size">&rarr; {size}</span>
+    <span data-phrase="out.toobig">&rarr; 太大了：{why}</span>
+    <span data-phrase="plan.none">加一个 SVG，这里就会写出它会出多大。</span>
+    <span data-phrase="plan.from">文件把自己画成 {fromWidth} &times; {fromHeight}；这次出来是 {width} &times; {height}，是它的 {times}。</span>
+    <span data-phrase="plan.stretched">形状被拉开填满框子，所以图会变形。</span>
+    <span data-phrase="plan.padded">它居中放在框子里，两边露出背景。</span>
+    <span data-phrase="plan.density">@{d}x 下 {width} &times; {height}</span>
+    <span data-phrase="plan.plus">另外还有 {list}。</span>
+    <span data-phrase="limit.side">{width} &times; {height} 超过了画布单边 {max} 像素的上限。除了一张空图什么都回不来。</span>
+    <span data-phrase="limit.pixels">{size} 超过了浏览器装得下的量&mdash;什么都还没编码，光画布就有 {mb} MB。得换个小一点的尺寸。</span>
+    <span data-phrase="limit.safari">{size} 超过了 Safari 在 iPhone 或 iPad 上 {ceiling} 兆像素的上限。在电脑上没问题；在手机上可能回来一张空图。</span>
+    <span data-phrase="unit.megapixels">{n} 兆像素</span>
+    <span data-phrase="format.png">无损，也是三种里唯一每个软件都能读的。平涂的颜色和硬边&mdash;图形基本就是这些&mdash;在它里面压得好，所以栅格化的标志本来就通常是 PNG 比 JPEG 小。</span>
+    <span data-phrase="format.jpeg">不能透明，而且它那种损失恰好在这类图上最难看：每条硬边周围一圈麻点。如果图形主要是照片一样的渐变还值得，别的时候很少。</span>
+    <span data-phrase="format.webp">像 PNG 一样能透明，同样画质下比另外两种都小。现在的浏览器都能读；老软件和有些印刷店还是打不开。</span>
+    <span data-phrase="format.webp.cannot">这个浏览器写不了 WebP，出来的会是 PNG。请从另外两种里挑一个。</span>
+    <span data-phrase="bg.none">图形里透明的地方仍然透明。</span>
+    <span data-phrase="bg.behind">铺在整张图后面，所以文件里没有透明的地方。</span>
+    <span data-phrase="bg.needed">{format} 没有透明，所以这个颜色会铺在图形后面。没有它，原本透明的地方都会变成黑色。</span>
+    <span data-phrase="preview.actual">按它将来的尺寸显示。</span>
+    <span data-phrase="preview.scaled">按 {size} 那个文件的 {times} 显示，是从矢量重画的而不是缩小的&mdash;所以那个尺寸看起来就是这样。</span>
+    <span data-phrase="preview.checkerboard">棋盘格的地方就是文件里将来透明的地方。</span>
+    <span data-phrase="join.sentences">{a}{b}</span>
+    <span data-phrase="join.and">{a} 和 {b}</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="join.comma">{a}，{b}</span>
+    <span data-phrase="size.b">{n} B</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="run.one">生成图片</span>
     <span data-phrase="run.many">生成 {count} 张图片</span>
     <span data-phrase="chosen.one">已选 1 个文件</span>

--- a/tests/js/svg-to-image.test.js
+++ b/tests/js/svg-to-image.test.js
@@ -237,7 +237,7 @@ test('sizedSvg: an ampersand in an attribute is not turned into broken XML', () 
 });
 
 test('sizedSvg: a file with no root element is refused rather than mangled', () => {
-  assert.throws(() => sizedSvg('<html></html>', 10, 10), /no <svg> element/);
+  assert.throws(() => sizedSvg('<html></html>', 10, 10), { message: 'read.nosvg' });
 });
 
 /* =========================================================== decodeSvgText */
@@ -406,11 +406,13 @@ test('atDensity: an odd 1x does not drift when it is doubled', () => {
 
 /* ============================================================= checkLimits */
 
+// The verdict names a sentence rather than writing one: sizing.js is copied
+// into fifteen languages, and only the page can read a phrase.
 test('checkLimits: an ordinary size passes without a word', () => {
   const verdict = checkLimits({ width: 1024, height: 1024 });
   assert.equal(verdict.ok, true);
   assert.equal(verdict.warn, false);
-  assert.equal(verdict.reason, '');
+  assert.equal(verdict.key, '');
 });
 
 test('checkLimits: past what Safari on a phone will do, it warns and still runs', () => {
@@ -418,39 +420,49 @@ test('checkLimits: past what Safari on a phone will do, it warns and still runs'
   const verdict = checkLimits({ width: side, height: side });
   assert.equal(verdict.ok, true);
   assert.equal(verdict.warn, true);
-  assert.match(verdict.reason, /iPhone|iPad/);
+  assert.equal(verdict.key, 'limit.safari');
+  assert.equal(verdict.values.ceiling, Math.round(WARN_PIXELS / 1e6));
 });
 
 test('checkLimits: past the side a canvas has, it refuses', () => {
   const verdict = checkLimits({ width: MAX_SIDE + 1, height: 10 });
   assert.equal(verdict.ok, false);
-  assert.match(verdict.reason, /blank/);
+  assert.equal(verdict.key, 'limit.side');
+  assert.equal(verdict.values.max, MAX_SIDE);
 });
 
 test('checkLimits: past what a browser will hold, it refuses', () => {
   const verdict = checkLimits({ width: 16000, height: 16000 });
   assert.equal(verdict.ok, false);
-  assert.match(verdict.reason, /megapixels/);
+  assert.equal(verdict.key, 'limit.pixels');
+  // The count is a phrase of its own, because "megapixels" is a word.
+  assert.equal(verdict.values.size.key, 'unit.megapixels');
+  assert.equal(verdict.values.size.values.n, 256);
 });
 
 /* ================================================================ describe */
 
+// A stand-in for `phrase()`: the numbers are what the tests are about, and
+// spelling the key out beside them shows which sentence carried them.
+const say = (key, values = {}) => `${key}(${Object.entries(values)
+  .map(([name, value]) => `${name}=${value}`).join(',')})`;
+
 test('describePlan: the sentence carries the numbers the run will use', () => {
   const intrinsic = { width: 24, height: 24, ratio: 1 };
   const plan = planSize(intrinsic, { mode: MODES.scale, scale: 4 });
-  const said = describePlan(plan, intrinsic, [1, 2]);
-  assert.match(said, /24 × 24/);
-  assert.match(said, /96 × 96/);
-  assert.match(said, /192 × 192/, 'the @2x size is not in the sentence');
+  const said = describePlan(plan, intrinsic, [1, 2], say);
+  assert.match(said, /fromWidth=24,fromHeight=24/);
+  assert.match(said, /width=96,height=96/);
+  assert.match(said, /width=192,height=192/, 'the @2x size is not in the sentence');
 });
 
 test('describePlan: padding and stretching are said out loud', () => {
   const intrinsic = { width: 800, height: 450, ratio: 800 / 450 };
   const padded = planSize(intrinsic, { mode: MODES.box, width: 600, height: 600, fit: FITS.pad });
-  assert.match(describePlan(padded, intrinsic, [1]), /centred/);
+  assert.match(describePlan(padded, intrinsic, [1], say), /plan\.padded/);
 
   const stretched = planSize(intrinsic, { mode: MODES.box, width: 600, height: 600, fit: FITS.stretch });
-  assert.match(describePlan(stretched, intrinsic, [1]), /distorted/);
+  assert.match(describePlan(stretched, intrinsic, [1], say), /plan\.stretched/);
 });
 
 test('times: a whole multiple has no decimals on it', () => {

--- a/tests/python/test_english_in_js.py
+++ b/tests/python/test_english_in_js.py
@@ -96,7 +96,8 @@ BASELINE = {
     # reader throws internally and never shows.
     'split-gif': 5,
     'stack-images': 7,
-    'svg-to-image': 27,
+    # An internal marker for an impossible mode, and a viewBox attribute.
+    'svg-to-image': 2,
     'timelapse-video': 0,
     # A filename template, a clock format, two CSS percentages and three class
     # names the timeline builds.

--- a/tools/svg-to-image/body.html
+++ b/tools/svg-to-image/body.html
@@ -212,6 +212,66 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.notsvg">{name}: this tool only reads SVG files. A PNG or a
+      JPEG is already pixels; the Image Resizer is the one for those.</span>
+    <span data-phrase="read.nosvg.named">{name}: there is no &lt;svg&gt; element in this
+      file.</span>
+    <span data-phrase="read.nosvg">There is no &lt;svg&gt; element in this file.</span>
+    <span data-phrase="file.failed">{name}: {why}</span>
+    <span data-phrase="draw.failed">This browser could not draw the SVG. It may not be
+      valid XML.</span>
+    <span data-phrase="encode.refused">This browser would not write {format} at that
+      size.</span>
+    <span data-phrase="out.size">&rarr; {size}</span>
+    <span data-phrase="out.toobig">&rarr; too big: {why}</span>
+    <span data-phrase="plan.none">Add an SVG and this says what size it will come out.</span>
+    <span data-phrase="plan.from">The file draws itself at {fromWidth} &times;
+      {fromHeight}; this comes out at {width} &times; {height}, which is {times} that.</span>
+    <span data-phrase="plan.stretched">The shape is stretched to fill the box, so the
+      drawing is distorted.</span>
+    <span data-phrase="plan.padded">It is centred in the box, with the background
+      showing either side.</span>
+    <span data-phrase="plan.density">{width} &times; {height} at @{d}x</span>
+    <span data-phrase="plan.plus">Plus {list}.</span>
+    <span data-phrase="limit.side">{width} &times; {height} is past the {max} pixel
+      limit a canvas has on a side. Nothing would come back but a blank image.</span>
+    <span data-phrase="limit.pixels">{size} is more than a browser will hold &mdash; it
+      is {mb} MB of canvas before anything is encoded. Ask for a smaller size.</span>
+    <span data-phrase="limit.safari">{size} is above the {ceiling} megapixel ceiling
+      Safari has on an iPhone or iPad. It will work on a desktop; on a phone it may come
+      back blank.</span>
+    <span data-phrase="unit.megapixels">{n} megapixels</span>
+    <span data-phrase="format.png">Lossless, and the only one of the three that every
+      piece of software reads. Flat colour and hard edges &mdash; which is most of what
+      a drawing is made of &mdash; compress well in it, so a rasterised logo is usually
+      smaller as a PNG than as a JPEG anyway.</span>
+    <span data-phrase="format.jpeg">No transparency, and lossy in the way that shows
+      worst on exactly this kind of picture: a ring of speckle around every hard edge.
+      Worth it for a drawing that is mostly photograph-like shading, and rarely
+      otherwise.</span>
+    <span data-phrase="format.webp">Transparency like a PNG, and a smaller file than
+      either of the others at the same quality. Read by every current browser; older
+      software and some print shops still will not open one.</span>
+    <span data-phrase="format.webp.cannot">This browser cannot write WebP, so a PNG
+      would come out instead. Pick one of the other two.</span>
+    <span data-phrase="bg.none">The transparent parts of the drawing stay transparent.</span>
+    <span data-phrase="bg.behind">Painted behind the whole picture, so nothing in the
+      file is transparent.</span>
+    <span data-phrase="bg.needed">{format} has no transparency, so this colour is
+      painted behind the drawing. Without it, everything that was transparent would come
+      out black.</span>
+    <span data-phrase="preview.actual">Shown at the size it will be.</span>
+    <span data-phrase="preview.scaled">Shown at {times} of the {size} file, redrawn from
+      the vector rather than shrunk &mdash; so this is what that size looks like.</span>
+    <span data-phrase="preview.checkerboard">The checkerboard is where the file will be
+      transparent.</span>
+    <span data-phrase="join.sentences">{a} {b}</span>
+    <span data-phrase="join.and">{a} and {b}</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="join.comma">{a}, {b}</span>
+    <span data-phrase="size.b">{n} B</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="run.one">Make the image</span>
     <span data-phrase="run.many">Make the {count} images</span>
     <span data-phrase="chosen.one">One file chosen</span>

--- a/tools/svg-to-image/src/files.js
+++ b/tools/svg-to-image/src/files.js
@@ -6,10 +6,10 @@
  * is English - octets in French, バイト in Japanese - and this module cannot
  * reach the markup a translation would live in. The symbol is the same in
  * every language the site is written in. */
-export function bytes(n) {
-  if (n < 1024) return `${n} B`;
-  if (n < 1024 * 1024) return `${(n / 1024).toFixed(n < 10240 ? 1 : 0)} KB`;
-  return `${(n / (1024 * 1024)).toFixed(2)} MB`;
+export function bytes(n, t) {
+  if (n < 1024) return t('size.b', { n });
+  if (n < 1024 * 1024) return t('size.kb', { n: (n / 1024).toFixed(n < 10240 ? 1 : 0) });
+  return t('size.mb', { n: (n / (1024 * 1024)).toFixed(2) });
 }
 
 /** "512 × 512", with a real multiplication sign. */

--- a/tools/svg-to-image/src/main.js
+++ b/tools/svg-to-image/src/main.js
@@ -117,8 +117,7 @@ async function addFiles(files) {
   try {
     for (const file of files) {
       if (!looksLikeSvg(file)) {
-        failures.push(`${file.name}: this tool only reads SVG files. `
-          + 'A PNG or a JPEG is already pixels; the Image Resizer is the one for those.');
+        failures.push(phrase('read.notsvg', { name: file.name }));
         continue;
       }
 
@@ -127,7 +126,7 @@ async function addFiles(files) {
       if (!intrinsic) {
         // Named .svg and holding something else, or truncated. Either way
         // there is no root element, so there is nothing to draw.
-        failures.push(`${file.name}: there is no <svg> element in this file.`);
+        failures.push(phrase('read.nosvg.named', { name: file.name }));
         continue;
       }
 
@@ -285,17 +284,20 @@ function renderList() {
 
     const sub = document.createElement('p');
     sub.className = 'file-sub';
-    sub.textContent = `${phrase(sourceKey(item.intrinsic), {
-      size: dimensions(item.intrinsic.width, item.intrinsic.height),
-    })} · ${humanBytes(item.file.size)}`;
+    sub.textContent = phrase('join.dot', {
+      a: phrase(sourceKey(item.intrinsic), {
+        size: dimensions(item.intrinsic.width, item.intrinsic.height),
+      }),
+      b: humanBytes(item.file.size, phrase),
+    });
 
     const out = document.createElement('p');
     out.className = 'file-out';
     const plan = planFor(item);
     const limit = checkLimits(atDensity(plan, densities().at(-1)));
     out.textContent = limit.ok
-      ? `→ ${dimensions(plan.width, plan.height)}`
-      : `→ too big: ${limit.reason}`;
+      ? phrase('out.size', { size: dimensions(plan.width, plan.height) })
+      : phrase('out.toobig', { why: phrase(limit.key, fill(limit.values)) });
     out.classList.toggle('warn', !limit.ok);
 
     main.append(name, sub, out);
@@ -330,17 +332,28 @@ function renderList() {
   }
 }
 
+/**
+ * A refusal's blanks, with any that are themselves a phrase resolved.
+ *
+ * sizing.js says how many megapixels inside a sentence about the limit, and
+ * the word for a megapixel is not English everywhere either.
+ */
+function fill(values = {}) {
+  return Object.fromEntries(Object.entries(values)
+    .map(([name, value]) => [name, value?.key ? phrase(value.key, value.values) : value]));
+}
+
 function renderNotes() {
   const item = activeItem();
   const set = settings();
 
   el.sizeSummary.textContent = item
-    ? describePlan(planFor(item), item.intrinsic, set.densities)
-    : 'Add an SVG and this says what size it will come out.';
+    ? describePlan(planFor(item), item.intrinsic, set.densities, phrase)
+    : phrase('plan.none');
 
   const worst = worstLimit();
   el.sizeWarning.hidden = !worst;
-  el.sizeWarning.textContent = worst?.reason ?? '';
+  el.sizeWarning.textContent = worst ? phrase(worst.key, fill(worst.values)) : '';
   el.sizeWarning.classList.toggle('warn', Boolean(worst && !worst.ok));
 
   el.formatNote.textContent = formatSentence(set.mime);
@@ -363,28 +376,16 @@ const everythingFits = () => items.every(
   (item) => checkLimits(atDensity(planFor(item), densities().at(-1))).ok);
 
 function formatSentence(mime) {
-  if (mime === PNG) {
-    return 'Lossless, and the only one of the three that every piece of software reads. '
-      + 'Flat colour and hard edges - which is most of what a drawing is made of - compress well in it, '
-      + 'so a rasterised logo is usually smaller as a PNG than as a JPEG anyway.';
-  }
-  if (mime === JPEG) {
-    return 'No transparency, and lossy in the way that shows worst on exactly this kind of picture: '
-      + 'a ring of speckle around every hard edge. Worth it for a drawing that is mostly photograph-like '
-      + 'shading, and rarely otherwise.';
-  }
-  return writable.has(WEBP)
-    ? 'Transparency like a PNG, and a smaller file than either of the others at the same quality. '
-      + 'Read by every current browser; older software and some print shops still will not open one.'
-    : 'This browser cannot write WebP, so a PNG would come out instead. Pick one of the other two.';
+  if (mime === PNG) return phrase('format.png');
+  if (mime === JPEG) return phrase('format.jpeg');
+  return phrase(writable.has(WEBP) ? 'format.webp' : 'format.webp.none');
 }
 
 function backgroundSentence({ mime, background }) {
-  if (!background) return 'The transparent parts of the drawing stay transparent.';
+  if (!background) return phrase('bg.none');
   return FORMATS[mime].alpha
-    ? 'Painted behind the whole picture, so nothing in the file is transparent.'
-    : `${FORMATS[mime].label} has no transparency, so this colour is painted behind the drawing. `
-      + 'Without it, everything that was transparent would come out black.';
+    ? phrase('bg.behind')
+    : phrase('bg.needed', { format: FORMATS[mime].label });
 }
 
 /* -------------------------------------------------------------- the preview */
@@ -432,7 +433,12 @@ async function drawPreview() {
       held.release();
     }
   } catch (error) {
-    if (token === previewToken) showLoadError(`${item.file.name}: ${error.message}`);
+    if (token === previewToken) {
+      showLoadError(phrase('file.failed', {
+        name: item.file.name,
+        why: phrase(error.message, fill(error.values)),
+      }));
+    }
     return;
   }
 
@@ -461,15 +467,15 @@ function shrinkPlan(plan, maxSide) {
 
 function previewSentence(full, shown, set) {
   const scale = shown.width === full.width
-    ? 'Shown at the size it will be.'
-    : `Shown at ${times(shown.width / full.width)} of the ${dimensions(full.width, full.height)} `
-      + 'file, redrawn from the vector rather than shrunk - so this is what that size looks like.';
+    ? phrase('preview.actual')
+    : phrase('preview.scaled', {
+      times: times(shown.width / full.width),
+      size: dimensions(full.width, full.height),
+    });
 
-  const alpha = set.background
-    ? ''
-    : ' The checkerboard is where the file will be transparent.';
-
-  return `${scale}${alpha}`;
+  return set.background
+    ? scale
+    : phrase('join.sentences', { a: scale, b: phrase('preview.checkerboard') });
 }
 
 /* ----------------------------------------------------------------- the run */
@@ -539,12 +545,12 @@ function renderResults() {
     ? phrase('written.one', {
       name: results[0].name,
       size: dimensions(results[0].plan.width, results[0].plan.height),
-      bytes: humanBytes(total),
+      bytes: humanBytes(total, phrase),
     })
     : phrase('written.many', {
       count: results.length.toLocaleString(),
       drawings: sources.toLocaleString(),
-      bytes: humanBytes(total),
+      bytes: humanBytes(total, phrase),
     });
 
   for (const one of results) el.resultList.append(resultRow(one));
@@ -566,7 +572,10 @@ function resultRow(one) {
 
   const headline = document.createElement('p');
   headline.className = 'result-headline';
-  headline.textContent = `${dimensions(one.plan.width, one.plan.height)}, ${humanBytes(one.blob.size)}`;
+  headline.textContent = phrase('join.comma', {
+    a: dimensions(one.plan.width, one.plan.height),
+    b: humanBytes(one.blob.size, phrase),
+  });
 
   const detail = document.createElement('p');
   detail.className = 'result-detail';

--- a/tools/svg-to-image/src/render.js
+++ b/tools/svg-to-image/src/render.js
@@ -90,7 +90,7 @@ export async function loadAt(text, width, height, { stretch = false } = {}) {
   try {
     await new Promise((resolve, reject) => {
       image.onload = () => resolve();
-      image.onerror = () => reject(new Error('this browser could not draw the SVG. It may not be valid XML.'));
+      image.onerror = () => reject(new Error('draw.failed'));
       image.src = url;
     });
 
@@ -155,7 +155,10 @@ export function draw(image, plan, { background }) {
 export async function encode(canvas, mime, quality) {
   const blob = await new Promise((resolve) => canvas.toBlob(resolve, mime, quality));
   if (!blob) {
-    throw new Error(`this browser would not write ${FORMATS[mime]?.label ?? mime} at that size.`);
+    // A key and its blank, because the caller is the only place a phrase
+    // can be read - see the note at the top of shared/js/phrases.js.
+    throw Object.assign(new Error('encode.refused'),
+      { values: { format: FORMATS[mime]?.label ?? mime } });
   }
   return blob;
 }

--- a/tools/svg-to-image/src/sizing.js
+++ b/tools/svg-to-image/src/sizing.js
@@ -92,7 +92,7 @@ export function planSize(intrinsic, settings) {
       width = longest * ratio;
     }
   } else {
-    throw new Error(`unknown size mode: ${mode}`);
+    throw new Error(`unknown size mode: ${mode}`);   // a bug here, never a file
   }
 
   return whole(px(width), px(height));
@@ -184,7 +184,9 @@ export function atDensity(plan, multiple) {
 /**
  * Whether this is a canvas a browser will actually produce.
  *
- * @returns {{ok: boolean, warn: boolean, reason: string}}
+ * @returns {{ok: boolean, warn: boolean, key: string, values: object}} `key`
+ *   names the sentence and is empty when there is nothing to say; a value
+ *   that is itself `{key, values}` is a phrase the caller resolves first.
  */
 export function checkLimits(plan) {
   const pixels = plan.width * plan.height;
@@ -193,8 +195,8 @@ export function checkLimits(plan) {
     return {
       ok: false,
       warn: false,
-      reason: `${plan.width} × ${plan.height} is past the ${MAX_SIDE} pixel limit a canvas has on a side. `
-        + 'Nothing would come back but a blank image.',
+      key: 'limit.side',
+      values: { width: plan.width, height: plan.height, max: MAX_SIDE },
     };
   }
 
@@ -202,8 +204,8 @@ export function checkLimits(plan) {
     return {
       ok: false,
       warn: false,
-      reason: `${megapixels(pixels)} is more than a browser will hold - it is ${Math.round(pixels * 4 / 1e6)} MB `
-        + 'of canvas before anything is encoded. Ask for a smaller size.',
+      key: 'limit.pixels',
+      values: { size: megapixels(pixels), mb: Math.round(pixels * 4 / 1e6) },
     };
   }
 
@@ -211,17 +213,18 @@ export function checkLimits(plan) {
     return {
       ok: true,
       warn: true,
-      reason: `${megapixels(pixels)} is above the ${Math.round(WARN_PIXELS / 1e6)} megapixel ceiling Safari has on `
-        + 'an iPhone or iPad. It will work on a desktop; on a phone it may come back blank.',
+      key: 'limit.safari',
+      values: { size: megapixels(pixels), ceiling: Math.round(WARN_PIXELS / 1e6) },
     };
   }
 
-  return { ok: true, warn: false, reason: '' };
+  return { ok: true, warn: false, key: '', values: {} };
 }
 
+/** A phrase and its blank, not a sentence: the word for it is not English. */
 export const megapixels = (pixels) => {
   const mp = pixels / 1e6;
-  return `${mp < 10 ? mp.toFixed(1) : Math.round(mp)} megapixels`;
+  return { key: 'unit.megapixels', values: { n: mp < 10 ? mp.toFixed(1) : Math.round(mp) } };
 };
 
 /**
@@ -229,21 +232,28 @@ export const megapixels = (pixels) => {
  * renderer is handed - so the page cannot describe something other than what
  * runs.
  */
-export function describePlan(plan, intrinsic, densities) {
-  const size = `${plan.width} × ${plan.height}`;
-  const from = `The file draws itself at ${intrinsic.width} × ${intrinsic.height}`;
+export function describePlan(plan, intrinsic, densities, t) {
+  const parts = [t('plan.from', {
+    fromWidth: intrinsic.width,
+    fromHeight: intrinsic.height,
+    width: plan.width,
+    height: plan.height,
+    times: times(plan.width / intrinsic.width),
+  })];
 
-  const shape = plan.stretch
-    ? ' The shape is stretched to fill the box, so the drawing is distorted.'
-    : plan.padded
-      ? ' It is centred in the box, with the background showing either side.'
-      : '';
+  // A clause spliced into a sentence cannot be translated, so each of the
+  // three shapes this can take is a sentence of its own.
+  if (plan.stretch) parts.push(t('plan.stretched'));
+  else if (plan.padded) parts.push(t('plan.padded'));
 
-  const extra = densities.length > 1
-    ? ` Plus ${densities.slice(1).map((d) => `${plan.width * d} × ${plan.height * d} at @${d}x`).join(' and ')}.`
-    : '';
+  if (densities.length > 1) {
+    const list = densities.slice(1)
+      .map((d) => t('plan.density', { width: plan.width * d, height: plan.height * d, d }))
+      .reduce((a, b) => t('join.and', { a, b }));
+    parts.push(t('plan.plus', { list }));
+  }
 
-  return `${from}; this comes out at ${size}, which is ${times(plan.width / intrinsic.width)} that.${shape}${extra}`;
+  return parts.reduce((a, b) => t('join.sentences', { a, b }));
 }
 
 /** "2x", "0.5x", "1.33x" - said the same way wherever a scale is shown. */

--- a/tools/svg-to-image/src/svg.js
+++ b/tools/svg-to-image/src/svg.js
@@ -316,7 +316,7 @@ const round = (n) => Math.max(1, Math.round(n * 1000) / 1000);
  */
 export function sizedSvg(text, width, height, { stretch = false } = {}) {
   const root = readRoot(text);
-  if (!root) throw new Error('there is no <svg> element in this file.');
+  if (!root) throw new Error('read.nosvg');
 
   const attrs = { ...root.attrs };
   const size = intrinsicSize(text);


### PR DESCRIPTION
svg-to-image showed twenty-seven English sentences from `src/`, which is copied byte for byte into all fifteen languages: the size summary, all three format notes, the background notes, the preview line and every canvas limit. They move into `#phrases`; the leaf modules hand back keys.

**Two modules had to change shape, not just wording.**

`checkLimits` returned a written-out `reason`. It names a sentence now, and the page writes it — sizing.js has no way to read a phrase:

```js
return {
  ok: false, warn: false,
  key: 'limit.pixels',
  values: { size: megapixels(pixels), mb: Math.round(pixels * 4 / 1e6) },
};
```

`megapixels()` returns `{key, values}` rather than a string, because "megapixels" is a word. `main.js` resolves the inner phrase before filling the outer one, which is how the sentence comes out whole in German:

```
256 Megapixel ist mehr, als ein Browser fasst — das sind 1024 MB Canvas,
bevor überhaupt etwas kodiert wird. Eine kleinere Größe wäre nötig.
```

`describePlan` glued a clause onto a sentence with a leading space, twice, then joined the extra densities with `" and "`. Each of the three shapes is a whole sentence now, the list folds with a `join.and` phrase and the sentences with `join.sentences` — none of which English gets to decide for the others. It takes the resolver as an argument, so the logic and its tests stay in sizing.js.

**Two sentences stay in the JavaScript on purpose** and the ratchet's comment now says so: the unrecognised size mode is a bug in this repository rather than anything a file can cause, and `0 0 w h` is a viewBox, not a sentence.

## Verified in the browser

SVGs dropped on the page in English and in German — a good one, a `.txt`, and an `.svg` holding `<html></html>` — with every format, both backgrounds, all three densities, and each limit resolved through the real `checkLimits`.

```
English  The file draws itself at 24 × 24; this comes out at 96 × 96, which is 4× that.
         Plus 192 × 192 at @2x and 288 × 288 at @3x.
German   Die Datei zeichnet sich selbst mit 24 × 24; heraus kommt 96 × 96,
         das ist 4× so groß. Dazu 192 × 192 bei @2x.
```

Every phrase in all fourteen locales was resolved and checked for the CJK wrap trap and for blank drift against the English.

## Tests

- `python -m unittest discover -t . -s tests/python` — 495 pass; the ratchet drops svg-to-image 27 → 2.
- `node --test "tests/js/*.test.js"` — 1939 pass. The `checkLimits` tests assert the key and the numbers beside it; `describePlan`'s take a stand-in resolver that spells the key out, so what the tests were about — that the sentence carries the numbers the run will use — is still what they check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)