### PR TITLE
Say the redaction in the reader's language, not only in English

### DIFF
--- a/locales/ar/tools/redact-image.html
+++ b/locales/ar/tools/redact-image.html
@@ -177,6 +177,53 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.nodecode">لم يستطع هذا المتصفح فكّ ترميز الصورة.</span>
+    <span data-phrase="read.failed">تعذّر فتح هذا الملف: {why}</span>
+    <span data-phrase="loaded.name">{name} &mdash; {width} x {height}</span>
+    <span data-phrase="region.where">{width} x {height} عند {x}، {y}</span>
+    <span data-phrase="region.pixelated">{where} &mdash; مبكسلة، كتل {size} بكسل
+      ({across} x {down})</span>
+    <span data-phrase="region.blurred">{where} &mdash; مطموسة، نصف قطر {radius} بكسل</span>
+    <span data-phrase="region.filled">{where} &mdash; محجوبة بالأسود</span>
+    <span data-phrase="region.aria">المنطقة {n}: {what}. مفاتيح الأسهم تحرّكها، وAlt مع
+      الأسهم يغيّر حجمها، وDelete يزيلها.</span>
+    <span data-phrase="region.choice">ما تفعله المنطقة {n}</span>
+    <span data-phrase="choice.fill">حجب بالأسود</span>
+    <span data-phrase="choice.pixelate">بكسلة</span>
+    <span data-phrase="choice.blur">طمس</span>
+    <span data-phrase="style.fill.one">واحدة محجوبة بالأسود</span>
+    <span data-phrase="style.fill.many">{n} محجوبة بالأسود</span>
+    <span data-phrase="style.pixelate.one">واحدة مبكسلة</span>
+    <span data-phrase="style.pixelate.many">{n} مبكسلة</span>
+    <span data-phrase="style.blur.one">واحدة مطموسة</span>
+    <span data-phrase="style.blur.many">{n} مطموسة</span>
+    <span data-phrase="count.one">منطقة واحدة: {parts}.</span>
+    <span data-phrase="count.many">{n} مناطق: {parts}.</span>
+    <span data-phrase="strength.light">خفيف</span>
+    <span data-phrase="strength.medium">متوسط</span>
+    <span data-phrase="strength.heavy">قوي</span>
+    <span data-phrase="strength.note">{label} &mdash; نحو {blocks} كتلة على الضلع الأقصر
+      من المربع، ونصف قطر طمس يساوي 1/{blur} منه.</span>
+    <span data-phrase="risk.mosaic">أدق فسيفساء هنا {across} x {down} كتلة من {size}
+      بكسل. وهذا يعني {averages} متوسطاً لما كان تحتها، وكلها باقية في الملف.</span>
+    <span data-phrase="risk.blur.one">نصف قطر الطمس {radius} بكسل. والطمس متوسط أيضاً،
+      والطمس الخفيف فوق نص واضح هو بالضبط الحالة التي عُكست من قبل.</span>
+    <span data-phrase="risk.blur.many">أصغر طمس نصف قطره {radius} بكسل. والطمس متوسط
+      أيضاً، والطمس الخفيف فوق نص واضح هو بالضبط الحالة التي عُكست من قبل.</span>
+    <span data-phrase="risk.advice">احجب بالأسود كل ما يُقرأ كنص.</span>
+    <span data-phrase="write.noencode">لم يستطع المتصفح ترميزها.</span>
+    <span data-phrase="write.failed">حدث خطأ أثناء كتابة الملف: {why}</span>
+    <span data-phrase="result.alt">الصورة المحجوبة، {width} في {height} بكسل</span>
+    <span data-phrase="result.file">{name} &mdash; {size}، {width} x {height}</span>
+    <span data-phrase="result.nothing">لم تُعلَّم أي منطقة، فهذه هي الصورة نفسها بعد
+      إعادة ترميزها.</span>
+    <span data-phrase="result.clean">كُتبت من البكسلات المحجوبة، فهي لا تحمل EXIF ولا
+      GPS ولا صورة مصغّرة مضمّنة ولا طبقة فيها الأصل.</span>
+    <span data-phrase="join.sentences">{a} {b}</span>
+    <span data-phrase="join.comma">{a}، {b}</span>
+    <span data-phrase="size.b">{n} بايت</span>
+    <span data-phrase="size.kb">{n} كيلوبايت</span>
+    <span data-phrase="size.mb">{n} ميغابايت</span>
     <span data-phrase="net.clean">صورك لم تذهب إلى أي مكان. {total} ملفاً
       حُمِّلت، كلها ملفات هذه الصفحة نفسها. {platform}</span>
     <span data-phrase="net.dirty">اتصل شيءٌ بـ {hosts}، وهو ما لا تفعله هذه

--- a/locales/de/tools/redact-image.html
+++ b/locales/de/tools/redact-image.html
@@ -190,6 +190,58 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.nodecode">dieser Browser konnte das Bild nicht dekodieren.</span>
+    <span data-phrase="read.failed">Diese Datei konnte nicht geöffnet werden: {why}</span>
+    <span data-phrase="loaded.name">{name} &mdash; {width} x {height}</span>
+    <span data-phrase="region.where">{width} x {height} bei {x}, {y}</span>
+    <span data-phrase="region.pixelated">{where} &mdash; verpixelt, {size} px große
+      Blöcke ({across} x {down})</span>
+    <span data-phrase="region.blurred">{where} &mdash; unscharf, {radius} px Radius</span>
+    <span data-phrase="region.filled">{where} &mdash; geschwärzt</span>
+    <span data-phrase="region.aria">Bereich {n}: {what}. Die Pfeiltasten verschieben
+      ihn, Alt und die Pfeiltasten ändern seine Größe, und Entf entfernt ihn.</span>
+    <span data-phrase="region.choice">Was Bereich {n} macht</span>
+    <span data-phrase="choice.fill">Schwärzen</span>
+    <span data-phrase="choice.pixelate">Verpixeln</span>
+    <span data-phrase="choice.blur">Weichzeichnen</span>
+    <span data-phrase="style.fill.one">{n} geschwärzt</span>
+    <span data-phrase="style.fill.many">{n} geschwärzt</span>
+    <span data-phrase="style.pixelate.one">{n} verpixelt</span>
+    <span data-phrase="style.pixelate.many">{n} verpixelt</span>
+    <span data-phrase="style.blur.one">{n} unscharf</span>
+    <span data-phrase="style.blur.many">{n} unscharf</span>
+    <span data-phrase="count.one">{n} Bereich: {parts}.</span>
+    <span data-phrase="count.many">{n} Bereiche: {parts}.</span>
+    <span data-phrase="strength.light">Leicht</span>
+    <span data-phrase="strength.medium">Mittel</span>
+    <span data-phrase="strength.heavy">Stark</span>
+    <span data-phrase="strength.note">{label} &mdash; etwa {blocks} Blöcke über die
+      kürzere Seite eines Kastens, und ein Weichzeichnungsradius von 1/{blur} davon.</span>
+    <span data-phrase="risk.mosaic">Das feinste Mosaik hier ist {across} x {down} Blöcke
+      zu je {size} px. Das sind {averages} Mittelwerte dessen, was darunter lag, und sie
+      bleiben in der Datei.</span>
+    <span data-phrase="risk.blur.one">Die Unschärfe hat einen Radius von {radius} px.
+      Auch eine Unschärfe ist ein Mittelwert, und eine kleine über scharfem Text ist
+      genau der Fall, der schon rückgängig gemacht worden ist.</span>
+    <span data-phrase="risk.blur.many">Die kleinste Unschärfe hat einen Radius von
+      {radius} px. Auch eine Unschärfe ist ein Mittelwert, und eine kleine über scharfem
+      Text ist genau der Fall, der schon rückgängig gemacht worden ist.</span>
+    <span data-phrase="risk.advice">Schwärzen Sie alles, was sich als Text lesen lässt.</span>
+    <span data-phrase="write.noencode">der Browser konnte es nicht kodieren.</span>
+    <span data-phrase="write.failed">Beim Schreiben der Datei ist etwas schiefgegangen:
+      {why}</span>
+    <span data-phrase="result.alt">Das geschwärzte Bild, {width} mal {height} Pixel</span>
+    <span data-phrase="result.file">{name} &mdash; {size}, {width} x {height}</span>
+    <span data-phrase="result.nothing">Es wurden keine Bereiche markiert, das ist also
+      dasselbe Bild, neu kodiert.</span>
+    <span data-phrase="result.clean">Aus den geschwärzten Pixeln geschrieben, es trägt
+      also kein EXIF, kein GPS, kein eingebettetes Vorschaubild und keine Ebene mit dem
+      Original darin.</span>
+    <span data-phrase="join.sentences">{a} {b}</span>
+    <span data-phrase="join.comma">{a}, {b}</span>
+    <span data-phrase="size.b">{n} B</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="net.clean">Ihre Bilder sind nirgendwohin gegangen.
       {total} Dateien geladen, allesamt eigene dieser Seite. {platform}</span>
     <span data-phrase="net.dirty">Etwas hat {hosts} kontaktiert, und das tut

--- a/locales/es/tools/redact-image.html
+++ b/locales/es/tools/redact-image.html
@@ -184,6 +184,58 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.nodecode">este navegador no ha podido descodificar la
+      imagen.</span>
+    <span data-phrase="read.failed">Este archivo no se ha podido abrir: {why}</span>
+    <span data-phrase="loaded.name">{name} &mdash; {width} x {height}</span>
+    <span data-phrase="region.where">{width} x {height} en {x}, {y}</span>
+    <span data-phrase="region.pixelated">{where} &mdash; pixelada, bloques de {size} px
+      ({across} x {down})</span>
+    <span data-phrase="region.blurred">{where} &mdash; desenfocada, radio de {radius} px</span>
+    <span data-phrase="region.filled">{where} &mdash; tapada en negro</span>
+    <span data-phrase="region.aria">Área {n}: {what}. Las flechas la mueven, Alt y las
+      flechas la redimensionan, y Supr la quita.</span>
+    <span data-phrase="region.choice">Qué hace el área {n}</span>
+    <span data-phrase="choice.fill">Tapar en negro</span>
+    <span data-phrase="choice.pixelate">Pixelar</span>
+    <span data-phrase="choice.blur">Desenfocar</span>
+    <span data-phrase="style.fill.one">{n} tapada en negro</span>
+    <span data-phrase="style.fill.many">{n} tapadas en negro</span>
+    <span data-phrase="style.pixelate.one">{n} pixelada</span>
+    <span data-phrase="style.pixelate.many">{n} pixeladas</span>
+    <span data-phrase="style.blur.one">{n} desenfocada</span>
+    <span data-phrase="style.blur.many">{n} desenfocadas</span>
+    <span data-phrase="count.one">{n} área: {parts}.</span>
+    <span data-phrase="count.many">{n} áreas: {parts}.</span>
+    <span data-phrase="strength.light">Suave</span>
+    <span data-phrase="strength.medium">Medio</span>
+    <span data-phrase="strength.heavy">Fuerte</span>
+    <span data-phrase="strength.note">{label}: unos {blocks} bloques a lo largo del lado
+      más corto de un área, y un radio de desenfoque de 1/{blur} de ese lado.</span>
+    <span data-phrase="risk.mosaic">El mosaico más fino que hay aquí es de {across} x
+      {down} bloques de {size} px. Eso son {averages} promedios de lo que había debajo,
+      y se quedan en el archivo.</span>
+    <span data-phrase="risk.blur.one">El desenfoque tiene un radio de {radius} px. Un
+      desenfoque también es un promedio, y uno pequeño sobre texto nítido es justo el
+      caso que ya se ha deshecho.</span>
+    <span data-phrase="risk.blur.many">El desenfoque más pequeño tiene un radio de
+      {radius} px. Un desenfoque también es un promedio, y uno pequeño sobre texto
+      nítido es justo el caso que ya se ha deshecho.</span>
+    <span data-phrase="risk.advice">Tapa en negro todo lo que se lea como texto.</span>
+    <span data-phrase="write.noencode">el navegador no ha podido codificarlo.</span>
+    <span data-phrase="write.failed">Algo ha salido mal al escribir el archivo: {why}</span>
+    <span data-phrase="result.alt">La imagen tapada, {width} por {height} píxeles</span>
+    <span data-phrase="result.file">{name} &mdash; {size}, {width} x {height}</span>
+    <span data-phrase="result.nothing">No se marcó ningún área, así que esta es la misma
+      imagen vuelta a codificar.</span>
+    <span data-phrase="result.clean">Escrita a partir de los píxeles tapados, así que no
+      lleva EXIF, ni GPS, ni miniatura incrustada, ni ninguna capa con el original
+      dentro.</span>
+    <span data-phrase="join.sentences">{a} {b}</span>
+    <span data-phrase="join.comma">{a}, {b}</span>
+    <span data-phrase="size.b">{n} B</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="net.clean">tus imágenes no han ido a ninguna parte.
       {total} archivos cargados, todos ellos de esta misma página. {platform}</span>
     <span data-phrase="net.dirty">algo ha contactado con {hosts}, cosa que esta

--- a/locales/fr/tools/redact-image.html
+++ b/locales/fr/tools/redact-image.html
@@ -188,6 +188,58 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.nodecode">ce navigateur n&rsquo;a pas pu décoder
+      l&rsquo;image.</span>
+    <span data-phrase="read.failed">Ce fichier n&rsquo;a pas pu être ouvert&nbsp;: {why}</span>
+    <span data-phrase="loaded.name">{name} &mdash; {width} x {height}</span>
+    <span data-phrase="region.where">{width} x {height} en {x}, {y}</span>
+    <span data-phrase="region.pixelated">{where} &mdash; pixelisé, blocs de {size} px
+      ({across} x {down})</span>
+    <span data-phrase="region.blurred">{where} &mdash; flouté, rayon de {radius} px</span>
+    <span data-phrase="region.filled">{where} &mdash; caviardé</span>
+    <span data-phrase="region.aria">Zone {n}&nbsp;: {what}. Les flèches la déplacent,
+      Alt et les flèches la redimensionnent, et Suppr la retire.</span>
+    <span data-phrase="region.choice">Ce que fait la zone {n}</span>
+    <span data-phrase="choice.fill">Caviarder</span>
+    <span data-phrase="choice.pixelate">Pixeliser</span>
+    <span data-phrase="choice.blur">Flouter</span>
+    <span data-phrase="style.fill.one">{n} caviardée</span>
+    <span data-phrase="style.fill.many">{n} caviardées</span>
+    <span data-phrase="style.pixelate.one">{n} pixelisée</span>
+    <span data-phrase="style.pixelate.many">{n} pixelisées</span>
+    <span data-phrase="style.blur.one">{n} floutée</span>
+    <span data-phrase="style.blur.many">{n} floutées</span>
+    <span data-phrase="count.one">{n} zone&nbsp;: {parts}.</span>
+    <span data-phrase="count.many">{n} zones&nbsp;: {parts}.</span>
+    <span data-phrase="strength.light">Léger</span>
+    <span data-phrase="strength.medium">Moyen</span>
+    <span data-phrase="strength.heavy">Fort</span>
+    <span data-phrase="strength.note">{label} &mdash; environ {blocks} blocs sur le côté
+      le plus court d&rsquo;une zone, et un rayon de flou de 1/{blur} de celui-ci.</span>
+    <span data-phrase="risk.mosaic">La mosaïque la plus fine ici fait {across} x {down}
+      blocs de {size} px. Cela fait {averages} moyennes de ce qu&rsquo;il y avait
+      dessous, laissées dans le fichier.</span>
+    <span data-phrase="risk.blur.one">Le flou a un rayon de {radius} px. Un flou est une
+      moyenne lui aussi, et un petit flou sur du texte net est précisément le cas qui a
+      déjà été remonté à l&rsquo;envers.</span>
+    <span data-phrase="risk.blur.many">Le plus petit flou a un rayon de {radius} px. Un
+      flou est une moyenne lui aussi, et un petit flou sur du texte net est précisément
+      le cas qui a déjà été remonté à l&rsquo;envers.</span>
+    <span data-phrase="risk.advice">Caviardez tout ce qui se lit comme du texte.</span>
+    <span data-phrase="write.noencode">le navigateur n&rsquo;a pas pu l&rsquo;encoder.</span>
+    <span data-phrase="write.failed">Quelque chose a mal tourné à l&rsquo;écriture du
+      fichier&nbsp;: {why}</span>
+    <span data-phrase="result.alt">L&rsquo;image caviardée, {width} sur {height} pixels</span>
+    <span data-phrase="result.file">{name} &mdash; {size}, {width} x {height}</span>
+    <span data-phrase="result.nothing">Aucune zone n&rsquo;a été marquée, c&rsquo;est
+      donc la même image réencodée.</span>
+    <span data-phrase="result.clean">Écrite à partir des pixels caviardés&nbsp;: elle ne
+      porte ni EXIF, ni GPS, ni vignette intégrée, ni calque contenant l&rsquo;original.</span>
+    <span data-phrase="join.sentences">{a} {b}</span>
+    <span data-phrase="join.comma">{a}, {b}</span>
+    <span data-phrase="size.b">{n} o</span>
+    <span data-phrase="size.kb">{n} Ko</span>
+    <span data-phrase="size.mb">{n} Mo</span>
     <span data-phrase="net.clean">vos images ne sont allées nulle part. {total}
       fichiers chargés, tous appartenant à cette page. {platform}</span>
     <span data-phrase="net.dirty">quelque chose a contacté {hosts}, ce que cet

--- a/locales/hi/tools/redact-image.html
+++ b/locales/hi/tools/redact-image.html
@@ -180,6 +180,56 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.nodecode">यह ब्राउज़र तस्वीर को डीकोड नहीं कर सका।</span>
+    <span data-phrase="read.failed">यह फ़ाइल खोली नहीं जा सकी: {why}</span>
+    <span data-phrase="loaded.name">{name} &mdash; {width} x {height}</span>
+    <span data-phrase="region.where">{x}, {y} पर {width} x {height}</span>
+    <span data-phrase="region.pixelated">{where} &mdash; पिक्सेलेटेड, {size} px के ब्लॉक
+      ({across} x {down})</span>
+    <span data-phrase="region.blurred">{where} &mdash; धुँधला, {radius} px त्रिज्या</span>
+    <span data-phrase="region.filled">{where} &mdash; काला किया हुआ</span>
+    <span data-phrase="region.aria">क्षेत्र {n}: {what}। तीर कुंजियाँ इसे खिसकाती हैं,
+      Alt के साथ तीर कुंजियाँ आकार बदलती हैं, और Delete इसे हटाता है।</span>
+    <span data-phrase="region.choice">क्षेत्र {n} क्या करता है</span>
+    <span data-phrase="choice.fill">काला कीजिए</span>
+    <span data-phrase="choice.pixelate">पिक्सेलेट कीजिए</span>
+    <span data-phrase="choice.blur">धुँधला कीजिए</span>
+    <span data-phrase="style.fill.one">{n} काला किया</span>
+    <span data-phrase="style.fill.many">{n} काले किए</span>
+    <span data-phrase="style.pixelate.one">{n} पिक्सेलेटेड</span>
+    <span data-phrase="style.pixelate.many">{n} पिक्सेलेटेड</span>
+    <span data-phrase="style.blur.one">{n} धुँधला</span>
+    <span data-phrase="style.blur.many">{n} धुँधले</span>
+    <span data-phrase="count.one">{n} क्षेत्र: {parts}।</span>
+    <span data-phrase="count.many">{n} क्षेत्र: {parts}।</span>
+    <span data-phrase="strength.light">हल्का</span>
+    <span data-phrase="strength.medium">मध्यम</span>
+    <span data-phrase="strength.heavy">तेज़</span>
+    <span data-phrase="strength.note">{label} &mdash; एक बॉक्स की छोटी भुजा पर क़रीब
+      {blocks} ब्लॉक, और उसी का 1/{blur} धुँधलेपन की त्रिज्या।</span>
+    <span data-phrase="risk.mosaic">यहाँ का सबसे बारीक मोज़ेक {across} x {down} ब्लॉक का
+      है, हर ब्लॉक {size} px। यानी नीचे जो था उसके {averages} औसत, जो फ़ाइल में ही रह
+      जाते हैं।</span>
+    <span data-phrase="risk.blur.one">धुँधलेपन की त्रिज्या {radius} px है। धुँधलापन भी
+      एक औसत ही है, और साफ़ लिखावट पर पड़ा हल्का धुँधलापन ठीक वही मामला है जिसे उलटकर
+      पढ़ा जा चुका है।</span>
+    <span data-phrase="risk.blur.many">सबसे छोटे धुँधलेपन की त्रिज्या {radius} px है।
+      धुँधलापन भी एक औसत ही है, और साफ़ लिखावट पर पड़ा हल्का धुँधलापन ठीक वही मामला है
+      जिसे उलटकर पढ़ा जा चुका है।</span>
+    <span data-phrase="risk.advice">जो भी टेक्स्ट की तरह पढ़ा जा सके, उसे काला कर दीजिए।</span>
+    <span data-phrase="write.noencode">ब्राउज़र इसे एनकोड नहीं कर सका।</span>
+    <span data-phrase="write.failed">फ़ाइल लिखते समय कुछ गड़बड़ हो गई: {why}</span>
+    <span data-phrase="result.alt">काली की हुई तस्वीर, {width} गुणा {height} पिक्सेल</span>
+    <span data-phrase="result.file">{name} &mdash; {size}, {width} x {height}</span>
+    <span data-phrase="result.nothing">कोई क्षेत्र चिह्नित नहीं किया गया, इसलिए यह वही
+      तस्वीर है, दोबारा एनकोड की हुई।</span>
+    <span data-phrase="result.clean">काले किए पिक्सेल से लिखी गई, इसलिए इसमें न EXIF है,
+      न GPS, न कोई अंदर रखा थंबनेल, और न ही कोई परत जिसमें मूल तस्वीर हो।</span>
+    <span data-phrase="join.sentences">{a} {b}</span>
+    <span data-phrase="join.comma">{a}, {b}</span>
+    <span data-phrase="size.b">{n} B</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="net.clean">आपकी तस्वीरें कहीं नहीं गईं। {total} फ़ाइलें
       लोड हुईं, और वे सब इसी साइट की अपनी हैं। {platform}</span>
     <span data-phrase="net.dirty">किसी चीज़ ने {hosts} से संपर्क किया, और यह टूल

--- a/locales/id/tools/redact-image.html
+++ b/locales/id/tools/redact-image.html
@@ -192,6 +192,58 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.nodecode">browser ini tidak bisa mengawakode gambarnya.</span>
+    <span data-phrase="read.failed">Berkas ini tidak bisa dibuka: {why}</span>
+    <span data-phrase="loaded.name">{name} &mdash; {width} x {height}</span>
+    <span data-phrase="region.where">{width} x {height} di {x}, {y}</span>
+    <span data-phrase="region.pixelated">{where} &mdash; dipikselkan, blok {size} px
+      ({across} x {down})</span>
+    <span data-phrase="region.blurred">{where} &mdash; dikaburkan, jari-jari {radius} px</span>
+    <span data-phrase="region.filled">{where} &mdash; dihitamkan</span>
+    <span data-phrase="region.aria">Area {n}: {what}. Tombol panah memindahkannya, Alt
+      dengan tombol panah mengubah ukurannya, dan Delete menghapusnya.</span>
+    <span data-phrase="region.choice">Apa yang dilakukan area {n}</span>
+    <span data-phrase="choice.fill">Hitamkan</span>
+    <span data-phrase="choice.pixelate">Pikselkan</span>
+    <span data-phrase="choice.blur">Kaburkan</span>
+    <span data-phrase="style.fill.one">{n} dihitamkan</span>
+    <span data-phrase="style.fill.many">{n} dihitamkan</span>
+    <span data-phrase="style.pixelate.one">{n} dipikselkan</span>
+    <span data-phrase="style.pixelate.many">{n} dipikselkan</span>
+    <span data-phrase="style.blur.one">{n} dikaburkan</span>
+    <span data-phrase="style.blur.many">{n} dikaburkan</span>
+    <span data-phrase="count.one">{n} area: {parts}.</span>
+    <span data-phrase="count.many">{n} area: {parts}.</span>
+    <span data-phrase="strength.light">Ringan</span>
+    <span data-phrase="strength.medium">Sedang</span>
+    <span data-phrase="strength.heavy">Berat</span>
+    <span data-phrase="strength.note">{label} &mdash; kira-kira {blocks} blok sepanjang
+      sisi terpendek sebuah kotak, dan jari-jari pengaburan sebesar 1/{blur} dari sisi
+      itu.</span>
+    <span data-phrase="risk.mosaic">Mosaik terhalus di sini {across} x {down} blok
+      berukuran {size} px. Itu {averages} nilai rata-rata dari apa yang ada di bawahnya,
+      dan semuanya tertinggal di berkasnya.</span>
+    <span data-phrase="risk.blur.one">Kaburnya berjari-jari {radius} px. Kabur juga
+      sebuah rata-rata, dan kabur tipis di atas teks yang tajam justru kasus yang sudah
+      pernah dibalik orang.</span>
+    <span data-phrase="risk.blur.many">Kabur yang paling kecil berjari-jari {radius} px.
+      Kabur juga sebuah rata-rata, dan kabur tipis di atas teks yang tajam justru kasus
+      yang sudah pernah dibalik orang.</span>
+    <span data-phrase="risk.advice">Hitamkan apa pun yang terbaca sebagai teks.</span>
+    <span data-phrase="write.noencode">browser tidak bisa mengodekannya.</span>
+    <span data-phrase="write.failed">Ada yang salah saat menulis berkasnya: {why}</span>
+    <span data-phrase="result.alt">Gambar yang sudah disensor, {width} kali {height}
+      piksel</span>
+    <span data-phrase="result.file">{name} &mdash; {size}, {width} x {height}</span>
+    <span data-phrase="result.nothing">Tidak ada area yang ditandai, jadi ini gambar
+      yang sama, dikodekan ulang.</span>
+    <span data-phrase="result.clean">Ditulis dari piksel yang sudah disensor, jadi tidak
+      membawa EXIF, GPS, gambar mini tersemat, maupun lapisan berisi aslinya.</span>
+    <span data-phrase="join.sentences">{a} {b}</span>
+    <span data-phrase="join.comma">{a}, {b}</span>
+    <span data-phrase="size.b">{n} B</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="net.clean">gambar Anda tidak pergi ke mana pun. {total}
       file dimuat, semuanya milik halaman ini sendiri. {platform}</span>
     <span data-phrase="net.dirty">sesuatu menghubungi {hosts}, dan itu tidak

--- a/locales/it/tools/redact-image.html
+++ b/locales/it/tools/redact-image.html
@@ -186,6 +186,58 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.nodecode">questo browser non è riuscito a decodificare
+      l&rsquo;immagine.</span>
+    <span data-phrase="read.failed">Questo file non si è potuto aprire: {why}</span>
+    <span data-phrase="loaded.name">{name} &mdash; {width} x {height}</span>
+    <span data-phrase="region.where">{width} x {height} a {x}, {y}</span>
+    <span data-phrase="region.pixelated">{where} &mdash; pixelata, blocchi da {size} px
+      ({across} x {down})</span>
+    <span data-phrase="region.blurred">{where} &mdash; sfocata, raggio di {radius} px</span>
+    <span data-phrase="region.filled">{where} &mdash; oscurata</span>
+    <span data-phrase="region.aria">Area {n}: {what}. Le frecce la spostano, Alt e le
+      frecce la ridimensionano, e Canc la toglie.</span>
+    <span data-phrase="region.choice">Che cosa fa l&rsquo;area {n}</span>
+    <span data-phrase="choice.fill">Oscura</span>
+    <span data-phrase="choice.pixelate">Pixela</span>
+    <span data-phrase="choice.blur">Sfoca</span>
+    <span data-phrase="style.fill.one">{n} oscurata</span>
+    <span data-phrase="style.fill.many">{n} oscurate</span>
+    <span data-phrase="style.pixelate.one">{n} pixelata</span>
+    <span data-phrase="style.pixelate.many">{n} pixelate</span>
+    <span data-phrase="style.blur.one">{n} sfocata</span>
+    <span data-phrase="style.blur.many">{n} sfocate</span>
+    <span data-phrase="count.one">{n} area: {parts}.</span>
+    <span data-phrase="count.many">{n} aree: {parts}.</span>
+    <span data-phrase="strength.light">Leggero</span>
+    <span data-phrase="strength.medium">Medio</span>
+    <span data-phrase="strength.heavy">Forte</span>
+    <span data-phrase="strength.note">{label} &mdash; circa {blocks} blocchi sul lato
+      corto di un&rsquo;area, e un raggio di sfocatura pari a 1/{blur} di quel lato.</span>
+    <span data-phrase="risk.mosaic">Il mosaico più fine qui è di {across} x {down}
+      blocchi da {size} px. Sono {averages} medie di ciò che c&rsquo;era sotto, lasciate
+      nel file.</span>
+    <span data-phrase="risk.blur.one">La sfocatura ha un raggio di {radius} px. Anche
+      una sfocatura è una media, e una piccola sopra del testo nitido è proprio il caso
+      che è già stato ricostruito a ritroso.</span>
+    <span data-phrase="risk.blur.many">La sfocatura più piccola ha un raggio di {radius}
+      px. Anche una sfocatura è una media, e una piccola sopra del testo nitido è
+      proprio il caso che è già stato ricostruito a ritroso.</span>
+    <span data-phrase="risk.advice">Oscura tutto ciò che si legge come testo.</span>
+    <span data-phrase="write.noencode">il browser non è riuscito a codificarlo.</span>
+    <span data-phrase="write.failed">Qualcosa è andato storto scrivendo il file: {why}</span>
+    <span data-phrase="result.alt">L&rsquo;immagine oscurata, {width} per {height} pixel</span>
+    <span data-phrase="result.file">{name} &mdash; {size}, {width} x {height}</span>
+    <span data-phrase="result.nothing">Non è stata segnata nessuna area, quindi questa è
+      la stessa immagine ricodificata.</span>
+    <span data-phrase="result.clean">Scritta a partire dai pixel oscurati, quindi non
+      porta EXIF, né GPS, né miniatura incorporata, né alcun livello con
+      l&rsquo;originale dentro.</span>
+    <span data-phrase="join.sentences">{a} {b}</span>
+    <span data-phrase="join.comma">{a}, {b}</span>
+    <span data-phrase="size.b">{n} B</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="net.clean">Le tue immagini non sono andate da nessuna
       parte. {total} file caricati, tutti quanti di questo sito. {platform}</span>
     <span data-phrase="net.dirty">Qualcosa ha contattato {hosts}, e questo

--- a/locales/ja/tools/redact-image.html
+++ b/locales/ja/tools/redact-image.html
@@ -158,6 +158,45 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.nodecode">このブラウザーは画像をデコードできませんでした。</span>
+    <span data-phrase="read.failed">このファイルは開けませんでした：{why}</span>
+    <span data-phrase="loaded.name">{name} &mdash; {width} x {height}</span>
+    <span data-phrase="region.where">{x}, {y}に{width} x {height}</span>
+    <span data-phrase="region.pixelated">{where} &mdash; モザイク、{size} pxのブロック（{across} x {down}）</span>
+    <span data-phrase="region.blurred">{where} &mdash; ぼかし、半径{radius} px</span>
+    <span data-phrase="region.filled">{where} &mdash; 黒塗り</span>
+    <span data-phrase="region.aria">領域{n}：{what}。矢印キーで移動、Altと矢印キーでサイズ変更、Deleteで削除します。</span>
+    <span data-phrase="region.choice">領域{n}の処理</span>
+    <span data-phrase="choice.fill">黒塗り</span>
+    <span data-phrase="choice.pixelate">モザイク</span>
+    <span data-phrase="choice.blur">ぼかし</span>
+    <span data-phrase="style.fill.one">黒塗り{n}件</span>
+    <span data-phrase="style.fill.many">黒塗り{n}件</span>
+    <span data-phrase="style.pixelate.one">モザイク{n}件</span>
+    <span data-phrase="style.pixelate.many">モザイク{n}件</span>
+    <span data-phrase="style.blur.one">ぼかし{n}件</span>
+    <span data-phrase="style.blur.many">ぼかし{n}件</span>
+    <span data-phrase="count.one">領域{n}件：{parts}。</span>
+    <span data-phrase="count.many">領域{n}件：{parts}。</span>
+    <span data-phrase="strength.light">弱</span>
+    <span data-phrase="strength.medium">中</span>
+    <span data-phrase="strength.heavy">強</span>
+    <span data-phrase="strength.note">{label} &mdash; 枠の短いほうの辺におよそ{blocks}ブロック、ぼかしの半径はその1/{blur}です。</span>
+    <span data-phrase="risk.mosaic">ここでいちばん細かいモザイクは{size} pxのブロックが{across} x {down}です。下にあったものの平均値が{averages}個、ファイルに残るということです。</span>
+    <span data-phrase="risk.blur.one">ぼかしの半径は{radius} pxです。ぼかしも平均であり、くっきりした文字に薄くかけたぼかしこそ、すでに逆算されてきた事例です。</span>
+    <span data-phrase="risk.blur.many">いちばん小さいぼかしの半径は{radius} pxです。ぼかしも平均であり、くっきりした文字に薄くかけたぼかしこそ、すでに逆算されてきた事例です。</span>
+    <span data-phrase="risk.advice">文字として読めるものはすべて黒く塗ってください。</span>
+    <span data-phrase="write.noencode">ブラウザーがエンコードできませんでした。</span>
+    <span data-phrase="write.failed">ファイルを書き出す途中で問題が起きました：{why}</span>
+    <span data-phrase="result.alt">黒塗りした画像、{width}×{height}ピクセル</span>
+    <span data-phrase="result.file">{name} &mdash; {size}、{width} x {height}</span>
+    <span data-phrase="result.nothing">領域が1つも指定されていないので、これは同じ画像を再エンコードしただけのものです。</span>
+    <span data-phrase="result.clean">黒塗りした画素から書き出しているので、EXIFもGPSも埋め込みサムネイルも、元の画像が入ったレイヤーもありません。</span>
+    <span data-phrase="join.sentences">{a}{b}</span>
+    <span data-phrase="join.comma">{a}、{b}</span>
+    <span data-phrase="size.b">{n} B</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="net.clean">画像はどこへも出ていません。{total}件のファイルを読み込み、そのすべてがこのサイト自身のものです。{platform}</span>
     <span data-phrase="net.dirty">何かが{hosts}へ接続しました。この道具は決してそれをしません。調べてみる価値があります。{platform}</span>
     <span data-phrase="net.platform.one">広告・計測・寄付ボタンのためのサイト自身のスクリプトが{hosts}のホストから読み込まれました。そのどれにも、画像も、その1バイトも渡っていません。</span>

--- a/locales/ko/tools/redact-image.html
+++ b/locales/ko/tools/redact-image.html
@@ -176,6 +176,52 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.nodecode">이 브라우저는 그림을 디코딩하지 못했습니다.</span>
+    <span data-phrase="read.failed">이 파일은 열지 못했습니다: {why}</span>
+    <span data-phrase="loaded.name">{name} &mdash; {width} x {height}</span>
+    <span data-phrase="region.where">{x}, {y}에 {width} x {height}</span>
+    <span data-phrase="region.pixelated">{where} &mdash; 모자이크, {size} px 블록 ({across} x
+      {down})</span>
+    <span data-phrase="region.blurred">{where} &mdash; 흐리게, 반지름 {radius} px</span>
+    <span data-phrase="region.filled">{where} &mdash; 검게 가림</span>
+    <span data-phrase="region.aria">영역 {n}: {what}. 화살표 키로 옮기고, Alt와 화살표 키로 크기를 바꾸며,
+      Delete로 지웁니다.</span>
+    <span data-phrase="region.choice">영역 {n}이 하는 일</span>
+    <span data-phrase="choice.fill">검게 가리기</span>
+    <span data-phrase="choice.pixelate">모자이크</span>
+    <span data-phrase="choice.blur">흐리게</span>
+    <span data-phrase="style.fill.one">검게 가림 {n}개</span>
+    <span data-phrase="style.fill.many">검게 가림 {n}개</span>
+    <span data-phrase="style.pixelate.one">모자이크 {n}개</span>
+    <span data-phrase="style.pixelate.many">모자이크 {n}개</span>
+    <span data-phrase="style.blur.one">흐리게 {n}개</span>
+    <span data-phrase="style.blur.many">흐리게 {n}개</span>
+    <span data-phrase="count.one">영역 {n}개: {parts}.</span>
+    <span data-phrase="count.many">영역 {n}개: {parts}.</span>
+    <span data-phrase="strength.light">약하게</span>
+    <span data-phrase="strength.medium">보통</span>
+    <span data-phrase="strength.heavy">강하게</span>
+    <span data-phrase="strength.note">{label} &mdash; 상자의 짧은 변을 따라 약 {blocks}블록, 흐림 반지름은
+      그 1/{blur}입니다.</span>
+    <span data-phrase="risk.mosaic">여기서 가장 고운 모자이크는 {size} px 블록이 {across} x {down}입니다.
+      그 아래 있던 것의 평균이 {averages}개, 파일에 그대로 남는다는 뜻입니다.</span>
+    <span data-phrase="risk.blur.one">흐림의 반지름은 {radius} px입니다. 흐림도 평균이고, 또렷한 글자 위에 옅게 건
+      흐림이야말로 이미 되짚어 풀린 사례입니다.</span>
+    <span data-phrase="risk.blur.many">가장 작은 흐림의 반지름은 {radius} px입니다. 흐림도 평균이고, 또렷한 글자
+      위에 옅게 건 흐림이야말로 이미 되짚어 풀린 사례입니다.</span>
+    <span data-phrase="risk.advice">글자로 읽히는 것은 모두 검게 가리세요.</span>
+    <span data-phrase="write.noencode">브라우저가 인코딩하지 못했습니다.</span>
+    <span data-phrase="write.failed">파일을 쓰는 중에 문제가 생겼습니다: {why}</span>
+    <span data-phrase="result.alt">가린 그림, {width} × {height} 픽셀</span>
+    <span data-phrase="result.file">{name} &mdash; {size}, {width} x {height}</span>
+    <span data-phrase="result.nothing">표시한 영역이 없어서, 같은 그림을 다시 인코딩한 것입니다.</span>
+    <span data-phrase="result.clean">가린 픽셀에서 써낸 것이라 EXIF도 GPS도 끼워 넣은 미리보기도, 원본이 든 레이어도
+      없습니다.</span>
+    <span data-phrase="join.sentences">{a} {b}</span>
+    <span data-phrase="join.comma">{a}, {b}</span>
+    <span data-phrase="size.b">{n} B</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="net.clean">이미지는 어디로도 가지 않았습니다. 파일 {total}개를 불러왔고 모두 이
       사이트의 것입니다. {platform}</span>
     <span data-phrase="net.dirty">무언가가 {hosts}에 접속했는데, 이 도구는 절대 그러지 않습니다. 살펴볼

--- a/locales/nl/tools/redact-image.html
+++ b/locales/nl/tools/redact-image.html
@@ -187,6 +187,59 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.nodecode">deze browser kon de afbeelding niet decoderen.</span>
+    <span data-phrase="read.failed">Dit bestand kon niet geopend worden: {why}</span>
+    <span data-phrase="loaded.name">{name} &mdash; {width} x {height}</span>
+    <span data-phrase="region.where">{width} x {height} op {x}, {y}</span>
+    <span data-phrase="region.pixelated">{where} &mdash; gepixeld, blokken van {size} px
+      ({across} x {down})</span>
+    <span data-phrase="region.blurred">{where} &mdash; vervaagd, straal van {radius} px</span>
+    <span data-phrase="region.filled">{where} &mdash; zwart gemaakt</span>
+    <span data-phrase="region.aria">Gebied {n}: {what}. De pijltoetsen verplaatsen het,
+      Alt met de pijltoetsen verandert de grootte, en Delete haalt het weg.</span>
+    <span data-phrase="region.choice">Wat gebied {n} doet</span>
+    <span data-phrase="choice.fill">Zwart maken</span>
+    <span data-phrase="choice.pixelate">Pixelen</span>
+    <span data-phrase="choice.blur">Vervagen</span>
+    <span data-phrase="style.fill.one">{n} zwart gemaakt</span>
+    <span data-phrase="style.fill.many">{n} zwart gemaakt</span>
+    <span data-phrase="style.pixelate.one">{n} gepixeld</span>
+    <span data-phrase="style.pixelate.many">{n} gepixeld</span>
+    <span data-phrase="style.blur.one">{n} vervaagd</span>
+    <span data-phrase="style.blur.many">{n} vervaagd</span>
+    <span data-phrase="count.one">{n} gebied: {parts}.</span>
+    <span data-phrase="count.many">{n} gebieden: {parts}.</span>
+    <span data-phrase="strength.light">Licht</span>
+    <span data-phrase="strength.medium">Middel</span>
+    <span data-phrase="strength.heavy">Zwaar</span>
+    <span data-phrase="strength.note">{label} &mdash; ongeveer {blocks} blokken over de
+      kortste zijde van een gebied, en een vervagingsstraal van 1/{blur} daarvan.</span>
+    <span data-phrase="risk.mosaic">Het fijnste mozaïek hier is {across} x {down}
+      blokken van {size} px. Dat zijn {averages} gemiddelden van wat eronder lag, en die
+      blijven in het bestand staan.</span>
+    <span data-phrase="risk.blur.one">De vervaging heeft een straal van {radius} px. Een
+      vervaging is ook een gemiddelde, en een kleine over scherpe tekst is precies het
+      geval dat al is teruggerekend.</span>
+    <span data-phrase="risk.blur.many">De kleinste vervaging heeft een straal van
+      {radius} px. Een vervaging is ook een gemiddelde, en een kleine over scherpe tekst
+      is precies het geval dat al is teruggerekend.</span>
+    <span data-phrase="risk.advice">Maak alles wat als tekst te lezen is zwart.</span>
+    <span data-phrase="write.noencode">de browser kon het niet coderen.</span>
+    <span data-phrase="write.failed">Er ging iets mis bij het schrijven van het bestand:
+      {why}</span>
+    <span data-phrase="result.alt">De zwart gemaakte afbeelding, {width} bij {height}
+      pixels</span>
+    <span data-phrase="result.file">{name} &mdash; {size}, {width} x {height}</span>
+    <span data-phrase="result.nothing">Er zijn geen gebieden gemarkeerd, dus dit is
+      dezelfde afbeelding opnieuw gecodeerd.</span>
+    <span data-phrase="result.clean">Geschreven uit de zwart gemaakte pixels, dus er zit
+      geen EXIF in, geen GPS, geen ingesloten miniatuur en geen laag met het origineel
+      erin.</span>
+    <span data-phrase="join.sentences">{a} {b}</span>
+    <span data-phrase="join.comma">{a}, {b}</span>
+    <span data-phrase="size.b">{n} B</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="net.clean">Je afbeeldingen zijn nergens heen gegaan.
       {total} bestanden geladen, allemaal van deze site zelf. {platform}</span>
     <span data-phrase="net.dirty">Iets heeft {hosts} benaderd, en dat doet dit

--- a/locales/pt/tools/redact-image.html
+++ b/locales/pt/tools/redact-image.html
@@ -183,6 +183,57 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.nodecode">este navegador não conseguiu decodificar a imagem.</span>
+    <span data-phrase="read.failed">Este arquivo não pôde ser aberto: {why}</span>
+    <span data-phrase="loaded.name">{name} &mdash; {width} x {height}</span>
+    <span data-phrase="region.where">{width} x {height} em {x}, {y}</span>
+    <span data-phrase="region.pixelated">{where} &mdash; pixelada, blocos de {size} px
+      ({across} x {down})</span>
+    <span data-phrase="region.blurred">{where} &mdash; borrada, raio de {radius} px</span>
+    <span data-phrase="region.filled">{where} &mdash; tapada de preto</span>
+    <span data-phrase="region.aria">Área {n}: {what}. As setas movem, Alt com as setas
+      redimensiona, e Del remove.</span>
+    <span data-phrase="region.choice">O que a área {n} faz</span>
+    <span data-phrase="choice.fill">Tapar de preto</span>
+    <span data-phrase="choice.pixelate">Pixelar</span>
+    <span data-phrase="choice.blur">Borrar</span>
+    <span data-phrase="style.fill.one">{n} tapada de preto</span>
+    <span data-phrase="style.fill.many">{n} tapadas de preto</span>
+    <span data-phrase="style.pixelate.one">{n} pixelada</span>
+    <span data-phrase="style.pixelate.many">{n} pixeladas</span>
+    <span data-phrase="style.blur.one">{n} borrada</span>
+    <span data-phrase="style.blur.many">{n} borradas</span>
+    <span data-phrase="count.one">{n} área: {parts}.</span>
+    <span data-phrase="count.many">{n} áreas: {parts}.</span>
+    <span data-phrase="strength.light">Leve</span>
+    <span data-phrase="strength.medium">Médio</span>
+    <span data-phrase="strength.heavy">Forte</span>
+    <span data-phrase="strength.note">{label} &mdash; cerca de {blocks} blocos ao longo
+      do lado mais curto de uma área, e um raio de borrão de 1/{blur} desse lado.</span>
+    <span data-phrase="risk.mosaic">O mosaico mais fino aqui é de {across} x {down}
+      blocos de {size} px. Isso dá {averages} médias do que estava por baixo, deixadas
+      no arquivo.</span>
+    <span data-phrase="risk.blur.one">O borrão tem um raio de {radius} px. Um borrão
+      também é uma média, e um pequeno sobre texto nítido é justamente o caso que já foi
+      desfeito.</span>
+    <span data-phrase="risk.blur.many">O menor borrão tem um raio de {radius} px. Um
+      borrão também é uma média, e um pequeno sobre texto nítido é justamente o caso que
+      já foi desfeito.</span>
+    <span data-phrase="risk.advice">Tape de preto tudo que se leia como texto.</span>
+    <span data-phrase="write.noencode">o navegador não conseguiu codificar.</span>
+    <span data-phrase="write.failed">Algo deu errado ao escrever o arquivo: {why}</span>
+    <span data-phrase="result.alt">A imagem tapada, {width} por {height} pixels</span>
+    <span data-phrase="result.file">{name} &mdash; {size}, {width} x {height}</span>
+    <span data-phrase="result.nothing">Nenhuma área foi marcada, então esta é a mesma
+      imagem recodificada.</span>
+    <span data-phrase="result.clean">Escrita a partir dos pixels tapados, então não
+      carrega EXIF, nem GPS, nem miniatura embutida, nem camada nenhuma com o original
+      dentro.</span>
+    <span data-phrase="join.sentences">{a} {b}</span>
+    <span data-phrase="join.comma">{a}, {b}</span>
+    <span data-phrase="size.b">{n} B</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="net.clean">As suas imagens não foram a lugar nenhum.
       {total} arquivos carregados, todos do próprio site. {platform}</span>
     <span data-phrase="net.dirty">Alguma coisa contatou {hosts}, e esta

--- a/locales/tr/tools/redact-image.html
+++ b/locales/tr/tools/redact-image.html
@@ -191,6 +191,57 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.nodecode">bu tarayıcı görseli çözemedi.</span>
+    <span data-phrase="read.failed">Bu dosya açılamadı: {why}</span>
+    <span data-phrase="loaded.name">{name} &mdash; {width} x {height}</span>
+    <span data-phrase="region.where">{x}, {y} konumunda {width} x {height}</span>
+    <span data-phrase="region.pixelated">{where} &mdash; pikselleştirildi, {size} px
+      bloklar ({across} x {down})</span>
+    <span data-phrase="region.blurred">{where} &mdash; bulanıklaştırıldı, {radius} px
+      yarıçap</span>
+    <span data-phrase="region.filled">{where} &mdash; karartıldı</span>
+    <span data-phrase="region.aria">Alan {n}: {what}. Ok tuşları onu taşır, Alt ile ok
+      tuşları boyutunu değiştirir, Delete onu siler.</span>
+    <span data-phrase="region.choice">Alan {n} ne yapıyor</span>
+    <span data-phrase="choice.fill">Karart</span>
+    <span data-phrase="choice.pixelate">Pikselleştir</span>
+    <span data-phrase="choice.blur">Bulanıklaştır</span>
+    <span data-phrase="style.fill.one">{n} karartıldı</span>
+    <span data-phrase="style.fill.many">{n} karartıldı</span>
+    <span data-phrase="style.pixelate.one">{n} pikselleştirildi</span>
+    <span data-phrase="style.pixelate.many">{n} pikselleştirildi</span>
+    <span data-phrase="style.blur.one">{n} bulanıklaştırıldı</span>
+    <span data-phrase="style.blur.many">{n} bulanıklaştırıldı</span>
+    <span data-phrase="count.one">{n} alan: {parts}.</span>
+    <span data-phrase="count.many">{n} alan: {parts}.</span>
+    <span data-phrase="strength.light">Hafif</span>
+    <span data-phrase="strength.medium">Orta</span>
+    <span data-phrase="strength.heavy">Güçlü</span>
+    <span data-phrase="strength.note">{label} &mdash; bir kutunun kısa kenarı boyunca
+      yaklaşık {blocks} blok ve onun 1/{blur} kadarı bulanıklık yarıçapı.</span>
+    <span data-phrase="risk.mosaic">Buradaki en ince mozaik {across} x {down} blok, her
+      biri {size} px. Bu, altta duranın {averages} ortalaması demek ve hepsi dosyada
+      kalıyor.</span>
+    <span data-phrase="risk.blur.one">Bulanıklığın yarıçapı {radius} px. Bulanıklık da
+      bir ortalamadır ve keskin metnin üstündeki küçük bir bulanıklık, tam da geri
+      çözülmüş olan durumdur.</span>
+    <span data-phrase="risk.blur.many">En küçük bulanıklığın yarıçapı {radius} px.
+      Bulanıklık da bir ortalamadır ve keskin metnin üstündeki küçük bir bulanıklık, tam
+      da geri çözülmüş olan durumdur.</span>
+    <span data-phrase="risk.advice">Metin olarak okunan her şeyi karartın.</span>
+    <span data-phrase="write.noencode">tarayıcı onu kodlayamadı.</span>
+    <span data-phrase="write.failed">Dosya yazılırken bir şeyler ters gitti: {why}</span>
+    <span data-phrase="result.alt">Karartılmış görsel, {width} çarpı {height} piksel</span>
+    <span data-phrase="result.file">{name} &mdash; {size}, {width} x {height}</span>
+    <span data-phrase="result.nothing">Hiçbir alan işaretlenmedi, dolayısıyla bu aynı
+      görselin yeniden kodlanmış hâli.</span>
+    <span data-phrase="result.clean">Karartılmış piksellerden yazıldı; bu yüzden ne
+      EXIF, ne GPS, ne gömülü küçük görsel, ne de özgün hâli tutan bir katman taşıyor.</span>
+    <span data-phrase="join.sentences">{a} {b}</span>
+    <span data-phrase="join.comma">{a}, {b}</span>
+    <span data-phrase="size.b">{n} B</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="net.clean">görselleriniz hiçbir yere gitmedi. {total}
       dosya yüklendi, hepsi bu sayfanın kendi dosyaları. {platform}</span>
     <span data-phrase="net.dirty">bir şey {hosts} ile iletişim kurdu; bu araç

--- a/locales/zh-TW/tools/redact-image.html
+++ b/locales/zh-TW/tools/redact-image.html
@@ -164,6 +164,45 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.nodecode">這個瀏覽器解不開這張圖片。</span>
+    <span data-phrase="read.failed">這個檔案打不開：{why}</span>
+    <span data-phrase="loaded.name">{name} &mdash; {width} x {height}</span>
+    <span data-phrase="region.where">{width} x {height}，位於 {x}, {y}</span>
+    <span data-phrase="region.pixelated">{where} &mdash; 打了馬賽克，{size} px 的方塊（{across} x {down}）</span>
+    <span data-phrase="region.blurred">{where} &mdash; 模糊，半徑 {radius} px</span>
+    <span data-phrase="region.filled">{where} &mdash; 塗黑</span>
+    <span data-phrase="region.aria">區域 {n}：{what}。方向鍵移動它，Alt 加方向鍵改變大小，Delete 刪除它。</span>
+    <span data-phrase="region.choice">區域 {n} 做什麼</span>
+    <span data-phrase="choice.fill">塗黑</span>
+    <span data-phrase="choice.pixelate">打馬賽克</span>
+    <span data-phrase="choice.blur">模糊</span>
+    <span data-phrase="style.fill.one">{n} 處塗黑</span>
+    <span data-phrase="style.fill.many">{n} 處塗黑</span>
+    <span data-phrase="style.pixelate.one">{n} 處馬賽克</span>
+    <span data-phrase="style.pixelate.many">{n} 處馬賽克</span>
+    <span data-phrase="style.blur.one">{n} 處模糊</span>
+    <span data-phrase="style.blur.many">{n} 處模糊</span>
+    <span data-phrase="count.one">{n} 處區域：{parts}。</span>
+    <span data-phrase="count.many">{n} 處區域：{parts}。</span>
+    <span data-phrase="strength.light">輕</span>
+    <span data-phrase="strength.medium">中</span>
+    <span data-phrase="strength.heavy">重</span>
+    <span data-phrase="strength.note">{label} &mdash; 沿框的短邊大約 {blocks} 個方塊，模糊半徑是它的 1/{blur}。</span>
+    <span data-phrase="risk.mosaic">這裡最細的馬賽克是 {across} x {down} 個 {size} px 的方塊。也就是把下面的東西平均成了 {averages} 個數，全都留在檔案裡。</span>
+    <span data-phrase="risk.blur.one">這處模糊的半徑是 {radius} px。模糊也是一種平均，而清晰文字上的一點點模糊，正是已經被人反推出來過的那種情況。</span>
+    <span data-phrase="risk.blur.many">最小的那處模糊半徑是 {radius} px。模糊也是一種平均，而清晰文字上的一點點模糊，正是已經被人反推出來過的那種情況。</span>
+    <span data-phrase="risk.advice">凡是能當文字讀出來的，都塗黑。</span>
+    <span data-phrase="write.noencode">瀏覽器沒能把它編碼出來。</span>
+    <span data-phrase="write.failed">寫檔案的時候出了問題：{why}</span>
+    <span data-phrase="result.alt">塗黑後的圖片，{width} × {height} 畫素</span>
+    <span data-phrase="result.file">{name} &mdash; {size}，{width} x {height}</span>
+    <span data-phrase="result.nothing">沒有標出任何區域，所以這就是同一張圖片重新編碼了一遍。</span>
+    <span data-phrase="result.clean">從塗黑後的畫素寫出來的，所以裡面沒有 EXIF、沒有 GPS、沒有內嵌縮圖，也沒有藏著原圖的圖層。</span>
+    <span data-phrase="join.sentences">{a}{b}</span>
+    <span data-phrase="join.comma">{a}，{b}</span>
+    <span data-phrase="size.b">{n} B</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="net.clean">你的圖片沒有去任何地方。載入了 {total} 個檔案，全都是本站自己的。{platform}</span>
     <span data-phrase="net.dirty">有東西聯絡了 {hosts}，而這個工具從不這麼做。值得去查一查。{platform}</span>
     <span data-phrase="net.platform.one">本站自己用於廣告、統計和捐贈按鈕的指令碼來自 {hosts} 個主機，它們誰也沒拿到圖片，或圖片裡的一個位元組。</span>

--- a/locales/zh/tools/redact-image.html
+++ b/locales/zh/tools/redact-image.html
@@ -164,6 +164,45 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.nodecode">这个浏览器解不开这张图片。</span>
+    <span data-phrase="read.failed">这个文件打不开：{why}</span>
+    <span data-phrase="loaded.name">{name} &mdash; {width} x {height}</span>
+    <span data-phrase="region.where">{width} x {height}，位于 {x}, {y}</span>
+    <span data-phrase="region.pixelated">{where} &mdash; 打了马赛克，{size} px 的方块（{across} x {down}）</span>
+    <span data-phrase="region.blurred">{where} &mdash; 模糊，半径 {radius} px</span>
+    <span data-phrase="region.filled">{where} &mdash; 涂黑</span>
+    <span data-phrase="region.aria">区域 {n}：{what}。方向键移动它，Alt 加方向键改变大小，Delete 删除它。</span>
+    <span data-phrase="region.choice">区域 {n} 做什么</span>
+    <span data-phrase="choice.fill">涂黑</span>
+    <span data-phrase="choice.pixelate">打马赛克</span>
+    <span data-phrase="choice.blur">模糊</span>
+    <span data-phrase="style.fill.one">{n} 处涂黑</span>
+    <span data-phrase="style.fill.many">{n} 处涂黑</span>
+    <span data-phrase="style.pixelate.one">{n} 处马赛克</span>
+    <span data-phrase="style.pixelate.many">{n} 处马赛克</span>
+    <span data-phrase="style.blur.one">{n} 处模糊</span>
+    <span data-phrase="style.blur.many">{n} 处模糊</span>
+    <span data-phrase="count.one">{n} 处区域：{parts}。</span>
+    <span data-phrase="count.many">{n} 处区域：{parts}。</span>
+    <span data-phrase="strength.light">轻</span>
+    <span data-phrase="strength.medium">中</span>
+    <span data-phrase="strength.heavy">重</span>
+    <span data-phrase="strength.note">{label} &mdash; 沿框的短边大约 {blocks} 个方块，模糊半径是它的 1/{blur}。</span>
+    <span data-phrase="risk.mosaic">这里最细的马赛克是 {across} x {down} 个 {size} px 的方块。也就是把下面的东西平均成了 {averages} 个数，全都留在文件里。</span>
+    <span data-phrase="risk.blur.one">这处模糊的半径是 {radius} px。模糊也是一种平均，而清晰文字上的一点点模糊，正是已经被人反推出来过的那种情况。</span>
+    <span data-phrase="risk.blur.many">最小的那处模糊半径是 {radius} px。模糊也是一种平均，而清晰文字上的一点点模糊，正是已经被人反推出来过的那种情况。</span>
+    <span data-phrase="risk.advice">凡是能当文字读出来的，都涂黑。</span>
+    <span data-phrase="write.noencode">浏览器没能把它编码出来。</span>
+    <span data-phrase="write.failed">写文件的时候出了问题：{why}</span>
+    <span data-phrase="result.alt">涂黑后的图片，{width} × {height} 像素</span>
+    <span data-phrase="result.file">{name} &mdash; {size}，{width} x {height}</span>
+    <span data-phrase="result.nothing">没有标出任何区域，所以这就是同一张图片重新编码了一遍。</span>
+    <span data-phrase="result.clean">从涂黑后的像素写出来的，所以里面没有 EXIF、没有 GPS、没有内嵌缩略图，也没有藏着原图的图层。</span>
+    <span data-phrase="join.sentences">{a}{b}</span>
+    <span data-phrase="join.comma">{a}，{b}</span>
+    <span data-phrase="size.b">{n} B</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="net.clean">你的图片没有去任何地方。加载了 {total} 个文件，全都是本站自己的。{platform}</span>
     <span data-phrase="net.dirty">有东西联系了 {hosts}，而这个工具从不这么做。值得去查一查。{platform}</span>
     <span data-phrase="net.platform.one">本站自己用于广告、统计和捐赠按钮的脚本来自 {hosts} 个主机，它们谁也没拿到图片，或图片里的一个字节。</span>

--- a/tests/js/redact-image.test.js
+++ b/tests/js/redact-image.test.js
@@ -403,61 +403,74 @@ test('chooseFormat: auto keeps a photograph a photograph', () => {
   assert.equal(chooseFormat('nonsense', 'image/jpeg'), FORMATS.png);
 });
 
+/**
+ * A stand-in for `phrase()`. These five functions ship in fifteen languages, so
+ * they name a sentence and take a resolver rather than writing English; spelling
+ * the key out beside its blanks keeps the tests about the numbers, which is what
+ * they were always about.
+ */
+const say = (key, values = {}) => `${key}(${Object.entries(values)
+  .map(([name, value]) => `${name}=${value}`).join(',')})`;
+
 test('sizeText: bytes, KB and MB, in the units people read', () => {
-  assert.equal(sizeText(900), '900 B');
-  assert.equal(sizeText(2048), '2.0 KB');
-  assert.equal(sizeText(5 * 1024 * 1024), '5.00 MB');
+  assert.equal(sizeText(900, say), 'size.b(n=900)');
+  assert.equal(sizeText(2048, say), 'size.kb(n=2.0)');
+  assert.equal(sizeText(5 * 1024 * 1024, say), 'size.mb(n=5.00)');
 });
 
 test('describeRegion: a mosaic row says how many blocks it is made of', () => {
-  const row = describeRegion({ x: 10, y: 20, width: 200, height: 100, style: 'pixelate' }, 'medium');
-  assert.match(row, /200 x 100 at 10, 20/);
-  assert.match(row, /11 px blocks \(19 x 10\)/);
+  const row = describeRegion(
+    { x: 10, y: 20, width: 200, height: 100, style: 'pixelate' }, 'medium', say,
+  );
+  assert.match(row, /width=200,height=100,x=10,y=20/);
+  assert.match(row, /size=11,across=19,down=10/);
 
   assert.match(
-    describeRegion({ x: 0, y: 0, width: 60, height: 60, style: 'fill' }, 'medium'),
-    /blacked out$/,
+    describeRegion({ x: 0, y: 0, width: 60, height: 60, style: 'fill' }, 'medium', say),
+    /^region\.filled\(/,
   );
   assert.match(
-    describeRegion({ x: 0, y: 0, width: 60, height: 60, style: 'blur' }, 'medium'),
-    /blurred, 4 px radius$/,
+    describeRegion({ x: 0, y: 0, width: 60, height: 60, style: 'blur' }, 'medium', say),
+    /radius=4/,
   );
 });
 
 test('countSummary: says nothing at all until there is something to say', () => {
-  assert.equal(countSummary([]), '');
-  assert.equal(countSummary([{ style: 'fill' }]), '1 area: 1 blacked out.');
-  assert.equal(
-    countSummary([{ style: 'fill' }, { style: 'fill' }, { style: 'blur' }]),
-    '3 areas: 2 blacked out, 1 blurred.',
-  );
+  assert.equal(countSummary([], say), '');
+  assert.match(countSummary([{ style: 'fill' }], say), /^count\.one\(n=1,/);
+  assert.match(countSummary([{ style: 'fill' }], say), /style\.fill\.one\(n=1\)/);
+
+  const three = countSummary([{ style: 'fill' }, { style: 'fill' }, { style: 'blur' }], say);
+  assert.match(three, /^count\.many\(n=3,/);
+  assert.match(three, /style\.fill\.many\(n=2\)/);
+  assert.match(three, /style\.blur\.one\(n=1\)/);
 });
 
 test('riskNote: silent when every box is a fill, and counted when one is not', () => {
-  assert.equal(riskNote([{ style: 'fill', width: 100, height: 100 }], 'medium'), null);
-  assert.equal(riskNote([], 'medium'), null);
+  assert.equal(riskNote([{ style: 'fill', width: 100, height: 100 }], 'medium', say), null);
+  assert.equal(riskNote([], 'medium', say), null);
 
-  const note = riskNote([{ style: 'pixelate', x: 0, y: 0, width: 300, height: 60 }], 'medium');
+  const note = riskNote([{ style: 'pixelate', x: 0, y: 0, width: 300, height: 60 }], 'medium', say);
   const blocks = blockCount({ width: 300, height: 60 }, 'medium');
-  assert.match(note, new RegExp(`${blocks.across} x ${blocks.down} blocks`));
-  assert.match(note, new RegExp(`${blocks.across * blocks.down} averages`));
-  assert.match(note, /Black out anything that reads as text\./);
+  assert.match(note, new RegExp(`across=${blocks.across},down=${blocks.down}`));
+  assert.match(note, new RegExp(`averages=${blocks.across * blocks.down}`));
+  assert.match(note, /risk\.advice/);
 });
 
 test('riskNote: reports the finest mosaic, because that is the one worth worrying about', () => {
   const coarse = { style: 'pixelate', x: 0, y: 0, width: 40, height: 40 };
   const fine = { style: 'pixelate', x: 0, y: 0, width: 600, height: 200 };
-  const note = riskNote([coarse, fine], 'medium');
+  const note = riskNote([coarse, fine], 'medium', say);
   const blocks = blockCount(fine, 'medium');
-  assert.match(note, new RegExp(`${blocks.across} x ${blocks.down} blocks`));
+  assert.match(note, new RegExp(`across=${blocks.across},down=${blocks.down}`));
 });
 
 test('riskNote: a blur is reported by its radius', () => {
-  const note = riskNote([{ style: 'blur', x: 0, y: 0, width: 280, height: 140 }], 'medium');
-  assert.match(note, /radius of 10 px/);
+  const note = riskNote([{ style: 'blur', x: 0, y: 0, width: 280, height: 140 }], 'medium', say);
+  assert.match(note, /risk\.blur\.one\(radius=10\)/);
 });
 
 test('strengthNote: names the setting and the number behind it', () => {
-  assert.match(strengthNote('heavy'), /^Heavy/);
-  assert.match(strengthNote('heavy'), new RegExp(`${STRENGTHS.heavy.blocks} blocks`));
+  assert.match(strengthNote('heavy', say), /label=strength\.heavy/);
+  assert.match(strengthNote('heavy', say), new RegExp(`blocks=${STRENGTHS.heavy.blocks}`));
 });

--- a/tests/python/test_english_in_js.py
+++ b/tests/python/test_english_in_js.py
@@ -90,7 +90,8 @@ BASELINE = {
     # The two left are a symbology's own name and a line of SVG markup.
     'qr-barcode': 2,
     'qr-barcode-reader': 13,
-    'redact-image': 17,
+    # A key template, and a CSS class name the stage builds.
+    'redact-image': 2,
     'redact-pdf': 15,
     'resize-image': 5,
     # The key template that picks between two whole sentences.

--- a/tools/redact-image/body.html
+++ b/tools/redact-image/body.html
@@ -184,6 +184,56 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="read.nodecode">this browser could not decode the picture.</span>
+    <span data-phrase="read.failed">That file could not be opened: {why}</span>
+    <span data-phrase="loaded.name">{name} &mdash; {width} x {height}</span>
+    <span data-phrase="region.where">{width} x {height} at {x}, {y}</span>
+    <span data-phrase="region.pixelated">{where} &mdash; pixelated, {size} px blocks
+      ({across} x {down})</span>
+    <span data-phrase="region.blurred">{where} &mdash; blurred, {radius} px radius</span>
+    <span data-phrase="region.filled">{where} &mdash; blacked out</span>
+    <span data-phrase="region.aria">Area {n}: {what}. The arrow keys move it, Alt and
+      the arrow keys resize it, and Delete removes it.</span>
+    <span data-phrase="region.choice">What area {n} does</span>
+    <span data-phrase="choice.fill">Black out</span>
+    <span data-phrase="choice.pixelate">Pixelate</span>
+    <span data-phrase="choice.blur">Blur</span>
+    <span data-phrase="style.fill.one">{n} blacked out</span>
+    <span data-phrase="style.fill.many">{n} blacked out</span>
+    <span data-phrase="style.pixelate.one">{n} pixelated</span>
+    <span data-phrase="style.pixelate.many">{n} pixelated</span>
+    <span data-phrase="style.blur.one">{n} blurred</span>
+    <span data-phrase="style.blur.many">{n} blurred</span>
+    <span data-phrase="count.one">{n} area: {parts}.</span>
+    <span data-phrase="count.many">{n} areas: {parts}.</span>
+    <span data-phrase="strength.light">Light</span>
+    <span data-phrase="strength.medium">Medium</span>
+    <span data-phrase="strength.heavy">Heavy</span>
+    <span data-phrase="strength.note">{label} &mdash; about {blocks} blocks across the
+      shorter side of a box, and a blur radius of 1/{blur} of it.</span>
+    <span data-phrase="risk.mosaic">The finest mosaic here is {across} x {down} blocks
+      of {size} px. That is {averages} averages of what was underneath, left in the
+      file.</span>
+    <span data-phrase="risk.blur.one">The blur has a radius of {radius} px. A blur is an
+      average too, and a small one over sharp text is the case that has been worked
+      backwards.</span>
+    <span data-phrase="risk.blur.many">The smallest blur has a radius of {radius} px. A
+      blur is an average too, and a small one over sharp text is the case that has been
+      worked backwards.</span>
+    <span data-phrase="risk.advice">Black out anything that reads as text.</span>
+    <span data-phrase="write.noencode">the browser could not encode it.</span>
+    <span data-phrase="write.failed">Something went wrong writing the file: {why}</span>
+    <span data-phrase="result.alt">The redacted picture, {width} by {height} pixels</span>
+    <span data-phrase="result.file">{name} &mdash; {size}, {width} x {height}</span>
+    <span data-phrase="result.nothing">No areas were marked, so this is the same picture
+      re-encoded.</span>
+    <span data-phrase="result.clean">Written from the redacted pixels, so it carries no
+      EXIF, no GPS, no embedded thumbnail and no layer with the original in it.</span>
+    <span data-phrase="join.sentences">{a} {b}</span>
+    <span data-phrase="join.comma">{a}, {b}</span>
+    <span data-phrase="size.b">{n} B</span>
+    <span data-phrase="size.kb">{n} KB</span>
+    <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="net.clean">your images have gone nowhere. {total} files
       loaded, all of them this page's own. {platform}</span>
     <span data-phrase="net.dirty">something contacted {hosts}, which this tool

--- a/tools/redact-image/src/files.js
+++ b/tools/redact-image/src/files.js
@@ -22,9 +22,9 @@ export function stemOf(name) {
  * that is the question this tool is answering.
  */
 export const STYLE_LABELS = {
-  fill: 'blacked out',
-  pixelate: 'pixelated',
-  blur: 'blurred',
+  fill: 'style.fill',
+  pixelate: 'style.pixelate',
+  blur: 'style.blur',
 };
 
 export const FORMATS = {
@@ -67,35 +67,42 @@ export function outName(stem, format) {
 }
 
 /** Bytes, as the page writes them. */
-export function sizeText(bytes) {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+export function sizeText(bytes, t) {
+  if (bytes < 1024) return t('size.b', { n: bytes });
+  if (bytes < 1024 * 1024) return t('size.kb', { n: (bytes / 1024).toFixed(1) });
+  return t('size.mb', { n: (bytes / (1024 * 1024)).toFixed(2) });
 }
 
 /** One row of the list: where the box is, and what it does to what is under it. */
-export function describeRegion(region, strength) {
-  const where = `${region.width} x ${region.height} at ${region.x}, ${region.y}`;
+export function describeRegion(region, strength, t) {
+  const where = t('region.where', {
+    width: region.width, height: region.height, x: region.x, y: region.y,
+  });
   if (region.style === 'pixelate') {
     const blocks = blockCount(region, strength);
-    return `${where} - pixelated, ${blocks.size} px blocks (${blocks.across} x ${blocks.down})`;
+    return t('region.pixelated', {
+      where, size: blocks.size, across: blocks.across, down: blocks.down,
+    });
   }
   if (region.style === 'blur') {
-    return `${where} - blurred, ${blurRadius(region, strength)} px radius`;
+    return t('region.blurred', { where, radius: blurRadius(region, strength) });
   }
-  return `${where} - blacked out`;
+  return t('region.filled', { where });
 }
 
 /** "3 areas: 2 blacked out, 1 pixelated". Empty until there is something to say. */
-export function countSummary(regions) {
+export function countSummary(regions, t) {
   if (regions.length === 0) return '';
   const counts = { fill: 0, pixelate: 0, blur: 0 };
   for (const region of regions) counts[region.style] = (counts[region.style] ?? 0) + 1;
+  // The comma between two of these is a phrase as well: not every language
+  // separates a list with one.
   const parts = Object.entries(counts)
     .filter(([, n]) => n > 0)
-    .map(([style, n]) => `${n} ${STYLE_LABELS[style]}`);
-  const noun = regions.length === 1 ? 'area' : 'areas';
-  return `${regions.length} ${noun}: ${parts.join(', ')}.`;
+    .map(([style, n]) => t(`${STYLE_LABELS[style]}.${n === 1 ? 'one' : 'many'}`, { n }))
+    .reduce((a, b) => t('join.comma', { a, b }));
+  return t(regions.length === 1 ? 'count.one' : 'count.many',
+    { n: regions.length, parts });
 }
 
 /**
@@ -110,7 +117,7 @@ export function countSummary(regions) {
  * Returns null when every box is a black fill, which is the case this page is
  * trying to talk people into.
  */
-export function riskNote(regions, strength) {
+export function riskNote(regions, strength, t) {
   const soft = regions.filter((region) => region.style !== 'fill');
   if (soft.length === 0) return null;
 
@@ -123,28 +130,30 @@ export function riskNote(regions, strength) {
       .map((region) => blockCount(region, strength))
       .reduce((worst, blocks) => (blocks.across * blocks.down > worst.across * worst.down
         ? blocks : worst));
-    parts.push(
-      `The finest mosaic here is ${finest.across} x ${finest.down} blocks of ${finest.size} px. `
-      + `That is ${finest.across * finest.down} averages of what was underneath, left in the file.`,
-    );
+    parts.push(t('risk.mosaic', {
+      across: finest.across,
+      down: finest.down,
+      size: finest.size,
+      averages: finest.across * finest.down,
+    }));
   }
 
   if (blurs.length > 0) {
     const radii = blurs.map((region) => blurRadius(region, strength));
-    parts.push(
-      `${blurs.length === 1 ? 'The blur' : 'The smallest blur'} has a radius of `
-      + `${Math.min(...radii)} px. A blur is an average too, and a small one over sharp `
-      + 'text is the case that has been worked backwards.',
-    );
+    parts.push(t(blurs.length === 1 ? 'risk.blur.one' : 'risk.blur.many',
+      { radius: Math.min(...radii) }));
   }
 
-  parts.push('Black out anything that reads as text.');
-  return parts.join(' ');
+  parts.push(t('risk.advice'));
+  // The space between two sentences is a phrase too: ja and zh do not put
+  // one after a full stop.
+  return parts.reduce((a, b) => t('join.sentences', { a, b }));
 }
 
 /** "Medium - 9 blocks across the shorter side of each box." */
-export function strengthNote(strength) {
+export function strengthNote(strength, t) {
   const chosen = strengthOf(strength);
-  return `${chosen.label} - about ${chosen.blocks} blocks across the shorter side of a box, `
-    + `and a blur radius of a ${chosen.blur}th of it.`;
+  return t('strength.note', {
+    label: t(chosen.label), blocks: chosen.blocks, blur: chosen.blur,
+  });
 }

--- a/tools/redact-image/src/main.js
+++ b/tools/redact-image/src/main.js
@@ -95,8 +95,10 @@ const stage = new Stage(el.stage, {
   onDelete: (id) => removeRegion(id),
   onGestureStart: () => snapshot(),
   regionOf: (id) => regions.find((region) => region.id === id),
-  describe: (region, index) => `Area ${index + 1}: ${describeRegion(region, el.strength.value)}. `
-    + 'The arrow keys move it, Alt and the arrow keys resize it, and Delete removes it.',
+  describe: (region, index) => phrase('region.aria', {
+    n: index + 1,
+    what: describeRegion(region, el.strength.value, phrase),
+  }),
 });
 
 /* ------------------------------------------------------------- the picture */
@@ -123,7 +125,7 @@ async function decode(file) {
     const image = await new Promise((resolve, reject) => {
       const element = new Image();
       element.onload = () => resolve(element);
-      element.onerror = () => reject(new Error('this browser could not decode the picture.'));
+      element.onerror = () => reject(new Error('read.nodecode'));
       element.src = url;
     });
     return { bitmap: image, width: image.naturalWidth, height: image.naturalHeight };
@@ -149,14 +151,18 @@ async function load(file) {
     selectedId = null;
     counter = 0;
 
-    el.loadedName.textContent = `${file.name} - ${decoded.width} x ${decoded.height}`;
+    el.loadedName.textContent = phrase('loaded.name', {
+      name: file.name, width: decoded.width, height: decoded.height,
+    });
     el.loaded.hidden = false;
     el.editEmpty.hidden = true;
     el.editControls.hidden = false;
     showFormatRow();
     refresh();
   } catch (error) {
-    showLoadError(`That file could not be opened: ${error.message}`);
+    // decode() throws a key; a browser that failed for its own reasons throws
+    // a sentence, and phrase() hands back what it does not recognise.
+    showLoadError(phrase('read.failed', { why: phrase(error.message) }));
   } finally {
     wired.done();
   }
@@ -298,12 +304,12 @@ function refresh() {
   el.undo.disabled = history.length === 0;
   el.clearBoxes.disabled = regions.length === 0;
   el.save.disabled = !picture || busy;
-  el.strengthNote.textContent = strengthNote(el.strength.value);
+  el.strengthNote.textContent = strengthNote(el.strength.value, phrase);
 }
 
 function renderList() {
   const strength = el.strength.value;
-  el.boxSummary.textContent = countSummary(regions);
+  el.boxSummary.textContent = countSummary(regions, phrase);
 
   const risk = riskNote(regions, strength);
   el.riskNote.textContent = risk ?? '';
@@ -328,13 +334,11 @@ function renderList() {
 
     const choice = document.createElement('select');
     choice.className = 'region-style';
-    choice.setAttribute('aria-label', `What area ${index + 1} does`);
-    for (const [value, label] of [
-      ['fill', 'Black out'], ['pixelate', 'Pixelate'], ['blur', 'Blur'],
-    ]) {
+    choice.setAttribute('aria-label', phrase('region.choice', { n: index + 1 }));
+    for (const value of ['fill', 'pixelate', 'blur']) {
       const option = document.createElement('option');
       option.value = value;
-      option.textContent = label;
+      option.textContent = phrase(`choice.${value}`);
       option.selected = region.style === value;
       choice.append(option);
     }
@@ -424,7 +428,7 @@ async function save() {
     const quality = format.lossy ? Number(el.quality.value) / 100 : undefined;
     const blob = await new Promise((resolve, reject) => {
       canvas.toBlob(
-        (made) => (made ? resolve(made) : reject(new Error('the browser could not encode it.'))),
+        (made) => (made ? resolve(made) : reject(new Error('write.noencode'))),
         format.mime,
         quality,
       );
@@ -434,7 +438,7 @@ async function save() {
     canvas.height = 0;
     showResult(blob, format);
   } catch (error) {
-    showLoadError(`Something went wrong writing the file: ${error.message}`);
+    showLoadError(phrase('write.failed', { why: phrase(error.message) }));
   } finally {
     busy = false;
     el.busy.hidden = true;
@@ -456,15 +460,20 @@ function showResult(blob, format) {
 
   const name = outName(stemOf(picture.file.name), format);
   el.resultImage.src = resultUrl;
-  el.resultImage.alt = `The redacted picture, ${picture.width} by ${picture.height} pixels`;
+  el.resultImage.alt = phrase('result.alt',
+    { width: picture.width, height: picture.height });
   el.download.href = resultUrl;
   el.download.download = name;
 
   const facts = [
-    `${name} - ${sizeText(blob.size)}, ${picture.width} x ${picture.height}`,
-    countSummary(regions) || 'No areas were marked, so this is the same picture re-encoded.',
-    'Written from the redacted pixels, so it carries no EXIF, no GPS, no embedded '
-    + 'thumbnail and no layer with the original in it.',
+    phrase('result.file', {
+      name,
+      size: sizeText(blob.size, phrase),
+      width: picture.width,
+      height: picture.height,
+    }),
+    countSummary(regions, phrase) || phrase('result.nothing'),
+    phrase('result.clean'),
   ];
   el.resultFacts.replaceChildren(...facts.map((line) => {
     const item = document.createElement('li');

--- a/tools/redact-image/src/regions.js
+++ b/tools/redact-image/src/regions.js
@@ -33,9 +33,11 @@ export const STYLES = ['fill', 'pixelate', 'blur'];
  * Measured against the box, one setting behaves the same way on both.
  */
 export const STRENGTHS = {
-  light: { id: 'light', label: 'Light', blocks: 14, blur: 22 },
-  medium: { id: 'medium', label: 'Medium', blocks: 9, blur: 14 },
-  heavy: { id: 'heavy', label: 'Heavy', blocks: 5, blur: 7 },
+  // `label` is a phrase key: this module ships in fifteen languages and the
+  // page is the only place a word can be read.
+  light: { id: 'light', label: 'strength.light', blocks: 14, blur: 22 },
+  medium: { id: 'medium', label: 'strength.medium', blocks: 9, blur: 14 },
+  heavy: { id: 'heavy', label: 'strength.heavy', blocks: 5, blur: 7 },
 };
 
 export const strengthOf = (id) => STRENGTHS[id] ?? STRENGTHS.medium;


### PR DESCRIPTION
This one matters more than most. The sentences redact-image showed were the ones talking somebody out of a mistake they cannot undo — how many averages of their bank account number are still in the file, and to black out anything that reads as text — and every one of them was English at fourteen of its fifteen addresses. Thirty-nine phrases move into the markup.

The five functions in `files.js` that write a sentence take the resolver as an argument now, the way svg-to-image's `describePlan` does. `STYLE_LABELS` and the three strength labels are keys rather than words.

**Three shapes had to change rather than move.**

`countSummary` built `"3 areas: 2 blacked out, 1 blurred."` out of an appended `s`, a joined list and a noun chosen by ternary. It is two whole sentences, six count phrases and a `join.comma`.

`riskNote` joined its parts with a literal space. That space is `join.sentences`, because ja and zh do not put one after a full stop.

`strengthNote` said **"a blur radius of a 7th of it"** — an English ordinal built from a number, which no other language can build the same way. The English says `1/{blur}` now, which every language can render, and the phrase table carries a comment saying why.

```
English  Heavy — about 5 blocks across the shorter side of a box,
         and a blur radius of 1/7 of it.
German   Stark — etwa 5 Blöcke über die kürzere Seite eines Kastens,
         und ein Weichzeichnungsradius von 1/7 davon.
```

## Verified in the browser

A picture with readable text on it, in English and in German, with every row shape, every count and both risk notes resolved through the real `files.js`:

```
English  The finest mosaic here is 43 x 9 blocks of 7 px. That is 387 averages of what
         was underneath, left in the file. Black out anything that reads as text.
German   Das feinste Mosaik hier ist 43 x 9 Blöcke zu je 7 px. Das sind 387 Mittelwerte
         dessen, was darunter lag, und sie bleiben in der Datei. Schwärzen Sie alles,
         was sich als Text lesen lässt.
```

All fourteen locales checked for missing keys, the CJK wrap trap and blank drift; the four differences are Arabic `.one` forms that spell the number out.

## Tests

- `python -m unittest discover -t . -s tests/python` — 495 pass; the ratchet drops redact-image 17 → 2, and what is left is a key template and a CSS class name.
- `node --test "tests/js/*.test.js"` — 1939 pass. The seven `files.js` tests pass a stand-in resolver that spells the key out beside its blanks, so what they were about — the block counts, the radii, the finest mosaic winning — is still exactly what they check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)