### PR TITLE
Stop redact-image's format select from widening the page

### DIFF
--- a/tools/redact-image/styles.css
+++ b/tools/redact-image/styles.css
@@ -265,7 +265,21 @@ kbd {
   margin-bottom: 1.1rem;
 }
 
-.field { display: flex; flex-direction: column; gap: 0.35rem; }
+/* `overflow-x: clip` rather than the `min-width: 0` two rules up, because this
+   is the other half of the same problem and that half does not answer it.
+   #format's box is already the width of its column; what is too wide is the
+   text inside it - "Auto - JPEG for a photo, PNG for anything else" - and
+   WebKit adds a <select>'s longest option to the scrollable width of every
+   ancestor even when the box itself fits. On a 390px phone that made the whole
+   document two pixels wider than the screen, which is a page that rubber-bands
+   sideways for no reason a reader can see. Nothing is lost by clipping: the
+   sentence was already being truncated, and the dropdown the browser opens is
+   not drawn inside this box.
+
+   `clip` rather than `hidden`: hidden would make this a scroll container,
+   which forces the other axis to `auto` and would cut off anything that ever
+   needs to escape upwards. */
+.field { display: flex; flex-direction: column; gap: 0.35rem; overflow-x: clip; }
 .field > label { font-size: 0.85rem; font-weight: 600; }
 
 .field-note {


### PR DESCRIPTION
On a 390px phone, `/redact-image/` is two pixels wider than the screen. The page rubber-bands sideways for no reason a reader can see.

The cause is `#format`, the save card's format select. Its box is already the width of its column; what is too wide is the text inside it — *"Auto — JPEG for a photo, PNG for anything else"* — and WebKit adds a `<select>`'s longest option to the scrollable width of every ancestor even when the box itself fits. Chromium does not, which is why this shows only in Safari — and on a phone, Safari is what an iPhone visitor has whichever browser they opened.

`min-width: 0` does not answer it. That is the fix two rules up in the same file, for `.option-row select`, and it addresses a different half of the problem: a flex item refusing to shrink. Here the item has already shrunk.

So `.field` gets `overflow-x: clip`. Nothing is lost — the sentence was already being truncated at that width, and the dropdown the browser opens is not drawn inside the box. `clip` rather than `hidden` because `hidden` would make this a scroll container, which forces the other axis to `auto`.

## Scope

Every page on the site was measured at 390px in WebKit, hub and all 36 tools. This is the only one that overflows, so the fix belongs in redact-image's own stylesheet rather than the frame's.

## Verified

`responsive.spec.ts` for `/redact-image/` — was failing on Mobile Safari at 2px, now passes on Mobile Safari, Desktop Safari and Mobile Chrome, with the select the same width it was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)