### PR TITLE
Say what the scanner refused in the reader's language

### DIFF
--- a/locales/ar/tools/document-scanner.html
+++ b/locales/ar/tools/document-scanner.html
@@ -265,6 +265,12 @@
     shared/js/phrases.js.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="build.nopages">لا صفحات تُكتب.</span>
+    <span data-phrase="encode.nodeflate">لا يوجد CompressionStream في هذا المتصفح، وهو
+      ما يحتاجه وضع الأبيض والأسود لضغط الصفحة. اختر أحد الأوضاع الأخرى.</span>
+    <span data-phrase="encode.nojpeg">لم يستطع هذا المتصفح ترميز الصفحة بصيغة JPEG.</span>
+    <span data-phrase="encode.nopage">لم يستطع هذا المتصفح ترميز الصفحة.</span>
+    <span data-phrase="warp.degenerate">هذه الزوايا الأربع لا تكوّن صفحة.</span>
     <span data-phrase="detect.found">وُجِدت الأركان الأربعة. تحقّق منها، واسحب
       ما حطّ منها في غير موضعه.</span>
     <span data-phrase="detect.unsure">لم تكن حوافّ الصفحة واضحة بما يكفي

--- a/locales/de/tools/document-scanner.html
+++ b/locales/de/tools/document-scanner.html
@@ -286,6 +286,14 @@
     shared/js/phrases.js.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="build.nopages">Es gibt keine Seiten zu schreiben.</span>
+    <span data-phrase="encode.nodeflate">Dieser Browser hat kein CompressionStream, das
+      der Schwarzweißmodus braucht, um eine Seite zu komprimieren. Nehmen Sie
+      stattdessen einen der anderen Modi.</span>
+    <span data-phrase="encode.nojpeg">Dieser Browser konnte die Seite nicht als JPEG
+      kodieren.</span>
+    <span data-phrase="encode.nopage">Dieser Browser konnte die Seite nicht kodieren.</span>
+    <span data-phrase="warp.degenerate">Diese vier Ecken ergeben keine Seite.</span>
     <span data-phrase="detect.found">Die vier Ecken wurden gefunden. Prüfen Sie
       sie und ziehen Sie die zurecht, die danebenliegen.</span>
     <span data-phrase="detect.unsure">Die Kanten der Seite waren nicht deutlich

--- a/locales/es/tools/document-scanner.html
+++ b/locales/es/tools/document-scanner.html
@@ -284,6 +284,14 @@
     shared/js/phrases.js.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="build.nopages">No hay páginas que escribir.</span>
+    <span data-phrase="encode.nodeflate">Este navegador no tiene CompressionStream, que
+      es lo que el modo en blanco y negro necesita para comprimir una página. Elige otro
+      de los modos.</span>
+    <span data-phrase="encode.nojpeg">Este navegador no ha podido codificar la página
+      como JPEG.</span>
+    <span data-phrase="encode.nopage">Este navegador no ha podido codificar la página.</span>
+    <span data-phrase="warp.degenerate">Esas cuatro esquinas no forman una página.</span>
     <span data-phrase="detect.found">Se han encontrado las cuatro esquinas.
       Compruébalas y arrastra las que hayan caído mal.</span>
     <span data-phrase="detect.unsure">Los bordes de la hoja no estaban lo

--- a/locales/fr/tools/document-scanner.html
+++ b/locales/fr/tools/document-scanner.html
@@ -286,6 +286,14 @@
     shared/js/phrases.js.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="build.nopages">Il n&rsquo;y a aucune page à écrire.</span>
+    <span data-phrase="encode.nodeflate">Ce navigateur n&rsquo;a pas de
+      CompressionStream, dont le mode noir et blanc a besoin pour compresser une page.
+      Choisissez plutôt un des autres modes.</span>
+    <span data-phrase="encode.nojpeg">Ce navigateur n&rsquo;a pas pu encoder la page en
+      JPEG.</span>
+    <span data-phrase="encode.nopage">Ce navigateur n&rsquo;a pas pu encoder la page.</span>
+    <span data-phrase="warp.degenerate">Ces quatre coins ne font pas une page.</span>
     <span data-phrase="detect.found">Les quatre coins ont été trouvés.
       Vérifiez-les et faites glisser ceux qui sont tombés à côté.</span>
     <span data-phrase="detect.unsure">Les bords de la page n'étaient pas assez

--- a/locales/hi/tools/document-scanner.html
+++ b/locales/hi/tools/document-scanner.html
@@ -278,6 +278,12 @@
     shared/js/phrases.js.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="build.nopages">लिखने को कोई पन्ना है ही नहीं।</span>
+    <span data-phrase="encode.nodeflate">इस ब्राउज़र में CompressionStream नहीं है, जो
+      श्वेत-श्याम मोड को पन्ना दबाने के लिए चाहिए। बाक़ी मोड में से कोई चुनिए।</span>
+    <span data-phrase="encode.nojpeg">यह ब्राउज़र पन्ने को JPEG में एनकोड नहीं कर सका।</span>
+    <span data-phrase="encode.nopage">यह ब्राउज़र पन्ने को एनकोड नहीं कर सका।</span>
+    <span data-phrase="warp.degenerate">वे चार कोने मिलकर कोई पन्ना नहीं बनाते।</span>
     <span data-phrase="detect.found">चारों कोने मिल गए। इन्हें जाँच लीजिए और जो
       हटे हुए हैं उन्हें खींचकर ठीक कर दीजिए।</span>
     <span data-phrase="detect.unsure">कागज़ के किनारे इतने साफ़ नहीं थे कि भरोसा

--- a/locales/id/tools/document-scanner.html
+++ b/locales/id/tools/document-scanner.html
@@ -288,6 +288,15 @@
     shared/js/phrases.js.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="build.nopages">Tidak ada halaman untuk ditulis.</span>
+    <span data-phrase="encode.nodeflate">Browser ini tidak punya CompressionStream, yang
+      dibutuhkan mode hitam putih untuk memampatkan halaman. Pilih salah satu mode yang
+      lain.</span>
+    <span data-phrase="encode.nojpeg">Browser ini tidak bisa mengodekan halamannya
+      sebagai JPEG.</span>
+    <span data-phrase="encode.nopage">Browser ini tidak bisa mengodekan halamannya.</span>
+    <span data-phrase="warp.degenerate">Keempat sudut itu tidak membentuk sebuah
+      halaman.</span>
     <span data-phrase="detect.found">Keempat sudutnya ditemukan. Periksa, dan
       seret yang mendarat keliru.</span>
     <span data-phrase="detect.unsure">Tepi halamannya tidak cukup jelas untuk

--- a/locales/it/tools/document-scanner.html
+++ b/locales/it/tools/document-scanner.html
@@ -286,6 +286,15 @@
     shared/js/phrases.js.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="build.nopages">Non ci sono pagine da scrivere.</span>
+    <span data-phrase="encode.nodeflate">Questo browser non ha CompressionStream, che
+      serve alla modalità in bianco e nero per comprimere una pagina. Scegli una delle
+      altre modalità.</span>
+    <span data-phrase="encode.nojpeg">Questo browser non è riuscito a codificare la
+      pagina come JPEG.</span>
+    <span data-phrase="encode.nopage">Questo browser non è riuscito a codificare la
+      pagina.</span>
+    <span data-phrase="warp.degenerate">Quei quattro angoli non fanno una pagina.</span>
     <span data-phrase="detect.found">I quattro angoli sono stati trovati.
       Controllali e sistema quelli che stanno fuori posto.</span>
     <span data-phrase="detect.unsure">I bordi della pagina non erano abbastanza

--- a/locales/ja/tools/document-scanner.html
+++ b/locales/ja/tools/document-scanner.html
@@ -248,6 +248,11 @@
     shared/js/phrases.js.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="build.nopages">書き出すページがありません。</span>
+    <span data-phrase="encode.nodeflate">このブラウザーにはCompressionStreamがなく、白黒モードがページを圧縮するのにそれが要ります。ほかのモードを選んでください。</span>
+    <span data-phrase="encode.nojpeg">このブラウザーはページをJPEGにエンコードできませんでした。</span>
+    <span data-phrase="encode.nopage">このブラウザーはページをエンコードできませんでした。</span>
+    <span data-phrase="warp.degenerate">その4つの角ではページになりません。</span>
     <span data-phrase="detect.found">四隅が見つかりました。確かめて、外れているものはドラッグして直してください。</span><span data-phrase="detect.unsure">紙の縁が、確信できるほどはっきりしていませんでした。この四隅は推測なので、進む前に紙の上までドラッグしてください。</span><span data-phrase="detect.nothing">この写真では紙を見分けられなかったので、四隅は写真の縁に置いてあります。紙の上までドラッグしてください。</span><span data-phrase="detect.flat">この画像には見つけるものがありません。縁がそもそもありません。</span><span data-phrase="detect.tiny">この画像は、中から紙を見つけるには小さすぎます。</span><span data-phrase="detect.edited">この四隅はもうあなたのものです。「四隅を探し直す」は写真を最初から測り直します。</span>
 
     <span data-phrase="corner.tl">左上の隅</span><span data-phrase="corner.tr">右上の隅</span><span data-phrase="corner.br">右下の隅</span><span data-phrase="corner.bl">左下の隅</span>

--- a/locales/ko/tools/document-scanner.html
+++ b/locales/ko/tools/document-scanner.html
@@ -275,6 +275,12 @@
     shared/js/phrases.js.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="build.nopages">쓸 쪽이 없습니다.</span>
+    <span data-phrase="encode.nodeflate">이 브라우저에는 흑백 모드가 쪽을 압축하는 데 필요한
+      CompressionStream이 없습니다. 다른 모드 가운데 하나를 고르세요.</span>
+    <span data-phrase="encode.nojpeg">이 브라우저는 쪽을 JPEG로 인코딩하지 못했습니다.</span>
+    <span data-phrase="encode.nopage">이 브라우저는 쪽을 인코딩하지 못했습니다.</span>
+    <span data-phrase="warp.degenerate">그 네 모서리로는 쪽이 만들어지지 않습니다.</span>
     <span data-phrase="detect.found">네 모서리를 찾았습니다. 확인하고 어긋난 것은
       끌어다 맞추십시오.</span>
     <span data-phrase="detect.unsure">종이의 가장자리가 확신할 만큼 뚜렷하지

--- a/locales/nl/tools/document-scanner.html
+++ b/locales/nl/tools/document-scanner.html
@@ -287,6 +287,13 @@
     shared/js/phrases.js.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="build.nopages">Er zijn geen pagina&rsquo;s om te schrijven.</span>
+    <span data-phrase="encode.nodeflate">Deze browser heeft geen CompressionStream, en
+      dat heeft de zwart-witmodus nodig om een pagina in te pakken. Kies een van de
+      andere modi.</span>
+    <span data-phrase="encode.nojpeg">Deze browser kon de pagina niet als JPEG coderen.</span>
+    <span data-phrase="encode.nopage">Deze browser kon de pagina niet coderen.</span>
+    <span data-phrase="warp.degenerate">Die vier hoeken vormen geen pagina.</span>
     <span data-phrase="detect.found">De vier hoeken zijn gevonden. Controleer ze
       en sleep de hoeken recht die ernaast liggen.</span>
     <span data-phrase="detect.unsure">De randen van de pagina waren niet duidelijk

--- a/locales/pt/tools/document-scanner.html
+++ b/locales/pt/tools/document-scanner.html
@@ -281,6 +281,14 @@
     shared/js/phrases.js.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="build.nopages">Não há páginas para escrever.</span>
+    <span data-phrase="encode.nodeflate">Este navegador não tem CompressionStream, que é
+      do que o modo preto e branco precisa para comprimir uma página. Escolha um dos
+      outros modos.</span>
+    <span data-phrase="encode.nojpeg">Este navegador não conseguiu codificar a página
+      como JPEG.</span>
+    <span data-phrase="encode.nopage">Este navegador não conseguiu codificar a página.</span>
+    <span data-phrase="warp.degenerate">Esses quatro cantos não formam uma página.</span>
     <span data-phrase="detect.found">Os quatro cantos foram encontrados. Confira e
       ajeite os que ficaram fora do lugar.</span>
     <span data-phrase="detect.unsure">As bordas da página não estavam nítidas o

--- a/locales/tr/tools/document-scanner.html
+++ b/locales/tr/tools/document-scanner.html
@@ -285,6 +285,13 @@
     shared/js/phrases.js.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="build.nopages">Yazılacak sayfa yok.</span>
+    <span data-phrase="encode.nodeflate">Bu tarayıcıda siyah beyaz kipin bir sayfayı
+      sıkıştırmak için ihtiyaç duyduğu CompressionStream yok. Diğer kiplerden birini
+      seçin.</span>
+    <span data-phrase="encode.nojpeg">Bu tarayıcı sayfayı JPEG olarak kodlayamadı.</span>
+    <span data-phrase="encode.nopage">Bu tarayıcı sayfayı kodlayamadı.</span>
+    <span data-phrase="warp.degenerate">O dört köşe bir sayfa oluşturmuyor.</span>
     <span data-phrase="detect.found">Dört köşe bulundu. Onları denetleyin ve
       yanlış düşenleri sürükleyin.</span>
     <span data-phrase="detect.unsure">Sayfanın kenarları emin olunacak kadar net

--- a/locales/zh-TW/tools/document-scanner.html
+++ b/locales/zh-TW/tools/document-scanner.html
@@ -250,6 +250,11 @@
     shared/js/phrases.js.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="build.nopages">沒有要寫的頁面。</span>
+    <span data-phrase="encode.nodeflate">這個瀏覽器沒有 CompressionStream，而黑白模式壓縮一頁正需要它。換用其他幾種模式之一。</span>
+    <span data-phrase="encode.nojpeg">這個瀏覽器沒能把這一頁編碼成 JPEG。</span>
+    <span data-phrase="encode.nopage">這個瀏覽器沒能把這一頁編碼出來。</span>
+    <span data-phrase="warp.degenerate">那四個角構不成一頁。</span>
     <span data-phrase="detect.found">四個角找到了。核對一下，偏了的拖回去。</span><span data-phrase="detect.unsure">紙的邊緣不夠清楚，沒法確定。這四個角是猜的，繼續之前先把它們拖到紙上。</span><span data-phrase="detect.nothing">這張照片裡認不出一張紙，所以角放在照片的邊上。把它們拖到紙上。</span><span data-phrase="detect.flat">這張圖裡沒有可找的東西，它根本沒有邊緣。</span><span data-phrase="detect.tiny">這張圖太小了，在裡面找不出一張紙。</span><span data-phrase="detect.edited">這四個角現在歸你了。「重新找角」會把照片從頭量一遍。</span>
 
     <span data-phrase="corner.tl">左上角</span><span data-phrase="corner.tr">右上角</span><span data-phrase="corner.br">右下角</span><span data-phrase="corner.bl">左下角</span>

--- a/locales/zh/tools/document-scanner.html
+++ b/locales/zh/tools/document-scanner.html
@@ -250,6 +250,11 @@
     shared/js/phrases.js.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="build.nopages">没有要写的页面。</span>
+    <span data-phrase="encode.nodeflate">这个浏览器没有 CompressionStream，而黑白模式压缩一页正需要它。换用其他几种模式之一。</span>
+    <span data-phrase="encode.nojpeg">这个浏览器没能把这一页编码成 JPEG。</span>
+    <span data-phrase="encode.nopage">这个浏览器没能把这一页编码出来。</span>
+    <span data-phrase="warp.degenerate">那四个角构不成一页。</span>
     <span data-phrase="detect.found">四个角找到了。核对一下，偏了的拖回去。</span><span data-phrase="detect.unsure">纸的边缘不够清楚，没法确定。这四个角是猜的，继续之前先把它们拖到纸上。</span><span data-phrase="detect.nothing">这张照片里认不出一张纸，所以角放在照片的边上。把它们拖到纸上。</span><span data-phrase="detect.flat">这张图里没有可找的东西，它根本没有边缘。</span><span data-phrase="detect.tiny">这张图太小了，在里面找不出一张纸。</span><span data-phrase="detect.edited">这四个角现在归你了。「重新找角」会把照片从头量一遍。</span>
 
     <span data-phrase="corner.tl">左上角</span><span data-phrase="corner.tr">右上角</span><span data-phrase="corner.br">右下角</span><span data-phrase="corner.bl">左下角</span>

--- a/tests/python/test_english_in_js.py
+++ b/tests/python/test_english_in_js.py
@@ -62,7 +62,10 @@ BASELINE = {
     'compress-pdf': 6,
     'crop-video': 0,
     'dicom-viewer': 15,
-    'document-scanner': 13,
+    # Three lines of PDF syntax, two CSS class names, an aspect ratio, a
+    # filename template, and one invariant check: orderCorners is only ever
+    # handed the four corners of a quad.
+    'document-scanner': 8,
     # A clock format, and one invariant check in each of the two speed
     # modules - main.js clamps the speed, so neither can be reached.
     'edit-audio': 3,

--- a/tools/document-scanner/body.html
+++ b/tools/document-scanner/body.html
@@ -272,6 +272,13 @@
     shared/js/phrases.js.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="build.nopages">There are no pages to write.</span>
+    <span data-phrase="encode.nodeflate">This browser has no CompressionStream, which
+      the black and white mode needs to compress a page. Choose one of the other modes
+      instead.</span>
+    <span data-phrase="encode.nojpeg">This browser could not encode the page as a JPEG.</span>
+    <span data-phrase="encode.nopage">This browser could not encode the page.</span>
+    <span data-phrase="warp.degenerate">Those four corners do not make a page.</span>
     <span data-phrase="detect.found">The four corners were found. Check them, and
       drag any that landed wrong.</span>
     <span data-phrase="detect.unsure">The edges of the page were not clear enough

--- a/tools/document-scanner/src/document.js
+++ b/tools/document-scanner/src/document.js
@@ -102,7 +102,7 @@ export function layoutPage(page, settings) {
  * @returns {Blob}
  */
 export function buildDocument(pages, settings) {
-  if (!pages.length) throw new Error('There are no pages to write.');
+  if (!pages.length) throw new Error('build.nopages');
 
   const pdf = new PdfWriter();
   const catalog = pdf.reserve();

--- a/tools/document-scanner/src/encode.js
+++ b/tools/document-scanner/src/encode.js
@@ -80,10 +80,7 @@ export function packMono({ data, width, height }) {
  */
 export async function deflate(bytes) {
   if (typeof CompressionStream !== 'function') {
-    throw new Error(
-      'This browser has no CompressionStream, which the black and white mode '
-      + 'needs to compress a page. Choose one of the other modes instead.',
-    );
+    throw new Error('encode.nodeflate');
   }
   const stream = new Blob([bytes]).stream().pipeThrough(new CompressionStream('deflate'));
   return new Uint8Array(await new Response(stream).arrayBuffer());
@@ -121,7 +118,7 @@ export async function encodePage(page, settings) {
   const blob = await new Promise((resolve) => canvas.toBlob(resolve, 'image/jpeg', quality));
   canvas.width = 0;
   canvas.height = 0;
-  if (!blob) throw new Error('This browser could not encode the page as a JPEG.');
+  if (!blob) throw new Error('encode.nojpeg');
 
   return {
     kind: 'dct',
@@ -156,7 +153,7 @@ export async function encodeImage(page, settings) {
   const blob = await new Promise((resolve) => canvas.toBlob(resolve, type, quality));
   canvas.width = 0;
   canvas.height = 0;
-  if (!blob) throw new Error('This browser could not encode the page.');
+  if (!blob) throw new Error('encode.nopage');
 
   return { blob, extension: page.mono ? 'png' : 'jpg' };
 }

--- a/tools/document-scanner/src/main.js
+++ b/tools/document-scanner/src/main.js
@@ -515,7 +515,10 @@ async function renderPreview() {
     // is worth putting right.
     renderStrip();
   } catch (error) {
-    showError(phrase('error.failed', { detail: error.message }));
+    // The leaf modules throw keys; a browser that failed for its own
+    // reasons throws a sentence, and phrase() hands back what it does not
+    // recognise.
+    showError(phrase('error.failed', { detail: phrase(error.message) }));
   } finally {
     if (previewToken === token) el.scanBusy.hidden = true;
   }
@@ -753,7 +756,10 @@ async function run(work) {
     await new Promise((resolve) => setTimeout(resolve, 0));
     await work(report);
   } catch (error) {
-    showError(phrase('error.failed', { detail: error.message }));
+    // The leaf modules throw keys; a browser that failed for its own
+    // reasons throws a sentence, and phrase() hands back what it does not
+    // recognise.
+    showError(phrase('error.failed', { detail: phrase(error.message) }));
   } finally {
     busy = false;
     el.busy.hidden = true;

--- a/tools/document-scanner/src/warp.js
+++ b/tools/document-scanner/src/warp.js
@@ -76,7 +76,9 @@ export function warpPage(source, quad, size) {
     [{ x: 0, y: 0 }, { x: width, y: 0 }, { x: width, y: height }, { x: 0, y: height }],
     inset(quad, INSET * samples),
   );
-  if (!toSource) throw new Error('Those four corners do not make a page.');
+  // A phrase key: this module ships in fifteen languages, and dragging a
+  // corner past its neighbours is something somebody can actually do.
+  if (!toSource) throw new Error('warp.degenerate');
   const out = new Uint8ClampedArray(width * height * 4);
   const step = 1 / samples;
   const first = step / 2;


### PR DESCRIPTION
Five of document-scanner's thirteen counted strings were sentences a reader sees. The other eight are PDF syntax, CSS class names, an aspect ratio and a filename template, and the ratchet's comment now says so.

The five move. `error.failed` already wrapped whatever the leaf modules threw in `Something went wrong making the file: {detail}`, so the leaves name a phrase and both catches resolve it — the shape the rest of the tools use:

```
German   Beim Erstellen der Datei ist etwas schiefgegangen:
         Diese vier Ecken ergeben keine Seite.
```

**One stays and one moves, for opposite reasons.** `geometry.js`'s `"a page has four corners"` stays: `orderCorners` is only ever handed the four corners of a quad, so it is a bug in this repository rather than anything a photograph can cause, and the ratchet comment records that. `warp.js`'s refusal moves — dragging one corner past its neighbours is something somebody can actually do, and they should read why in their own language.

## Verified in the browser

All five resolved on the German page, including the nesting inside `error.failed`.

## Tests

- `python -m unittest discover -t . -s tests/python` — 495 pass; the ratchet drops document-scanner 13 → 8.
- `node --test "tests/js/*.test.js"` — 1939 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)