### PR TITLE
Say the GIF in the reader's language, not only in English

### DIFF
--- a/locales/ar/tools/video-to-gif.html
+++ b/locales/ar/tools/video-to-gif.html
@@ -172,6 +172,47 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="step.reading">جارٍ قراءة الملف&hellip;</span>
+    <span data-phrase="open.notopened">تعذّر فتح ذلك الملف.</span>
+    <span data-phrase="preview.none">هذا المتصفح لا يشغّل هذا الملف، فلا معاينة إذاً.
+      ومع ذلك تُقرأ الإطارات وتُحوَّل &mdash; حدّد المقطع أدناه بأوقاته.</span>
+    <span data-phrase="size.plain">{width} x {height}</span>
+    <span data-phrase="len.unknown">غير معروفة</span>
+    <span data-phrase="src.codec">{codec} ‏({entry})</span>
+    <span data-phrase="src.codec.turned">{codec} ‏({entry})، مُدار {degrees} درجة</span>
+    <span data-phrase="src.byplayer">قرأه مشغّل المتصفح نفسه</span>
+    <span data-phrase="path.codecs">WebCodecs، إطاراً إطاراً</span>
+    <span data-phrase="path.player">المشغّل، قفزة لكل إطار</span>
+    <span data-phrase="sum.section">من {from} إلى {to} ({span} ث)</span>
+    <span data-phrase="size.from">{width} x {height} (من {fromWidth} x {fromHeight})</span>
+    <span data-phrase="sum.bytes">من {low} إلى {high}</span>
+    <span data-phrase="note.wider">هذا أعرض من الفيديو نفسه ({px} بكسل)، وذلك لا يضيف
+      تفاصيل لم تكن موجودة أصلاً &mdash; بل يضيف بايتات فقط.</span>
+    <span data-phrase="note.memory">يبقى كل إطار في الذاكرة أثناء اختيار لوحة الألوان،
+      وهو بهذه الإعدادات نحو {size}.</span>
+    <span data-phrase="note.memory.toobig">هذا أكثر مما ستحاوله هذه الأداة &mdash; مقطع
+      أقصر أو عرض أصغر أو معدل إطارات أقل يحل الأمر.</span>
+    <span data-phrase="note.memory.ok">مقطع أقصر أو عرض أصغر أو معدل إطارات أقل، كلها
+      تخفّضه.</span>
+    <span data-phrase="step.readframe">قراءة الإطار {done} من {total}</span>
+    <span data-phrase="step.writeframe">كتابة الإطار {done} من {total}</span>
+    <span data-phrase="n.frame.one">إطار واحد</span>
+    <span data-phrase="n.frame.many">{n} إطاراً</span>
+    <span data-phrase="out.dropped">{frames} ({n} متطابقة، أُسقطت)</span>
+    <span data-phrase="out.fps">{n} إطار/ث</span>
+    <span data-phrase="out.colours">{n} لوناً</span>
+    <span data-phrase="export.tooshort">هذا المقطع أقصر من أن يؤخذ منه إطار.</span>
+    <span data-phrase="export.toobig">هذا يحتاج ذاكرة أكثر مما ستطلبه هذه الأداة من
+      متصفح. اختصر المقطع، أو أنقص العرض أو معدل الإطارات.</span>
+    <span data-phrase="export.failed">حدث خطأ أثناء صنع ملف GIF.</span>
+    <span data-phrase="read.noframes">لم يُفَكّ ترميز أي إطار من هذا الملف.</span>
+    <span data-phrase="play.stopped">لم يعد المتصفح قادراً على تشغيل هذا الملف في منتصف
+      الطريق.</span>
+    <span data-phrase="join.sentences">{a} {b}</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="size.kb">{n} كيلوبايت</span>
+    <span data-phrase="size.mb">{n} ميغابايت</span>
+    <span data-phrase="size.gb">{n} غيغابايت</span>
     <span data-phrase="read.midframe">ينتهي الملف في منتصف إطار.</span>
     <span data-phrase="read.avcshort">سجل إعداد H.264 أقصر مما ينبغي.</span>
     <span data-phrase="read.hevcshort">سجل إعداد HEVC أقصر مما ينبغي.</span>

--- a/locales/de/tools/video-to-gif.html
+++ b/locales/de/tools/video-to-gif.html
@@ -175,6 +175,52 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="step.reading">Die Datei wird gelesen&hellip;</span>
+    <span data-phrase="open.notopened">Diese Datei konnte nicht geöffnet werden.</span>
+    <span data-phrase="preview.none">Dieser Browser spielt diese Datei nicht ab, es gibt
+      also keine Vorschau. Die Bilder werden trotzdem gelesen und umgewandelt &mdash;
+      der Abschnitt lässt sich unten über seine Zeiten markieren.</span>
+    <span data-phrase="size.plain">{width} x {height}</span>
+    <span data-phrase="len.unknown">unbekannt</span>
+    <span data-phrase="src.codec">{codec} ({entry})</span>
+    <span data-phrase="src.codec.turned">{codec} ({entry}), um {degrees} Grad gedreht</span>
+    <span data-phrase="src.byplayer">vom Player des Browsers gelesen</span>
+    <span data-phrase="path.codecs">WebCodecs, Bild für Bild</span>
+    <span data-phrase="path.player">der Player, ein Sprung pro Bild</span>
+    <span data-phrase="sum.section">{from} bis {to} ({span} s)</span>
+    <span data-phrase="size.from">{width} x {height} (aus {fromWidth} x {fromHeight})</span>
+    <span data-phrase="sum.bytes">{low} bis {high}</span>
+    <span data-phrase="note.wider">Das ist breiter als das Video selbst ({px} px), und
+      das kann keine Details hinzufügen, die nie da waren &mdash; nur Bytes.</span>
+    <span data-phrase="note.memory">Während die Palette gewählt wird, liegt jedes Bild
+      im Speicher, bei diesen Einstellungen etwa {size}.</span>
+    <span data-phrase="note.memory.toobig">Das ist mehr, als dieses Werkzeug versuchen
+      wird &mdash; ein kürzerer Abschnitt, eine kleinere Breite oder eine niedrigere
+      Bildrate hilft.</span>
+    <span data-phrase="note.memory.ok">Ein kürzerer Abschnitt, eine kleinere Breite oder
+      eine niedrigere Bildrate bringen es herunter.</span>
+    <span data-phrase="step.readframe">Bild {done} von {total} wird gelesen</span>
+    <span data-phrase="step.writeframe">Bild {done} von {total} wird geschrieben</span>
+    <span data-phrase="n.frame.one">{n} Bild</span>
+    <span data-phrase="n.frame.many">{n} Bilder</span>
+    <span data-phrase="out.dropped">{frames} ({n} identisch, weggelassen)</span>
+    <span data-phrase="out.fps">{n} fps</span>
+    <span data-phrase="out.colours">{n} Farben</span>
+    <span data-phrase="export.tooshort">Dieser Abschnitt ist zu kurz, um ein Bild daraus
+      zu nehmen.</span>
+    <span data-phrase="export.toobig">Dafür bräuchte es mehr Speicher, als dieses
+      Werkzeug einem Browser abverlangt. Ein kürzerer Abschnitt, eine kleinere Breite
+      oder eine niedrigere Bildrate hilft.</span>
+    <span data-phrase="export.failed">Beim Erstellen des GIFs ist etwas schiefgegangen.</span>
+    <span data-phrase="read.noframes">Aus dieser Datei ließen sich keine Bilder
+      dekodieren.</span>
+    <span data-phrase="play.stopped">Der Browser konnte diese Datei mittendrin nicht
+      mehr abspielen.</span>
+    <span data-phrase="join.sentences">{a} {b}</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
+    <span data-phrase="size.gb">{n} GB</span>
     <span data-phrase="read.midframe">Die Datei endet mitten in einem Einzelbild.</span>
     <span data-phrase="read.avcshort">Der H.264-Konfigurationsdatensatz ist zu kurz.</span>
     <span data-phrase="read.hevcshort">Der HEVC-Konfigurationsdatensatz ist zu kurz.</span>

--- a/locales/es/tools/video-to-gif.html
+++ b/locales/es/tools/video-to-gif.html
@@ -175,6 +175,52 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="step.reading">Leyendo el archivo&hellip;</span>
+    <span data-phrase="open.notopened">Ese archivo no se ha podido abrir.</span>
+    <span data-phrase="preview.none">Este navegador no reproduce este archivo, así que
+      no hay vista previa. Los fotogramas se leen y se convierten igualmente: marca la
+      sección abajo por sus tiempos.</span>
+    <span data-phrase="size.plain">{width} x {height}</span>
+    <span data-phrase="len.unknown">desconocida</span>
+    <span data-phrase="src.codec">{codec} ({entry})</span>
+    <span data-phrase="src.codec.turned">{codec} ({entry}), girado {degrees} grados</span>
+    <span data-phrase="src.byplayer">leído por el propio reproductor del navegador</span>
+    <span data-phrase="path.codecs">WebCodecs, fotograma a fotograma</span>
+    <span data-phrase="path.player">el reproductor, un salto por fotograma</span>
+    <span data-phrase="sum.section">de {from} a {to} ({span} s)</span>
+    <span data-phrase="size.from">{width} x {height} (desde {fromWidth} x {fromHeight})</span>
+    <span data-phrase="sum.bytes">de {low} a {high}</span>
+    <span data-phrase="note.wider">Eso es más ancho que el propio vídeo ({px} px), y eso
+      no puede añadir detalle que nunca estuvo ahí: solo bytes.</span>
+    <span data-phrase="note.memory">Cada fotograma se queda en memoria mientras se elige
+      la paleta, lo que con estos ajustes son unos {size}.</span>
+    <span data-phrase="note.memory.toobig">Eso es más de lo que esta herramienta va a
+      intentar: una sección más corta, un ancho menor o una cadencia más baja lo
+      arreglan.</span>
+    <span data-phrase="note.memory.ok">Una sección más corta, un ancho menor o una
+      cadencia más baja lo bajan.</span>
+    <span data-phrase="step.readframe">Leyendo el fotograma {done} de {total}</span>
+    <span data-phrase="step.writeframe">Escribiendo el fotograma {done} de {total}</span>
+    <span data-phrase="n.frame.one">{n} fotograma</span>
+    <span data-phrase="n.frame.many">{n} fotogramas</span>
+    <span data-phrase="out.dropped">{frames} ({n} idénticos, descartados)</span>
+    <span data-phrase="out.fps">{n} fps</span>
+    <span data-phrase="out.colours">{n} colores</span>
+    <span data-phrase="export.tooshort">Esa sección es demasiado corta para sacarle un
+      fotograma.</span>
+    <span data-phrase="export.toobig">Eso necesitaría más memoria de la que esta
+      herramienta le va a pedir a un navegador. Acorta la sección, o baja el ancho o la
+      cadencia.</span>
+    <span data-phrase="export.failed">Algo ha salido mal al hacer el GIF.</span>
+    <span data-phrase="read.noframes">De este archivo no se ha podido descodificar
+      ningún fotograma.</span>
+    <span data-phrase="play.stopped">El navegador ha dejado de poder reproducir este
+      archivo a medio camino.</span>
+    <span data-phrase="join.sentences">{a} {b}</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
+    <span data-phrase="size.gb">{n} GB</span>
     <span data-phrase="read.midframe">El archivo termina en mitad de un fotograma.</span>
     <span data-phrase="read.avcshort">El registro de configuración H.264 es demasiado corto.</span>
     <span data-phrase="read.hevcshort">El registro de configuración HEVC es demasiado corto.</span>

--- a/locales/fr/tools/video-to-gif.html
+++ b/locales/fr/tools/video-to-gif.html
@@ -175,6 +175,55 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="step.reading">Lecture du fichier&hellip;</span>
+    <span data-phrase="open.notopened">Ce fichier n&rsquo;a pas pu être ouvert.</span>
+    <span data-phrase="preview.none">Ce navigateur ne lit pas ce fichier, il n&rsquo;y a
+      donc pas d&rsquo;aperçu. Les images sont quand même lues et converties&nbsp;: la
+      section se marque ci-dessous par ses temps.</span>
+    <span data-phrase="size.plain">{width} x {height}</span>
+    <span data-phrase="len.unknown">inconnue</span>
+    <span data-phrase="src.codec">{codec} ({entry})</span>
+    <span data-phrase="src.codec.turned">{codec} ({entry}), tourné de {degrees} degrés</span>
+    <span data-phrase="src.byplayer">lu par le lecteur du navigateur</span>
+    <span data-phrase="path.codecs">WebCodecs, image par image</span>
+    <span data-phrase="path.player">le lecteur, un déplacement par image</span>
+    <span data-phrase="sum.section">de {from} à {to} ({span} s)</span>
+    <span data-phrase="size.from">{width} x {height} (à partir de {fromWidth} x
+      {fromHeight})</span>
+    <span data-phrase="sum.bytes">de {low} à {high}</span>
+    <span data-phrase="note.wider">C&rsquo;est plus large que la vidéo elle-même ({px}
+      px), ce qui ne peut pas ajouter du détail qui n&rsquo;a jamais existé &mdash;
+      seulement des octets.</span>
+    <span data-phrase="note.memory">Chaque image reste en mémoire pendant le choix de la
+      palette, ce qui fait environ {size} avec ces réglages.</span>
+    <span data-phrase="note.memory.toobig">C&rsquo;est plus que ce que cet outil tentera
+      &mdash; une section plus courte, une largeur plus petite ou une cadence plus basse
+      y remédient.</span>
+    <span data-phrase="note.memory.ok">Une section plus courte, une largeur plus petite
+      ou une cadence plus basse font toutes baisser ce chiffre.</span>
+    <span data-phrase="step.readframe">Lecture de l&rsquo;image {done} sur {total}</span>
+    <span data-phrase="step.writeframe">Écriture de l&rsquo;image {done} sur {total}</span>
+    <span data-phrase="n.frame.one">{n} image</span>
+    <span data-phrase="n.frame.many">{n} images</span>
+    <span data-phrase="out.dropped">{frames} ({n} identiques, retirées)</span>
+    <span data-phrase="out.fps">{n} fps</span>
+    <span data-phrase="out.colours">{n} couleurs</span>
+    <span data-phrase="export.tooshort">Cette section est trop courte pour en tirer une
+      image.</span>
+    <span data-phrase="export.toobig">Cela demanderait plus de mémoire que cet outil
+      n&rsquo;en réclame à un navigateur. Raccourcissez la section, ou baissez la
+      largeur ou la cadence.</span>
+    <span data-phrase="export.failed">Quelque chose a mal tourné pendant la fabrication
+      du GIF.</span>
+    <span data-phrase="read.noframes">Aucune image n&rsquo;a pu être décodée dans ce
+      fichier.</span>
+    <span data-phrase="play.stopped">Le navigateur n&rsquo;a plus réussi à lire ce
+      fichier en cours de route.</span>
+    <span data-phrase="join.sentences">{a} {b}</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="size.kb">{n} Ko</span>
+    <span data-phrase="size.mb">{n} Mo</span>
+    <span data-phrase="size.gb">{n} Go</span>
     <span data-phrase="read.midframe">Le fichier se termine au milieu d&rsquo;une image.</span>
     <span data-phrase="read.avcshort">L&rsquo;enregistrement de configuration H.264 est trop court.</span>
     <span data-phrase="read.hevcshort">L&rsquo;enregistrement de configuration HEVC est trop court.</span>

--- a/locales/hi/tools/video-to-gif.html
+++ b/locales/hi/tools/video-to-gif.html
@@ -174,6 +174,48 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="step.reading">फ़ाइल पढ़ी जा रही है&hellip;</span>
+    <span data-phrase="open.notopened">वह फ़ाइल खोली नहीं जा सकी।</span>
+    <span data-phrase="preview.none">यह ब्राउज़र इस फ़ाइल को चलाता नहीं, इसलिए
+      पूर्वावलोकन नहीं है। फ़्रेम फिर भी पढ़े और बदले जाते हैं &mdash; नीचे समयों से
+      हिस्सा चुन लीजिए।</span>
+    <span data-phrase="size.plain">{width} x {height}</span>
+    <span data-phrase="len.unknown">अज्ञात</span>
+    <span data-phrase="src.codec">{codec} ({entry})</span>
+    <span data-phrase="src.codec.turned">{codec} ({entry}), {degrees} डिग्री घुमाया हुआ</span>
+    <span data-phrase="src.byplayer">ब्राउज़र के अपने प्लेयर से पढ़ा गया</span>
+    <span data-phrase="path.codecs">WebCodecs, फ़्रेम-दर-फ़्रेम</span>
+    <span data-phrase="path.player">प्लेयर, हर फ़्रेम पर एक छलाँग</span>
+    <span data-phrase="sum.section">{from} से {to} तक ({span} से)</span>
+    <span data-phrase="size.from">{width} x {height} ({fromWidth} x {fromHeight} से)</span>
+    <span data-phrase="sum.bytes">{low} से {high} तक</span>
+    <span data-phrase="note.wider">यह ख़ुद वीडियो ({px} px) से चौड़ा है, और इससे वह
+      ब्योरा नहीं आ जाता जो कभी था ही नहीं &mdash; सिर्फ़ बाइट बढ़ते हैं।</span>
+    <span data-phrase="note.memory">रंग-पट्टी चुनते समय हर फ़्रेम याददाश्त में रहता है,
+      जो इन सेटिंग्स पर लगभग {size} है।</span>
+    <span data-phrase="note.memory.toobig">यह उससे ज़्यादा है जितना यह औज़ार आज़माएगा
+      &mdash; छोटा हिस्सा, कम चौड़ाई या कम फ़्रेम दर इसे ठीक कर देगी।</span>
+    <span data-phrase="note.memory.ok">छोटा हिस्सा, कम चौड़ाई या कम फ़्रेम दर, तीनों इसे
+      नीचे लाते हैं।</span>
+    <span data-phrase="step.readframe">{total} में से फ़्रेम {done} पढ़ा जा रहा है</span>
+    <span data-phrase="step.writeframe">{total} में से फ़्रेम {done} लिखा जा रहा है</span>
+    <span data-phrase="n.frame.one">{n} फ़्रेम</span>
+    <span data-phrase="n.frame.many">{n} फ़्रेम</span>
+    <span data-phrase="out.dropped">{frames} ({n} एक जैसे, छोड़े गए)</span>
+    <span data-phrase="out.fps">{n} fps</span>
+    <span data-phrase="out.colours">{n} रंग</span>
+    <span data-phrase="export.tooshort">वह हिस्सा इतना छोटा है कि उसमें से एक फ़्रेम भी
+      नहीं निकलता।</span>
+    <span data-phrase="export.toobig">इसके लिए उतनी याददाश्त चाहिए जितनी यह औज़ार किसी
+      ब्राउज़र से नहीं माँगेगा। हिस्सा छोटा कीजिए, या चौड़ाई या फ़्रेम दर घटाइए।</span>
+    <span data-phrase="export.failed">GIF बनाते समय कुछ गड़बड़ हो गई।</span>
+    <span data-phrase="read.noframes">इस फ़ाइल से कोई फ़्रेम डीकोड नहीं हो सका।</span>
+    <span data-phrase="play.stopped">ब्राउज़र बीच में ही इस फ़ाइल को चला नहीं पाया।</span>
+    <span data-phrase="join.sentences">{a} {b}</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
+    <span data-phrase="size.gb">{n} GB</span>
     <span data-phrase="read.midframe">फ़ाइल एक फ़्रेम के बीचोंबीच ख़त्म हो जाती है।</span>
     <span data-phrase="read.avcshort">H.264 का कॉन्फ़िगरेशन रिकॉर्ड बहुत छोटा है।</span>
     <span data-phrase="read.hevcshort">HEVC का कॉन्फ़िगरेशन रिकॉर्ड बहुत छोटा है।</span>

--- a/locales/id/tools/video-to-gif.html
+++ b/locales/id/tools/video-to-gif.html
@@ -180,6 +180,53 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="step.reading">Membaca berkasnya&hellip;</span>
+    <span data-phrase="open.notopened">Berkas itu tidak bisa dibuka.</span>
+    <span data-phrase="preview.none">Browser ini tidak memainkan berkas ini, jadi tidak
+      ada pratinjau. Bingkainya tetap dibaca dan diubah &mdash; tandai bagiannya di
+      bawah lewat waktunya.</span>
+    <span data-phrase="size.plain">{width} x {height}</span>
+    <span data-phrase="len.unknown">tidak diketahui</span>
+    <span data-phrase="src.codec">{codec} ({entry})</span>
+    <span data-phrase="src.codec.turned">{codec} ({entry}), diputar {degrees} derajat</span>
+    <span data-phrase="src.byplayer">dibaca pemutar bawaan browser</span>
+    <span data-phrase="path.codecs">WebCodecs, bingkai demi bingkai</span>
+    <span data-phrase="path.player">pemutar, satu lompatan tiap bingkai</span>
+    <span data-phrase="sum.section">{from} sampai {to} ({span} dtk)</span>
+    <span data-phrase="size.from">{width} x {height} (dari {fromWidth} x {fromHeight})</span>
+    <span data-phrase="sum.bytes">{low} sampai {high}</span>
+    <span data-phrase="note.wider">Itu lebih lebar daripada videonya sendiri ({px} px),
+      dan itu tidak bisa menambah rincian yang memang tidak pernah ada &mdash; hanya
+      menambah bita.</span>
+    <span data-phrase="note.memory">Tiap bingkai ditahan di memori selama paletnya
+      dipilih, yang dengan setelan ini kira-kira {size}.</span>
+    <span data-phrase="note.memory.toobig">Itu lebih dari yang akan dicoba alat ini
+      &mdash; bagian yang lebih pendek, lebar yang lebih kecil, atau laju bingkai yang
+      lebih rendah akan menolong.</span>
+    <span data-phrase="note.memory.ok">Bagian yang lebih pendek, lebar yang lebih kecil,
+      atau laju bingkai yang lebih rendah sama-sama menurunkannya.</span>
+    <span data-phrase="step.readframe">Membaca bingkai {done} dari {total}</span>
+    <span data-phrase="step.writeframe">Menulis bingkai {done} dari {total}</span>
+    <span data-phrase="n.frame.one">{n} bingkai</span>
+    <span data-phrase="n.frame.many">{n} bingkai</span>
+    <span data-phrase="out.dropped">{frames} ({n} sama persis, dibuang)</span>
+    <span data-phrase="out.fps">{n} fps</span>
+    <span data-phrase="out.colours">{n} warna</span>
+    <span data-phrase="export.tooshort">Bagian itu terlalu pendek untuk diambil satu
+      bingkai pun.</span>
+    <span data-phrase="export.toobig">Itu perlu memori lebih banyak daripada yang akan
+      diminta alat ini kepada browser. Pendekkan bagiannya, atau turunkan lebar atau
+      laju bingkainya.</span>
+    <span data-phrase="export.failed">Ada yang salah saat membuat GIF-nya.</span>
+    <span data-phrase="read.noframes">Tidak ada bingkai yang bisa diawakode dari berkas
+      ini.</span>
+    <span data-phrase="play.stopped">Browser berhenti bisa memainkan berkas ini di
+      tengah jalan.</span>
+    <span data-phrase="join.sentences">{a} {b}</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
+    <span data-phrase="size.gb">{n} GB</span>
     <span data-phrase="read.midframe">File-nya berhenti di tengah sebuah bingkai.</span>
     <span data-phrase="read.avcshort">Rekaman konfigurasi H.264 terlalu pendek.</span>
     <span data-phrase="read.hevcshort">Rekaman konfigurasi HEVC terlalu pendek.</span>

--- a/locales/it/tools/video-to-gif.html
+++ b/locales/it/tools/video-to-gif.html
@@ -174,6 +174,51 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="step.reading">Lettura del file&hellip;</span>
+    <span data-phrase="open.notopened">Quel file non si è potuto aprire.</span>
+    <span data-phrase="preview.none">Questo browser non riproduce questo file, quindi
+      non c&rsquo;è anteprima. I fotogrammi vengono letti e convertiti lo stesso: segna
+      la sezione qui sotto con i suoi tempi.</span>
+    <span data-phrase="size.plain">{width} x {height}</span>
+    <span data-phrase="len.unknown">sconosciuta</span>
+    <span data-phrase="src.codec">{codec} ({entry})</span>
+    <span data-phrase="src.codec.turned">{codec} ({entry}), ruotato di {degrees} gradi</span>
+    <span data-phrase="src.byplayer">letto dal lettore del browser</span>
+    <span data-phrase="path.codecs">WebCodecs, fotogramma per fotogramma</span>
+    <span data-phrase="path.player">il lettore, un salto per fotogramma</span>
+    <span data-phrase="sum.section">da {from} a {to} ({span} s)</span>
+    <span data-phrase="size.from">{width} x {height} (da {fromWidth} x {fromHeight})</span>
+    <span data-phrase="sum.bytes">da {low} a {high}</span>
+    <span data-phrase="note.wider">È più largo del video stesso ({px} px), e questo non
+      può aggiungere dettaglio che non c&rsquo;è mai stato &mdash; solo byte.</span>
+    <span data-phrase="note.memory">Ogni fotogramma resta in memoria mentre si sceglie
+      la tavolozza, cioè circa {size} con queste impostazioni.</span>
+    <span data-phrase="note.memory.toobig">È più di quanto questo strumento tenterà: una
+      sezione più corta, una larghezza minore o una cadenza più bassa risolvono.</span>
+    <span data-phrase="note.memory.ok">Una sezione più corta, una larghezza minore o una
+      cadenza più bassa lo fanno scendere.</span>
+    <span data-phrase="step.readframe">Lettura del fotogramma {done} di {total}</span>
+    <span data-phrase="step.writeframe">Scrittura del fotogramma {done} di {total}</span>
+    <span data-phrase="n.frame.one">{n} fotogramma</span>
+    <span data-phrase="n.frame.many">{n} fotogrammi</span>
+    <span data-phrase="out.dropped">{frames} ({n} identici, scartati)</span>
+    <span data-phrase="out.fps">{n} fps</span>
+    <span data-phrase="out.colours">{n} colori</span>
+    <span data-phrase="export.tooshort">Quella sezione è troppo corta per ricavarne un
+      fotogramma.</span>
+    <span data-phrase="export.toobig">Servirebbe più memoria di quanta questo strumento
+      chiederà a un browser. Accorcia la sezione, oppure abbassa la larghezza o la
+      cadenza.</span>
+    <span data-phrase="export.failed">Qualcosa è andato storto mentre si creava il GIF.</span>
+    <span data-phrase="read.noframes">Da questo file non si è potuto decodificare alcun
+      fotogramma.</span>
+    <span data-phrase="play.stopped">Il browser non è più riuscito a riprodurre questo
+      file a metà strada.</span>
+    <span data-phrase="join.sentences">{a} {b}</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
+    <span data-phrase="size.gb">{n} GB</span>
     <span data-phrase="read.midframe">Il file finisce a metà di un fotogramma.</span>
     <span data-phrase="read.avcshort">Il record di configurazione H.264 è troppo corto.</span>
     <span data-phrase="read.hevcshort">Il record di configurazione HEVC è troppo corto.</span>

--- a/locales/ja/tools/video-to-gif.html
+++ b/locales/ja/tools/video-to-gif.html
@@ -168,6 +168,40 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="step.reading">ファイルを読み込んでいます&hellip;</span>
+    <span data-phrase="open.notopened">そのファイルは開けませんでした。</span>
+    <span data-phrase="preview.none">このブラウザーはこのファイルを再生しないので、プレビューはありません。フレームの読み取りと変換はできますので、下の時刻で範囲を指定してください。</span>
+    <span data-phrase="size.plain">{width} x {height}</span>
+    <span data-phrase="len.unknown">不明</span>
+    <span data-phrase="src.codec">{codec}（{entry}）</span>
+    <span data-phrase="src.codec.turned">{codec}（{entry}）、{degrees}度回転</span>
+    <span data-phrase="src.byplayer">ブラウザー自身のプレーヤーで読み取り</span>
+    <span data-phrase="path.codecs">WebCodecs、フレーム単位</span>
+    <span data-phrase="path.player">プレーヤー、1フレームにつき1回のシーク</span>
+    <span data-phrase="sum.section">{from}〜{to}（{span}秒）</span>
+    <span data-phrase="size.from">{width} x {height}（{fromWidth} x {fromHeight}から）</span>
+    <span data-phrase="sum.bytes">{low}〜{high}</span>
+    <span data-phrase="note.wider">これは動画そのもの（{px} px）より横に大きく、もともと無かった細部が増えるわけではありません。増えるのはバイト数だけです。</span>
+    <span data-phrase="note.memory">パレットを決めるあいだ全フレームをメモリーに置くため、この設定では約{size}になります。</span>
+    <span data-phrase="note.memory.toobig">これはこの道具が試す上限を超えています。範囲を短くするか、幅かフレームレートを下げてください。</span>
+    <span data-phrase="note.memory.ok">範囲を短くするか、幅を小さくするか、フレームレートを下げれば、いずれも下がります。</span>
+    <span data-phrase="step.readframe">{total}フレーム中{done}フレーム目を読み込んでいます</span>
+    <span data-phrase="step.writeframe">{total}フレーム中{done}フレーム目を書き出しています</span>
+    <span data-phrase="n.frame.one">{n}フレーム</span>
+    <span data-phrase="n.frame.many">{n}フレーム</span>
+    <span data-phrase="out.dropped">{frames}（うち{n}枚は同一のため除外）</span>
+    <span data-phrase="out.fps">{n} fps</span>
+    <span data-phrase="out.colours">{n}色</span>
+    <span data-phrase="export.tooshort">この範囲は短すぎて、フレームを1枚も取れません。</span>
+    <span data-phrase="export.toobig">それにはこの道具がブラウザーに求める以上のメモリーが要ります。範囲を短くするか、幅かフレームレートを下げてください。</span>
+    <span data-phrase="export.failed">GIFを作る途中で問題が起きました。</span>
+    <span data-phrase="read.noframes">このファイルからはフレームを1枚もデコードできませんでした。</span>
+    <span data-phrase="play.stopped">ブラウザーが途中でこのファイルを再生できなくなりました。</span>
+    <span data-phrase="join.sentences">{a}{b}</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
+    <span data-phrase="size.gb">{n} GB</span>
     <span data-phrase="read.midframe">ファイルが1コマの途中で終わっています。</span>
     <span data-phrase="read.avcshort">H.264の設定レコードが短すぎます。</span>
     <span data-phrase="read.hevcshort">HEVCの設定レコードが短すぎます。</span>

--- a/locales/ko/tools/video-to-gif.html
+++ b/locales/ko/tools/video-to-gif.html
@@ -174,6 +174,44 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="step.reading">파일을 읽는 중&hellip;</span>
+    <span data-phrase="open.notopened">그 파일은 열지 못했습니다.</span>
+    <span data-phrase="preview.none">이 브라우저는 이 파일을 재생하지 않아서 미리보기가 없습니다. 프레임은 그래도 읽어서
+      변환하니, 아래에서 시간으로 구간을 정하세요.</span>
+    <span data-phrase="size.plain">{width} x {height}</span>
+    <span data-phrase="len.unknown">알 수 없음</span>
+    <span data-phrase="src.codec">{codec} ({entry})</span>
+    <span data-phrase="src.codec.turned">{codec} ({entry}), {degrees}도 돌아감</span>
+    <span data-phrase="src.byplayer">브라우저 자체 재생기로 읽음</span>
+    <span data-phrase="path.codecs">WebCodecs, 프레임 단위</span>
+    <span data-phrase="path.player">재생기, 프레임마다 한 번씩 탐색</span>
+    <span data-phrase="sum.section">{from}부터 {to}까지 ({span}초)</span>
+    <span data-phrase="size.from">{width} x {height} ({fromWidth} x {fromHeight}에서)</span>
+    <span data-phrase="sum.bytes">{low}에서 {high}</span>
+    <span data-phrase="note.wider">이것은 영상 자체({px} px)보다 넓습니다. 없던 세부가 생기지는 않고 용량만 늘어납니다.</span>
+    <span data-phrase="note.memory">팔레트를 고르는 동안 모든 프레임이 메모리에 남아 있어서, 이 설정에서는 약
+      {size}입니다.</span>
+    <span data-phrase="note.memory.toobig">이것은 이 도구가 시도할 한계를 넘습니다. 구간을 줄이거나 너비나 프레임 속도를
+      낮추세요.</span>
+    <span data-phrase="note.memory.ok">구간을 줄이거나 너비를 작게 하거나 프레임 속도를 낮추면 모두 줄어듭니다.</span>
+    <span data-phrase="step.readframe">{total}프레임 중 {done}번째를 읽는 중</span>
+    <span data-phrase="step.writeframe">{total}프레임 중 {done}번째를 쓰는 중</span>
+    <span data-phrase="n.frame.one">{n}프레임</span>
+    <span data-phrase="n.frame.many">{n}프레임</span>
+    <span data-phrase="out.dropped">{frames} ({n}장은 같아서 버림)</span>
+    <span data-phrase="out.fps">{n} fps</span>
+    <span data-phrase="out.colours">{n}색</span>
+    <span data-phrase="export.tooshort">그 구간은 프레임을 한 장도 뽑기에 너무 짧습니다.</span>
+    <span data-phrase="export.toobig">그러려면 이 도구가 브라우저에 요구할 것보다 많은 메모리가 필요합니다. 구간을 줄이거나
+      너비나 프레임 속도를 낮추세요.</span>
+    <span data-phrase="export.failed">GIF를 만드는 중에 문제가 생겼습니다.</span>
+    <span data-phrase="read.noframes">이 파일에서는 프레임을 하나도 디코딩하지 못했습니다.</span>
+    <span data-phrase="play.stopped">브라우저가 도중에 이 파일을 재생하지 못하게 되었습니다.</span>
+    <span data-phrase="join.sentences">{a} {b}</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
+    <span data-phrase="size.gb">{n} GB</span>
     <span data-phrase="read.midframe">파일이 프레임 한가운데에서 끝났습니다.</span>
     <span data-phrase="read.avcshort">H.264 설정 레코드가 너무 짧습니다.</span>
     <span data-phrase="read.hevcshort">HEVC 설정 레코드가 너무 짧습니다.</span>

--- a/locales/nl/tools/video-to-gif.html
+++ b/locales/nl/tools/video-to-gif.html
@@ -174,6 +174,50 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="step.reading">Het bestand wordt gelezen&hellip;</span>
+    <span data-phrase="open.notopened">Dat bestand kon niet geopend worden.</span>
+    <span data-phrase="preview.none">Deze browser speelt dit bestand niet af, dus er is
+      geen voorbeeld. De beelden worden toch gelezen en omgezet &mdash; markeer het stuk
+      hieronder met zijn tijden.</span>
+    <span data-phrase="size.plain">{width} x {height}</span>
+    <span data-phrase="len.unknown">onbekend</span>
+    <span data-phrase="src.codec">{codec} ({entry})</span>
+    <span data-phrase="src.codec.turned">{codec} ({entry}), {degrees} graden gedraaid</span>
+    <span data-phrase="src.byplayer">gelezen door de eigen speler van de browser</span>
+    <span data-phrase="path.codecs">WebCodecs, beeld voor beeld</span>
+    <span data-phrase="path.player">de speler, één sprong per beeld</span>
+    <span data-phrase="sum.section">{from} tot {to} ({span} s)</span>
+    <span data-phrase="size.from">{width} x {height} (uit {fromWidth} x {fromHeight})</span>
+    <span data-phrase="sum.bytes">{low} tot {high}</span>
+    <span data-phrase="note.wider">Dat is breder dan de video zelf ({px} px), en dat kan
+      geen detail toevoegen dat er nooit was &mdash; alleen bytes.</span>
+    <span data-phrase="note.memory">Elk beeld blijft in het geheugen terwijl het palet
+      gekozen wordt, met deze instellingen ongeveer {size}.</span>
+    <span data-phrase="note.memory.toobig">Dat is meer dan dit gereedschap gaat proberen
+      &mdash; een korter stuk, een kleinere breedte of een lagere beeldsnelheid helpt.</span>
+    <span data-phrase="note.memory.ok">Een korter stuk, een kleinere breedte of een
+      lagere beeldsnelheid brengen het omlaag.</span>
+    <span data-phrase="step.readframe">Beeld {done} van {total} wordt gelezen</span>
+    <span data-phrase="step.writeframe">Beeld {done} van {total} wordt geschreven</span>
+    <span data-phrase="n.frame.one">{n} beeld</span>
+    <span data-phrase="n.frame.many">{n} beelden</span>
+    <span data-phrase="out.dropped">{frames} ({n} identiek, weggelaten)</span>
+    <span data-phrase="out.fps">{n} fps</span>
+    <span data-phrase="out.colours">{n} kleuren</span>
+    <span data-phrase="export.tooshort">Dat stuk is te kort om er een beeld uit te
+      halen.</span>
+    <span data-phrase="export.toobig">Daar zou meer geheugen voor nodig zijn dan dit
+      gereedschap een browser vraagt. Kort het stuk in, of verlaag de breedte of de
+      beeldsnelheid.</span>
+    <span data-phrase="export.failed">Er ging iets mis bij het maken van de GIF.</span>
+    <span data-phrase="read.noframes">Uit dit bestand vielen geen beelden te decoderen.</span>
+    <span data-phrase="play.stopped">De browser kon dit bestand halverwege niet meer
+      afspelen.</span>
+    <span data-phrase="join.sentences">{a} {b}</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
+    <span data-phrase="size.gb">{n} GB</span>
     <span data-phrase="read.midframe">Het bestand houdt midden in een frame op.</span>
     <span data-phrase="read.avcshort">Het H.264-configuratierecord is te kort.</span>
     <span data-phrase="read.hevcshort">Het HEVC-configuratierecord is te kort.</span>

--- a/locales/pt/tools/video-to-gif.html
+++ b/locales/pt/tools/video-to-gif.html
@@ -174,6 +174,53 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="step.reading">Lendo o arquivo&hellip;</span>
+    <span data-phrase="open.notopened">Esse arquivo não pôde ser aberto.</span>
+    <span data-phrase="preview.none">Este navegador não toca este arquivo, então não há
+      prévia. Os quadros são lidos e convertidos mesmo assim: marque a seção abaixo
+      pelos tempos dela.</span>
+    <span data-phrase="size.plain">{width} x {height}</span>
+    <span data-phrase="len.unknown">desconhecida</span>
+    <span data-phrase="src.codec">{codec} ({entry})</span>
+    <span data-phrase="src.codec.turned">{codec} ({entry}), girado {degrees} graus</span>
+    <span data-phrase="src.byplayer">lido pelo próprio player do navegador</span>
+    <span data-phrase="path.codecs">WebCodecs, quadro a quadro</span>
+    <span data-phrase="path.player">o player, um salto por quadro</span>
+    <span data-phrase="sum.section">de {from} a {to} ({span} s)</span>
+    <span data-phrase="size.from">{width} x {height} (a partir de {fromWidth} x
+      {fromHeight})</span>
+    <span data-phrase="sum.bytes">de {low} a {high}</span>
+    <span data-phrase="note.wider">Isso é mais largo que o próprio vídeo ({px} px), e
+      isso não acrescenta detalhe que nunca existiu &mdash; só bytes.</span>
+    <span data-phrase="note.memory">Cada quadro fica na memória enquanto a paleta é
+      escolhida, o que com estes ajustes dá uns {size}.</span>
+    <span data-phrase="note.memory.toobig">Isso é mais do que esta ferramenta vai
+      tentar: uma seção mais curta, uma largura menor ou uma taxa de quadros mais baixa
+      resolve.</span>
+    <span data-phrase="note.memory.ok">Uma seção mais curta, uma largura menor ou uma
+      taxa de quadros mais baixa baixam esse número.</span>
+    <span data-phrase="step.readframe">Lendo o quadro {done} de {total}</span>
+    <span data-phrase="step.writeframe">Escrevendo o quadro {done} de {total}</span>
+    <span data-phrase="n.frame.one">{n} quadro</span>
+    <span data-phrase="n.frame.many">{n} quadros</span>
+    <span data-phrase="out.dropped">{frames} ({n} idênticos, descartados)</span>
+    <span data-phrase="out.fps">{n} fps</span>
+    <span data-phrase="out.colours">{n} cores</span>
+    <span data-phrase="export.tooshort">Essa seção é curta demais para tirar um quadro
+      dela.</span>
+    <span data-phrase="export.toobig">Isso precisaria de mais memória do que esta
+      ferramenta vai pedir a um navegador. Encurte a seção, ou baixe a largura ou a taxa
+      de quadros.</span>
+    <span data-phrase="export.failed">Algo deu errado ao fazer o GIF.</span>
+    <span data-phrase="read.noframes">Não foi possível decodificar quadro algum deste
+      arquivo.</span>
+    <span data-phrase="play.stopped">O navegador deixou de conseguir tocar este arquivo
+      no meio do caminho.</span>
+    <span data-phrase="join.sentences">{a} {b}</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
+    <span data-phrase="size.gb">{n} GB</span>
     <span data-phrase="read.midframe">O arquivo termina no meio de um quadro.</span>
     <span data-phrase="read.avcshort">O registro de configuração H.264 é curto demais.</span>
     <span data-phrase="read.hevcshort">O registro de configuração HEVC é curto demais.</span>

--- a/locales/tr/tools/video-to-gif.html
+++ b/locales/tr/tools/video-to-gif.html
@@ -180,6 +180,50 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="step.reading">Dosya okunuyor&hellip;</span>
+    <span data-phrase="open.notopened">Bu dosya açılamadı.</span>
+    <span data-phrase="preview.none">Bu tarayıcı bu dosyayı oynatmıyor, dolayısıyla
+      önizleme yok. Kareler yine de okunup dönüştürülür &mdash; bölümü aşağıda
+      süreleriyle işaretleyin.</span>
+    <span data-phrase="size.plain">{width} x {height}</span>
+    <span data-phrase="len.unknown">bilinmiyor</span>
+    <span data-phrase="src.codec">{codec} ({entry})</span>
+    <span data-phrase="src.codec.turned">{codec} ({entry}), {degrees} derece döndürülmüş</span>
+    <span data-phrase="src.byplayer">tarayıcının kendi oynatıcısıyla okundu</span>
+    <span data-phrase="path.codecs">WebCodecs, kare kare</span>
+    <span data-phrase="path.player">oynatıcı, kare başına bir atlama</span>
+    <span data-phrase="sum.section">{from} &ndash; {to} ({span} sn)</span>
+    <span data-phrase="size.from">{width} x {height} ({fromWidth} x {fromHeight}
+      boyutundan)</span>
+    <span data-phrase="sum.bytes">{low} &ndash; {high}</span>
+    <span data-phrase="note.wider">Bu, videonun kendisinden ({px} px) daha geniş; hiç
+      var olmamış ayrıntıyı ekleyemez, yalnızca bayt ekler.</span>
+    <span data-phrase="note.memory">Palet seçilirken her kare bellekte tutulur; bu
+      ayarlarda yaklaşık {size} eder.</span>
+    <span data-phrase="note.memory.toobig">Bu, bu aracın deneyeceğinden fazla &mdash;
+      daha kısa bir bölüm, daha küçük bir genişlik ya da daha düşük bir kare hızı bunu
+      çözer.</span>
+    <span data-phrase="note.memory.ok">Daha kısa bir bölüm, daha küçük bir genişlik ya
+      da daha düşük bir kare hızı bunu aşağı çeker.</span>
+    <span data-phrase="step.readframe">{total} kareden {done}. okunuyor</span>
+    <span data-phrase="step.writeframe">{total} kareden {done}. yazılıyor</span>
+    <span data-phrase="n.frame.one">{n} kare</span>
+    <span data-phrase="n.frame.many">{n} kare</span>
+    <span data-phrase="out.dropped">{frames} ({n} tanesi aynı, atıldı)</span>
+    <span data-phrase="out.fps">{n} fps</span>
+    <span data-phrase="out.colours">{n} renk</span>
+    <span data-phrase="export.tooshort">O bölüm, içinden kare almak için fazla kısa.</span>
+    <span data-phrase="export.toobig">Bu, bu aracın bir tarayıcıdan isteyeceğinden fazla
+      bellek gerektirir. Bölümü kısaltın ya da genişliği veya kare hızını düşürün.</span>
+    <span data-phrase="export.failed">GIF yapılırken bir şeyler ters gitti.</span>
+    <span data-phrase="read.noframes">Bu dosyadan hiç kare çözülemedi.</span>
+    <span data-phrase="play.stopped">Tarayıcı yarı yolda bu dosyayı oynatamaz hâle
+      geldi.</span>
+    <span data-phrase="join.sentences">{a} {b}</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
+    <span data-phrase="size.gb">{n} GB</span>
     <span data-phrase="read.midframe">Dosya bir karenin ortasında bitiyor.</span>
     <span data-phrase="read.avcshort">H.264 yapılandırma kaydı fazla kısa.</span>
     <span data-phrase="read.hevcshort">HEVC yapılandırma kaydı fazla kısa.</span>

--- a/locales/zh-TW/tools/video-to-gif.html
+++ b/locales/zh-TW/tools/video-to-gif.html
@@ -175,6 +175,40 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="step.reading">正在讀取檔案&hellip;</span>
+    <span data-phrase="open.notopened">那個檔案打不開。</span>
+    <span data-phrase="preview.none">這個瀏覽器不播這個檔案，所以沒有預覽。幀照樣能讀出來並轉換&mdash;在下面按時間標出這一段就行。</span>
+    <span data-phrase="size.plain">{width} x {height}</span>
+    <span data-phrase="len.unknown">未知</span>
+    <span data-phrase="src.codec">{codec}（{entry}）</span>
+    <span data-phrase="src.codec.turned">{codec}（{entry}），旋轉了 {degrees} 度</span>
+    <span data-phrase="src.byplayer">由瀏覽器內建的播放器讀取</span>
+    <span data-phrase="path.codecs">WebCodecs，逐幀</span>
+    <span data-phrase="path.player">播放器，每幀跳轉一次</span>
+    <span data-phrase="sum.section">{from} 到 {to}（{span} 秒）</span>
+    <span data-phrase="size.from">{width} x {height}（由 {fromWidth} x {fromHeight} 而來）</span>
+    <span data-phrase="sum.bytes">{low} 到 {high}</span>
+    <span data-phrase="note.wider">這比影片本身（{px} px）還寬，而這並不能補出本來就沒有的細節&mdash;只會多出位元組。</span>
+    <span data-phrase="note.memory">挑調色盤的時候每一幀都留在記憶體裡，按現在的設定大約 {size}。</span>
+    <span data-phrase="note.memory.toobig">這超過了這個工具願意嘗試的量&mdash;把這一段截短，或者把寬度或幀率調低。</span>
+    <span data-phrase="note.memory.ok">把這一段截短、把寬度調小或者把幀率調低，都能降下來。</span>
+    <span data-phrase="step.readframe">正在讀第 {done} 幀，共 {total} 幀</span>
+    <span data-phrase="step.writeframe">正在寫第 {done} 幀，共 {total} 幀</span>
+    <span data-phrase="n.frame.one">{n} 幀</span>
+    <span data-phrase="n.frame.many">{n} 幀</span>
+    <span data-phrase="out.dropped">{frames}（其中 {n} 幀相同，已丟棄）</span>
+    <span data-phrase="out.fps">{n} fps</span>
+    <span data-phrase="out.colours">{n} 種顏色</span>
+    <span data-phrase="export.tooshort">這一段太短了，一幀也取不出來。</span>
+    <span data-phrase="export.toobig">那需要的記憶體比這個工具願意向瀏覽器要的還多。把這一段截短，或者把寬度或幀率調低。</span>
+    <span data-phrase="export.failed">做 GIF 的時候出了問題。</span>
+    <span data-phrase="read.noframes">這個檔案裡一幀也解不出來。</span>
+    <span data-phrase="play.stopped">瀏覽器中途就播不了這個檔案了。</span>
+    <span data-phrase="join.sentences">{a}{b}</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
+    <span data-phrase="size.gb">{n} GB</span>
     <span data-phrase="read.midframe">檔案斷在一幀的中間。</span>
     <span data-phrase="read.avcshort">H.264 的配置記錄太短。</span>
     <span data-phrase="read.hevcshort">HEVC 的配置記錄太短。</span>

--- a/locales/zh/tools/video-to-gif.html
+++ b/locales/zh/tools/video-to-gif.html
@@ -175,6 +175,40 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="step.reading">正在读取文件&hellip;</span>
+    <span data-phrase="open.notopened">那个文件打不开。</span>
+    <span data-phrase="preview.none">这个浏览器不播这个文件，所以没有预览。帧照样能读出来并转换&mdash;在下面按时间标出这一段就行。</span>
+    <span data-phrase="size.plain">{width} x {height}</span>
+    <span data-phrase="len.unknown">未知</span>
+    <span data-phrase="src.codec">{codec}（{entry}）</span>
+    <span data-phrase="src.codec.turned">{codec}（{entry}），旋转了 {degrees} 度</span>
+    <span data-phrase="src.byplayer">由浏览器自带的播放器读取</span>
+    <span data-phrase="path.codecs">WebCodecs，逐帧</span>
+    <span data-phrase="path.player">播放器，每帧跳转一次</span>
+    <span data-phrase="sum.section">{from} 到 {to}（{span} 秒）</span>
+    <span data-phrase="size.from">{width} x {height}（由 {fromWidth} x {fromHeight} 而来）</span>
+    <span data-phrase="sum.bytes">{low} 到 {high}</span>
+    <span data-phrase="note.wider">这比视频本身（{px} px）还宽，而这并不能补出本来就没有的细节&mdash;只会多出字节。</span>
+    <span data-phrase="note.memory">挑调色板的时候每一帧都留在内存里，按现在的设置大约 {size}。</span>
+    <span data-phrase="note.memory.toobig">这超过了这个工具愿意尝试的量&mdash;把这一段截短，或者把宽度或帧率调低。</span>
+    <span data-phrase="note.memory.ok">把这一段截短、把宽度调小或者把帧率调低，都能降下来。</span>
+    <span data-phrase="step.readframe">正在读第 {done} 帧，共 {total} 帧</span>
+    <span data-phrase="step.writeframe">正在写第 {done} 帧，共 {total} 帧</span>
+    <span data-phrase="n.frame.one">{n} 帧</span>
+    <span data-phrase="n.frame.many">{n} 帧</span>
+    <span data-phrase="out.dropped">{frames}（其中 {n} 帧相同，已丢弃）</span>
+    <span data-phrase="out.fps">{n} fps</span>
+    <span data-phrase="out.colours">{n} 种颜色</span>
+    <span data-phrase="export.tooshort">这一段太短了，一帧也取不出来。</span>
+    <span data-phrase="export.toobig">那需要的内存比这个工具愿意向浏览器要的还多。把这一段截短，或者把宽度或帧率调低。</span>
+    <span data-phrase="export.failed">做 GIF 的时候出了问题。</span>
+    <span data-phrase="read.noframes">这个文件里一帧也解不出来。</span>
+    <span data-phrase="play.stopped">浏览器中途就播不了这个文件了。</span>
+    <span data-phrase="join.sentences">{a}{b}</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
+    <span data-phrase="size.gb">{n} GB</span>
     <span data-phrase="read.midframe">文件断在一帧的中间。</span>
     <span data-phrase="read.avcshort">H.264 的配置记录太短。</span>
     <span data-phrase="read.hevcshort">HEVC 的配置记录太短。</span>

--- a/tests/python/test_english_in_js.py
+++ b/tests/python/test_english_in_js.py
@@ -102,7 +102,8 @@ BASELINE = {
     # names the timeline builds.
     'trim-audio': 7,
     'trim-video': 9,
-    'video-to-gif': 23,
+    # A CSS class name the range bar builds and two CSS percentages.
+    'video-to-gif': 3,
 }
 
 # Modules that hold somebody else's vocabulary rather than this site's prose.

--- a/tools/video-to-gif/body.html
+++ b/tools/video-to-gif/body.html
@@ -173,6 +173,48 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="step.reading">Reading the file&hellip;</span>
+    <span data-phrase="open.notopened">That file could not be opened.</span>
+    <span data-phrase="preview.none">This browser will not play this file, so there is
+      no preview. The frames are still read and converted &mdash; mark the section by
+      its times below.</span>
+    <span data-phrase="size.plain">{width} x {height}</span>
+    <span data-phrase="len.unknown">unknown</span>
+    <span data-phrase="src.codec">{codec} ({entry})</span>
+    <span data-phrase="src.codec.turned">{codec} ({entry}), turned {degrees} degrees</span>
+    <span data-phrase="src.byplayer">read by the browser&rsquo;s own player</span>
+    <span data-phrase="path.codecs">WebCodecs, frame by frame</span>
+    <span data-phrase="path.player">the player, one seek per frame</span>
+    <span data-phrase="sum.section">{from} to {to} ({span}s)</span>
+    <span data-phrase="size.from">{width} x {height} (from {fromWidth} x {fromHeight})</span>
+    <span data-phrase="sum.bytes">{low} to {high}</span>
+    <span data-phrase="note.wider">That is wider than the video itself ({px} px), which
+      cannot add detail that was never there &mdash; only bytes.</span>
+    <span data-phrase="note.memory">Every frame is held in memory while the palette is
+      chosen, which for these settings is about {size}.</span>
+    <span data-phrase="note.memory.toobig">That is more than this tool will attempt
+      &mdash; shorten the section, or drop the width or the frame rate.</span>
+    <span data-phrase="note.memory.ok">A shorter section, a smaller width or a lower
+      frame rate all bring it down.</span>
+    <span data-phrase="step.readframe">Reading frame {done} of {total}</span>
+    <span data-phrase="step.writeframe">Writing frame {done} of {total}</span>
+    <span data-phrase="n.frame.one">{n} frame</span>
+    <span data-phrase="n.frame.many">{n} frames</span>
+    <span data-phrase="out.dropped">{frames} ({n} identical, dropped)</span>
+    <span data-phrase="out.fps">{n} fps</span>
+    <span data-phrase="out.colours">{n} colours</span>
+    <span data-phrase="export.tooshort">That section is too short to take a frame from.</span>
+    <span data-phrase="export.toobig">That would need more memory than this tool will
+      ask a browser for. Shorten the section, or drop the width or the frame rate.</span>
+    <span data-phrase="export.failed">Something went wrong while making the GIF.</span>
+    <span data-phrase="read.noframes">No frames could be decoded from this file.</span>
+    <span data-phrase="play.stopped">The browser stopped being able to play this file
+      partway through.</span>
+    <span data-phrase="join.sentences">{a} {b}</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
+    <span data-phrase="size.gb">{n} GB</span>
     <span data-phrase="read.midframe">The file ends in the middle of a frame.</span>
     <span data-phrase="read.avcshort">The H.264 configuration record is too short.</span>
     <span data-phrase="read.hevcshort">The HEVC configuration record is too short.</span>

--- a/tools/video-to-gif/src/frames.js
+++ b/tools/video-to-gif/src/frames.js
@@ -207,7 +207,7 @@ export async function framesByDecoding({
     if (failure) throw failure;
 
     sampler.finish();
-    if (!sampler.frames.length) throw new Error('No frames could be decoded from this file.');
+    if (!sampler.frames.length) throw new Error('read.noframes');
     return sampler.frames;
   } finally {
     if (decoder.state !== 'closed') decoder.close();
@@ -305,7 +305,7 @@ function seek(video, seconds) {
       settled = true;
       clearTimeout(timer);
       video.removeEventListener('seeked', onSeeked);
-      reject(new Error('The browser stopped being able to play this file partway through.'));
+      reject(new Error('play.stopped'));
     };
 
     const timer = setTimeout(finish, SEEK_TIMEOUT);

--- a/tools/video-to-gif/src/main.js
+++ b/tools/video-to-gif/src/main.js
@@ -173,7 +173,7 @@ async function loadFile(picked) {
   releaseFile();
 
   file = picked;
-  picker.busy('Reading the file...');
+  picker.busy(phrase('step.reading'));
 
   try {
     objectUrl = URL.createObjectURL(picked);
@@ -235,7 +235,9 @@ async function loadFile(picked) {
     updateSummary();
   } catch (error) {
     console.error(error);
-    showError(error?.message || 'That file could not be opened.');
+    // The leaf modules throw keys; a browser that failed for its own reasons
+    // throws a sentence, and phrase() hands back what it does not recognise.
+    showError(error?.message ? phrase(error.message) : phrase('open.notopened'));
     resetView();
   } finally {
     picker.done();
@@ -257,8 +259,7 @@ function showPreview(playable) {
   el.preview.hidden = !playable;
   el.stageNote.hidden = playable;
   if (!playable) {
-    el.stageNote.textContent = 'This browser will not play this file, so there is no preview. '
-      + 'The frames are still read and converted - mark the section by its times below.';
+    el.stageNote.textContent = phrase('preview.none');
   }
 }
 
@@ -266,17 +267,23 @@ function describeSource() {
   el.source.hidden = false;
   el.srcName.textContent = file.name;
   el.srcSize.textContent = formatBytes(file.size);
-  el.srcFrame.textContent = `${source.width} x ${source.height}`;
-  el.srcLength.textContent = duration ? formatTime(duration) : 'unknown';
+  el.srcFrame.textContent = phrase('size.plain',
+    { width: source.width, height: source.height });
+  el.srcLength.textContent = duration ? formatTime(duration) : phrase('len.unknown');
 
   if (media) {
-    const turned = media.video.rotation ? `, turned ${media.video.rotation} degrees` : '';
-    el.srcCodec.textContent = `${media.video.codec} (${media.video.entryType})${turned}`;
+    el.srcCodec.textContent = media.video.rotation
+      ? phrase('src.codec.turned', {
+        codec: media.video.codec,
+        entry: media.video.entryType,
+        degrees: media.video.rotation,
+      })
+      : phrase('src.codec', { codec: media.video.codec, entry: media.video.entryType });
   } else {
-    el.srcCodec.textContent = "read by the browser's own player";
+    el.srcCodec.textContent = phrase('src.byplayer');
   }
 
-  el.srcPath.textContent = canRead ? 'WebCodecs, frame by frame' : 'the player, one seek per frame';
+  el.srcPath.textContent = phrase(canRead ? 'path.codecs' : 'path.player');
 
   el.pathNote.hidden = canRead;
   if (!canRead) {
@@ -437,26 +444,34 @@ function updateSummary() {
   const { size, times } = plan();
   const span = Math.max(0, section.end - section.start);
 
-  el.sumSection.textContent = `${formatTime(section.start)} to ${formatTime(section.end)}`
-    + ` (${span.toFixed(2)}s)`;
-  el.sumSize.textContent = `${size.width} x ${size.height}`
-    + ` (from ${source.width} x ${source.height})`;
+  el.sumSection.textContent = phrase('sum.section', {
+    from: formatTime(section.start),
+    to: formatTime(section.end),
+    span: span.toFixed(2),
+  });
+  el.sumSize.textContent = phrase('size.from', {
+    width: size.width,
+    height: size.height,
+    fromWidth: source.width,
+    fromHeight: source.height,
+  });
   el.sumFrames.textContent = `${times.length.toLocaleString()}`;
 
   const { low, high } = estimateBytes({ frames: times.length, ...size });
-  el.sumBytes.textContent = `${formatBytes(low)} to ${formatBytes(high)}`;
+  el.sumBytes.textContent = phrase('sum.bytes',
+    { low: formatBytes(low), high: formatBytes(high) });
 
   el.widthNote.hidden = size.width <= source.width;
-  el.widthNote.textContent = `That is wider than the video itself (${source.width} px), `
-    + 'which cannot add detail that was never there - only bytes.';
+  el.widthNote.textContent = phrase('note.wider', { px: source.width });
 
   const memory = workingBytes({ frames: times.length, ...size });
   el.memoryNote.hidden = memory < (300 << 20);
-  el.memoryNote.textContent = `Every frame is held in memory while the palette is chosen, `
-    + `which for these settings is about ${formatBytes(memory)}. `
-    + (memory > MEMORY_LIMIT
-      ? 'That is more than this tool will attempt - shorten the section, or drop the width or the frame rate.'
-      : 'A shorter section, a smaller width or a lower frame rate all bring it down.');
+  // Two sentences, and the space between them is a phrase as well: ja and
+  // zh do not put one after a full stop.
+  el.memoryNote.textContent = phrase('join.sentences', {
+    a: phrase('note.memory', { size: formatBytes(memory) }),
+    b: phrase(memory > MEMORY_LIMIT ? 'note.memory.toobig' : 'note.memory.ok'),
+  });
 
   el.exportBtn.disabled = exporting || memory > MEMORY_LIMIT || span <= 0;
 }
@@ -482,9 +497,10 @@ function setProgress({ phase, done, total }) {
   const fraction = total > 0 ? base + share * Math.min(1, done / total) : base;
   el.progressBar.style.width = `${(fraction * 100).toFixed(1)}%`;
 
-  el.progressLabel.textContent = phase === 'reading'
-    ? `Reading frame ${done.toLocaleString()} of ${total.toLocaleString()}`
-    : `Writing frame ${done.toLocaleString()} of ${total.toLocaleString()}`;
+  el.progressLabel.textContent = phrase(
+    phase === 'reading' ? 'step.readframe' : 'step.writeframe',
+    { done: done.toLocaleString(), total: total.toLocaleString() },
+  );
 }
 
 function outputFilename() {
@@ -493,9 +509,11 @@ function outputFilename() {
 }
 
 function formatBytes(bytes) {
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
-  if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
-  return `${(bytes / 1024 / 1024 / 1024).toFixed(2)} GB`;
+  if (bytes < 1024 * 1024) return phrase('size.kb', { n: (bytes / 1024).toFixed(0) });
+  if (bytes < 1024 * 1024 * 1024) {
+    return phrase('size.mb', { n: (bytes / 1024 / 1024).toFixed(1) });
+  }
+  return phrase('size.gb', { n: (bytes / 1024 / 1024 / 1024).toFixed(2) });
 }
 
 async function runExport() {
@@ -503,12 +521,11 @@ async function runExport() {
 
   const { size, fps, times } = plan();
   if (!times.length) {
-    showError('That section is too short to take a frame from.');
+    showError(phrase('export.tooshort'));
     return;
   }
   if (workingBytes({ frames: times.length, ...size }) > MEMORY_LIMIT) {
-    showError('That would need more memory than this tool will ask a browser for. '
-      + 'Shorten the section, or drop the width or the frame rate.');
+    showError(phrase('export.toobig'));
     return;
   }
 
@@ -561,21 +578,24 @@ async function runExport() {
     el.resultImage.src = lastResultUrl;
     el.download.href = lastResultUrl;
     el.download.download = outputFilename();
+    const written = phrase(result.written === 1 ? 'n.frame.one' : 'n.frame.many',
+      { n: result.written });
     el.resultInfo.textContent = [
-      `${size.width} x ${size.height}`,
-      `${result.written} frame${result.written === 1 ? '' : 's'}`
-        + (result.dropped ? ` (${result.dropped} identical, dropped)` : ''),
-      `${fps} fps`,
-      `${result.colors} colours`,
+      phrase('size.plain', { width: size.width, height: size.height }),
+      result.dropped
+        ? phrase('out.dropped', { frames: written, n: result.dropped })
+        : written,
+      phrase('out.fps', { n: fps }),
+      phrase('out.colours', { n: result.colors }),
       formatBytes(result.blob.size),
-    ].join(' · ');
+    ].reduce((a, b) => phrase('join.dot', { a, b }));
     el.result.hidden = false;
     el.progress.hidden = true;
     el.result.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
   } catch (error) {
     el.progress.hidden = true;
     if (error?.name !== 'AbortError') {
-      showError(error?.message || 'Something went wrong while making the GIF.');
+      showError(error?.message ? phrase(error.message) : phrase('export.failed'));
       console.error(error);
     }
   } finally {


### PR DESCRIPTION
video-to-gif showed twenty-three English sentences from `src/`, which is copied byte for byte into all fifteen languages: the source description, the whole summary, both memory warnings, the progress line and the line under the finished GIF. Thirty-four phrases move into the markup.

**Three shapes needed splitting rather than translating.**

The memory note was one sentence with a second glued onto it by `+`, chosen by a ternary. It is two phrases joined by `join.sentences`, because whether a space follows a full stop is the language's business — neither ja nor zh puts one there.

The result line appended `frame${n === 1 ? '' : 's'}` and then, if frames were dropped, a parenthesis onto the end of *that*. The count is two whole phrases now, and the parenthesis takes the count in a blank rather than being concatenated after it:

```
English  240 x 180 · 40 frames (8 identical, dropped) · 12 fps · 55 colours · 25 KB
German   240 x 180 · 40 Bilder (8 identisch, weggelassen) · 12 fps · 55 Farben · 25 KB
```

`sumSection` and `sumBytes` were ranges built with the English words "to" and "from" between two clock times. Both are phrases, which lets a language put the preposition where it belongs — French and Spanish need one at each end (`de 0:00 à 0:04`).

**Fifteen of the thirty-four keys** say word for word what reverse-video, timelapse-video or crop-video already say, and all three shipped translated; reusing their wording keeps the video tools reading like one voice.

## Verified in the browser

An MP4 built in the page with `VideoEncoder` and crop-video's writer, converted end to end in English and in German:

```
English  0:00.000 to 0:04.000 (4.00s) · Writing frame 48 of 48
         Every frame is held in memory while the palette is chosen, which for
         these settings is about 7.9 MB. A shorter section, a smaller width or
         a lower frame rate all bring it down.
German   0:00.000 bis 0:04.000 (4.00 s) · Bild 48 von 48 wird geschrieben
```

Every phrase in all fourteen locales was resolved and checked for the CJK wrap trap and for blank drift; the one difference is Arabic's `n.frame.one`, which says "إطار واحد" and has no number to put in.

## Tests

- `python -m unittest discover -t . -s tests/python` — 495 pass; the ratchet drops video-to-gif 23 → 3. What is left is a CSS class name the range bar builds and two CSS percentages.
- `node --test "tests/js/*.test.js"` — 1939 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)