### PR TITLE
Say why qr-barcode-reader's and id-photo's counts do not move

### DIFF
--- a/tests/python/test_english_in_js.py
+++ b/tests/python/test_english_in_js.py
@@ -77,8 +77,10 @@ BASELINE = {
     'hash-checksum': 10,
     # A CSS class name and the two halves of one internal state name.
     'heic-to-jpg': 3,
-    # A filename template, a dimension pair, a CSS percentage, a phrase key, the
-    # note written into a padded JPEG, and the eight published citations.
+    # All thirteen are accounted for and none of them moves: a filename
+    # template, a dimension pair, a CSS percentage, a phrase key, the note
+    # written into a padded JPEG, and the eight published citations, which
+    # stay as published so that somebody can search for them.
     'id-photo': 13,
     # A CSS class name and one line of the CSS rule the tool writes out.
     'image-to-data-uri': 2,
@@ -92,6 +94,11 @@ BASELINE = {
     'password-generator': 8,
     # The two left are a symbology's own name and a line of SVG markup.
     'qr-barcode': 2,
+    # None of these thirteen reaches a reader. Six are qr-decode.js's
+    # diagnostics, which detect.js catches and turns into a null; two are
+    # camera.js's and main.js's markers, which are likewise swallowed by
+    # their callers; two are a symbology's published name; and three are a
+    # digit pair, a CSS selector and a key template.
     'qr-barcode-reader': 13,
     # A key template, and a CSS class name the stage builds.
     'redact-image': 2,

--- a/tools/qr-barcode-reader/src/qr-decode.js
+++ b/tools/qr-barcode-reader/src/qr-decode.js
@@ -58,6 +58,19 @@ const ECI_CHARSETS = {
 };
 
 /** A failure this page can explain, as opposed to a bug in it. */
+/**
+ * A symbol that was found and could not be read.
+ *
+ * The sentences below are diagnostics, not something a reader is shown:
+ * detect.js catches this and answers with a null, so the page says only
+ * that it found nothing. That is why they are English in a file copied
+ * into fifteen languages - moving them into the markup would translate
+ * text nobody reads.
+ *
+ * If any of them should ever reach the page - "too blurred, try a sharper
+ * picture" is a good deal more use than "nothing found" - it becomes a
+ * phrase key first, the way every other tool's leaf modules do it.
+ */
 export class UnreadableError extends Error {}
 
 /* ------------------------------------------------------- the two BCH fields */


### PR DESCRIPTION
Both tools sit at thirteen and both stay there. I went through every string in each, and neither has a sentence left that a reader can see — so the useful change is the record of that, not a translation.

## qr-barcode-reader

Six of the thirteen are `qr-decode.js`'s refusals. They read as if somebody sees them:

```js
throw new UnreadableError(
  'The code was found, but too much of it is damaged or blurred to rebuild. '
  + 'A sharper picture, or one taken straight on, is usually all it needs.');
```

But `decodeMatrix` has exactly one caller, and it does this:

```js
} catch (error) {
  if (error instanceof UnreadableError) return null;
```

`camera.js`'s `'no camera interface'` and `main.js`'s `'not a picture this browser can open'` are swallowed the same way — `reasonFor()` maps to a key without looking at the message, and `readFiles` catches with `catch { broken = true; }`. Two more are a symbology's published name, and three are a digit pair, a CSS selector and a key template.

`qr-decode.js` gains a docblock saying this, because the file as written invites the opposite conclusion.

**Worth deciding separately.** *"The code was found, but too much of it is damaged or blurred to rebuild — a sharper picture is usually all it needs"* is a great deal more use than the "nothing found" the page currently shows, and after this the machinery to say it is one key away. That is a change to what the tool tells people rather than a translation, so I've left it alone and flagged it instead.

## id-photo

Its comment already listed the thirteen. It now says they are all accounted for, and why the eight published citations stay as published — a translated citation finds nothing when somebody searches for it.

## Tests

- `python -m unittest discover -t . -s tests/python` — 495 pass.
- `node --test "tests/js/*.test.js"` — 1939 pass. Nothing behavioural changed; `qr-read.test.js` still asserts `UnreadableError` by type, which is what it was always doing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)