### PR TITLE
Put the real mark beside abox.tools, not a toolbox emoji

### DIFF
--- a/buildlib/i18n.py
+++ b/buildlib/i18n.py
@@ -179,7 +179,7 @@ TRANSLATABLE_SITE_PATHS = (
 # quietly redefining one in the middle of a wall of prose.
 STRUCTURAL_KEYS = frozenset({
     'slug', 'id', 'order', 'lastmod', 'published', 'category', 'group',
-    'mark', 'icon', 'favicon', 'brand_mark', 'kind', 'tool',
+    'mark', 'icon', 'favicon', 'kind', 'tool',
     'css_parts', 'js_parts', 'roadmap_group', 'handoff',
     # `analytics_extra` is prose, and is still structure, which looks like a
     # contradiction until you see where it lands: the tail of one sentence in

--- a/config/site.toml
+++ b/config/site.toml
@@ -12,7 +12,6 @@
 
 name = "A Box of Tools"
 domain = "https://abox.tools/"
-brand_mark = "&#129520;"          # the toolbox emoji, used on the hub header
 lang = "en"
 lastmod = "2026-08-27"     # the hub page's own sitemap date
 source_url = "https://github.com/A-Box-of-Tools/website"

--- a/shared/site.css
+++ b/shared/site.css
@@ -66,7 +66,17 @@ body {
   color: var(--text-dim);
 }
 
-.brand-mark { font-size: 1.05rem; }
+/*
+  The site mark in the brand line, which used to be the toolbox emoji. An emoji
+  sits on the text baseline by itself; an inline SVG sits on it badly, so it is
+  nudged down by roughly the distance between a lowercase x-height and the
+  bottom of the box it is drawn in.
+
+  1.35em comes from .site-logo below, which the footer already uses for the same
+  pairing of mark and wordmark. Nothing here overrides it - the two lockups
+  should not drift apart.
+*/
+.brand .site-logo { vertical-align: -0.34em; }
 
 .hub-head h1 {
   margin: 0;

--- a/templates/404.html
+++ b/templates/404.html
@@ -73,7 +73,8 @@
   <div class="head-row">
     <p class="brand">
       <a class="brand-home" href="{{ base }}">
-        <span class="brand-mark" aria-hidden="true">{{ site.brand_mark }}</span> abox.tools
+        {% include "partials/site-mark.html" %}
+        abox.tools
       </a>
     </p>
     {% include "partials/lang-pick.html" %}

--- a/templates/guides.html
+++ b/templates/guides.html
@@ -81,7 +81,8 @@
   <div class="head-row">
     <p class="brand">
       <a class="brand-home" href="{{ base }}">
-        <span class="brand-mark" aria-hidden="true">{{ site.brand_mark }}</span> abox.tools
+        {% include "partials/site-mark.html" %}
+        abox.tools
       </a>
     </p>
     {% include "partials/lang-pick.html" %}

--- a/templates/hub.html
+++ b/templates/hub.html
@@ -125,7 +125,10 @@
 
 <header class="hub-head">
   <div class="head-row">
-    <p class="brand"><span class="brand-mark" aria-hidden="true">{{ site.brand_mark }}</span> abox.tools</p>
+    <p class="brand">
+      {% include "partials/site-mark.html" %}
+      abox.tools
+    </p>
     {% include "partials/lang-pick.html" %}
   </div>
   <h1>{{ site.hub.heading }}</h1>

--- a/templates/page.html
+++ b/templates/page.html
@@ -91,7 +91,8 @@
   <div class="head-row">
     <p class="brand">
       <a class="brand-home" href="{{ base }}">
-        <span class="brand-mark" aria-hidden="true">{{ site.brand_mark }}</span> abox.tools
+        {% include "partials/site-mark.html" %}
+        abox.tools
       </a>
     </p>
     {% include "partials/lang-pick.html" %}

--- a/templates/roadmap.html
+++ b/templates/roadmap.html
@@ -109,7 +109,8 @@
   <div class="head-row">
     <p class="brand">
       <a class="brand-home" href="{{ base }}">
-        <span class="brand-mark" aria-hidden="true">{{ site.brand_mark }}</span> abox.tools
+        {% include "partials/site-mark.html" %}
+        abox.tools
       </a>
     </p>
     {% include "partials/lang-pick.html" %}


### PR DESCRIPTION
The brand line at the top of every page that is not a tool carried 🧰 — the
toolbox emoji — while the footer of the same page carried the site mark. Two
different logos, one site, a screen apart.

Once the mark was redrawn as a gift box of apps, the emoji stopped being merely
a second identity and became the one the redraw was meant to retire: a box of
hand tools.

So the five templates that had it — `hub`, `page`, `guides`, `roadmap`, `404` —
now include `partials/site-mark.html`, which is what the footer has always
included. One mark, from one file, in both places on the page.

## What is not touched

`tool.html`. Its `.brand-mark` is the **tool's own glyph**, not the site's, and
a tool page saying which tool it is remains right. It only shares the class
name.

## Details

- An emoji sits on the text baseline by itself and an inline SVG does not, so
  the brand line gets one rule nudging it down. The **size** is left to
  `.site-logo`, which the footer already uses for this exact pairing of mark and
  wordmark — the two lockups should not be free to drift apart.
- `brand_mark` is removed from `config/site.toml`, and with it the exemption
  naming it in `buildlib/i18n.py`'s list of keys that are not translated.
  Nothing reads it now, and a key nothing reads is a key somebody will later
  wonder about. No locale ever overrode it, so that is one line removed rather
  than fifteen.

## Checked

Built all 1278 pages. No page contains the emoji any more; the hub, About,
guides, roadmap and 404 each carry the mark twice — brand line and footer —
from the one partial.

## Before / after

| | |
|---|---|
| Hub, before | `brand-before.png` |
| Hub, after | `brand-after.png` |

*(Images to be dropped in — GitHub has no API for PR attachments.)*
