### PR TITLE
Say it again when the card goes back to waiting

### DIFF
--- a/shared/js/file-picker.js
+++ b/shared/js/file-picker.js
@@ -154,6 +154,11 @@ export function wireFilePicker({ input, dropzone, onFiles, idleTitle }) {
       for (const card of document.querySelectorAll('main .card')) {
         if (card.dataset.waited === 'yes') card.setAttribute('inert', '');
       }
+      // And it says so again. These two arrived as separate changes - one
+      // puts the card back when a file is turned away, the other gives a
+      // waiting card its sentence - so a refused file dimmed the card and
+      // left it as bare as it was before either of them.
+      sayWaiting();
     },
   };
 }


### PR DESCRIPTION
Two changes arrived separately and didn't quite meet.

**#267** puts the last card back to `inert` when a file is turned away. **#269** gives a waiting card the sentence saying what would open it. Between them, a refused file dimmed the card and left it **as bare as it had been before either change** — the sentence was removed when the files were handed over, and nothing put it back.

`waiting()` now says it again. This is the one line I flagged when the two were opened as separate branches.

Verified on a local build: rubbish leaves split-gif's frames card inert **with its sentence back**, exactly as it looked before anything was chosen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)