### PR TITLE
Say what is in the header in the reader's language

### DIFF
--- a/locales/ar/tools/dicom-viewer.html
+++ b/locales/ar/tools/dicom-viewer.html
@@ -168,6 +168,43 @@
     wins over the frame's one.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="file.failed">{name}: {why}</span>
+    <span data-phrase="series.label">{what} ({files})</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="facts.size">{width} &times; {height}</span>
+    <span data-phrase="facts.size.frames">{width} &times; {height}، {frames}</span>
+    <span data-phrase="unit.value">{n} {unit}</span>
+    <span data-phrase="value.fragment.one">شظية مضغوطة واحدة، {bytes} بايت</span>
+    <span data-phrase="value.fragment.many">{n} شظية مضغوطة، {bytes} بايت</span>
+    <span data-phrase="value.notshown">{bytes} بايت، غير معروضة</span>
+    <span data-phrase="value.empty">(فارغ)</span>
+    <span data-phrase="value.bytes">{bytes} بايت: {head}</span>
+    <span data-phrase="value.bytes.more">{bytes} بايت: {head} &hellip;</span>
+    <span data-phrase="age.day.one">يوم واحد</span>
+    <span data-phrase="age.day.many">{n} يوماً</span>
+    <span data-phrase="age.week.one">أسبوع واحد</span>
+    <span data-phrase="age.week.many">{n} أسبوعاً</span>
+    <span data-phrase="age.month.one">شهر واحد</span>
+    <span data-phrase="age.month.many">{n} شهراً</span>
+    <span data-phrase="age.year.one">سنة واحدة</span>
+    <span data-phrase="age.year.many">{n} سنة</span>
+    <span data-phrase="code.monochrome1">MONOCHROME1 (الصفر أبيض)</span>
+    <span data-phrase="code.monochrome2">MONOCHROME2 (الصفر أسود)</span>
+    <span data-phrase="code.palette">PALETTE COLOR (يشير إلى جداول الألوان)</span>
+    <span data-phrase="code.ybrfull">YBR_FULL (لون، على شكل إضاءة وفرقين)</span>
+    <span data-phrase="code.ybr422">YBR_FULL_422 (لون، والفرقان بنصف العرض)</span>
+    <span data-phrase="code.hfs">HFS (الرأس أولاً، على الظهر)</span>
+    <span data-phrase="code.hfp">HFP (الرأس أولاً، على البطن)</span>
+    <span data-phrase="code.ffs">FFS (القدمان أولاً، على الظهر)</span>
+    <span data-phrase="code.ffp">FFP (القدمان أولاً، على البطن)</span>
+    <span data-phrase="code.male">M (ذكر)</span>
+    <span data-phrase="code.female">F (أنثى)</span>
+    <span data-phrase="code.other">O (غير ذلك)</span>
+    <span data-phrase="report.size">{size} ({bytes})</span>
+    <span data-phrase="report.spacing.value">{row} &times; {column} مم</span>
+    <span data-phrase="report.none">(لا شيء)</span>
+    <span data-phrase="tag.private">(خاص)</span>
+    <span data-phrase="tag.unknown">(غير معروف)</span>
     <span data-phrase="open.notdicom">لا توجد علامة DICM عند البايت 128، والبايتات الأولى ليست عنصر DICOM أيضاً</span>
     <span data-phrase="jpeg.nosoi">لا يبدأ هذا الجزء بعلامة JPEG SOI</span>
     <span data-phrase="jpeg.scanfirst">وصل مسح JPEG قبل ترويسة إطاره</span>

--- a/locales/de/tools/dicom-viewer.html
+++ b/locales/de/tools/dicom-viewer.html
@@ -181,6 +181,45 @@
     wins over the frame's one.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="file.failed">{name}: {why}</span>
+    <span data-phrase="series.label">{what} ({files})</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="facts.size">{width} &times; {height}</span>
+    <span data-phrase="facts.size.frames">{width} &times; {height}, {frames}</span>
+    <span data-phrase="unit.value">{n} {unit}</span>
+    <span data-phrase="value.fragment.one">{n} komprimiertes Fragment, {bytes} Bytes</span>
+    <span data-phrase="value.fragment.many">{n} komprimierte Fragmente, {bytes} Bytes</span>
+    <span data-phrase="value.notshown">{bytes} Bytes, nicht gezeigt</span>
+    <span data-phrase="value.empty">(leer)</span>
+    <span data-phrase="value.bytes">{bytes} Bytes: {head}</span>
+    <span data-phrase="value.bytes.more">{bytes} Bytes: {head} &hellip;</span>
+    <span data-phrase="age.day.one">{n} Tag</span>
+    <span data-phrase="age.day.many">{n} Tage</span>
+    <span data-phrase="age.week.one">{n} Woche</span>
+    <span data-phrase="age.week.many">{n} Wochen</span>
+    <span data-phrase="age.month.one">{n} Monat</span>
+    <span data-phrase="age.month.many">{n} Monate</span>
+    <span data-phrase="age.year.one">{n} Jahr</span>
+    <span data-phrase="age.year.many">{n} Jahre</span>
+    <span data-phrase="code.monochrome1">MONOCHROME1 (0 ist weiß)</span>
+    <span data-phrase="code.monochrome2">MONOCHROME2 (0 ist schwarz)</span>
+    <span data-phrase="code.palette">PALETTE COLOR (verweist in die Farbtabellen)</span>
+    <span data-phrase="code.ybrfull">YBR_FULL (Farbe, als Helligkeit und zwei
+      Differenzen)</span>
+    <span data-phrase="code.ybr422">YBR_FULL_422 (Farbe, mit den Differenzen in halber
+      Breite)</span>
+    <span data-phrase="code.hfs">HFS (Kopf voran, auf dem Rücken)</span>
+    <span data-phrase="code.hfp">HFP (Kopf voran, auf dem Bauch)</span>
+    <span data-phrase="code.ffs">FFS (Füße voran, auf dem Rücken)</span>
+    <span data-phrase="code.ffp">FFP (Füße voran, auf dem Bauch)</span>
+    <span data-phrase="code.male">M (männlich)</span>
+    <span data-phrase="code.female">F (weiblich)</span>
+    <span data-phrase="code.other">O (anderes)</span>
+    <span data-phrase="report.size">{size} ({bytes})</span>
+    <span data-phrase="report.spacing.value">{row} &times; {column} mm</span>
+    <span data-phrase="report.none">(keine)</span>
+    <span data-phrase="tag.private">(privat)</span>
+    <span data-phrase="tag.unknown">(unbekannt)</span>
     <span data-phrase="open.notdicom">bei Byte 128 steht keine DICM-Kennung, und die ersten Bytes sind auch kein
       DICOM-Element</span>
     <span data-phrase="jpeg.nosoi">dieses Fragment beginnt nicht mit einer JPEG-SOI-Marke</span>

--- a/locales/es/tools/dicom-viewer.html
+++ b/locales/es/tools/dicom-viewer.html
@@ -181,6 +181,44 @@
     wins over the frame's one.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="file.failed">{name}: {why}</span>
+    <span data-phrase="series.label">{what} ({files})</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="facts.size">{width} &times; {height}</span>
+    <span data-phrase="facts.size.frames">{width} &times; {height}, {frames}</span>
+    <span data-phrase="unit.value">{n} {unit}</span>
+    <span data-phrase="value.fragment.one">{n} fragmento comprimido, {bytes} bytes</span>
+    <span data-phrase="value.fragment.many">{n} fragmentos comprimidos, {bytes} bytes</span>
+    <span data-phrase="value.notshown">{bytes} bytes, no mostrados</span>
+    <span data-phrase="value.empty">(vacío)</span>
+    <span data-phrase="value.bytes">{bytes} bytes: {head}</span>
+    <span data-phrase="value.bytes.more">{bytes} bytes: {head} &hellip;</span>
+    <span data-phrase="age.day.one">{n} día</span>
+    <span data-phrase="age.day.many">{n} días</span>
+    <span data-phrase="age.week.one">{n} semana</span>
+    <span data-phrase="age.week.many">{n} semanas</span>
+    <span data-phrase="age.month.one">{n} mes</span>
+    <span data-phrase="age.month.many">{n} meses</span>
+    <span data-phrase="age.year.one">{n} año</span>
+    <span data-phrase="age.year.many">{n} años</span>
+    <span data-phrase="code.monochrome1">MONOCHROME1 (0 es blanco)</span>
+    <span data-phrase="code.monochrome2">MONOCHROME2 (0 es negro)</span>
+    <span data-phrase="code.palette">PALETTE COLOR (indexa en las tablas de consulta)</span>
+    <span data-phrase="code.ybrfull">YBR_FULL (color, como luminancia y dos diferencias)</span>
+    <span data-phrase="code.ybr422">YBR_FULL_422 (color, con las diferencias a media
+      anchura)</span>
+    <span data-phrase="code.hfs">HFS (cabeza primero, boca arriba)</span>
+    <span data-phrase="code.hfp">HFP (cabeza primero, boca abajo)</span>
+    <span data-phrase="code.ffs">FFS (pies primero, boca arriba)</span>
+    <span data-phrase="code.ffp">FFP (pies primero, boca abajo)</span>
+    <span data-phrase="code.male">M (masculino)</span>
+    <span data-phrase="code.female">F (femenino)</span>
+    <span data-phrase="code.other">O (otro)</span>
+    <span data-phrase="report.size">{size} ({bytes})</span>
+    <span data-phrase="report.spacing.value">{row} &times; {column} mm</span>
+    <span data-phrase="report.none">(ninguno)</span>
+    <span data-phrase="tag.private">(privado)</span>
+    <span data-phrase="tag.unknown">(desconocido)</span>
     <span data-phrase="open.notdicom">no hay marca DICM en el byte 128, y los primeros bytes tampoco son un elemento DICOM</span>
     <span data-phrase="jpeg.nosoi">este fragmento no empieza por una marca JPEG SOI</span>
     <span data-phrase="jpeg.scanfirst">llegó un barrido JPEG antes que su cabecera de trama</span>

--- a/locales/fr/tools/dicom-viewer.html
+++ b/locales/fr/tools/dicom-viewer.html
@@ -181,6 +181,46 @@
     wins over the frame's one.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="file.failed">{name}&nbsp;: {why}</span>
+    <span data-phrase="series.label">{what} ({files})</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="facts.size">{width} &times; {height}</span>
+    <span data-phrase="facts.size.frames">{width} &times; {height}, {frames}</span>
+    <span data-phrase="unit.value">{n} {unit}</span>
+    <span data-phrase="value.fragment.one">{n} fragment compressé, {bytes} octets</span>
+    <span data-phrase="value.fragment.many">{n} fragments compressés, {bytes} octets</span>
+    <span data-phrase="value.notshown">{bytes} octets, non affichés</span>
+    <span data-phrase="value.empty">(vide)</span>
+    <span data-phrase="value.bytes">{bytes} octets&nbsp;: {head}</span>
+    <span data-phrase="value.bytes.more">{bytes} octets&nbsp;: {head} &hellip;</span>
+    <span data-phrase="age.day.one">{n} jour</span>
+    <span data-phrase="age.day.many">{n} jours</span>
+    <span data-phrase="age.week.one">{n} semaine</span>
+    <span data-phrase="age.week.many">{n} semaines</span>
+    <span data-phrase="age.month.one">{n} mois</span>
+    <span data-phrase="age.month.many">{n} mois</span>
+    <span data-phrase="age.year.one">{n} an</span>
+    <span data-phrase="age.year.many">{n} ans</span>
+    <span data-phrase="code.monochrome1">MONOCHROME1 (0 est blanc)</span>
+    <span data-phrase="code.monochrome2">MONOCHROME2 (0 est noir)</span>
+    <span data-phrase="code.palette">PALETTE COLOR (renvoie aux tables de
+      correspondance)</span>
+    <span data-phrase="code.ybrfull">YBR_FULL (couleur, en luminance et deux
+      différences)</span>
+    <span data-phrase="code.ybr422">YBR_FULL_422 (couleur, avec les différences à
+      demi-largeur)</span>
+    <span data-phrase="code.hfs">HFS (tête en avant, sur le dos)</span>
+    <span data-phrase="code.hfp">HFP (tête en avant, sur le ventre)</span>
+    <span data-phrase="code.ffs">FFS (pieds en avant, sur le dos)</span>
+    <span data-phrase="code.ffp">FFP (pieds en avant, sur le ventre)</span>
+    <span data-phrase="code.male">M (masculin)</span>
+    <span data-phrase="code.female">F (féminin)</span>
+    <span data-phrase="code.other">O (autre)</span>
+    <span data-phrase="report.size">{size} ({bytes})</span>
+    <span data-phrase="report.spacing.value">{row} &times; {column} mm</span>
+    <span data-phrase="report.none">(aucun)</span>
+    <span data-phrase="tag.private">(privé)</span>
+    <span data-phrase="tag.unknown">(inconnu)</span>
     <span data-phrase="open.notdicom">il n&rsquo;y a pas de marque DICM à l&rsquo;octet 128, et les premiers octets ne
       sont pas non plus un élément DICOM</span>
     <span data-phrase="jpeg.nosoi">ce fragment ne commence pas par une marque JPEG SOI</span>

--- a/locales/hi/tools/dicom-viewer.html
+++ b/locales/hi/tools/dicom-viewer.html
@@ -180,6 +180,43 @@
     wins over the frame's one.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="file.failed">{name}: {why}</span>
+    <span data-phrase="series.label">{what} ({files})</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="facts.size">{width} &times; {height}</span>
+    <span data-phrase="facts.size.frames">{width} &times; {height}, {frames}</span>
+    <span data-phrase="unit.value">{n} {unit}</span>
+    <span data-phrase="value.fragment.one">{n} संपीड़ित टुकड़ा, {bytes} बाइट</span>
+    <span data-phrase="value.fragment.many">{n} संपीड़ित टुकड़े, {bytes} बाइट</span>
+    <span data-phrase="value.notshown">{bytes} बाइट, दिखाए नहीं गए</span>
+    <span data-phrase="value.empty">(ख़ाली)</span>
+    <span data-phrase="value.bytes">{bytes} बाइट: {head}</span>
+    <span data-phrase="value.bytes.more">{bytes} बाइट: {head} &hellip;</span>
+    <span data-phrase="age.day.one">{n} दिन</span>
+    <span data-phrase="age.day.many">{n} दिन</span>
+    <span data-phrase="age.week.one">{n} सप्ताह</span>
+    <span data-phrase="age.week.many">{n} सप्ताह</span>
+    <span data-phrase="age.month.one">{n} महीना</span>
+    <span data-phrase="age.month.many">{n} महीने</span>
+    <span data-phrase="age.year.one">{n} वर्ष</span>
+    <span data-phrase="age.year.many">{n} वर्ष</span>
+    <span data-phrase="code.monochrome1">MONOCHROME1 (0 का मतलब सफ़ेद)</span>
+    <span data-phrase="code.monochrome2">MONOCHROME2 (0 का मतलब काला)</span>
+    <span data-phrase="code.palette">PALETTE COLOR (रंग तालिकाओं की ओर इशारा करता है)</span>
+    <span data-phrase="code.ybrfull">YBR_FULL (रंग, चमक और दो अंतरों के रूप में)</span>
+    <span data-phrase="code.ybr422">YBR_FULL_422 (रंग, अंतर आधी चौड़ाई पर)</span>
+    <span data-phrase="code.hfs">HFS (सिर पहले, पीठ के बल)</span>
+    <span data-phrase="code.hfp">HFP (सिर पहले, पेट के बल)</span>
+    <span data-phrase="code.ffs">FFS (पैर पहले, पीठ के बल)</span>
+    <span data-phrase="code.ffp">FFP (पैर पहले, पेट के बल)</span>
+    <span data-phrase="code.male">M (पुरुष)</span>
+    <span data-phrase="code.female">F (स्त्री)</span>
+    <span data-phrase="code.other">O (अन्य)</span>
+    <span data-phrase="report.size">{size} ({bytes})</span>
+    <span data-phrase="report.spacing.value">{row} &times; {column} मिमी</span>
+    <span data-phrase="report.none">(कोई नहीं)</span>
+    <span data-phrase="tag.private">(निजी)</span>
+    <span data-phrase="tag.unknown">(अज्ञात)</span>
     <span data-phrase="open.notdicom">128वें बाइट पर DICM चिह्न नहीं है, और शुरुआती बाइट भी कोई DICOM तत्व नहीं हैं</span>
     <span data-phrase="jpeg.nosoi">यह टुकड़ा JPEG के SOI चिह्न से शुरू नहीं होता</span>
     <span data-phrase="jpeg.scanfirst">JPEG का स्कैन अपने फ़्रेम शीर्ष से पहले ही आ गया</span>

--- a/locales/id/tools/dicom-viewer.html
+++ b/locales/id/tools/dicom-viewer.html
@@ -181,6 +181,44 @@
     wins over the frame's one.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="file.failed">{name}: {why}</span>
+    <span data-phrase="series.label">{what} ({files})</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="facts.size">{width} &times; {height}</span>
+    <span data-phrase="facts.size.frames">{width} &times; {height}, {frames}</span>
+    <span data-phrase="unit.value">{n} {unit}</span>
+    <span data-phrase="value.fragment.one">{n} serpihan terkompresi, {bytes} bita</span>
+    <span data-phrase="value.fragment.many">{n} serpihan terkompresi, {bytes} bita</span>
+    <span data-phrase="value.notshown">{bytes} bita, tidak ditampilkan</span>
+    <span data-phrase="value.empty">(kosong)</span>
+    <span data-phrase="value.bytes">{bytes} bita: {head}</span>
+    <span data-phrase="value.bytes.more">{bytes} bita: {head} &hellip;</span>
+    <span data-phrase="age.day.one">{n} hari</span>
+    <span data-phrase="age.day.many">{n} hari</span>
+    <span data-phrase="age.week.one">{n} minggu</span>
+    <span data-phrase="age.week.many">{n} minggu</span>
+    <span data-phrase="age.month.one">{n} bulan</span>
+    <span data-phrase="age.month.many">{n} bulan</span>
+    <span data-phrase="age.year.one">{n} tahun</span>
+    <span data-phrase="age.year.many">{n} tahun</span>
+    <span data-phrase="code.monochrome1">MONOCHROME1 (0 berarti putih)</span>
+    <span data-phrase="code.monochrome2">MONOCHROME2 (0 berarti hitam)</span>
+    <span data-phrase="code.palette">PALETTE COLOR (menunjuk ke tabel warna)</span>
+    <span data-phrase="code.ybrfull">YBR_FULL (warna, sebagai kecerahan dan dua selisih)</span>
+    <span data-phrase="code.ybr422">YBR_FULL_422 (warna, dengan selisihnya setengah
+      lebar)</span>
+    <span data-phrase="code.hfs">HFS (kepala dulu, telentang)</span>
+    <span data-phrase="code.hfp">HFP (kepala dulu, telungkup)</span>
+    <span data-phrase="code.ffs">FFS (kaki dulu, telentang)</span>
+    <span data-phrase="code.ffp">FFP (kaki dulu, telungkup)</span>
+    <span data-phrase="code.male">M (laki-laki)</span>
+    <span data-phrase="code.female">F (perempuan)</span>
+    <span data-phrase="code.other">O (lainnya)</span>
+    <span data-phrase="report.size">{size} ({bytes})</span>
+    <span data-phrase="report.spacing.value">{row} &times; {column} mm</span>
+    <span data-phrase="report.none">(tidak ada)</span>
+    <span data-phrase="tag.private">(privat)</span>
+    <span data-phrase="tag.unknown">(tidak dikenal)</span>
     <span data-phrase="open.notdicom">tidak ada penanda DICM di bita ke-128, dan bita-bita pertamanya pun bukan elemen
       DICOM</span>
     <span data-phrase="jpeg.nosoi">fragmen ini tidak dimulai dengan penanda JPEG SOI</span>

--- a/locales/it/tools/dicom-viewer.html
+++ b/locales/it/tools/dicom-viewer.html
@@ -181,6 +181,45 @@
     wins over the frame's one.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="file.failed">{name}: {why}</span>
+    <span data-phrase="series.label">{what} ({files})</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="facts.size">{width} &times; {height}</span>
+    <span data-phrase="facts.size.frames">{width} &times; {height}, {frames}</span>
+    <span data-phrase="unit.value">{n} {unit}</span>
+    <span data-phrase="value.fragment.one">{n} frammento compresso, {bytes} byte</span>
+    <span data-phrase="value.fragment.many">{n} frammenti compressi, {bytes} byte</span>
+    <span data-phrase="value.notshown">{bytes} byte, non mostrati</span>
+    <span data-phrase="value.empty">(vuoto)</span>
+    <span data-phrase="value.bytes">{bytes} byte: {head}</span>
+    <span data-phrase="value.bytes.more">{bytes} byte: {head} &hellip;</span>
+    <span data-phrase="age.day.one">{n} giorno</span>
+    <span data-phrase="age.day.many">{n} giorni</span>
+    <span data-phrase="age.week.one">{n} settimana</span>
+    <span data-phrase="age.week.many">{n} settimane</span>
+    <span data-phrase="age.month.one">{n} mese</span>
+    <span data-phrase="age.month.many">{n} mesi</span>
+    <span data-phrase="age.year.one">{n} anno</span>
+    <span data-phrase="age.year.many">{n} anni</span>
+    <span data-phrase="code.monochrome1">MONOCHROME1 (0 è bianco)</span>
+    <span data-phrase="code.monochrome2">MONOCHROME2 (0 è nero)</span>
+    <span data-phrase="code.palette">PALETTE COLOR (indicizza le tabelle di
+      consultazione)</span>
+    <span data-phrase="code.ybrfull">YBR_FULL (colore, come luminanza e due differenze)</span>
+    <span data-phrase="code.ybr422">YBR_FULL_422 (colore, con le differenze a metà
+      larghezza)</span>
+    <span data-phrase="code.hfs">HFS (testa avanti, supino)</span>
+    <span data-phrase="code.hfp">HFP (testa avanti, prono)</span>
+    <span data-phrase="code.ffs">FFS (piedi avanti, supino)</span>
+    <span data-phrase="code.ffp">FFP (piedi avanti, prono)</span>
+    <span data-phrase="code.male">M (maschio)</span>
+    <span data-phrase="code.female">F (femmina)</span>
+    <span data-phrase="code.other">O (altro)</span>
+    <span data-phrase="report.size">{size} ({bytes})</span>
+    <span data-phrase="report.spacing.value">{row} &times; {column} mm</span>
+    <span data-phrase="report.none">(nessuno)</span>
+    <span data-phrase="tag.private">(privato)</span>
+    <span data-phrase="tag.unknown">(sconosciuto)</span>
     <span data-phrase="open.notdicom">al byte 128 non c&rsquo;è alcun marcatore DICM, e i primi byte non sono nemmeno un
       elemento DICOM</span>
     <span data-phrase="jpeg.nosoi">questo frammento non comincia con un marcatore JPEG SOI</span>

--- a/locales/ja/tools/dicom-viewer.html
+++ b/locales/ja/tools/dicom-viewer.html
@@ -174,6 +174,43 @@
     wins over the frame's one.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="file.failed">{name}：{why}</span>
+    <span data-phrase="series.label">{what}（{files}）</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="facts.size">{width} &times; {height}</span>
+    <span data-phrase="facts.size.frames">{width} &times; {height}、{frames}</span>
+    <span data-phrase="unit.value">{n} {unit}</span>
+    <span data-phrase="value.fragment.one">圧縮フラグメント{n}個、{bytes}バイト</span>
+    <span data-phrase="value.fragment.many">圧縮フラグメント{n}個、{bytes}バイト</span>
+    <span data-phrase="value.notshown">{bytes}バイト（表示していません）</span>
+    <span data-phrase="value.empty">（空）</span>
+    <span data-phrase="value.bytes">{bytes}バイト：{head}</span>
+    <span data-phrase="value.bytes.more">{bytes}バイト：{head} &hellip;</span>
+    <span data-phrase="age.day.one">{n}日</span>
+    <span data-phrase="age.day.many">{n}日</span>
+    <span data-phrase="age.week.one">{n}週</span>
+    <span data-phrase="age.week.many">{n}週</span>
+    <span data-phrase="age.month.one">{n}か月</span>
+    <span data-phrase="age.month.many">{n}か月</span>
+    <span data-phrase="age.year.one">{n}歳</span>
+    <span data-phrase="age.year.many">{n}歳</span>
+    <span data-phrase="code.monochrome1">MONOCHROME1（0が白）</span>
+    <span data-phrase="code.monochrome2">MONOCHROME2（0が黒）</span>
+    <span data-phrase="code.palette">PALETTE COLOR（ルックアップテーブルを参照）</span>
+    <span data-phrase="code.ybrfull">YBR_FULL（カラー。輝度と2つの色差）</span>
+    <span data-phrase="code.ybr422">YBR_FULL_422（カラー。色差は半分の幅）</span>
+    <span data-phrase="code.hfs">HFS（頭から、仰向け）</span>
+    <span data-phrase="code.hfp">HFP（頭から、うつ伏せ）</span>
+    <span data-phrase="code.ffs">FFS（足から、仰向け）</span>
+    <span data-phrase="code.ffp">FFP（足から、うつ伏せ）</span>
+    <span data-phrase="code.male">M（男性）</span>
+    <span data-phrase="code.female">F（女性）</span>
+    <span data-phrase="code.other">O（その他）</span>
+    <span data-phrase="report.size">{size}（{bytes}）</span>
+    <span data-phrase="report.spacing.value">{row} &times; {column} mm</span>
+    <span data-phrase="report.none">（なし）</span>
+    <span data-phrase="tag.private">（プライベート）</span>
+    <span data-phrase="tag.unknown">（不明）</span>
     <span data-phrase="open.notdicom">128バイト目にDICMの印がなく、先頭のバイトもDICOM要素ではありません</span>
     <span data-phrase="jpeg.nosoi">この断片はJPEGのSOIマーカーで始まっていません</span>
     <span data-phrase="jpeg.scanfirst">JPEGのスキャンがフレームヘッダーより先に来ました</span>

--- a/locales/ko/tools/dicom-viewer.html
+++ b/locales/ko/tools/dicom-viewer.html
@@ -179,6 +179,43 @@
     wins over the frame's one.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="file.failed">{name}: {why}</span>
+    <span data-phrase="series.label">{what} ({files})</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="facts.size">{width} &times; {height}</span>
+    <span data-phrase="facts.size.frames">{width} &times; {height}, {frames}</span>
+    <span data-phrase="unit.value">{n} {unit}</span>
+    <span data-phrase="value.fragment.one">압축 조각 {n}개, {bytes}바이트</span>
+    <span data-phrase="value.fragment.many">압축 조각 {n}개, {bytes}바이트</span>
+    <span data-phrase="value.notshown">{bytes}바이트, 보이지 않음</span>
+    <span data-phrase="value.empty">(비어 있음)</span>
+    <span data-phrase="value.bytes">{bytes}바이트: {head}</span>
+    <span data-phrase="value.bytes.more">{bytes}바이트: {head} &hellip;</span>
+    <span data-phrase="age.day.one">{n}일</span>
+    <span data-phrase="age.day.many">{n}일</span>
+    <span data-phrase="age.week.one">{n}주</span>
+    <span data-phrase="age.week.many">{n}주</span>
+    <span data-phrase="age.month.one">{n}개월</span>
+    <span data-phrase="age.month.many">{n}개월</span>
+    <span data-phrase="age.year.one">{n}세</span>
+    <span data-phrase="age.year.many">{n}세</span>
+    <span data-phrase="code.monochrome1">MONOCHROME1 (0이 흰색)</span>
+    <span data-phrase="code.monochrome2">MONOCHROME2 (0이 검은색)</span>
+    <span data-phrase="code.palette">PALETTE COLOR (색 참조표를 가리킴)</span>
+    <span data-phrase="code.ybrfull">YBR_FULL (색, 밝기와 두 색차로)</span>
+    <span data-phrase="code.ybr422">YBR_FULL_422 (색, 색차는 절반 너비로)</span>
+    <span data-phrase="code.hfs">HFS (머리부터, 누운 자세)</span>
+    <span data-phrase="code.hfp">HFP (머리부터, 엎드린 자세)</span>
+    <span data-phrase="code.ffs">FFS (발부터, 누운 자세)</span>
+    <span data-phrase="code.ffp">FFP (발부터, 엎드린 자세)</span>
+    <span data-phrase="code.male">M (남성)</span>
+    <span data-phrase="code.female">F (여성)</span>
+    <span data-phrase="code.other">O (기타)</span>
+    <span data-phrase="report.size">{size} ({bytes})</span>
+    <span data-phrase="report.spacing.value">{row} &times; {column} mm</span>
+    <span data-phrase="report.none">(없음)</span>
+    <span data-phrase="tag.private">(비공개)</span>
+    <span data-phrase="tag.unknown">(알 수 없음)</span>
     <span data-phrase="open.notdicom">128번 바이트에 DICM 표식이 없고, 앞쪽 바이트도 DICOM 요소가 아닙니다</span>
     <span data-phrase="jpeg.nosoi">이 조각은 JPEG SOI 표식으로 시작하지 않습니다</span>
     <span data-phrase="jpeg.scanfirst">JPEG 스캔이 프레임 헤더보다 먼저 왔습니다</span>

--- a/locales/nl/tools/dicom-viewer.html
+++ b/locales/nl/tools/dicom-viewer.html
@@ -181,6 +181,45 @@
     wins over the frame's one.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="file.failed">{name}: {why}</span>
+    <span data-phrase="series.label">{what} ({files})</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="facts.size">{width} &times; {height}</span>
+    <span data-phrase="facts.size.frames">{width} &times; {height}, {frames}</span>
+    <span data-phrase="unit.value">{n} {unit}</span>
+    <span data-phrase="value.fragment.one">{n} gecomprimeerd fragment, {bytes} bytes</span>
+    <span data-phrase="value.fragment.many">{n} gecomprimeerde fragmenten, {bytes} bytes</span>
+    <span data-phrase="value.notshown">{bytes} bytes, niet getoond</span>
+    <span data-phrase="value.empty">(leeg)</span>
+    <span data-phrase="value.bytes">{bytes} bytes: {head}</span>
+    <span data-phrase="value.bytes.more">{bytes} bytes: {head} &hellip;</span>
+    <span data-phrase="age.day.one">{n} dag</span>
+    <span data-phrase="age.day.many">{n} dagen</span>
+    <span data-phrase="age.week.one">{n} week</span>
+    <span data-phrase="age.week.many">{n} weken</span>
+    <span data-phrase="age.month.one">{n} maand</span>
+    <span data-phrase="age.month.many">{n} maanden</span>
+    <span data-phrase="age.year.one">{n} jaar</span>
+    <span data-phrase="age.year.many">{n} jaar</span>
+    <span data-phrase="code.monochrome1">MONOCHROME1 (0 is wit)</span>
+    <span data-phrase="code.monochrome2">MONOCHROME2 (0 is zwart)</span>
+    <span data-phrase="code.palette">PALETTE COLOR (verwijst naar de opzoektabellen)</span>
+    <span data-phrase="code.ybrfull">YBR_FULL (kleur, als helderheid en twee
+      verschillen)</span>
+    <span data-phrase="code.ybr422">YBR_FULL_422 (kleur, met de verschillen op halve
+      breedte)</span>
+    <span data-phrase="code.hfs">HFS (hoofd eerst, op de rug)</span>
+    <span data-phrase="code.hfp">HFP (hoofd eerst, op de buik)</span>
+    <span data-phrase="code.ffs">FFS (voeten eerst, op de rug)</span>
+    <span data-phrase="code.ffp">FFP (voeten eerst, op de buik)</span>
+    <span data-phrase="code.male">M (man)</span>
+    <span data-phrase="code.female">F (vrouw)</span>
+    <span data-phrase="code.other">O (anders)</span>
+    <span data-phrase="report.size">{size} ({bytes})</span>
+    <span data-phrase="report.spacing.value">{row} &times; {column} mm</span>
+    <span data-phrase="report.none">(geen)</span>
+    <span data-phrase="tag.private">(privé)</span>
+    <span data-phrase="tag.unknown">(onbekend)</span>
     <span data-phrase="open.notdicom">er staat geen DICM-markering op byte 128, en de eerste bytes zijn ook geen
       DICOM-element</span>
     <span data-phrase="jpeg.nosoi">dit fragment begint niet met een JPEG-SOI-markering</span>

--- a/locales/pt/tools/dicom-viewer.html
+++ b/locales/pt/tools/dicom-viewer.html
@@ -181,6 +181,44 @@
     wins over the frame's one.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="file.failed">{name}: {why}</span>
+    <span data-phrase="series.label">{what} ({files})</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="facts.size">{width} &times; {height}</span>
+    <span data-phrase="facts.size.frames">{width} &times; {height}, {frames}</span>
+    <span data-phrase="unit.value">{n} {unit}</span>
+    <span data-phrase="value.fragment.one">{n} fragmento comprimido, {bytes} bytes</span>
+    <span data-phrase="value.fragment.many">{n} fragmentos comprimidos, {bytes} bytes</span>
+    <span data-phrase="value.notshown">{bytes} bytes, não mostrados</span>
+    <span data-phrase="value.empty">(vazio)</span>
+    <span data-phrase="value.bytes">{bytes} bytes: {head}</span>
+    <span data-phrase="value.bytes.more">{bytes} bytes: {head} &hellip;</span>
+    <span data-phrase="age.day.one">{n} dia</span>
+    <span data-phrase="age.day.many">{n} dias</span>
+    <span data-phrase="age.week.one">{n} semana</span>
+    <span data-phrase="age.week.many">{n} semanas</span>
+    <span data-phrase="age.month.one">{n} mês</span>
+    <span data-phrase="age.month.many">{n} meses</span>
+    <span data-phrase="age.year.one">{n} ano</span>
+    <span data-phrase="age.year.many">{n} anos</span>
+    <span data-phrase="code.monochrome1">MONOCHROME1 (0 é branco)</span>
+    <span data-phrase="code.monochrome2">MONOCHROME2 (0 é preto)</span>
+    <span data-phrase="code.palette">PALETTE COLOR (indexa nas tabelas de consulta)</span>
+    <span data-phrase="code.ybrfull">YBR_FULL (cor, como luminância e duas diferenças)</span>
+    <span data-phrase="code.ybr422">YBR_FULL_422 (cor, com as diferenças em meia
+      largura)</span>
+    <span data-phrase="code.hfs">HFS (cabeça primeiro, de barriga para cima)</span>
+    <span data-phrase="code.hfp">HFP (cabeça primeiro, de barriga para baixo)</span>
+    <span data-phrase="code.ffs">FFS (pés primeiro, de barriga para cima)</span>
+    <span data-phrase="code.ffp">FFP (pés primeiro, de barriga para baixo)</span>
+    <span data-phrase="code.male">M (masculino)</span>
+    <span data-phrase="code.female">F (feminino)</span>
+    <span data-phrase="code.other">O (outro)</span>
+    <span data-phrase="report.size">{size} ({bytes})</span>
+    <span data-phrase="report.spacing.value">{row} &times; {column} mm</span>
+    <span data-phrase="report.none">(nenhum)</span>
+    <span data-phrase="tag.private">(privado)</span>
+    <span data-phrase="tag.unknown">(desconhecido)</span>
     <span data-phrase="open.notdicom">não há marca DICM no byte 128, e os primeiros bytes também não são um elemento DICOM</span>
     <span data-phrase="jpeg.nosoi">este fragmento não começa com uma marca JPEG SOI</span>
     <span data-phrase="jpeg.scanfirst">uma varredura JPEG chegou antes do seu cabeçalho de quadro</span>

--- a/locales/tr/tools/dicom-viewer.html
+++ b/locales/tr/tools/dicom-viewer.html
@@ -180,6 +180,43 @@
     wins over the frame's one.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="file.failed">{name}: {why}</span>
+    <span data-phrase="series.label">{what} ({files})</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="facts.size">{width} &times; {height}</span>
+    <span data-phrase="facts.size.frames">{width} &times; {height}, {frames}</span>
+    <span data-phrase="unit.value">{n} {unit}</span>
+    <span data-phrase="value.fragment.one">{n} sıkıştırılmış parça, {bytes} bayt</span>
+    <span data-phrase="value.fragment.many">{n} sıkıştırılmış parça, {bytes} bayt</span>
+    <span data-phrase="value.notshown">{bytes} bayt, gösterilmedi</span>
+    <span data-phrase="value.empty">(boş)</span>
+    <span data-phrase="value.bytes">{bytes} bayt: {head}</span>
+    <span data-phrase="value.bytes.more">{bytes} bayt: {head} &hellip;</span>
+    <span data-phrase="age.day.one">{n} gün</span>
+    <span data-phrase="age.day.many">{n} gün</span>
+    <span data-phrase="age.week.one">{n} hafta</span>
+    <span data-phrase="age.week.many">{n} hafta</span>
+    <span data-phrase="age.month.one">{n} ay</span>
+    <span data-phrase="age.month.many">{n} ay</span>
+    <span data-phrase="age.year.one">{n} yıl</span>
+    <span data-phrase="age.year.many">{n} yıl</span>
+    <span data-phrase="code.monochrome1">MONOCHROME1 (0 beyazdır)</span>
+    <span data-phrase="code.monochrome2">MONOCHROME2 (0 siyahtır)</span>
+    <span data-phrase="code.palette">PALETTE COLOR (renk tablolarına başvurur)</span>
+    <span data-phrase="code.ybrfull">YBR_FULL (renk; parlaklık ve iki fark olarak)</span>
+    <span data-phrase="code.ybr422">YBR_FULL_422 (renk; farklar yarım genişlikte)</span>
+    <span data-phrase="code.hfs">HFS (baş önde, sırtüstü)</span>
+    <span data-phrase="code.hfp">HFP (baş önde, yüzüstü)</span>
+    <span data-phrase="code.ffs">FFS (ayaklar önde, sırtüstü)</span>
+    <span data-phrase="code.ffp">FFP (ayaklar önde, yüzüstü)</span>
+    <span data-phrase="code.male">M (erkek)</span>
+    <span data-phrase="code.female">F (kadın)</span>
+    <span data-phrase="code.other">O (diğer)</span>
+    <span data-phrase="report.size">{size} ({bytes})</span>
+    <span data-phrase="report.spacing.value">{row} &times; {column} mm</span>
+    <span data-phrase="report.none">(yok)</span>
+    <span data-phrase="tag.private">(özel)</span>
+    <span data-phrase="tag.unknown">(bilinmiyor)</span>
     <span data-phrase="open.notdicom">128. baytta DICM imi yok, ve ilk baytlar da bir DICOM ögesi değil</span>
     <span data-phrase="jpeg.nosoi">bu parça bir JPEG SOI imiyle başlamıyor</span>
     <span data-phrase="jpeg.scanfirst">bir JPEG taraması kendi çerçeve başlığından önce geldi</span>

--- a/locales/zh-TW/tools/dicom-viewer.html
+++ b/locales/zh-TW/tools/dicom-viewer.html
@@ -176,6 +176,43 @@
     wins over the frame's one.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="file.failed">{name}：{why}</span>
+    <span data-phrase="series.label">{what}（{files}）</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="facts.size">{width} &times; {height}</span>
+    <span data-phrase="facts.size.frames">{width} &times; {height}，{frames}</span>
+    <span data-phrase="unit.value">{n} {unit}</span>
+    <span data-phrase="value.fragment.one">{n} 個壓縮分片，{bytes} 位元組</span>
+    <span data-phrase="value.fragment.many">{n} 個壓縮分片，{bytes} 位元組</span>
+    <span data-phrase="value.notshown">{bytes} 位元組，未顯示</span>
+    <span data-phrase="value.empty">（空）</span>
+    <span data-phrase="value.bytes">{bytes} 位元組：{head}</span>
+    <span data-phrase="value.bytes.more">{bytes} 位元組：{head} &hellip;</span>
+    <span data-phrase="age.day.one">{n} 天</span>
+    <span data-phrase="age.day.many">{n} 天</span>
+    <span data-phrase="age.week.one">{n} 周</span>
+    <span data-phrase="age.week.many">{n} 周</span>
+    <span data-phrase="age.month.one">{n} 個月</span>
+    <span data-phrase="age.month.many">{n} 個月</span>
+    <span data-phrase="age.year.one">{n} 歲</span>
+    <span data-phrase="age.year.many">{n} 歲</span>
+    <span data-phrase="code.monochrome1">MONOCHROME1（0 是白）</span>
+    <span data-phrase="code.monochrome2">MONOCHROME2（0 是黑）</span>
+    <span data-phrase="code.palette">PALETTE COLOR（查色表索引）</span>
+    <span data-phrase="code.ybrfull">YBR_FULL（彩色，用亮度加兩個色差）</span>
+    <span data-phrase="code.ybr422">YBR_FULL_422（彩色，色差取一半寬度）</span>
+    <span data-phrase="code.hfs">HFS（頭先進，仰臥）</span>
+    <span data-phrase="code.hfp">HFP（頭先進，俯臥）</span>
+    <span data-phrase="code.ffs">FFS（腳先進，仰臥）</span>
+    <span data-phrase="code.ffp">FFP（腳先進，俯臥）</span>
+    <span data-phrase="code.male">M（男）</span>
+    <span data-phrase="code.female">F（女）</span>
+    <span data-phrase="code.other">O（其他）</span>
+    <span data-phrase="report.size">{size}（{bytes}）</span>
+    <span data-phrase="report.spacing.value">{row} &times; {column} 毫米</span>
+    <span data-phrase="report.none">（無）</span>
+    <span data-phrase="tag.private">（私有）</span>
+    <span data-phrase="tag.unknown">（未知）</span>
     <span data-phrase="open.notdicom">第 128 個位元組處沒有 DICM 標記，開頭的位元組也不是一個 DICOM 元素</span>
     <span data-phrase="jpeg.nosoi">這個片段不是以 JPEG 的 SOI 標記開頭的</span>
     <span data-phrase="jpeg.scanfirst">JPEG 的掃描段出現在它的幀頭之前</span>

--- a/locales/zh/tools/dicom-viewer.html
+++ b/locales/zh/tools/dicom-viewer.html
@@ -176,6 +176,43 @@
     wins over the frame's one.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="file.failed">{name}：{why}</span>
+    <span data-phrase="series.label">{what}（{files}）</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="facts.size">{width} &times; {height}</span>
+    <span data-phrase="facts.size.frames">{width} &times; {height}，{frames}</span>
+    <span data-phrase="unit.value">{n} {unit}</span>
+    <span data-phrase="value.fragment.one">{n} 个压缩分片，{bytes} 字节</span>
+    <span data-phrase="value.fragment.many">{n} 个压缩分片，{bytes} 字节</span>
+    <span data-phrase="value.notshown">{bytes} 字节，未显示</span>
+    <span data-phrase="value.empty">（空）</span>
+    <span data-phrase="value.bytes">{bytes} 字节：{head}</span>
+    <span data-phrase="value.bytes.more">{bytes} 字节：{head} &hellip;</span>
+    <span data-phrase="age.day.one">{n} 天</span>
+    <span data-phrase="age.day.many">{n} 天</span>
+    <span data-phrase="age.week.one">{n} 周</span>
+    <span data-phrase="age.week.many">{n} 周</span>
+    <span data-phrase="age.month.one">{n} 个月</span>
+    <span data-phrase="age.month.many">{n} 个月</span>
+    <span data-phrase="age.year.one">{n} 岁</span>
+    <span data-phrase="age.year.many">{n} 岁</span>
+    <span data-phrase="code.monochrome1">MONOCHROME1（0 是白）</span>
+    <span data-phrase="code.monochrome2">MONOCHROME2（0 是黑）</span>
+    <span data-phrase="code.palette">PALETTE COLOR（查色表索引）</span>
+    <span data-phrase="code.ybrfull">YBR_FULL（彩色，用亮度加两个色差）</span>
+    <span data-phrase="code.ybr422">YBR_FULL_422（彩色，色差取一半宽度）</span>
+    <span data-phrase="code.hfs">HFS（头先进，仰卧）</span>
+    <span data-phrase="code.hfp">HFP（头先进，俯卧）</span>
+    <span data-phrase="code.ffs">FFS（脚先进，仰卧）</span>
+    <span data-phrase="code.ffp">FFP（脚先进，俯卧）</span>
+    <span data-phrase="code.male">M（男）</span>
+    <span data-phrase="code.female">F（女）</span>
+    <span data-phrase="code.other">O（其他）</span>
+    <span data-phrase="report.size">{size}（{bytes}）</span>
+    <span data-phrase="report.spacing.value">{row} &times; {column} 毫米</span>
+    <span data-phrase="report.none">（无）</span>
+    <span data-phrase="tag.private">（私有）</span>
+    <span data-phrase="tag.unknown">（未知）</span>
     <span data-phrase="open.notdicom">第 128 个字节处没有 DICM 标记，开头的字节也不是一个 DICOM 元素</span>
     <span data-phrase="jpeg.nosoi">这个片段不是以 JPEG 的 SOI 标记开头的</span>
     <span data-phrase="jpeg.scanfirst">JPEG 的扫描段出现在它的帧头之前</span>

--- a/tests/js/dicom-parse.test.js
+++ b/tests/js/dicom-parse.test.js
@@ -417,14 +417,21 @@ test('a UTF-8 name survives being declared', () => {
   assert.equal(text(dataset, '00100010', decoder), 'Müller^Jörg');
 });
 
+/* A stand-in for `phrase()`. values.js ships in fifteen languages, so what
+   it hands back is a key and its blanks. */
+const say = (key, values = {}) => (
+  Object.keys(values).length ? `${key}(${Object.values(values).join(',')})` : key);
+
 test('dates, times, ages and names are written out for a person', () => {
   assert.equal(date('20190314'), '14 March 2019');
   assert.equal(date('1975.03.14'), '14 March 1975');
   assert.equal(date('not a date'), null);
   assert.equal(time('134522'), '13:45:22');
   assert.equal(time('1345'), '13:45:00');
-  assert.equal(age('045Y'), '45 years');
-  assert.equal(age('001M'), '1 month');
+  // `age` names a sentence and takes a resolver: "45 years" is not one
+  // noun with an `s` on it in a language whose plural is not a suffix.
+  assert.equal(age('045Y', say), 'age.year.many(45)');
+  assert.equal(age('001M', say), 'age.month.one(1)');
   // Reordered and not recased. Names in DICOM files are conventionally written
   // in capitals, and a viewer that title-cased them would turn MCDONALD into
   // Mcdonald and O'BRIEN into O'brien - which is inventing, on the one field

--- a/tests/python/test_english_in_js.py
+++ b/tests/python/test_english_in_js.py
@@ -61,7 +61,9 @@ BASELINE = {
     'compress-image': 2,
     'compress-pdf': 6,
     'crop-video': 0,
-    'dicom-viewer': 15,
+    # Two internal keys, a DOM id, a clock format, one key template and the
+    # fixed-width layout of a line in the text report.
+    'dicom-viewer': 6,
     'document-scanner': 13,
     'edit-audio': 18,
     'encode-text': 0,

--- a/tools/dicom-viewer/body.html
+++ b/tools/dicom-viewer/body.html
@@ -176,6 +176,44 @@
     wins over the frame's one.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="file.failed">{name}: {why}</span>
+    <span data-phrase="series.label">{what} ({files})</span>
+    <span data-phrase="join.dot">{a} &middot; {b}</span>
+    <span data-phrase="facts.size">{width} &times; {height}</span>
+    <span data-phrase="facts.size.frames">{width} &times; {height}, {frames}</span>
+    <span data-phrase="unit.value">{n} {unit}</span>
+    <span data-phrase="value.fragment.one">{n} compressed fragment, {bytes} bytes</span>
+    <span data-phrase="value.fragment.many">{n} compressed fragments, {bytes} bytes</span>
+    <span data-phrase="value.notshown">{bytes} bytes, not shown</span>
+    <span data-phrase="value.empty">(empty)</span>
+    <span data-phrase="value.bytes">{bytes} bytes: {head}</span>
+    <span data-phrase="value.bytes.more">{bytes} bytes: {head} &hellip;</span>
+    <span data-phrase="age.day.one">{n} day</span>
+    <span data-phrase="age.day.many">{n} days</span>
+    <span data-phrase="age.week.one">{n} week</span>
+    <span data-phrase="age.week.many">{n} weeks</span>
+    <span data-phrase="age.month.one">{n} month</span>
+    <span data-phrase="age.month.many">{n} months</span>
+    <span data-phrase="age.year.one">{n} year</span>
+    <span data-phrase="age.year.many">{n} years</span>
+    <span data-phrase="code.monochrome1">MONOCHROME1 (0 is white)</span>
+    <span data-phrase="code.monochrome2">MONOCHROME2 (0 is black)</span>
+    <span data-phrase="code.palette">PALETTE COLOR (indexes into the lookup tables)</span>
+    <span data-phrase="code.ybrfull">YBR_FULL (colour, as luminance and two differences)</span>
+    <span data-phrase="code.ybr422">YBR_FULL_422 (colour, with the differences at half
+      width)</span>
+    <span data-phrase="code.hfs">HFS (head first, supine)</span>
+    <span data-phrase="code.hfp">HFP (head first, prone)</span>
+    <span data-phrase="code.ffs">FFS (feet first, supine)</span>
+    <span data-phrase="code.ffp">FFP (feet first, prone)</span>
+    <span data-phrase="code.male">M (male)</span>
+    <span data-phrase="code.female">F (female)</span>
+    <span data-phrase="code.other">O (other)</span>
+    <span data-phrase="report.size">{size} ({bytes})</span>
+    <span data-phrase="report.spacing.value">{row} &times; {column} mm</span>
+    <span data-phrase="report.none">(none)</span>
+    <span data-phrase="tag.private">(private)</span>
+    <span data-phrase="tag.unknown">(unknown)</span>
     <span data-phrase="open.notdicom">there is no DICM marker at byte 128, and the first bytes are not a DICOM element either</span>
     <span data-phrase="jpeg.nosoi">this fragment does not start with a JPEG SOI marker</span>
     <span data-phrase="jpeg.scanfirst">a JPEG scan arrived before its frame header</span>

--- a/tools/dicom-viewer/src/format.js
+++ b/tools/dicom-viewer/src/format.js
@@ -41,10 +41,12 @@ export function millimetres(value) {
  * showing `100.0 HU` where the answer is exactly 100 suggests a precision the
  * scanner did not have.
  */
-export function quantity(value, unit) {
+export function quantity(value, unit, t) {
   const shown = Number.isInteger(value) ? String(value)
     : Math.abs(value) >= 100 ? value.toFixed(1) : value.toFixed(3).replace(/0+$/, '').replace(/\.$/, '');
-  return unit ? `${shown} ${unit}` : shown;
+  // Where the unit goes is the language's business: it follows the number
+  // in English and precedes it in some others.
+  return unit ? t('unit.value', { n: shown, unit }) : shown;
 }
 
 /** A window, said the way a workstation says it: centre first, then width. */

--- a/tools/dicom-viewer/src/main.js
+++ b/tools/dicom-viewer/src/main.js
@@ -171,7 +171,10 @@ async function openFiles(files) {
         // The decoders throw the key of a sentence; phrase() hands back
         // anything it does not know unchanged, so a real message from the
         // platform still arrives intact.
-        refused.push(`${files[at].name}: ${phrase(error.message, error.values)}`);
+        refused.push(phrase('file.failed', {
+          name: files[at].name,
+          why: phrase(error.message, error.values),
+        }));
       }
     }
   } finally {
@@ -311,8 +314,13 @@ function seriesLabel(series) {
   if (parts.length === 0) parts.push(series.instances[0].name);
 
   const held = series.instances.length;
-  return `${parts.join(' · ')} (${
-    phrase(held === 1 ? 'series.files.one' : 'series.files', { count: count(held) })})`;
+  // The dot between two parts is a phrase too, and so is the bracket: not
+  // every language brackets an aside the same way.
+  return phrase('series.label', {
+    what: parts.reduce((a, b) => phrase('join.dot', { a, b })),
+    files: phrase(held === 1 ? 'series.files.one' : 'series.files',
+      { count: count(held) }),
+  });
 }
 
 el.seriesPick.addEventListener('change', () => chooseSeries(Number(el.seriesPick.value)));
@@ -840,7 +848,7 @@ function probe(event) {
   const stored = shown.values[row * shown.width + column];
   const { value, unit } = measured(stored, open.image);
   el.overlayBR.textContent = phrase('probe.value', {
-    value: quantity(value, unit), column, row,
+    value: quantity(value, unit, phrase), column, row,
   });
 }
 
@@ -972,8 +980,11 @@ function renderFacts(file) {
   el.factSop.textContent = file.sopClass ?? NOTHING;
   el.factModality.textContent = text(file.dataset, '00080060', file.decoder) || NOTHING;
   el.factSize.textContent = info
-    ? `${info.columns} × ${info.rows}${info.frames > 1
-      ? `, ${phrase('facts.frames', { count: count(info.frames) })}` : ''}`
+    ? phrase(info.frames > 1 ? 'facts.size.frames' : 'facts.size', {
+      width: info.columns,
+      height: info.rows,
+      frames: phrase('facts.frames', { count: count(info.frames) }),
+    })
     : phrase('facts.nopixels');
   el.factStored.textContent = info
     ? phrase(info.samplesPerPixel === 1 ? 'facts.stored.one' : 'facts.stored', {
@@ -1018,14 +1029,15 @@ function renderRange() {
   el.factRange.textContent = shown.samples === 3
     ? phrase('facts.colour')
     : phrase('facts.range', {
-      low: quantity(low.value, low.unit), high: quantity(high.value, high.unit),
+      low: quantity(low.value, low.unit, phrase),
+      high: quantity(high.value, high.unit, phrase),
     });
 }
 
 /* ------------------------------------------------------------- the identity */
 
 function renderIdentity(file) {
-  const show = (element) => display(element, file.decoder);
+  const show = (element) => display(element, file.decoder, phrase);
   const fromMeta = identifiers(walk(file.meta), show);
   const fromBody = identifiers(walk(file.dataset), show);
   const found = fromMeta.found.concat(fromBody.found);

--- a/tools/dicom-viewer/src/report.js
+++ b/tools/dicom-viewer/src/report.js
@@ -44,9 +44,10 @@ export function report(file, decoder, t) {
   say(t('report.title', { name: file.name }));
   say('='.repeat(Math.min(72, 16 + file.name.length)));
   say();
-  row(size, `${fileSize(file.size)} (${t('report.bytes', {
-    count: file.size.toLocaleString(),
-  })})`);
+  row(size, t('report.size', {
+    size: fileSize(file.size),
+    bytes: t('report.bytes', { count: file.size.toLocaleString() }),
+  }));
   row(syntax, file.syntax.name);
   row('', file.syntax.uid);
   if (file.sopClass) row(object, file.sopClass);
@@ -59,7 +60,9 @@ export function report(file, decoder, t) {
         : t('report.samples', { count: samplesPerPixel })}, ${photometric}`);
     if (count > 1) row(frames, count);
     if (file.image.spacing) {
-      row(spacing, `${file.image.spacing.row} × ${file.image.spacing.column} mm`);
+      row(spacing, t('report.spacing.value', {
+        row: file.image.spacing.row, column: file.image.spacing.column,
+      }));
     }
   }
 
@@ -75,13 +78,13 @@ export function report(file, decoder, t) {
   say();
   say(meta);
   say('-'.repeat(meta.length));
-  dump(file.meta, decoder, say);
+  dump(file.meta, decoder, say, t);
 
   const dataset = t('report.dataset');
   say();
   say(dataset);
   say('-'.repeat(dataset.length));
-  dump(file.dataset, decoder, say);
+  dump(file.dataset, decoder, say, t);
 
   say();
   say(t('report.origin', { origin: file.origin }));
@@ -90,17 +93,17 @@ export function report(file, decoder, t) {
 }
 
 /** Every element of a dataset, one per line, nesting and all. */
-function dump(dataset, decoder, say) {
+function dump(dataset, decoder, say, t) {
   if (!dataset || dataset.elements.length === 0) {
-    say('  (none)');
+    say(`  ${t('report.none')}`);
     return;
   }
 
   for (const { element, depth } of walk(dataset)) {
     const indent = '  '.repeat(depth + 1);
     const known = describe(element.tag);
-    const name = known.name ?? (known.private ? '(private)' : '(unknown)');
-    const { shown } = display(element, decoder);
+    const name = known.name ?? t(known.private ? 'tag.private' : 'tag.unknown');
+    const { shown } = display(element, decoder, t);
 
     // The name column is padded to a width the great majority of names fit in
     // and is allowed to overrun for the few that do not. A column wide enough

--- a/tools/dicom-viewer/src/values.js
+++ b/tools/dicom-viewer/src/values.js
@@ -195,7 +195,7 @@ const hex4 = (value) => value.toString(16).padStart(4, '0');
  * the whole design. A viewer that shows only the tidied form cannot be checked
  * against anything, and one that shows only the raw form is a hex dump.
  */
-export function display(element, decoder) {
+export function display(element, decoder, t) {
   const { vr } = element;
 
   if (element.items) {
@@ -206,45 +206,53 @@ export function display(element, decoder) {
     const total = element.fragments.reduce((sum, part) => sum + part.length, 0);
     const count = element.fragments.length;
     return {
-      shown: `${count === 1 ? '1 compressed fragment' : `${count} compressed fragments`}, ${
-        total.toLocaleString()} bytes`,
+      shown: t(count === 1 ? 'value.fragment.one' : 'value.fragment.many',
+        { n: count, bytes: total.toLocaleString() }),
       raw: '',
     };
   }
   if (!element.value) {
-    return { shown: `${element.length.toLocaleString()} bytes, not shown`, raw: '' };
+    return {
+      shown: t('value.notshown', { bytes: element.length.toLocaleString() }),
+      raw: '',
+    };
   }
 
   const list = values(element, decoder);
   if (list.length === 0) {
-    return { shown: element.length === 0 ? '(empty)' : binary(element), raw: '' };
+    return {
+      shown: element.length === 0 ? t('value.empty') : binary(element, t),
+      raw: '',
+    };
   }
 
   const raw = TEXT.has(vr) ? trim(decoder.decode(element.value)) : '';
-  const shown = list.map((value) => pretty(vr, value)).join(' \\ ');
+  const shown = list.map((value) => pretty(vr, value, t)).join(' \\ ');
   return { shown, raw: shown === raw ? '' : raw };
 }
 
 /** Bytes with no readable form: the first of them, and how many there are. */
-function binary(element) {
+function binary(element, t) {
   const head = Array.from(element.value.subarray(0, 16))
     .map((byte) => byte.toString(16).padStart(2, '0'))
     .join(' ');
-  const more = element.value.length > 16 ? ' …' : '';
-  return `${element.length.toLocaleString()} bytes: ${head}${more}`;
+  return t(element.value.length > 16 ? 'value.bytes.more' : 'value.bytes', {
+    bytes: element.length.toLocaleString(),
+    head,
+  });
 }
 
-function pretty(vr, value) {
+function pretty(vr, value, t) {
   if (vr === 'DA') return date(String(value)) ?? String(value);
   if (vr === 'TM') return time(String(value)) ?? String(value);
   if (vr === 'DT') return dateTime(String(value)) ?? String(value);
   if (vr === 'PN') return personName(String(value));
-  if (vr === 'AS') return age(String(value)) ?? String(value);
+  if (vr === 'AS') return age(String(value), t) ?? String(value);
   if (vr === 'UI') {
     const name = uidName(trim(String(value)));
     return name ? `${name} (${trim(String(value))})` : trim(String(value));
   }
-  if (vr === 'CS') return code(String(value));
+  if (vr === 'CS') return code(String(value), t);
   return String(value);
 }
 
@@ -303,12 +311,14 @@ export function personName(value) {
 }
 
 /** `045Y` as `45 years`, which is the only form the VR allows. */
-export function age(value) {
+export function age(value, t) {
   const match = /^(\d{3})([DWMY])$/.exec(value.trim().toUpperCase());
   if (!match) return null;
   const count = Number(match[1]);
+  // Eight whole phrases rather than a noun with an `s` on it: a language
+  // whose plural is not a suffix cannot be served by appending one.
   const unit = { D: 'day', W: 'week', M: 'month', Y: 'year' }[match[2]];
-  return `${count} ${unit}${count === 1 ? '' : 's'}`;
+  return t(`age.${unit}.${count === 1 ? 'one' : 'many'}`, { n: count });
 }
 
 /**
@@ -319,20 +329,26 @@ export function age(value) {
  * what the picture is, which way round it is - is useful, and expanding the
  * rest would be a dictionary of its own that went out of date.
  */
+// The code itself is the standard's and is the same everywhere; the gloss
+// after it is this tool's own, so each entry is a phrase key and the phrase
+// carries both. RGB needs no gloss and so needs no key.
 const CODES = {
-  MONOCHROME1: 'MONOCHROME1 (0 is white)',
-  MONOCHROME2: 'MONOCHROME2 (0 is black)',
-  'PALETTE COLOR': 'PALETTE COLOR (indexes into the lookup tables)',
-  RGB: 'RGB',
-  'YBR_FULL': 'YBR_FULL (colour, as luminance and two differences)',
-  'YBR_FULL_422': 'YBR_FULL_422 (colour, with the differences at half width)',
-  HFS: 'HFS (head first, supine)',
-  HFP: 'HFP (head first, prone)',
-  FFS: 'FFS (feet first, supine)',
-  FFP: 'FFP (feet first, prone)',
-  M: 'M (male)',
-  F: 'F (female)',
-  O: 'O (other)',
+  MONOCHROME1: 'code.monochrome1',
+  MONOCHROME2: 'code.monochrome2',
+  'PALETTE COLOR': 'code.palette',
+  'YBR_FULL': 'code.ybrfull',
+  'YBR_FULL_422': 'code.ybr422',
+  HFS: 'code.hfs',
+  HFP: 'code.hfp',
+  FFS: 'code.ffs',
+  FFP: 'code.ffp',
+  M: 'code.male',
+  F: 'code.female',
+  O: 'code.other',
 };
 
-const code = (value) => CODES[String(value).trim().toUpperCase()] ?? String(value).trim();
+const code = (value, t) => {
+  const clean = String(value).trim();
+  const key = CODES[clean.toUpperCase()];
+  return key ? t(key) : clean;
+};


### PR DESCRIPTION
dicom-viewer already had 106 phrases in its markup; fifteen sentences were still in `src/`. Thirty-seven move now.

**The DICOM dictionaries stay English** and are already in `NOT_OURS` — PS3.6 attribute names and PS3.5 transfer syntaxes are what every DICOM tool prints. **The twelve coded values in `values.js` are a different case**: the code is the standard's and the gloss after it is ours, so each entry is a key and the phrase carries both, with the code untouched where somebody can still search for it.

```
MONOCHROME1 (0 is white)          MONOCHROME1 (0 ist weiß)
HFS (head first, supine)          HFS (Kopf voran, auf dem Rücken)
YBR_FULL (colour, as luminance    YBR_FULL (Farbe, als Helligkeit
  and two differences)              und zwei Differenzen)
```

**`age()` built "45 years" by appending an `s`** to one of four nouns. Eight whole phrases now — a language whose plural is not a suffix cannot be served by appending one.

`quantity()`, `display()` and `dump()` take the resolver as an argument, the way svg-to-image's `describePlan` does. `report.js` already had one and now hands it on to the two functions it calls.

One collision worth knowing about: `report.spacing` was already the row's *label* ("Pixel spacing"), so the value beside it is `report.spacing.value`.

## Verified in the browser

Every new phrase resolved on the English and German pages, through the real `values.js` and `format.js`:

```
English  45 years · 1 month · 7 days · 100 HU · CT · Chest (40 files)
         512 × 512, 30 frames · 1.2 MB (1,234,567 bytes) · 0.5 × 0.5 mm
German   45 Jahre · 1 Monat · 7 Tage · 100 HU · CT · Thorax (40 Dateien)
         512 × 512, 30 Bilder · 1,2 MB (1.234.567 Bytes) · 0,5 × 0,5 mm
```

All fourteen locales checked for missing keys, the CJK wrap trap and blank drift; the five differences are Arabic `.one` forms that spell the number out.

## Tests

- `python -m unittest discover -t . -s tests/python` — 495 pass; the ratchet drops dicom-viewer 15 → 6, and the comment now names the six: two internal keys, a DOM id, a clock format, one key template and the fixed-width layout of a line in the text report.
- `node --test "tests/js/*.test.js"` — 1939 pass. The two report tests already used a stand-in resolver, so they only needed `dump()`'s new argument; the `age` assertions now check the key and its number, and the file gained the same stand-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)