### PR TITLE
Say the data URI in the reader's language, not only in English

### DIFF
--- a/locales/ar/tools/image-to-data-uri.html
+++ b/locales/ar/tools/image-to-data-uri.html
@@ -142,6 +142,52 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.notimage">{name}: هذه ليست صيغة صور تعرفها هذه الأداة. ولا
+      بد أن يكون النوع في معرّف URI للبيانات صحيحاً، فهي لا تخمّنه.</span>
+    <span data-phrase="read.mismatch">الاسم يقول {extension}، لكن البايتات {label}.
+      ويقول المعرّف {mime}، وهو الذي سينجح.</span>
+    <span data-phrase="row.remove">أخرج {name} من القائمة</span>
+    <span data-phrase="n.image.one">صورة واحدة</span>
+    <span data-phrase="n.image.many">{n} صورة</span>
+    <span data-phrase="results.one">صورة واحدة، {size} من النص في المجمل. ولم يذهب شيء
+      منها إلى أي مكان.</span>
+    <span data-phrase="results.many">{n} صور، {size} من النص في المجمل. ولم يذهب شيء
+      منها إلى أي مكان.</span>
+    <span data-phrase="facts.in">{size} داخلاً</span>
+    <span data-phrase="facts.out">{n} محرفاً خارجاً</span>
+    <span data-phrase="overhead.same">بحجم الملف نفسه</span>
+    <span data-phrase="overhead.larger">أكبر من الملف بنسبة {percent}%</span>
+    <span data-phrase="overhead.smaller">أصغر من الملف بنسبة {percent}%</span>
+    <span data-phrase="verdict.tiny">صغير بما يكفي ليكون مكسباً واضحاً: طلب واحد أقل،
+      ولا يضاف شيء يُذكر إلى الملف الذي يحل فيه.</span>
+    <span data-phrase="verdict.icon">حجم عادي لأيقونة مضمّنة. ويستحق العناء لشيء يظهر في
+      كل صفحة.</span>
+    <span data-phrase="verdict.large">كبير على صورة مضمّنة. فكل ما يضم صفحة الأنماط هذه
+      صار يحمله، ولم يعد ممكناً تخزينه مؤقتاً وحده.</span>
+    <span data-phrase="verdict.toobig">أكبر من أن يُضمَّن. فلو قُدّم ملفاً عادياً لخُزّن
+      مؤقتاً مرة واحدة ولجُلب على التوازي؛ أما مضمّناً فهو على المسار الحرج لكل صفحة
+      ويُعاد تنزيله كلما تغيّر أي شيء حوله.</span>
+    <span data-phrase="kind.exif">EXIF</span>
+    <span data-phrase="kind.xmp">XMP</span>
+    <span data-phrase="kind.iptc">IPTC</span>
+    <span data-phrase="kind.icc">ملف تعريف ألوان</span>
+    <span data-phrase="kind.time">ختم زمني</span>
+    <span data-phrase="kind.comment">تعليق</span>
+    <span data-phrase="kind.text">نص</span>
+    <span data-phrase="meta.plain">يحمل {size} من {kinds}. ويُنسخ ذلك إلى المعرّف مع
+      الصورة.</span>
+    <span data-phrase="meta.share">يحمل {size} من {kinds}، أي {percent}% من الملف.
+      ويُنسخ ذلك إلى المعرّف مع الصورة.</span>
+    <span data-phrase="render.failed">رفض هذا المتصفح رسم النتيجة. المعرّف سليم البنية؛
+      لكن الصيغة مما لا يستطيع فكّ ترميزه.</span>
+    <span data-phrase="sniff.unrenderable">لا يرسم هذه الصيغة متصفح غير سفاري، فسيكون
+      المعرّف صحيحاً ولن تظهر الصورة. حوّلها أولاً.</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="join.comma">{a}، {b}</span>
+    <span data-phrase="join.and">{a} و{b}</span>
+    <span data-phrase="size.b">{n} بايت</span>
+    <span data-phrase="size.kb">{n} كيلوبايت</span>
+    <span data-phrase="size.mb">{n} ميغابايت</span>
     <span data-phrase="net.clean">صورك لم تذهب إلى أي مكان. {total} ملفاً
       حُمِّلت، كلها ملفات هذه الصفحة نفسها. {platform}</span>
     <span data-phrase="net.dirty">اتصل شيءٌ بـ {hosts}، وهو ما لا تفعله هذه

--- a/locales/de/tools/image-to-data-uri.html
+++ b/locales/de/tools/image-to-data-uri.html
@@ -148,6 +148,56 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.notimage">{name}: das ist kein Bildformat, das dieses
+      Werkzeug kennt. Der Typ in einer Daten-URI muss stimmen, deshalb wird hier nicht
+      geraten.</span>
+    <span data-phrase="read.mismatch">Der Name sagt {extension}, die Bytes sind aber
+      {label}. Die URI sagt {mime}, und das ist das, was funktioniert.</span>
+    <span data-phrase="row.remove">{name} von der Liste nehmen</span>
+    <span data-phrase="n.image.one">{n} Bild</span>
+    <span data-phrase="n.image.many">{n} Bilder</span>
+    <span data-phrase="results.one">{n} Bild, insgesamt {size} Text. Nichts davon war
+      irgendwo.</span>
+    <span data-phrase="results.many">{n} Bilder, insgesamt {size} Text. Nichts davon war
+      irgendwo.</span>
+    <span data-phrase="facts.in">{size} hinein</span>
+    <span data-phrase="facts.out">{n} Zeichen heraus</span>
+    <span data-phrase="overhead.same">so groß wie die Datei</span>
+    <span data-phrase="overhead.larger">{percent}% größer als die Datei</span>
+    <span data-phrase="overhead.smaller">{percent}% kleiner als die Datei</span>
+    <span data-phrase="verdict.tiny">Klein genug, dass sich das klar lohnt: eine Anfrage
+      weniger, und der Datei, in der es landet, wird kaum etwas hinzugefügt.</span>
+    <span data-phrase="verdict.icon">Eine normale Größe für ein eingebettetes Icon.
+      Lohnt sich für etwas, das auf jeder Seite auftaucht.</span>
+    <span data-phrase="verdict.large">Groß für ein eingebettetes Bild. Alles, was dieses
+      Stylesheet einbindet, trägt es jetzt mit, und es lässt sich nicht mehr für sich
+      zwischenspeichern.</span>
+    <span data-phrase="verdict.toobig">Zu groß zum Einbetten. Als gewöhnliche Datei
+      ausgeliefert würde das einmal zwischengespeichert und parallel geladen;
+      eingebettet liegt es auf dem kritischen Pfad jeder Seite und wird jedes Mal neu
+      geladen, wenn sich irgendetwas darum herum ändert.</span>
+    <span data-phrase="kind.exif">EXIF</span>
+    <span data-phrase="kind.xmp">XMP</span>
+    <span data-phrase="kind.iptc">IPTC</span>
+    <span data-phrase="kind.icc">einem Farbprofil</span>
+    <span data-phrase="kind.time">einem Zeitstempel</span>
+    <span data-phrase="kind.comment">einem Kommentar</span>
+    <span data-phrase="kind.text">Text</span>
+    <span data-phrase="meta.plain">Enthält {size} an {kinds}. Das wird zusammen mit dem
+      Bild in die URI kopiert.</span>
+    <span data-phrase="meta.share">Enthält {size} an {kinds}, also {percent}% der Datei.
+      Das wird zusammen mit dem Bild in die URI kopiert.</span>
+    <span data-phrase="render.failed">Dieser Browser wollte das Ergebnis nicht zeichnen.
+      Die URI ist wohlgeformt; das Format ist eines, das er nicht dekodieren kann.</span>
+    <span data-phrase="sniff.unrenderable">Außer Safari zeichnet kein Browser dieses
+      Format, die URI wird also gültig sein und das Bild trotzdem nicht erscheinen.
+      Wandeln Sie es vorher um.</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="join.comma">{a}, {b}</span>
+    <span data-phrase="join.and">{a} und {b}</span>
+    <span data-phrase="size.b">{n} Bytes</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="net.clean">Ihre Bilder sind nirgendwohin gegangen.
       {total} Dateien geladen, allesamt eigene dieser Seite. {platform}</span>
     <span data-phrase="net.dirty">Etwas hat {hosts} kontaktiert, und das tut

--- a/locales/es/tools/image-to-data-uri.html
+++ b/locales/es/tools/image-to-data-uri.html
@@ -146,6 +146,55 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.notimage">{name}: este no es un formato de imagen que esta
+      herramienta reconozca. El tipo de una URI de datos tiene que ser el correcto, así
+      que no va a adivinar ninguno.</span>
+    <span data-phrase="read.mismatch">El nombre dice {extension}, pero los bytes son
+      {label}. La URI dice {mime}, que es el que va a funcionar.</span>
+    <span data-phrase="row.remove">Quitar {name} de la lista</span>
+    <span data-phrase="n.image.one">{n} imagen</span>
+    <span data-phrase="n.image.many">{n} imágenes</span>
+    <span data-phrase="results.one">{n} imagen, {size} de texto en total. Nada de eso ha
+      ido a ningún sitio.</span>
+    <span data-phrase="results.many">{n} imágenes, {size} de texto en total. Nada de eso
+      ha ido a ningún sitio.</span>
+    <span data-phrase="facts.in">{size} de entrada</span>
+    <span data-phrase="facts.out">{n} caracteres de salida</span>
+    <span data-phrase="overhead.same">del mismo tamaño que el archivo</span>
+    <span data-phrase="overhead.larger">un {percent}% mayor que el archivo</span>
+    <span data-phrase="overhead.smaller">un {percent}% menor que el archivo</span>
+    <span data-phrase="verdict.tiny">Lo bastante pequeño como para que salga claramente
+      a cuenta: una petición menos, y casi nada añadido al archivo donde acaba.</span>
+    <span data-phrase="verdict.icon">Un tamaño normal para un icono incrustado. Merece
+      la pena para algo que aparece en todas las páginas.</span>
+    <span data-phrase="verdict.large">Grande para una imagen incrustada. Todo lo que
+      incluya esta hoja de estilos la lleva ahora consigo, y ya no se puede cachear por
+      su cuenta.</span>
+    <span data-phrase="verdict.toobig">Demasiado grande para incrustarlo. Servido como
+      archivo normal se cachearía una vez y se descargaría en paralelo; incrustado, está
+      en el camino crítico de cada página y se vuelve a descargar cada vez que cambia
+      cualquier cosa a su alrededor.</span>
+    <span data-phrase="kind.exif">EXIF</span>
+    <span data-phrase="kind.xmp">XMP</span>
+    <span data-phrase="kind.iptc">IPTC</span>
+    <span data-phrase="kind.icc">un perfil de color</span>
+    <span data-phrase="kind.time">una marca de tiempo</span>
+    <span data-phrase="kind.comment">un comentario</span>
+    <span data-phrase="kind.text">texto</span>
+    <span data-phrase="meta.plain">Lleva {size} de {kinds}. Se copia dentro de la URI
+      junto con la imagen.</span>
+    <span data-phrase="meta.share">Lleva {size} de {kinds}, que es el {percent}% del
+      archivo. Se copia dentro de la URI junto con la imagen.</span>
+    <span data-phrase="render.failed">Este navegador no ha querido dibujar el resultado.
+      La URI está bien formada; el formato es uno que no sabe descodificar.</span>
+    <span data-phrase="sniff.unrenderable">Ningún navegador salvo Safari dibuja este
+      formato, así que la URI será válida y la imagen no aparecerá. Conviértela primero.</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="join.comma">{a}, {b}</span>
+    <span data-phrase="join.and">{a} y {b}</span>
+    <span data-phrase="size.b">{n} bytes</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="net.clean">tus imágenes no han ido a ninguna parte.
       {total} archivos cargados, todos ellos de esta misma página. {platform}</span>
     <span data-phrase="net.dirty">algo ha contactado con {hosts}, cosa que esta

--- a/locales/fr/tools/image-to-data-uri.html
+++ b/locales/fr/tools/image-to-data-uri.html
@@ -147,6 +147,58 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.notimage">{name}&nbsp;: ce n&rsquo;est pas un format
+      d&rsquo;image que cet outil reconnaît. Le type dans une URI de données doit être
+      juste, il n&rsquo;en devinera donc pas un.</span>
+    <span data-phrase="read.mismatch">Le nom dit {extension}, mais les octets sont du
+      {label}. L&rsquo;URI dit {mime}, et c&rsquo;est celui qui marchera.</span>
+    <span data-phrase="row.remove">Retirer {name} de la liste</span>
+    <span data-phrase="n.image.one">{n} image</span>
+    <span data-phrase="n.image.many">{n} images</span>
+    <span data-phrase="results.one">{n} image, {size} de texte en tout. Rien de tout
+      cela n&rsquo;est allé où que ce soit.</span>
+    <span data-phrase="results.many">{n} images, {size} de texte en tout. Rien de tout
+      cela n&rsquo;est allé où que ce soit.</span>
+    <span data-phrase="facts.in">{size} en entrée</span>
+    <span data-phrase="facts.out">{n} caractères en sortie</span>
+    <span data-phrase="overhead.same">la même taille que le fichier</span>
+    <span data-phrase="overhead.larger">{percent}% de plus que le fichier</span>
+    <span data-phrase="overhead.smaller">{percent}% de moins que le fichier</span>
+    <span data-phrase="verdict.tiny">Assez petit pour que ce soit un gain net&nbsp;: une
+      requête de moins, et presque rien d&rsquo;ajouté au fichier où cela atterrit.</span>
+    <span data-phrase="verdict.icon">Une taille normale pour une icône intégrée. Cela
+      vaut le coup pour quelque chose qui apparaît sur toutes les pages.</span>
+    <span data-phrase="verdict.large">Gros pour une image intégrée. Tout ce qui inclut
+      cette feuille de style la transporte désormais, et elle ne peut plus être mise en
+      cache toute seule.</span>
+    <span data-phrase="verdict.toobig">Trop gros pour être intégré. Servi comme fichier
+      ordinaire, cela serait mis en cache une fois et récupéré en parallèle&nbsp;;
+      intégré, cela se trouve sur le chemin critique de chaque page et est retéléchargé
+      dès que quoi que ce soit autour change.</span>
+    <span data-phrase="kind.exif">EXIF</span>
+    <span data-phrase="kind.xmp">XMP</span>
+    <span data-phrase="kind.iptc">IPTC</span>
+    <span data-phrase="kind.icc">un profil colorimétrique</span>
+    <span data-phrase="kind.time">un horodatage</span>
+    <span data-phrase="kind.comment">un commentaire</span>
+    <span data-phrase="kind.text">du texte</span>
+    <span data-phrase="meta.plain">Contient {size} de métadonnées&nbsp;: {kinds}. Tout
+      cela est copié dans l&rsquo;URI en même temps que l&rsquo;image.</span>
+    <span data-phrase="meta.share">Contient {size} de métadonnées, soit {percent}% du
+      fichier&nbsp;: {kinds}. Tout cela est copié dans l&rsquo;URI en même temps que
+      l&rsquo;image.</span>
+    <span data-phrase="render.failed">Ce navigateur a refusé de dessiner le résultat.
+      L&rsquo;URI est bien formée&nbsp;; le format en est un qu&rsquo;il ne sait pas
+      décoder.</span>
+    <span data-phrase="sniff.unrenderable">Aucun navigateur à part Safari ne dessine ce
+      format&nbsp;: l&rsquo;URI sera valide et l&rsquo;image n&rsquo;apparaîtra pas.
+      Convertissez-la d&rsquo;abord.</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="join.comma">{a}, {b}</span>
+    <span data-phrase="join.and">{a} et {b}</span>
+    <span data-phrase="size.b">{n} octets</span>
+    <span data-phrase="size.kb">{n} Ko</span>
+    <span data-phrase="size.mb">{n} Mo</span>
     <span data-phrase="net.clean">vos images ne sont allées nulle part. {total}
       fichiers chargés, tous appartenant à cette page. {platform}</span>
     <span data-phrase="net.dirty">quelque chose a contacté {hosts}, ce que cet

--- a/locales/hi/tools/image-to-data-uri.html
+++ b/locales/hi/tools/image-to-data-uri.html
@@ -147,6 +147,52 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.notimage">{name}: यह ऐसा इमेज फ़ॉर्मैट नहीं जिसे यह औज़ार
+      पहचानता हो। डेटा URI में टाइप सही होना ही चाहिए, इसलिए यह अंदाज़ा नहीं लगाएगा।</span>
+    <span data-phrase="read.mismatch">नाम {extension} कहता है, पर बाइट {label} हैं। URI
+      {mime} कहता है, और वही चलेगा।</span>
+    <span data-phrase="row.remove">{name} को सूची से हटाइए</span>
+    <span data-phrase="n.image.one">{n} तस्वीर</span>
+    <span data-phrase="n.image.many">{n} तस्वीरें</span>
+    <span data-phrase="results.one">{n} तस्वीर, कुल {size} टेक्स्ट। इसमें से कुछ भी कहीं
+      नहीं गया।</span>
+    <span data-phrase="results.many">{n} तस्वीरें, कुल {size} टेक्स्ट। इसमें से कुछ भी
+      कहीं नहीं गया।</span>
+    <span data-phrase="facts.in">{size} अंदर</span>
+    <span data-phrase="facts.out">{n} अक्षर बाहर</span>
+    <span data-phrase="overhead.same">फ़ाइल जितना ही बड़ा</span>
+    <span data-phrase="overhead.larger">फ़ाइल से {percent}% बड़ा</span>
+    <span data-phrase="overhead.smaller">फ़ाइल से {percent}% छोटा</span>
+    <span data-phrase="verdict.tiny">इतना छोटा कि यह साफ़ फ़ायदे का सौदा है: एक अनुरोध
+      कम, और जिस फ़ाइल में यह बैठेगा उसमें कुछ ख़ास जुड़ता भी नहीं।</span>
+    <span data-phrase="verdict.icon">अंदर रखे आइकन के लिए सामान्य आकार। हर पन्ने पर
+      दिखने वाली चीज़ के लिए सार्थक है।</span>
+    <span data-phrase="verdict.large">अंदर रखी तस्वीर के लिए बड़ा। जो कुछ भी यह
+      स्टाइलशीट शामिल करता है वह अब इसे भी ढोता है, और यह अलग से कैश नहीं हो सकती।</span>
+    <span data-phrase="verdict.toobig">अंदर रखने के लिए बहुत बड़ा। सामान्य फ़ाइल की तरह
+      परोसा जाता तो एक बार कैश होकर समांतर आता; अंदर रखे जाने पर यह हर पन्ने के नाज़ुक
+      रास्ते पर है और आसपास कुछ भी बदलते ही दोबारा डाउनलोड होता है।</span>
+    <span data-phrase="kind.exif">EXIF</span>
+    <span data-phrase="kind.xmp">XMP</span>
+    <span data-phrase="kind.iptc">IPTC</span>
+    <span data-phrase="kind.icc">एक रंग प्रोफ़ाइल</span>
+    <span data-phrase="kind.time">एक टाइमस्टैंप</span>
+    <span data-phrase="kind.comment">एक टिप्पणी</span>
+    <span data-phrase="kind.text">टेक्स्ट</span>
+    <span data-phrase="meta.plain">इसमें {size} का {kinds} है। वह तस्वीर के साथ ही URI
+      में उतर जाता है।</span>
+    <span data-phrase="meta.share">इसमें {size} का {kinds} है, जो फ़ाइल का {percent}%
+      है। वह तस्वीर के साथ ही URI में उतर जाता है।</span>
+    <span data-phrase="render.failed">इस ब्राउज़र ने नतीजा बनाने से मना कर दिया। URI ठीक
+      बना है; फ़ॉर्मैट ही ऐसा है जिसे वह डीकोड नहीं कर सकता।</span>
+    <span data-phrase="sniff.unrenderable">Safari के सिवा कोई ब्राउज़र इस फ़ॉर्मैट को
+      नहीं बनाता, इसलिए URI वैध तो होगा पर तस्वीर दिखेगी नहीं। पहले इसे बदल लीजिए।</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="join.comma">{a}, {b}</span>
+    <span data-phrase="join.and">{a} और {b}</span>
+    <span data-phrase="size.b">{n} बाइट</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="net.clean">आपकी तस्वीरें कहीं नहीं गईं। {total} फ़ाइलें
       लोड हुईं, और वे सब इसी साइट की अपनी हैं। {platform}</span>
     <span data-phrase="net.dirty">किसी चीज़ ने {hosts} से संपर्क किया, और यह टूल

--- a/locales/id/tools/image-to-data-uri.html
+++ b/locales/id/tools/image-to-data-uri.html
@@ -153,6 +153,55 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.notimage">{name}: ini bukan format gambar yang dikenali alat
+      ini. Jenis di dalam URI data harus tepat, jadi ia tidak akan menebak-nebak.</span>
+    <span data-phrase="read.mismatch">Namanya menyebut {extension}, tetapi bitanya
+      {label}. URI-nya menyebut {mime}, dan itulah yang akan jalan.</span>
+    <span data-phrase="row.remove">Keluarkan {name} dari daftar</span>
+    <span data-phrase="n.image.one">{n} gambar</span>
+    <span data-phrase="n.image.many">{n} gambar</span>
+    <span data-phrase="results.one">{n} gambar, seluruhnya {size} teks. Tidak ada satu
+      pun yang pergi ke mana pun.</span>
+    <span data-phrase="results.many">{n} gambar, seluruhnya {size} teks. Tidak ada satu
+      pun yang pergi ke mana pun.</span>
+    <span data-phrase="facts.in">{size} masuk</span>
+    <span data-phrase="facts.out">{n} karakter keluar</span>
+    <span data-phrase="overhead.same">seukuran berkasnya</span>
+    <span data-phrase="overhead.larger">{percent}% lebih besar daripada berkasnya</span>
+    <span data-phrase="overhead.smaller">{percent}% lebih kecil daripada berkasnya</span>
+    <span data-phrase="verdict.tiny">Cukup kecil sehingga ini jelas menguntungkan: satu
+      permintaan lebih sedikit, dan hampir tidak ada tambahan bagi berkas yang
+      menampungnya.</span>
+    <span data-phrase="verdict.icon">Ukuran yang wajar untuk ikon yang disisipkan.
+      Setimpal untuk sesuatu yang muncul di tiap halaman.</span>
+    <span data-phrase="verdict.large">Besar untuk gambar sisipan. Semua yang menyertakan
+      lembar gaya ini kini ikut membawanya, dan ia tidak bisa lagi disinggahkan sendiri.</span>
+    <span data-phrase="verdict.toobig">Terlalu besar untuk disisipkan. Kalau disajikan
+      sebagai berkas biasa, ini akan disinggahkan sekali dan diambil paralel; kalau
+      disisipkan, ia ada di jalur kritis tiap halaman dan diunduh ulang tiap kali ada
+      yang berubah di sekitarnya.</span>
+    <span data-phrase="kind.exif">EXIF</span>
+    <span data-phrase="kind.xmp">XMP</span>
+    <span data-phrase="kind.iptc">IPTC</span>
+    <span data-phrase="kind.icc">profil warna</span>
+    <span data-phrase="kind.time">stempel waktu</span>
+    <span data-phrase="kind.comment">komentar</span>
+    <span data-phrase="kind.text">teks</span>
+    <span data-phrase="meta.plain">Membawa {size} berupa {kinds}. Itu ikut disalin ke
+      dalam URI bersama gambarnya.</span>
+    <span data-phrase="meta.share">Membawa {size} berupa {kinds}, yaitu {percent}% dari
+      berkasnya. Itu ikut disalin ke dalam URI bersama gambarnya.</span>
+    <span data-phrase="render.failed">Browser ini tidak mau menggambar hasilnya. URI-nya
+      benar bentuknya; formatnya saja yang tidak bisa ia awakode.</span>
+    <span data-phrase="sniff.unrenderable">Tidak ada browser selain Safari yang
+      menggambar format ini, jadi URI-nya akan sah dan gambarnya tidak akan muncul. Ubah
+      dulu formatnya.</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="join.comma">{a}, {b}</span>
+    <span data-phrase="join.and">{a} dan {b}</span>
+    <span data-phrase="size.b">{n} bita</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="net.clean">gambar Anda tidak pergi ke mana pun. {total}
       file dimuat, semuanya milik halaman ini sendiri. {platform}</span>
     <span data-phrase="net.dirty">sesuatu menghubungi {hosts}, dan itu tidak

--- a/locales/it/tools/image-to-data-uri.html
+++ b/locales/it/tools/image-to-data-uri.html
@@ -147,6 +147,57 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.notimage">{name}: questo non è un formato immagine che
+      questo strumento conosca. Il tipo in una URI di dati deve essere quello giusto,
+      quindi non ne indovinerà uno.</span>
+    <span data-phrase="read.mismatch">Il nome dice {extension}, ma i byte sono {label}.
+      La URI dice {mime}, che è quello che funzionerà.</span>
+    <span data-phrase="row.remove">Togli {name} dalla lista</span>
+    <span data-phrase="n.image.one">{n} immagine</span>
+    <span data-phrase="n.image.many">{n} immagini</span>
+    <span data-phrase="results.one">{n} immagine, {size} di testo in tutto. Niente di
+      tutto ciò è andato da nessuna parte.</span>
+    <span data-phrase="results.many">{n} immagini, {size} di testo in tutto. Niente di
+      tutto ciò è andato da nessuna parte.</span>
+    <span data-phrase="facts.in">{size} in ingresso</span>
+    <span data-phrase="facts.out">{n} caratteri in uscita</span>
+    <span data-phrase="overhead.same">della stessa dimensione del file</span>
+    <span data-phrase="overhead.larger">più grande del file del {percent}%</span>
+    <span data-phrase="overhead.smaller">più piccolo del file del {percent}%</span>
+    <span data-phrase="verdict.tiny">Abbastanza piccolo perché convenga
+      senz&rsquo;altro: una richiesta in meno, e quasi niente aggiunto al file in cui
+      finisce.</span>
+    <span data-phrase="verdict.icon">Una dimensione normale per un&rsquo;icona
+      incorporata. Ne vale la pena per qualcosa che compare su ogni pagina.</span>
+    <span data-phrase="verdict.large">Grande per un&rsquo;immagine incorporata. Tutto
+      ciò che include questo foglio di stile ora se la porta dietro, e non può più
+      essere messa in cache per conto suo.</span>
+    <span data-phrase="verdict.toobig">Troppo grande da incorporare. Servito come file
+      normale verrebbe messo in cache una volta e scaricato in parallelo; incorporato,
+      sta sul percorso critico di ogni pagina e viene riscaricato ogni volta che cambia
+      qualunque cosa attorno.</span>
+    <span data-phrase="kind.exif">EXIF</span>
+    <span data-phrase="kind.xmp">XMP</span>
+    <span data-phrase="kind.iptc">IPTC</span>
+    <span data-phrase="kind.icc">un profilo colore</span>
+    <span data-phrase="kind.time">una marca temporale</span>
+    <span data-phrase="kind.comment">un commento</span>
+    <span data-phrase="kind.text">testo</span>
+    <span data-phrase="meta.plain">Porta {size} di {kinds}. Viene copiato nella URI
+      insieme all&rsquo;immagine.</span>
+    <span data-phrase="meta.share">Porta {size} di {kinds}, cioè il {percent}% del file.
+      Viene copiato nella URI insieme all&rsquo;immagine.</span>
+    <span data-phrase="render.failed">Questo browser non ha voluto disegnare il
+      risultato. La URI è ben formata; il formato è uno che non sa decodificare.</span>
+    <span data-phrase="sniff.unrenderable">Nessun browser tranne Safari disegna questo
+      formato, quindi la URI sarà valida e l&rsquo;immagine non comparirà. Convertila
+      prima.</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="join.comma">{a}, {b}</span>
+    <span data-phrase="join.and">{a} e {b}</span>
+    <span data-phrase="size.b">{n} byte</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="net.clean">Le tue immagini non sono andate da nessuna
       parte. {total} file caricati, tutti quanti di questo sito. {platform}</span>
     <span data-phrase="net.dirty">Qualcosa ha contattato {hosts}, e questo

--- a/locales/ja/tools/image-to-data-uri.html
+++ b/locales/ja/tools/image-to-data-uri.html
@@ -131,6 +131,39 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.notimage">{name}：これはこの道具が知っている画像形式ではありません。データURIの中の種別は正しくなければならないので、推測はしません。</span>
+    <span data-phrase="read.mismatch">名前は{extension}ですが、中身のバイトは{label}です。URIには{mime}と書いてあり、動くのはこちらです。</span>
+    <span data-phrase="row.remove">{name}を一覧から外す</span>
+    <span data-phrase="n.image.one">{n}枚</span>
+    <span data-phrase="n.image.many">{n}枚</span>
+    <span data-phrase="results.one">画像{n}件、テキストは合計{size}。どれもどこにも送られていません。</span>
+    <span data-phrase="results.many">画像{n}件、テキストは合計{size}。どれもどこにも送られていません。</span>
+    <span data-phrase="facts.in">入力{size}</span>
+    <span data-phrase="facts.out">出力{n}文字</span>
+    <span data-phrase="overhead.same">ファイルと同じ大きさ</span>
+    <span data-phrase="overhead.larger">ファイルより{percent}%大きい</span>
+    <span data-phrase="overhead.smaller">ファイルより{percent}%小さい</span>
+    <span data-phrase="verdict.tiny">明らかに得になるほど小さいサイズです。リクエストが1つ減り、埋め込む先のファイルもほとんど大きくなりません。</span>
+    <span data-phrase="verdict.icon">埋め込みアイコンとしてはふつうの大きさです。どのページにも出るものなら見合います。</span>
+    <span data-phrase="verdict.large">埋め込む画像としては大きめです。このスタイルシートを読み込むものすべてがこれを抱えることになり、単独ではキャッシュできなくなります。</span>
+    <span data-phrase="verdict.toobig">埋め込むには大きすぎます。ふつうのファイルとして配れば一度キャッシュされて並行して取得できますが、埋め込むとすべてのページのクリティカルパスに乗り、周りの何かが変わるたびに丸ごと再取得されます。</span>
+    <span data-phrase="kind.exif">EXIF</span>
+    <span data-phrase="kind.xmp">XMP</span>
+    <span data-phrase="kind.iptc">IPTC</span>
+    <span data-phrase="kind.icc">カラープロファイル</span>
+    <span data-phrase="kind.time">タイムスタンプ</span>
+    <span data-phrase="kind.comment">コメント</span>
+    <span data-phrase="kind.text">テキスト</span>
+    <span data-phrase="meta.plain">{kinds}が{size}分入っています。これも画像と一緒にURIへ複写されます。</span>
+    <span data-phrase="meta.share">{kinds}が{size}分入っており、ファイルの{percent}%にあたります。これも画像と一緒にURIへ複写されます。</span>
+    <span data-phrase="render.failed">このブラウザーは結果を描画しませんでした。URIの形式は正しく、デコードできない形式だというだけです。</span>
+    <span data-phrase="sniff.unrenderable">この形式を描画するブラウザーはSafari以外にありません。URIは正しくても画像は出ません。先に変換してください。</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="join.comma">{a}、{b}</span>
+    <span data-phrase="join.and">{a}と{b}</span>
+    <span data-phrase="size.b">{n}バイト</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="net.clean">画像はどこへも出ていません。{total}件のファイルを読み込み、そのすべてがこのサイト自身のものです。{platform}</span>
     <span data-phrase="net.dirty">何かが{hosts}へ接続しました。この道具は決してそれをしません。調べてみる価値があります。{platform}</span>
     <span data-phrase="net.platform.one">広告・計測・寄付ボタンのためのサイト自身のスクリプトが{hosts}のホストから読み込まれました。そのどれにも、画像も、その1バイトも渡っていません。</span>

--- a/locales/ko/tools/image-to-data-uri.html
+++ b/locales/ko/tools/image-to-data-uri.html
@@ -143,6 +143,46 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.notimage">{name}: 이 도구가 아는 이미지 형식이 아닙니다. 데이터 URI 안의 종류는 맞아야
+      해서, 짐작해서 넣지 않습니다.</span>
+    <span data-phrase="read.mismatch">이름은 {extension}이라고 하는데 바이트는 {label}입니다. URI에는
+      {mime}이 적히고, 실제로 되는 쪽은 그것입니다.</span>
+    <span data-phrase="row.remove">{name}을 목록에서 빼기</span>
+    <span data-phrase="n.image.one">이미지 {n}개</span>
+    <span data-phrase="n.image.many">이미지 {n}개</span>
+    <span data-phrase="results.one">이미지 {n}개, 글자는 모두 {size}. 어느 것도 어디에도 가지 않았습니다.</span>
+    <span data-phrase="results.many">이미지 {n}개, 글자는 모두 {size}. 어느 것도 어디에도 가지 않았습니다.</span>
+    <span data-phrase="facts.in">입력 {size}</span>
+    <span data-phrase="facts.out">출력 {n}자</span>
+    <span data-phrase="overhead.same">파일과 같은 크기</span>
+    <span data-phrase="overhead.larger">파일보다 {percent}% 큼</span>
+    <span data-phrase="overhead.smaller">파일보다 {percent}% 작음</span>
+    <span data-phrase="verdict.tiny">분명히 이득일 만큼 작습니다. 요청이 하나 줄고, 들어가는 파일도 거의 커지지 않습니다.</span>
+    <span data-phrase="verdict.icon">끼워 넣는 아이콘으로는 흔한 크기입니다. 모든 쪽에 나오는 것이라면 그럴 만합니다.</span>
+    <span data-phrase="verdict.large">끼워 넣는 그림치고는 큽니다. 이 스타일시트를 불러오는 모든 것이 이제 이걸 함께
+      짊어지고, 따로 캐시할 수도 없습니다.</span>
+    <span data-phrase="verdict.toobig">끼워 넣기에는 너무 큽니다. 보통 파일로 내주면 한 번 캐시되고 병렬로 받아지지만, 끼워
+      넣으면 모든 쪽의 임계 경로에 놓이고 주변에서 뭐라도 바뀔 때마다 통째로 다시 내려받게 됩니다.</span>
+    <span data-phrase="kind.exif">EXIF</span>
+    <span data-phrase="kind.xmp">XMP</span>
+    <span data-phrase="kind.iptc">IPTC</span>
+    <span data-phrase="kind.icc">색 프로필</span>
+    <span data-phrase="kind.time">시각 기록</span>
+    <span data-phrase="kind.comment">주석</span>
+    <span data-phrase="kind.text">텍스트</span>
+    <span data-phrase="meta.plain">{kinds}이 {size}만큼 들어 있습니다. 그림과 함께 URI로 복사됩니다.</span>
+    <span data-phrase="meta.share">{kinds}이 {size}만큼 들어 있고, 파일의 {percent}%입니다. 그림과 함께
+      URI로 복사됩니다.</span>
+    <span data-phrase="render.failed">이 브라우저는 결과를 그리지 않았습니다. URI 자체는 제대로 되어 있고, 형식이
+      디코딩하지 못하는 것일 뿐입니다.</span>
+    <span data-phrase="sniff.unrenderable">Safari 말고는 이 형식을 그리는 브라우저가 없어서, URI는 올바른데 그림은
+      나오지 않습니다. 먼저 변환하세요.</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="join.comma">{a}, {b}</span>
+    <span data-phrase="join.and">{a}와 {b}</span>
+    <span data-phrase="size.b">{n}바이트</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="net.clean">이미지는 어디로도 가지 않았습니다. 파일 {total}개를 불러왔고 모두 이
       사이트의 것입니다. {platform}</span>
     <span data-phrase="net.dirty">무언가가 {hosts}에 접속했는데, 이 도구는 절대 그러지 않습니다. 살펴볼

--- a/locales/nl/tools/image-to-data-uri.html
+++ b/locales/nl/tools/image-to-data-uri.html
@@ -146,6 +146,55 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.notimage">{name}: dit is geen beeldformaat dat dit
+      gereedschap herkent. Het type in een data-URI moet kloppen, dus het gaat er geen
+      raden.</span>
+    <span data-phrase="read.mismatch">De naam zegt {extension}, maar de bytes zijn
+      {label}. De URI zegt {mime}, en dat is degene die zal werken.</span>
+    <span data-phrase="row.remove">{name} van de lijst halen</span>
+    <span data-phrase="n.image.one">{n} afbeelding</span>
+    <span data-phrase="n.image.many">{n} afbeeldingen</span>
+    <span data-phrase="results.one">{n} afbeelding, {size} tekst in totaal. Niets ervan
+      is ergens geweest.</span>
+    <span data-phrase="results.many">{n} afbeeldingen, {size} tekst in totaal. Niets
+      ervan is ergens geweest.</span>
+    <span data-phrase="facts.in">{size} erin</span>
+    <span data-phrase="facts.out">{n} tekens eruit</span>
+    <span data-phrase="overhead.same">even groot als het bestand</span>
+    <span data-phrase="overhead.larger">{percent}% groter dan het bestand</span>
+    <span data-phrase="overhead.smaller">{percent}% kleiner dan het bestand</span>
+    <span data-phrase="verdict.tiny">Klein genoeg dat dit duidelijk winst is: één
+      verzoek minder, en er wordt weinig toegevoegd aan het bestand waar het in belandt.</span>
+    <span data-phrase="verdict.icon">Een normale grootte voor een ingesloten pictogram.
+      De moeite waard voor iets dat op elke pagina staat.</span>
+    <span data-phrase="verdict.large">Groot voor een ingesloten afbeelding. Alles wat
+      deze stylesheet insluit draagt hem nu mee, en hij kan niet meer apart in de cache.</span>
+    <span data-phrase="verdict.toobig">Te groot om in te sluiten. Als gewoon bestand
+      geserveerd zou dit één keer in de cache komen en parallel opgehaald worden;
+      ingesloten staat het op het kritieke pad van elke pagina en wordt het opnieuw
+      opgehaald zodra er iets omheen verandert.</span>
+    <span data-phrase="kind.exif">EXIF</span>
+    <span data-phrase="kind.xmp">XMP</span>
+    <span data-phrase="kind.iptc">IPTC</span>
+    <span data-phrase="kind.icc">een kleurprofiel</span>
+    <span data-phrase="kind.time">een tijdstempel</span>
+    <span data-phrase="kind.comment">een opmerking</span>
+    <span data-phrase="kind.text">tekst</span>
+    <span data-phrase="meta.plain">Bevat {size} aan {kinds}. Dat wordt samen met het
+      beeld in de URI gekopieerd.</span>
+    <span data-phrase="meta.share">Bevat {size} aan {kinds}, oftewel {percent}% van het
+      bestand. Dat wordt samen met het beeld in de URI gekopieerd.</span>
+    <span data-phrase="render.failed">Deze browser wilde het resultaat niet tekenen. De
+      URI is welgevormd; het formaat is er een dat hij niet kan decoderen.</span>
+    <span data-phrase="sniff.unrenderable">Geen enkele browser behalve Safari tekent dit
+      formaat, dus de URI wordt geldig en de afbeelding verschijnt niet. Zet hem eerst
+      om.</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="join.comma">{a}, {b}</span>
+    <span data-phrase="join.and">{a} en {b}</span>
+    <span data-phrase="size.b">{n} bytes</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="net.clean">Je afbeeldingen zijn nergens heen gegaan.
       {total} bestanden geladen, allemaal van deze site zelf. {platform}</span>
     <span data-phrase="net.dirty">Iets heeft {hosts} benaderd, en dat doet dit

--- a/locales/pt/tools/image-to-data-uri.html
+++ b/locales/pt/tools/image-to-data-uri.html
@@ -146,6 +146,54 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.notimage">{name}: este não é um formato de imagem que esta
+      ferramenta reconheça. O tipo numa URI de dados tem que estar certo, então ela não
+      vai chutar nenhum.</span>
+    <span data-phrase="read.mismatch">O nome diz {extension}, mas os bytes são {label}.
+      A URI diz {mime}, que é o que vai funcionar.</span>
+    <span data-phrase="row.remove">Tirar {name} da lista</span>
+    <span data-phrase="n.image.one">{n} imagem</span>
+    <span data-phrase="n.image.many">{n} imagens</span>
+    <span data-phrase="results.one">{n} imagem, {size} de texto no total. Nada disso foi
+      a lugar nenhum.</span>
+    <span data-phrase="results.many">{n} imagens, {size} de texto no total. Nada disso
+      foi a lugar nenhum.</span>
+    <span data-phrase="facts.in">{size} de entrada</span>
+    <span data-phrase="facts.out">{n} caracteres de saída</span>
+    <span data-phrase="overhead.same">do mesmo tamanho que o arquivo</span>
+    <span data-phrase="overhead.larger">{percent}% maior que o arquivo</span>
+    <span data-phrase="overhead.smaller">{percent}% menor que o arquivo</span>
+    <span data-phrase="verdict.tiny">Pequeno o bastante para valer claramente a pena:
+      uma requisição a menos, e quase nada acrescentado ao arquivo onde vai parar.</span>
+    <span data-phrase="verdict.icon">Um tamanho normal para um ícone embutido. Vale a
+      pena para algo que aparece em toda página.</span>
+    <span data-phrase="verdict.large">Grande para uma imagem embutida. Tudo o que inclui
+      esta folha de estilo passa a carregá-la, e ela não pode mais ser cacheada sozinha.</span>
+    <span data-phrase="verdict.toobig">Grande demais para embutir. Servido como arquivo
+      comum isso seria cacheado uma vez e baixado em paralelo; embutido, fica no caminho
+      crítico de toda página e é baixado de novo sempre que qualquer coisa em volta
+      muda.</span>
+    <span data-phrase="kind.exif">EXIF</span>
+    <span data-phrase="kind.xmp">XMP</span>
+    <span data-phrase="kind.iptc">IPTC</span>
+    <span data-phrase="kind.icc">um perfil de cor</span>
+    <span data-phrase="kind.time">uma marca de tempo</span>
+    <span data-phrase="kind.comment">um comentário</span>
+    <span data-phrase="kind.text">texto</span>
+    <span data-phrase="meta.plain">Carrega {size} de {kinds}. Isso é copiado para dentro
+      da URI junto com a imagem.</span>
+    <span data-phrase="meta.share">Carrega {size} de {kinds}, o que dá {percent}% do
+      arquivo. Isso é copiado para dentro da URI junto com a imagem.</span>
+    <span data-phrase="render.failed">Este navegador não quis desenhar o resultado. A
+      URI está bem formada; o formato é um que ele não consegue decodificar.</span>
+    <span data-phrase="sniff.unrenderable">Nenhum navegador além do Safari desenha este
+      formato, então a URI vai ser válida e a imagem não vai aparecer. Converta antes.</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="join.comma">{a}, {b}</span>
+    <span data-phrase="join.and">{a} e {b}</span>
+    <span data-phrase="size.b">{n} bytes</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="net.clean">As suas imagens não foram a lugar nenhum.
       {total} arquivos carregados, todos do próprio site. {platform}</span>
     <span data-phrase="net.dirty">Alguma coisa contatou {hosts}, e esta

--- a/locales/tr/tools/image-to-data-uri.html
+++ b/locales/tr/tools/image-to-data-uri.html
@@ -153,6 +153,54 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.notimage">{name}: bu, bu aracın tanıdığı bir görsel biçimi
+      değil. Bir veri URI&rsquo;sindeki tür doğru olmak zorunda, o yüzden tahmin
+      yürütmez.</span>
+    <span data-phrase="read.mismatch">Ad {extension} diyor ama baytlar {label}. URI
+      {mime} diyor ve işe yarayacak olan bu.</span>
+    <span data-phrase="row.remove">{name} ögesini listeden çıkar</span>
+    <span data-phrase="n.image.one">{n} görsel</span>
+    <span data-phrase="n.image.many">{n} görsel</span>
+    <span data-phrase="results.one">{n} görsel, toplam {size} metin. Hiçbiri hiçbir yere
+      gitmedi.</span>
+    <span data-phrase="results.many">{n} görsel, toplam {size} metin. Hiçbiri hiçbir
+      yere gitmedi.</span>
+    <span data-phrase="facts.in">{size} girdi</span>
+    <span data-phrase="facts.out">{n} karakter çıktı</span>
+    <span data-phrase="overhead.same">dosyayla aynı boyutta</span>
+    <span data-phrase="overhead.larger">dosyadan %{percent} daha büyük</span>
+    <span data-phrase="overhead.smaller">dosyadan %{percent} daha küçük</span>
+    <span data-phrase="verdict.tiny">Bunun açıkça kazanç olacağı kadar küçük: bir istek
+      eksik ve indiği dosyaya neredeyse hiçbir şey eklenmiyor.</span>
+    <span data-phrase="verdict.icon">Gömülü bir simge için olağan bir boyut. Her sayfada
+      görünen bir şey için buna değer.</span>
+    <span data-phrase="verdict.large">Gömülü bir görsel için büyük. Bu stil sayfasını
+      içeren her şey artık onu da taşıyor ve tek başına önbelleğe alınamıyor.</span>
+    <span data-phrase="verdict.toobig">Gömülemeyecek kadar büyük. Sıradan bir dosya
+      olarak sunulsa bir kez önbelleğe alınır ve koşut olarak indirilirdi; gömülü hâlde
+      her sayfanın kritik yolunda duruyor ve çevresindeki herhangi bir şey değiştiğinde
+      yeniden indiriliyor.</span>
+    <span data-phrase="kind.exif">EXIF</span>
+    <span data-phrase="kind.xmp">XMP</span>
+    <span data-phrase="kind.iptc">IPTC</span>
+    <span data-phrase="kind.icc">bir renk profili</span>
+    <span data-phrase="kind.time">bir zaman damgası</span>
+    <span data-phrase="kind.comment">bir yorum</span>
+    <span data-phrase="kind.text">metin</span>
+    <span data-phrase="meta.plain">{size} kadar {kinds} taşıyor. Bu, görselle birlikte
+      URI&rsquo;ye kopyalanıyor.</span>
+    <span data-phrase="meta.share">{size} kadar {kinds} taşıyor, yani dosyanın
+      %{percent} kadarı. Bu, görselle birlikte URI&rsquo;ye kopyalanıyor.</span>
+    <span data-phrase="render.failed">Bu tarayıcı sonucu çizmek istemedi. URI düzgün
+      biçimli; biçim onun çözemediği bir biçim.</span>
+    <span data-phrase="sniff.unrenderable">Safari dışında hiçbir tarayıcı bu biçimi
+      çizmiyor, dolayısıyla URI geçerli olacak ama görsel görünmeyecek. Önce dönüştürün.</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="join.comma">{a}, {b}</span>
+    <span data-phrase="join.and">{a} ve {b}</span>
+    <span data-phrase="size.b">{n} bayt</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="net.clean">görselleriniz hiçbir yere gitmedi. {total}
       dosya yüklendi, hepsi bu sayfanın kendi dosyaları. {platform}</span>
     <span data-phrase="net.dirty">bir şey {hosts} ile iletişim kurdu; bu araç

--- a/locales/zh-TW/tools/image-to-data-uri.html
+++ b/locales/zh-TW/tools/image-to-data-uri.html
@@ -137,6 +137,39 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.notimage">{name}：這不是這個工具認得的圖片格式。資料 URI 裡的類型必須寫對，所以它不會去猜。</span>
+    <span data-phrase="read.mismatch">檔名說是 {extension}，但位元組是 {label}。URI 裡寫的是 {mime}，能用的是這個。</span>
+    <span data-phrase="row.remove">把 {name} 從列表裡去掉</span>
+    <span data-phrase="n.image.one">{n} 張圖片</span>
+    <span data-phrase="n.image.many">{n} 張圖片</span>
+    <span data-phrase="results.one">{n} 張圖片，一共 {size} 文字。這些都沒去過任何地方。</span>
+    <span data-phrase="results.many">{n} 張圖片，一共 {size} 文字。這些都沒去過任何地方。</span>
+    <span data-phrase="facts.in">進 {size}</span>
+    <span data-phrase="facts.out">出 {n} 個字元</span>
+    <span data-phrase="overhead.same">和檔案一樣大</span>
+    <span data-phrase="overhead.larger">比檔案大 {percent}%</span>
+    <span data-phrase="overhead.smaller">比檔案小 {percent}%</span>
+    <span data-phrase="verdict.tiny">小到這麼做明顯划算：少一次請求，落進去的那個檔案也幾乎沒變大。</span>
+    <span data-phrase="verdict.icon">內嵌圖示的正常大小。對每個頁面都出現的東西來說值得。</span>
+    <span data-phrase="verdict.large">作為內嵌圖片偏大了。凡是引用這份樣式表的都得帶著它，而且它自己沒法單獨快取。</span>
+    <span data-phrase="verdict.toobig">太大了，不適合內嵌。當成普通檔案發出去只會快取一次並且並行下載；內嵌之後它就落在每個頁面的關鍵路徑上，周圍任何東西一變就要整份重下。</span>
+    <span data-phrase="kind.exif">EXIF</span>
+    <span data-phrase="kind.xmp">XMP</span>
+    <span data-phrase="kind.iptc">IPTC</span>
+    <span data-phrase="kind.icc">一份色彩配置</span>
+    <span data-phrase="kind.time">一個時間戳</span>
+    <span data-phrase="kind.comment">一段註釋</span>
+    <span data-phrase="kind.text">文字</span>
+    <span data-phrase="meta.plain">裡面有 {size} 的{kinds}。它會跟著圖片一起被抄進 URI。</span>
+    <span data-phrase="meta.share">裡面有 {size} 的{kinds}，佔檔案的 {percent}%。它會跟著圖片一起被抄進 URI。</span>
+    <span data-phrase="render.failed">這個瀏覽器不肯畫出結果。URI 本身沒問題，只是這個格式它解不了。</span>
+    <span data-phrase="sniff.unrenderable">除了 Safari，沒有瀏覽器畫得出這個格式，所以 URI 會是有效的，圖卻不會出現。請先轉換一下。</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="join.comma">{a}，{b}</span>
+    <span data-phrase="join.and">{a} 和 {b}</span>
+    <span data-phrase="size.b">{n} 位元組</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="net.clean">你的圖片沒有去任何地方。載入了 {total} 個檔案，全都是本站自己的。{platform}</span>
     <span data-phrase="net.dirty">有東西聯絡了 {hosts}，而這個工具從不這麼做。值得去查一查。{platform}</span>
     <span data-phrase="net.platform.one">本站自己用於廣告、統計和捐贈按鈕的指令碼來自 {hosts} 個主機，它們誰也沒拿到圖片，或圖片裡的一個位元組。</span>

--- a/locales/zh/tools/image-to-data-uri.html
+++ b/locales/zh/tools/image-to-data-uri.html
@@ -137,6 +137,39 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.notimage">{name}：这不是这个工具认得的图片格式。数据 URI 里的类型必须写对，所以它不会去猜。</span>
+    <span data-phrase="read.mismatch">文件名说是 {extension}，但字节是 {label}。URI 里写的是 {mime}，能用的是这个。</span>
+    <span data-phrase="row.remove">把 {name} 从列表里去掉</span>
+    <span data-phrase="n.image.one">{n} 张图片</span>
+    <span data-phrase="n.image.many">{n} 张图片</span>
+    <span data-phrase="results.one">{n} 张图片，一共 {size} 文字。这些都没去过任何地方。</span>
+    <span data-phrase="results.many">{n} 张图片，一共 {size} 文字。这些都没去过任何地方。</span>
+    <span data-phrase="facts.in">进 {size}</span>
+    <span data-phrase="facts.out">出 {n} 个字符</span>
+    <span data-phrase="overhead.same">和文件一样大</span>
+    <span data-phrase="overhead.larger">比文件大 {percent}%</span>
+    <span data-phrase="overhead.smaller">比文件小 {percent}%</span>
+    <span data-phrase="verdict.tiny">小到这么做明显划算：少一次请求，落进去的那个文件也几乎没变大。</span>
+    <span data-phrase="verdict.icon">内嵌图标的正常大小。对每个页面都出现的东西来说值得。</span>
+    <span data-phrase="verdict.large">作为内嵌图片偏大了。凡是引用这份样式表的都得带着它，而且它自己没法单独缓存。</span>
+    <span data-phrase="verdict.toobig">太大了，不适合内嵌。当成普通文件发出去只会缓存一次并且并行下载；内嵌之后它就落在每个页面的关键路径上，周围任何东西一变就要整份重下。</span>
+    <span data-phrase="kind.exif">EXIF</span>
+    <span data-phrase="kind.xmp">XMP</span>
+    <span data-phrase="kind.iptc">IPTC</span>
+    <span data-phrase="kind.icc">一份色彩配置</span>
+    <span data-phrase="kind.time">一个时间戳</span>
+    <span data-phrase="kind.comment">一段注释</span>
+    <span data-phrase="kind.text">文字</span>
+    <span data-phrase="meta.plain">里面有 {size} 的{kinds}。它会跟着图片一起被抄进 URI。</span>
+    <span data-phrase="meta.share">里面有 {size} 的{kinds}，占文件的 {percent}%。它会跟着图片一起被抄进 URI。</span>
+    <span data-phrase="render.failed">这个浏览器不肯画出结果。URI 本身没问题，只是这个格式它解不了。</span>
+    <span data-phrase="sniff.unrenderable">除了 Safari，没有浏览器画得出这个格式，所以 URI 会是有效的，图却不会出现。请先转换一下。</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="join.comma">{a}，{b}</span>
+    <span data-phrase="join.and">{a} 和 {b}</span>
+    <span data-phrase="size.b">{n} 字节</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="net.clean">你的图片没有去任何地方。加载了 {total} 个文件，全都是本站自己的。{platform}</span>
     <span data-phrase="net.dirty">有东西联系了 {hosts}，而这个工具从不这么做。值得去查一查。{platform}</span>
     <span data-phrase="net.platform.one">本站自己用于广告、统计和捐赠按钮的脚本来自 {hosts} 个主机，它们谁也没拿到图片，或图片里的一个字节。</span>

--- a/tests/js/data-uri-metadata.test.js
+++ b/tests/js/data-uri-metadata.test.js
@@ -12,6 +12,10 @@
  * fourteen bytes present in essentially every JPEG - means it fires on
  * everything, which is the same as it never firing, because nobody reads a
  * warning that is always on.
+ *
+ * A kind is a phrase key rather than a word. EXIF, XMP and IPTC keep their
+ * published names on the page, but "a colour profile" and "a timestamp" are
+ * this tool's own words, and this module ships in fifteen languages.
  */
 
 import test from 'node:test';
@@ -29,7 +33,7 @@ test('EXIF in a JPEG is found, and its size is the whole segment', () => {
   const exif = segment(0xe1, concat(EXIF_ID, TIFF_LE));
   const found = metadata(jpeg([exif]), 'image/jpeg');
 
-  assert.deepEqual(found.kinds, ['EXIF']);
+  assert.deepEqual(found.kinds, ['kind.exif']);
   // The marker and the length field are part of what a data URI would carry,
   // so the figure on the page counts them.
   assert.equal(found.bytes, exif.length);
@@ -52,7 +56,7 @@ test('XMP, ICC, IPTC and a comment are told apart', () => {
 
   assert.deepEqual(
     metadata(file, 'image/jpeg').kinds,
-    ['XMP', 'a colour profile', 'IPTC', 'a comment'],
+    ['kind.xmp', 'kind.icc', 'kind.iptc', 'kind.comment'],
   );
 });
 
@@ -60,7 +64,7 @@ test('two EXIF-carrying segments are one kind and two sizes', () => {
   const one = segment(0xe1, concat(EXIF_ID, TIFF_LE));
   const found = metadata(jpeg([one, one]), 'image/jpeg');
 
-  assert.deepEqual(found.kinds, ['EXIF']);
+  assert.deepEqual(found.kinds, ['kind.exif']);
   assert.equal(found.bytes, one.length * 2);
 });
 
@@ -82,20 +86,20 @@ test('PNG text chunks are found', () => {
   const text = textChunk('Comment', 'taken at home');
   const found = metadata(png([text]), 'image/png');
 
-  assert.deepEqual(found.kinds, ['text']);
+  assert.deepEqual(found.kinds, ['kind.text']);
   assert.equal(found.bytes, text.length);
 });
 
 test('an eXIf chunk in a PNG is EXIF', () => {
   const exif = chunk('eXIf', TIFF_LE);
-  assert.deepEqual(metadata(png([exif]), 'image/png').kinds, ['EXIF']);
+  assert.deepEqual(metadata(png([exif]), 'image/png').kinds, ['kind.exif']);
 });
 
 test('an iTXt holding XMP is named as XMP, not as text', () => {
   // Where an editor puts the things people expect EXIF to hold, so lumping it
   // in with "text" would understate what is being copied.
   const xmp = chunk('iTXt', concat(ascii('XML:com.adobe.xmp\0'), ascii('\0\0\0\0<x:xmpmeta/>')));
-  assert.deepEqual(metadata(png([xmp]), 'image/png').kinds, ['XMP']);
+  assert.deepEqual(metadata(png([xmp]), 'image/png').kinds, ['kind.xmp']);
 });
 
 test('a colour profile and a timestamp are both named', () => {
@@ -103,7 +107,7 @@ test('a colour profile and a timestamp are both named', () => {
     chunk('iCCP', concat(ascii('sRGB\0\0'), ascii('deflated'))),
     chunk('tIME', new Uint8Array(7)),
   ]);
-  assert.deepEqual(metadata(file, 'image/png').kinds, ['a colour profile', 'a timestamp']);
+  assert.deepEqual(metadata(file, 'image/png').kinds, ['kind.icc', 'kind.time']);
 });
 
 test('an ordinary PNG reports nothing', () => {
@@ -116,7 +120,7 @@ test('WebP EXIF and XMP chunks are found', () => {
   const exif = webpChunk('EXIF', TIFF_LE);
   const found = metadata(webp([VP8_CHUNK, exif]), 'image/webp');
 
-  assert.deepEqual(found.kinds, ['EXIF']);
+  assert.deepEqual(found.kinds, ['kind.exif']);
   assert.equal(found.bytes, TIFF_LE.length + 8);
 });
 
@@ -127,7 +131,7 @@ test('an odd-length WebP chunk does not desynchronise the walk', () => {
   const odd = webpChunk('XMP ', ascii('seven..'));
   const file = webp([VP8_CHUNK, odd, webpChunk('EXIF', TIFF_LE)]);
 
-  assert.deepEqual(metadata(file, 'image/webp').kinds, ['XMP', 'EXIF']);
+  assert.deepEqual(metadata(file, 'image/webp').kinds, ['kind.xmp', 'kind.exif']);
 });
 
 test('a plain WebP reports nothing', () => {

--- a/tests/python/test_english_in_js.py
+++ b/tests/python/test_english_in_js.py
@@ -77,7 +77,8 @@ BASELINE = {
     # A filename template, a dimension pair, a CSS percentage, a phrase key, the
     # note written into a padded JPEG, and the eight published citations.
     'id-photo': 13,
-    'image-to-data-uri': 20,
+    # A CSS class name and one line of the CSS rule the tool writes out.
+    'image-to-data-uri': 2,
     'image-to-ico': 6,
     # The /Producer string written into the PDF, five lines of PDF syntax, a
     # CSS pixel value, a key template and the output filename.

--- a/tools/image-to-data-uri/body.html
+++ b/tools/image-to-data-uri/body.html
@@ -146,6 +146,52 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.notimage">{name}: this is not an image format this tool
+      recognises. The type in a data URI has to be right, so it will not guess one.</span>
+    <span data-phrase="read.mismatch">The name says {extension}, but the bytes are
+      {label}. The URI says {mime}, which is the one that will work.</span>
+    <span data-phrase="row.remove">Take {name} off the list</span>
+    <span data-phrase="n.image.one">{n} image</span>
+    <span data-phrase="n.image.many">{n} images</span>
+    <span data-phrase="results.one">{n} picture, {size} of text in total. None of it has
+      been anywhere.</span>
+    <span data-phrase="results.many">{n} pictures, {size} of text in total. None of it
+      has been anywhere.</span>
+    <span data-phrase="facts.in">{size} in</span>
+    <span data-phrase="facts.out">{n} characters out</span>
+    <span data-phrase="overhead.same">the same size as the file</span>
+    <span data-phrase="overhead.larger">{percent}% larger than the file</span>
+    <span data-phrase="overhead.smaller">{percent}% smaller than the file</span>
+    <span data-phrase="verdict.tiny">Small enough that this is a clear win: one fewer
+      request, and nothing much added to the file it lands in.</span>
+    <span data-phrase="verdict.icon">A normal size for an inlined icon. Worth it for
+      something that appears on every page.</span>
+    <span data-phrase="verdict.large">Large for an inline picture. Everything that
+      includes this stylesheet now carries it, and it cannot be cached on its own.</span>
+    <span data-phrase="verdict.toobig">Too big to inline. Served as an ordinary file
+      this would be cached once and fetched in parallel; inlined, it is on the critical
+      path of every page and re-downloaded whenever anything around it changes.</span>
+    <span data-phrase="kind.exif">EXIF</span>
+    <span data-phrase="kind.xmp">XMP</span>
+    <span data-phrase="kind.iptc">IPTC</span>
+    <span data-phrase="kind.icc">a colour profile</span>
+    <span data-phrase="kind.time">a timestamp</span>
+    <span data-phrase="kind.comment">a comment</span>
+    <span data-phrase="kind.text">text</span>
+    <span data-phrase="meta.plain">Carries {size} of {kinds}. It is copied into the URI
+      along with the picture.</span>
+    <span data-phrase="meta.share">Carries {size} of {kinds}, which is {percent}% of the
+      file. It is copied into the URI along with the picture.</span>
+    <span data-phrase="render.failed">This browser would not draw the result. The URI is
+      well formed; the format is one it cannot decode.</span>
+    <span data-phrase="sniff.unrenderable">No browser except Safari draws this format,
+      so the URI will be valid and the picture will not appear. Convert it first.</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="join.comma">{a}, {b}</span>
+    <span data-phrase="join.and">{a} and {b}</span>
+    <span data-phrase="size.b">{n} bytes</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="net.clean">your images have gone nowhere. {total} files
       loaded, all of them this page's own. {platform}</span>
     <span data-phrase="net.dirty">something contacted {hosts}, which this tool

--- a/tools/image-to-data-uri/src/files.js
+++ b/tools/image-to-data-uri/src/files.js
@@ -2,10 +2,10 @@
 
 /** KB and MB mean 1024 and 1024*1024 here, which is what a file manager shows
  *  on every platform except macOS. */
-export function bytes(n) {
-  if (n < 1024) return `${n} bytes`;
-  if (n < 1024 * 1024) return `${(n / 1024).toFixed(n < 10240 ? 1 : 0)} KB`;
-  return `${(n / (1024 * 1024)).toFixed(2)} MB`;
+export function bytes(n, t) {
+  if (n < 1024) return t('size.b', { n });
+  if (n < 1024 * 1024) return t('size.kb', { n: (n / 1024).toFixed(n < 10240 ? 1 : 0) });
+  return t('size.mb', { n: (n / (1024 * 1024)).toFixed(2) });
 }
 
 /** "1,204,556" - a character count is read, not compared, so it gets commas. */
@@ -15,11 +15,15 @@ export function count(n) {
 
 /** "a third longer", as a number. A data URI is ASCII, so one character is one
  *  byte and the length of the string is the size of the thing. */
-export function overhead(fileBytes, uriLength) {
+export function overhead(fileBytes, uriLength, t) {
   if (!fileBytes) return '';
   const delta = Math.round(((uriLength - fileBytes) / fileBytes) * 100);
-  if (delta === 0) return 'the same size as the file';
-  return delta > 0 ? `${delta}% larger than the file` : `${-delta}% smaller than the file`;
+  if (delta === 0) return t('overhead.same');
+  // Three whole sentences: Turkish writes the sign in front of the number,
+  // and a comparison is not built the same way in every language either.
+  return delta > 0
+    ? t('overhead.larger', { percent: delta })
+    : t('overhead.smaller', { percent: -delta });
 }
 
 /**
@@ -36,31 +40,16 @@ export function overhead(fileBytes, uriLength) {
  * The thresholds are round numbers rather than measurements. They are where
  * the advice changes, not where the browser does anything different.
  *
- * @returns {{level: 'good'|'fair'|'poor', text: string}}
+ * `key` names the sentence rather than holding it: this module ships in
+ * fifteen languages and only the page can read a phrase.
+ *
+ * @returns {{level: 'good'|'fair'|'poor', key: string}}
  */
 export function verdict(uriLength) {
-  if (uriLength <= 2 * 1024) {
-    return {
-      level: 'good',
-      text: 'Small enough that this is a clear win: one fewer request, and nothing much added to the file it lands in.',
-    };
-  }
-  if (uriLength <= 10 * 1024) {
-    return {
-      level: 'good',
-      text: 'A normal size for an inlined icon. Worth it for something that appears on every page.',
-    };
-  }
-  if (uriLength <= 50 * 1024) {
-    return {
-      level: 'fair',
-      text: 'Large for an inline picture. Everything that includes this stylesheet now carries it, and it cannot be cached on its own.',
-    };
-  }
-  return {
-    level: 'poor',
-    text: 'Too big to inline. Served as an ordinary file this would be cached once and fetched in parallel; inlined, it is on the critical path of every page and re-downloaded whenever anything around it changes.',
-  };
+  if (uriLength <= 2 * 1024) return { level: 'good', key: 'verdict.tiny' };
+  if (uriLength <= 10 * 1024) return { level: 'good', key: 'verdict.icon' };
+  if (uriLength <= 50 * 1024) return { level: 'fair', key: 'verdict.large' };
+  return { level: 'poor', key: 'verdict.toobig' };
 }
 
 /**
@@ -70,17 +59,24 @@ export function verdict(uriLength) {
  * a fact, and "a third of what you are about to paste is not the picture" is
  * the reason to do something about it.
  */
-export function metadataNote(meta, fileBytes) {
+export function metadataNote(meta, fileBytes, t) {
   const share = fileBytes ? Math.round((meta.bytes / fileBytes) * 100) : 0;
-  const kinds = list(meta.kinds);
-  const portion = share >= 5 ? `, which is ${share}% of the file` : '';
-  return `Carries ${bytes(meta.bytes)} of ${kinds}${portion}. It is copied into the URI along with the picture.`;
+  const values = { size: bytes(meta.bytes, t), kinds: list(meta.kinds, t), percent: share };
+  // A clause spliced into a sentence cannot be translated, so the version
+  // with the proportion in it is a sentence of its own.
+  return t(share >= 5 ? 'meta.share' : 'meta.plain', values);
 }
 
 /** "EXIF", "EXIF and XMP", "EXIF, XMP and a colour profile". */
-export function list(items) {
-  if (items.length <= 1) return items[0] ?? '';
-  return `${items.slice(0, -1).join(', ')} and ${items[items.length - 1]}`;
+export function list(items, t) {
+  const said = items.map((item) => t(item));
+  if (said.length <= 1) return said[0] ?? '';
+  // The last join is a different word from the others in most languages,
+  // so the two separators are two phrases.
+  return t('join.and', {
+    a: said.slice(0, -1).reduce((x, y) => t('join.comma', { a: x, b: y })),
+    b: said[said.length - 1],
+  });
 }
 
 /** "4032 x 3024", with a real multiplication sign. */

--- a/tools/image-to-data-uri/src/main.js
+++ b/tools/image-to-data-uri/src/main.js
@@ -96,7 +96,7 @@ async function addFiles(files) {
       const kind = sniff(data);
 
       if (!kind) {
-        failures.push(`${file.name}: this is not an image format this tool recognises. The type in a data URI has to be right, so it will not guess one.`);
+        failures.push(phrase('read.notimage', { name: file.name }));
         continue;
       }
 
@@ -110,7 +110,11 @@ async function addFiles(files) {
         label: kind.label,
         note: kind.note ?? '',
         mismatch: declared && declared !== kind.mime
-          ? `The name says ${file.name.replace(/^.*\./, '.')}, but the bytes are ${kind.label}. The URI says ${kind.mime}, which is the one that will work.`
+          ? phrase('read.mismatch', {
+            extension: file.name.replace(/^.*\./, '.'),
+            label: kind.label,
+            mime: kind.mime,
+          })
           : '',
         meta: metadata(data, kind.mime),
         svg: kind.mime === 'image/svg+xml',
@@ -243,7 +247,8 @@ function draw() {
   const shape = currentShape();
   const rows = results();
 
-  el.countLabel.textContent = `${items.length} ${items.length === 1 ? 'image' : 'images'}`;
+  el.countLabel.textContent = phrase(items.length === 1 ? 'n.image.one' : 'n.image.many',
+    { n: items.length });
   el.listToolbar.hidden = items.length === 0;
   el.emptyNote.hidden = items.length > 0;
   el.results.hidden = items.length === 0;
@@ -253,8 +258,10 @@ function draw() {
   if (!items.length) return;
 
   const total = rows.reduce((sum, row) => sum + renderShape(shape, row).length, 0);
-  el.resultsSummary.textContent =
-    `${items.length} ${items.length === 1 ? 'picture' : 'pictures'}, ${humanBytes(total)} of text in total. None of it has been anywhere.`;
+  el.resultsSummary.textContent = phrase(
+    items.length === 1 ? 'results.one' : 'results.many',
+    { n: items.length, size: humanBytes(total, phrase) },
+  );
 
   el.resultList.replaceChildren(...rows.map((row) => resultRow(shape, row)));
 }
@@ -285,9 +292,9 @@ function drawFileList() {
     sub.className = 'file-sub';
     sub.textContent = [
       item.label,
-      humanBytes(item.file.size),
+      humanBytes(item.file.size, phrase),
       item.width && item.height && item.renders ? dimensions(item.width, item.height) : null,
-    ].filter(Boolean).join(' · ');
+    ].filter(Boolean).reduce((a, b) => phrase('join.dot', { a, b }));
     text.appendChild(sub);
 
     main.appendChild(text);
@@ -296,8 +303,9 @@ function drawFileList() {
     const remove = document.createElement('button');
     remove.type = 'button';
     remove.className = 'row-remove';
-    remove.title = `Take ${item.file.name} off the list`;
-    remove.setAttribute('aria-label', `Take ${item.file.name} off the list`);
+    const removeLabel = phrase('row.remove', { name: item.file.name });
+    remove.title = removeLabel;
+    remove.setAttribute('aria-label', removeLabel);
     remove.textContent = '×';
     remove.disabled = busy;
     remove.addEventListener('click', () => removeItem(item.id));
@@ -336,27 +344,27 @@ function resultRow(shape, row) {
   const facts = [
     item.mime,
     item.width && item.height && item.renders ? dimensions(item.width, item.height) : null,
-    `${humanBytes(item.file.size)} in`,
-    `${count(code.length)} characters out`,
-    overhead(item.file.size, row.uri.length),
+    phrase('facts.in', { size: humanBytes(item.file.size, phrase) }),
+    phrase('facts.out', { n: count(code.length) }),
+    overhead(item.file.size, row.uri.length, phrase),
   ].filter(Boolean);
 
   const sub = document.createElement('p');
   sub.className = 'result-sub';
-  sub.textContent = facts.join(' · ');
+  sub.textContent = facts.reduce((a, b) => phrase('join.dot', { a, b }));
   meta.appendChild(sub);
 
   const call = verdict(row.uri.length);
   const judgement = document.createElement('p');
   judgement.className = `result-verdict ${call.level}`;
-  judgement.textContent = call.text;
+  judgement.textContent = phrase(call.key);
   meta.appendChild(judgement);
 
   for (const warning of [
     item.mismatch,
     item.note,
-    item.renders ? '' : 'This browser would not draw the result. The URI is well formed; the format is one it cannot decode.',
-    item.meta ? metadataNote(item.meta, item.file.size) : '',
+    item.renders ? '' : phrase('render.failed'),
+    item.meta ? metadataNote(item.meta, item.file.size, phrase) : '',
   ]) {
     if (!warning) continue;
     const line = document.createElement('p');

--- a/tools/image-to-data-uri/src/metadata.js
+++ b/tools/image-to-data-uri/src/metadata.js
@@ -106,25 +106,25 @@ function jpeg(bytes) {
 
 function jpegKind(bytes, marker, body) {
   if (marker === 0xe1) {
-    if (ascii(bytes, body, 'Exif\0\0')) return 'EXIF';
-    if (ascii(bytes, body, 'http://ns.adobe.com/xap/1.0/\0')) return 'XMP';
+    if (ascii(bytes, body, 'Exif\0\0')) return 'kind.exif';
+    if (ascii(bytes, body, 'http://ns.adobe.com/xap/1.0/\0')) return 'kind.xmp';
     return null;
   }
-  if (marker === 0xe2 && ascii(bytes, body, 'ICC_PROFILE\0')) return 'a colour profile';
-  if (marker === 0xed && ascii(bytes, body, 'Photoshop 3.0\0')) return 'IPTC';
-  if (marker === 0xfe) return 'a comment';
+  if (marker === 0xe2 && ascii(bytes, body, 'ICC_PROFILE\0')) return 'kind.icc';
+  if (marker === 0xed && ascii(bytes, body, 'Photoshop 3.0\0')) return 'kind.iptc';
+  if (marker === 0xfe) return 'kind.comment';
   return null;
 }
 
 /* --------------------------------------------------------------------- PNG */
 
 const PNG_CHUNKS = {
-  eXIf: 'EXIF',
-  iTXt: 'text',
-  tEXt: 'text',
-  zTXt: 'text',
-  iCCP: 'a colour profile',
-  tIME: 'a timestamp',
+  eXIf: 'kind.exif',
+  iTXt: 'kind.text',
+  tEXt: 'kind.text',
+  zTXt: 'kind.text',
+  iCCP: 'kind.icc',
+  tIME: 'kind.time',
 };
 
 function png(bytes) {
@@ -137,7 +137,7 @@ function png(bytes) {
     // iTXt often holds XMP, which is worth naming separately: it is where a
     // photo editor puts the things people expect EXIF to hold.
     const kind = type === 'iTXt' && ascii(bytes, at + 8, 'XML:com.adobe.xmp\0')
-      ? 'XMP'
+      ? 'kind.xmp'
       : PNG_CHUNKS[type];
     if (kind) hits.push({ kind, bytes: length + 12 });
     if (type === 'IEND') break;
@@ -150,9 +150,9 @@ function png(bytes) {
 /* -------------------------------------------------------------------- WebP */
 
 const WEBP_CHUNKS = {
-  EXIF: 'EXIF',
-  'XMP ': 'XMP',
-  ICCP: 'a colour profile',
+  EXIF: 'kind.exif',
+  'XMP ': 'kind.xmp',
+  ICCP: 'kind.icc',
 };
 
 function webp(bytes) {

--- a/tools/image-to-data-uri/src/sniff.js
+++ b/tools/image-to-data-uri/src/sniff.js
@@ -54,7 +54,9 @@ function brands(bytes) {
  * scanner produces - and both make a data URI that is perfectly well-formed
  * and renders nowhere.
  */
-const UNRENDERABLE = 'No browser except Safari draws this format, so the URI will be valid and the picture will not appear. Convert it first.';
+// A phrase key: this module ships in fifteen languages, and the page is the
+// only place a sentence can be read.
+const UNRENDERABLE = 'sniff.unrenderable';
 
 const TESTS = [
   (b) => starts(b, 0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a)


### PR DESCRIPTION
image-to-data-uri showed twenty English sentences from `src/`, which is copied byte for byte into all fifteen languages: the whole verdict, the metadata warning, every fact under a result. Thirty-three phrases move into the markup.

`verdict()` returned a written-out sentence with its level. It names one now and the page writes it, because `files.js` has no way to read a phrase. The three functions that *compose* — `overhead`, `metadataNote` and `list` — take the resolver as an argument, the way svg-to-image's `describePlan` does.

`metadata.js` named what it found in words: `'a colour profile'`, `'a timestamp'`. Those are keys now. EXIF, XMP and IPTC stay untranslated — that is what the formats are called — but the other four are this tool's own description of what it saw, and a German reader should get German.

## Two things only showed up once the sentences were in a language with cases

**German.** `Enthält 474 Bytes an ein Farbprofil` is wrong: `an` takes the dative. The German kinds are dative, because that clause is the only place they are ever read, and there is a comment in the table saying so.

```
before  Enthält 474 Bytes an ein Farbprofil.
after   Enthält 474 Bytes an einem Farbprofil.
        Enthält 29 KB an EXIF und einem Zeitstempel, also 33% der Datei.
```

**French.** `Contient 29 Ko de EXIF` needs an elision that depends on which kind comes first — and which one is first is not knowable at the call site. The French sentence puts the kinds after a colon instead:

```
Contient 29 Ko de métadonnées, soit 33% du fichier : EXIF et un horodatage.
```

`list()` also folds with *two* separators rather than one, because the last join is a different word from the others in every language it was written in — `EXIF, XMP und einem Farbprofil`.

## Verified in the browser

A 16×16 PNG, a 600×600 JPEG carrying an ICC profile and a `.txt`, in English and in German, plus every verdict tier and both metadata sentences resolved through the real `files.js`:

```
English  image/png · 16 × 16 · 119 bytes in · 182 characters out · 53% larger than the file
         2 pictures, 43 KB of text in total. None of it has been anywhere.
German   image/png · 16 × 16 · 119 Bytes hinein · 182 Zeichen heraus · 53% größer als die Datei
         2 Bilder, insgesamt 43 KB Text. Nichts davon war irgendwo.
```

All fourteen locales checked for missing keys, the CJK wrap trap and blank drift; the two differences are Arabic `.one` forms that spell the number out.

## Tests

- `python -m unittest discover -t . -s tests/python` — 495 pass; the ratchet drops image-to-data-uri 20 → 2, and what is left is a CSS class name and one line of the CSS rule the tool writes out.
- `node --test "tests/js/*.test.js"` — 1939 pass. The metadata tests assert the keys now, and the file's header says why a kind is a key rather than a word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)