### PR TITLE
Underline the links inside the licence sentence

### DIFF
--- a/shared/css/tool-frame.css
+++ b/shared/css/tool-frame.css
@@ -1165,6 +1165,15 @@ footer a:hover { text-decoration: underline; }
   text-align: center;
 }
 
+/* Underlined, unlike the rest of the footer's links, because these sit inside
+   a sentence rather than in a list of their own. A link in a block of text
+   that is marked by colour alone is invisible to a reader who cannot see that
+   colour - there is nothing else to tell them where the sentence stops and
+   the link starts. The links above are each on their own line, where their
+   position does that job. */
+.footer-licence a { text-decoration: underline; }
+
+
 /* The language switcher, across the foot of the page above the closing line.
 
    A row of plain links and nothing else: no JavaScript, no cookie, no

--- a/shared/site.css
+++ b/shared/site.css
@@ -777,6 +777,15 @@ footer a:hover { text-decoration: underline; }
   text-align: center;
 }
 
+/* Underlined, unlike the rest of the footer's links, because these sit inside
+   a sentence rather than in a list of their own. A link in a block of text
+   that is marked by colour alone is invisible to a reader who cannot see that
+   colour - there is nothing else to tell them where the sentence stops and
+   the link starts. The links above are each on their own line, where their
+   position does that job. */
+.footer-licence a { text-decoration: underline; }
+
+
 /* The language switcher, across the foot of the page above the closing line.
 
    A row of plain links and nothing else: no JavaScript, no cookie, no


### PR DESCRIPTION
The footer's links carry no underline, which is right for the ones above it: each sits on its own line, where its position says what it is.

The licence line is different — **its links are inside a sentence**. A link in a block of text marked by colour alone is invisible to a reader who cannot see that colour; there's nothing else to tell them where the sentence stops and the link starts.

axe rates it **serious**, and the footer is on every page — so **51 of the QA suite's 52 failures** turned out to be this one line. (The 52nd was a local filesystem error in my own run, not a site problem.)

Both stylesheets, and only the licence paragraph: the link lists above it keep the treatment they have.

Verified: all 84 accessibility tests pass against a local build, up from 75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)