### PR TITLE
Draw the site mark on About, at a size worth looking at

### DIFF
--- a/buildlib/site.py
+++ b/buildlib/site.py
@@ -564,6 +564,13 @@ def load_page(path, site, root):
     # out. build.py checks the slug names a tool that exists.
     page.setdefault('tool', '')
 
+    # Whether the page draws the site mark above its heading. Only About does,
+    # because only About is the page a reader lands on to find out who is
+    # behind the site - and a page answering that question should show the mark
+    # it is answering for, at a size somebody can actually look at rather than
+    # the 1.35em it gets in the brand line and the footer.
+    page.setdefault('mark', False)
+
     page['url'] = f'{site["domain"]}{page["slug"]}/'
     page['dir'] = path.parent
     # How far this page sits below the root, so the frame around it can point at

--- a/pages/about/page.toml
+++ b/pages/about/page.toml
@@ -21,6 +21,10 @@ nav = "About"
 title = "About abox.tools &mdash; Who Makes These Tools, and Why"
 description = "An independent, self-funded project: thirty-six tools that run entirely in your browser, the reason they are built that way, how the site pays for itself, and how to check every claim on it for yourself."
 
+# The one page that draws the site mark full size above its heading. See the
+# note beside the default in buildlib/site.py.
+mark = true
+
 heading = "About abox.tools"
 lede = """
     One person, in Ontario, building the tools they kept needing and kept not

--- a/shared/site.css
+++ b/shared/site.css
@@ -458,33 +458,25 @@ code {
 .brand-home:hover { color: var(--accent); }
 
 /*
-  The heading block, and to its right the site mark on the one page that asks
-  for it. A flex row with a single child lays out exactly as the bare elements
-  did, so every page that does not set `mark` is unmoved by this.
+  The site mark opening the article, on the one page that asks for it. It sits
+  inside <main>, so it takes the prose column's own left edge and lines up with
+  the headings and paragraphs under it rather than with the frame around them.
 
-  The text leads and the mark follows, in the markup as well as on screen. That
-  keeps the heading first for anyone reading the page in order, and it means
-  Arabic mirrors the pair from `margin-inline-start` alone rather than needing a
-  rule of its own.
-
-  `margin-inline-start: auto` pushes the mark to the far edge of the header
-  rather than parking it against the lede. The lede wraps at 62ch and the
-  header is 940 wide, so sitting it right after the text would leave it
-  stranded mid-column; at the edge it balances the language picker above it.
-
-  `align-items: center` rather than flex-start: the mark is a picture with its
-  weight low and left, and hung off the cap height of the h1 it looks dropped.
-
-  The selector for the size is two deep because .site-logo below sets 1.35em
-  for the brand line and the footer, and this has to outrank it without
-  changing what those get. Sized in px rather than em because this one is a
-  picture rather than a glyph in a line of type, so it should not resize with
-  whatever font-size the header happens to inherit.
+  There is a rule below setting .site-logo to 1.35em for the brand line and the
+  footer; this is two selectors deep so it outranks that without changing what
+  those get. Sized in px rather than em because this one is a picture rather
+  than a glyph sitting in a line of type, so it should not resize with whatever
+  font-size it happens to inherit.
 */
-.head-lockup { display: flex; align-items: center; gap: 1.75rem; }
-.head-text { min-width: 0; }
-.page-mark { flex: none; line-height: 0; margin-inline-start: auto; }
-.page-mark .site-logo { width: 124px; height: 124px; }
+.page-mark { margin: 0 0 1.9rem; line-height: 0; }
+.page-mark .site-logo { width: 116px; height: 116px; }
+
+@media (max-width: 620px) {
+  .page-mark { margin-bottom: 1.4rem; }
+  .page-mark .site-logo { width: 84px; height: 84px; }
+}
+
+.site-logo { width: 124px; height: 124px; }
 
 /* Side by side stops working well before the phone widths: the lede is 62ch
    and the header has no room left to push the mark into. Stacked, it goes back

--- a/shared/site.css
+++ b/shared/site.css
@@ -458,14 +458,22 @@ code {
 .brand-home:hover { color: var(--accent); }
 
 /*
-  The heading block, and beside it the site mark on the one page that asks for
-  it. A flex row with a single child lays out exactly as the bare elements did,
-  so every page that does not set `mark` is unmoved by this.
+  The heading block, and to its right the site mark on the one page that asks
+  for it. A flex row with a single child lays out exactly as the bare elements
+  did, so every page that does not set `mark` is unmoved by this.
 
-  The mark leads, because it is the thing being introduced and the heading is
-  what introduces it. `align-items: center` rather than flex-start: the mark is
-  a picture with its own weight low and left, and hanging it off the cap height
-  of the h1 leaves it looking dropped.
+  The text leads and the mark follows, in the markup as well as on screen. That
+  keeps the heading first for anyone reading the page in order, and it means
+  Arabic mirrors the pair from `margin-inline-start` alone rather than needing a
+  rule of its own.
+
+  `margin-inline-start: auto` pushes the mark to the far edge of the header
+  rather than parking it against the lede. The lede wraps at 62ch and the
+  header is 940 wide, so sitting it right after the text would leave it
+  stranded mid-column; at the edge it balances the language picker above it.
+
+  `align-items: center` rather than flex-start: the mark is a picture with its
+  weight low and left, and hung off the cap height of the h1 it looks dropped.
 
   The selector for the size is two deep because .site-logo below sets 1.35em
   for the brand line and the footer, and this has to outrank it without
@@ -473,10 +481,22 @@ code {
   picture rather than a glyph in a line of type, so it should not resize with
   whatever font-size the header happens to inherit.
 */
-.head-lockup { display: flex; align-items: center; gap: 1.5rem; }
+.head-lockup { display: flex; align-items: center; gap: 1.75rem; }
 .head-text { min-width: 0; }
-.page-mark { flex: none; line-height: 0; }
-.page-mark .site-logo { width: 118px; height: 118px; }
+.page-mark { flex: none; line-height: 0; margin-inline-start: auto; }
+.page-mark .site-logo { width: 124px; height: 124px; }
+
+/* Side by side stops working well before the phone widths: the lede is 62ch
+   and the header has no room left to push the mark into. Stacked, it goes back
+   to leading, because a picture alone at the end of a column of text reads as
+   something that fell off the bottom. */
+@media (max-width: 820px) {
+  .head-lockup { display: block; }
+  .page-mark { margin: 0.2rem 0 0.9rem; }
+  .page-mark .site-logo { width: 76px; height: 76px; }
+}
+
+.site-logo { width: 118px; height: 118px; }
 
 /* Side by side stops being side by side well before the phone widths: the lede
    is 62ch and the mark takes 118px out of the front of it. */

--- a/shared/site.css
+++ b/shared/site.css
@@ -458,16 +458,35 @@ code {
 .brand-home:hover { color: var(--accent); }
 
 /*
-  The site mark above a page heading, on the one page that asks for it. The
-  selector is two deep because .site-logo below sets 1.35em for the brand line
-  and the footer, and this has to outrank it without changing what those get.
+  The heading block, and beside it the site mark on the one page that asks for
+  it. A flex row with a single child lays out exactly as the bare elements did,
+  so every page that does not set `mark` is unmoved by this.
 
-  Sized in px rather than em: this one is a picture rather than a glyph sitting
-  in a line of type, so it should not resize with whatever font-size the header
-  happens to inherit.
+  The mark leads, because it is the thing being introduced and the heading is
+  what introduces it. `align-items: center` rather than flex-start: the mark is
+  a picture with its own weight low and left, and hanging it off the cap height
+  of the h1 leaves it looking dropped.
+
+  The selector for the size is two deep because .site-logo below sets 1.35em
+  for the brand line and the footer, and this has to outrank it without
+  changing what those get. Sized in px rather than em because this one is a
+  picture rather than a glyph in a line of type, so it should not resize with
+  whatever font-size the header happens to inherit.
 */
-.page-mark { margin: 0.4rem 0 1rem; line-height: 0; }
-.page-mark .site-logo { width: 104px; height: 104px; }
+.head-lockup { display: flex; align-items: center; gap: 1.5rem; }
+.head-text { min-width: 0; }
+.page-mark { flex: none; line-height: 0; }
+.page-mark .site-logo { width: 118px; height: 118px; }
+
+/* Side by side stops being side by side well before the phone widths: the lede
+   is 62ch and the mark takes 118px out of the front of it. */
+@media (max-width: 760px) {
+  .head-lockup { display: block; }
+  .page-mark { margin: 0.2rem 0 0.9rem; }
+  .page-mark .site-logo { width: 76px; height: 76px; }
+}
+
+.site-logo { width: 104px; height: 104px; }
 
 @media (max-width: 620px) {
   .page-mark .site-logo { width: 76px; height: 76px; }

--- a/shared/site.css
+++ b/shared/site.css
@@ -457,6 +457,22 @@ code {
 .brand-home { color: inherit; text-decoration: none; }
 .brand-home:hover { color: var(--accent); }
 
+/*
+  The site mark above a page heading, on the one page that asks for it. The
+  selector is two deep because .site-logo below sets 1.35em for the brand line
+  and the footer, and this has to outrank it without changing what those get.
+
+  Sized in px rather than em: this one is a picture rather than a glyph sitting
+  in a line of type, so it should not resize with whatever font-size the header
+  happens to inherit.
+*/
+.page-mark { margin: 0.4rem 0 1rem; line-height: 0; }
+.page-mark .site-logo { width: 104px; height: 104px; }
+
+@media (max-width: 620px) {
+  .page-mark .site-logo { width: 76px; height: 76px; }
+}
+
 .site-logo {
   width: 1.35em;
   height: 1.35em;

--- a/templates/page.html
+++ b/templates/page.html
@@ -112,7 +112,10 @@
   </nav>
 {% endif %}  <!--
     The heading, the lede and the date are wrapped so that a page which asks
-    for the site mark can set the two side by side. The wrapper is written on
+    for the site mark can set the two side by side, the text leading and the
+    mark to its right. The mark comes after the text in the markup rather than
+    being floated: that way Arabic mirrors the pair without a second rule, and
+    a reader on a screen reader meets the heading before the decoration. The wrapper is written on
     every page rather than only on those, because a flex row with one child
     lays out exactly as the bare elements did - so nothing else in the tree
     moves, and there is no second shape of this header to keep working.
@@ -125,10 +128,7 @@
     knowing which page is which.
   -->
   <div class="head-lockup">
-{% if page.mark %}    <div class="page-mark">
-{% include "partials/site-mark.html" %}
-    </div>
-{% endif %}    <div class="head-text">
+    <div class="head-text">
       <h1>{{ page.heading }}</h1>
       <p class="lede">
 {{ page.lede }}
@@ -145,7 +145,10 @@
       </p>
 {% endif %}      <p class="legal-date">{{ ui.last_updated }} {{ page.updated }}</p>
     </div>
-  </div>
+{% if page.mark %}    <div class="page-mark">
+{% include "partials/site-mark.html" %}
+    </div>
+{% endif %}  </div>
 </header>
 
 <!--

--- a/templates/page.html
+++ b/templates/page.html
@@ -110,45 +110,21 @@
     <span aria-hidden="true">&rsaquo;</span>
 {% endfor %}    <span aria-current="page">{{ page.nav }}</span>
   </nav>
-{% endif %}  <!--
-    The heading, the lede and the date are wrapped so that a page which asks
-    for the site mark can set the two side by side, the text leading and the
-    mark to its right. The mark comes after the text in the markup rather than
-    being floated: that way Arabic mirrors the pair without a second rule, and
-    a reader on a screen reader meets the heading before the decoration. The wrapper is written on
-    every page rather than only on those, because a flex row with one child
-    lays out exactly as the bare elements did - so nothing else in the tree
-    moves, and there is no second shape of this header to keep working.
-
-    The mark is drawn at a size worth looking at on the one page whose job is
-    to say who is behind all this. Everywhere else it is 1.35em in the brand
-    line and again in the footer, which identifies a page rather than being
-    looked at. Set by `mark` in the page's own toml and defaulted off in
-    buildlib/site.py, so this is a page opting in rather than the template
-    knowing which page is which.
-  -->
-  <div class="head-lockup">
-    <div class="head-text">
-      <h1>{{ page.heading }}</h1>
-      <p class="lede">
+{% endif %}  <h1>{{ page.heading }}</h1>
+  <p class="lede">
 {{ page.lede }}
-      </p>
-      <!--
-        The tool this guide is about, named once at the top where somebody who
-        already knows what they want can leave immediately. `tool` is empty on
-        a legal page and on a guide about no tool in particular, and then this
-        is not written at all.
-      -->
-{% if tool %}      <p class="guide-cta">
-        <a class="guide-cta-link" href="{{ base }}{{ tool.out_slug }}/">{{ ui.guide.open_tool }}</a>
-        <span class="guide-cta-note">{{ tool.tagline }}</span>
-      </p>
-{% endif %}      <p class="legal-date">{{ ui.last_updated }} {{ page.updated }}</p>
-    </div>
-{% if page.mark %}    <div class="page-mark">
-{% include "partials/site-mark.html" %}
-    </div>
-{% endif %}  </div>
+  </p>
+  <!--
+    The tool this guide is about, named once at the top where somebody who
+    already knows what they want can leave immediately. `tool` is empty on a
+    legal page and on a guide about no tool in particular, and then this is not
+    written at all.
+  -->
+{% if tool %}  <p class="guide-cta">
+    <a class="guide-cta-link" href="{{ base }}{{ tool.out_slug }}/">{{ ui.guide.open_tool }}</a>
+    <span class="guide-cta-note">{{ tool.tagline }}</span>
+  </p>
+{% endif %}  <p class="legal-date">{{ ui.last_updated }} {{ page.updated }}</p>
 </header>
 
 <!--
@@ -161,7 +137,23 @@
   and a privacy policy, scanned for the one clause somebody came for, is not.
 -->
 <main id="main" class="{{ main_class }}">
-{{ body }}
+  <!--
+    The site mark, above the article rather than beside the page heading. It
+    belongs to what the page says rather than to the frame around it: the frame
+    already carries the mark twice, small, in the brand line and the footer, and
+    a third copy out there would just be more furniture. Here it opens the piece
+    of writing that explains who is behind the site.
+
+    Set by `mark` in the page's own toml and defaulted off in buildlib/site.py,
+    so this is a page opting in rather than the template knowing which page is
+    which. Written by the frame and not by pages/about/body.html, because that
+    body exists in fifteen translated copies and markup put there is markup
+    fifteen times.
+  -->
+{% if page.mark %}  <div class="page-mark">
+{% include "partials/site-mark.html" %}
+  </div>
+{% endif %}{{ body }}
 </main>
 
 {% include "partials/footer.html" %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -110,6 +110,17 @@
     <span aria-hidden="true">&rsaquo;</span>
 {% endfor %}    <span aria-current="page">{{ page.nav }}</span>
   </nav>
+{% endif %}  <!--
+    The site mark, drawn at a size worth looking at, on the one page whose job
+    is to say who is behind all this. Everywhere else it is 1.35em in the brand
+    line and again in the footer, which is enough to identify a page and not
+    enough to be looked at. Set by `mark` in the page's own toml, defaulted off
+    in buildlib/site.py, so this is a page opting in rather than the template
+    knowing which page is which.
+  -->
+{% if page.mark %}  <div class="page-mark">
+{% include "partials/site-mark.html" %}
+  </div>
 {% endif %}  <h1>{{ page.heading }}</h1>
   <p class="lede">
 {{ page.lede }}

--- a/templates/page.html
+++ b/templates/page.html
@@ -111,31 +111,41 @@
 {% endfor %}    <span aria-current="page">{{ page.nav }}</span>
   </nav>
 {% endif %}  <!--
-    The site mark, drawn at a size worth looking at, on the one page whose job
-    is to say who is behind all this. Everywhere else it is 1.35em in the brand
-    line and again in the footer, which is enough to identify a page and not
-    enough to be looked at. Set by `mark` in the page's own toml, defaulted off
-    in buildlib/site.py, so this is a page opting in rather than the template
+    The heading, the lede and the date are wrapped so that a page which asks
+    for the site mark can set the two side by side. The wrapper is written on
+    every page rather than only on those, because a flex row with one child
+    lays out exactly as the bare elements did - so nothing else in the tree
+    moves, and there is no second shape of this header to keep working.
+
+    The mark is drawn at a size worth looking at on the one page whose job is
+    to say who is behind all this. Everywhere else it is 1.35em in the brand
+    line and again in the footer, which identifies a page rather than being
+    looked at. Set by `mark` in the page's own toml and defaulted off in
+    buildlib/site.py, so this is a page opting in rather than the template
     knowing which page is which.
   -->
-{% if page.mark %}  <div class="page-mark">
+  <div class="head-lockup">
+{% if page.mark %}    <div class="page-mark">
 {% include "partials/site-mark.html" %}
-  </div>
-{% endif %}  <h1>{{ page.heading }}</h1>
-  <p class="lede">
+    </div>
+{% endif %}    <div class="head-text">
+      <h1>{{ page.heading }}</h1>
+      <p class="lede">
 {{ page.lede }}
-  </p>
-  <!--
-    The tool this guide is about, named once at the top where somebody who
-    already knows what they want can leave immediately. `tool` is empty on a
-    legal page and on a guide about no tool in particular, and then this is not
-    written at all.
-  -->
-{% if tool %}  <p class="guide-cta">
-    <a class="guide-cta-link" href="{{ base }}{{ tool.out_slug }}/">{{ ui.guide.open_tool }}</a>
-    <span class="guide-cta-note">{{ tool.tagline }}</span>
-  </p>
-{% endif %}  <p class="legal-date">{{ ui.last_updated }} {{ page.updated }}</p>
+      </p>
+      <!--
+        The tool this guide is about, named once at the top where somebody who
+        already knows what they want can leave immediately. `tool` is empty on
+        a legal page and on a guide about no tool in particular, and then this
+        is not written at all.
+      -->
+{% if tool %}      <p class="guide-cta">
+        <a class="guide-cta-link" href="{{ base }}{{ tool.out_slug }}/">{{ ui.guide.open_tool }}</a>
+        <span class="guide-cta-note">{{ tool.tagline }}</span>
+      </p>
+{% endif %}      <p class="legal-date">{{ ui.last_updated }} {{ page.updated }}</p>
+    </div>
+  </div>
 </header>
 
 <!--


### PR DESCRIPTION
The mark is already on every page twice — 1.35em in the brand line, and again
in the footer. At that size it identifies a page rather than being looked at.

About is the one page whose job is to say who is behind the site, and a page
answering that question should show the mark it is answering for.

It sits **inside `<main>`, above the article** — not in the page header. The
header is the frame; the frame already carries the mark twice, and a third copy
out there is more furniture rather than more identity. Above the article it
opens the piece of writing that explains who is behind the site, which is the
thing it stands for.

That placement also gets its alignment for free: inside `<main>` it takes the
prose column's own left edge, so it lines up with the headings and paragraphs
under it. Earlier passes put it in the header and tried to chase that alignment
with a gap; the column is 68ch centred in a 940px `main`, so the offset is a
function of viewport and font metrics and there was no number to match.

## How it is switched on

`mark = true` in `pages/about/page.toml`, defaulted off in `buildlib/site.py`
beside `kind` and `tool`. A page opts in; the template does not know which page
is which.

**The default is load-bearing.** This template engine raises `no such value` on
a missing key rather than treating it as false, so without
`page.setdefault('mark', False)` every other `page.toml` in the tree would have
had to declare `mark = false` just to keep building.

## Not in the body, deliberately

`pages/about/body.html` exists in fifteen translated copies. Markup put there is
markup fifteen times — the same trap the guide screenshots have, where a shape
that has since been redrawn goes on being described in fourteen languages by
files nobody thought to touch. The frame writes it once.

## Checked

- Built all 1278 pages. `page-mark` appears on `/about/` and nowhere else —
  contact, privacy, terms and a guide all return zero.
- The page header is byte-identical to `main`. The entire diff in
  `templates/page.html` is the block inside `<main>`.

## One consequence worth naming

`indexnow.py` decides what a deploy announces by comparing the bytes inside
`<main>`. The mark is now inside it, so this will announce `/about/` in all
fifteen languages. That is correct — the page did change — and it is one page
rather than the whole site.

## Before / after

| | |
|---|---|
| About, before | `about-before.png` |
| About, after | `about-inarticle.png` |

*(Images to be dropped in — GitHub has no API for PR attachments.)*

---

## Still outstanding

The brand line at the top still uses `site.brand_mark`, the **toolbox emoji**
🧰 — the old identity, in pink, on a page that now shows the new mark below it.
Two different logos for one site. That emoji is in five templates (`hub`,
`page`, `guides`, `roadmap`, `404`), so replacing it is a wider change than this
PR and I have left it alone.
