### PR TITLE
Tell display() how to say things at the two places that forgot

### DIFF
--- a/tools/dicom-viewer/src/main.js
+++ b/tools/dicom-viewer/src/main.js
@@ -1105,7 +1105,7 @@ function matching() {
 
   return rows.filter(({ element }) => {
     const known = describe(element.tag);
-    const { shown: value } = display(element, open.decoder);
+    const { shown: value } = display(element, open.decoder, phrase);
     return (asTag !== null && element.tag.includes(asTag))
       || (known.name ?? '').toLowerCase().includes(query)
       || value.toLowerCase().includes(query);
@@ -1143,7 +1143,7 @@ function lede(list, page, query) {
 
 function tagRow(element, depth, meta) {
   const known = describe(element.tag);
-  const { shown: value, raw, sequence } = display(element, open.decoder);
+  const { shown: value, raw, sequence } = display(element, open.decoder, phrase);
 
   const row = document.createElement('tr');
   if (meta) row.className = 'meta-row';


### PR DESCRIPTION
`#284` gave `display()` a third argument — the function that turns a key into a sentence in the reader's language — and updated **three of its five callers**. The two it missed draw the tag table, so `t` arrived `undefined` and any value needing translation threw:

```
TypeError: t is not a function
  at binary (dicom-viewer/src/values.js:239)
  at display (dicom-viewer/src/values.js:224)
  at tagRow (dicom-viewer/src/main.js:1146)
```

## Why it hid

Most files never reach those paths. `t` is only called for a value with **no readable form** — bytes shown as hex, an empty element, a value too long to print. A whole DICOM has few of those; a **truncated** one is made of them.

So this never appeared on a file anyone would normally open, and only surfaced on a file cut short — which is exactly the shape an interrupted download takes, and the one a viewer is most likely to be handed by someone who already suspects something is wrong with it.

## Found by

The QA suite's bad-input pass, in the test asserting *a file cut short does not crash the page*.

Verified: 43 tests across bad-input and dicom-viewer pass against a local build; 1,939 JavaScript tests pass; build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)