### PR TITLE
Put a deadline on asking the browser what it can encode

### DIFF
--- a/shared/js/codec-support.js
+++ b/shared/js/codec-support.js
@@ -1,0 +1,71 @@
+/**
+ * Asking a browser what it can encode, with a deadline on the answer.
+ *
+ * WHY THERE IS A DEADLINE
+ *
+ * `VideoEncoder.isConfigSupported` is specified to return a promise, and every
+ * browser that implements the class is expected to settle it. One does not.
+ * On the WebKit build this site's QA suite runs against, the promise from
+ * `VideoEncoder.isConfigSupported` is still pending two minutes later, while
+ * `VideoDecoder.isConfigSupported` on the same build answers immediately -
+ * which is how video-to-gif works there and everything that encodes did not.
+ *
+ * What "did not" looked like was worse than a refusal. `pickH264Codec` awaits
+ * that promise inside a loop over nine candidate codec strings, so pressing
+ * Create video started a wait that never ended: no progress bar, no error, no
+ * second attempt, a button that had visibly been pressed and a page that never
+ * said anything again. Every one of the five tools that encodes did this.
+ *
+ * A capability question is not work. Nothing is being encoded while it is
+ * outstanding, and a browser that cannot say within two seconds whether it
+ * supports H.264 Baseline at 320x240 is not a browser that was about to encode
+ * any. So no answer is read as no, the tool falls through to whatever it does
+ * when a codec is unavailable, and the visitor is told - which is the whole of
+ * what these tools promise to do when they cannot do the work.
+ *
+ * WHY THE THIRD ANSWER
+ *
+ * `null` means the browser did not reply, and it is worth telling apart from a
+ * plain no. A caller walking a list of codecs should stop at the first silence
+ * rather than pay the deadline nine times over: the silence was about the
+ * browser, not about the codec string it was holding.
+ */
+
+/**
+ * How long to wait for a browser to answer a question about itself.
+ *
+ * Generous. Chrome answers these in single-digit milliseconds, and the point
+ * is not to hurry a slow machine - it is to end a wait that has no end.
+ */
+const PATIENCE = 2000;
+
+/**
+ * Ask a WebCodecs class whether it supports a configuration.
+ *
+ * @param {{isConfigSupported?: (config: object) => Promise<{supported?: boolean}>}} codec
+ *        `VideoEncoder`, `VideoDecoder`, `AudioEncoder` or `AudioDecoder`.
+ * @param {object} config  the configuration to ask about
+ * @param {number} [ms]    how long to wait before giving up
+ * @returns {Promise<boolean|null>} true, false, or null for no answer in time
+ */
+export async function askSupported(codec, config, ms = PATIENCE) {
+  if (typeof codec?.isConfigSupported !== 'function') return false;
+
+  let timer;
+  const silence = Symbol('no answer');
+  try {
+    const answer = await Promise.race([
+      codec.isConfigSupported(config),
+      new Promise((resolve) => { timer = setTimeout(() => resolve(silence), ms); }),
+    ]);
+    if (answer === silence) return null;
+    return Boolean(answer && answer.supported);
+  } catch {
+    // A codec string this browser cannot even parse, or a class that threw
+    // rather than rejecting. Not supported, and not silence either: the
+    // browser did answer, in its own way.
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/tests/js/codec-support.test.js
+++ b/tests/js/codec-support.test.js
@@ -1,0 +1,63 @@
+/**
+ * shared/js/codec-support.js - a question about the browser, with a deadline.
+ *
+ * The test that matters here is the third one. A promise that never settles is
+ * not a hypothetical: it is what `VideoEncoder.isConfigSupported` returns on
+ * the WebKit build this site's QA suite runs against, and awaiting it is what
+ * made Create video a button that could be pressed once and then never
+ * answered again, on all five tools that encode.
+ *
+ * It is also the one behaviour no browser will demonstrate on demand, so it is
+ * tested with a promise that simply never resolves - which is exactly what the
+ * code has to survive, and can be written down in one line here.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { askSupported } from '../../shared/js/codec-support.js';
+
+/** A stand-in for VideoEncoder and friends, answering however the test says. */
+const codec = (answer) => ({ isConfigSupported: () => answer });
+
+test('a yes is true', async () => {
+  assert.equal(await askSupported(codec(Promise.resolve({ supported: true })), {}), true);
+});
+
+test('a no is false', async () => {
+  assert.equal(await askSupported(codec(Promise.resolve({ supported: false })), {}), false);
+});
+
+test('silence is null, and does not take the page with it', async () => {
+  const started = Date.now();
+  const answer = await askSupported(codec(new Promise(() => {})), {}, 40);
+
+  // null rather than false, because a caller walking nine codec strings has
+  // to be able to stop at the first silence instead of waiting nine times.
+  assert.equal(answer, null);
+  assert.ok(Date.now() - started < 2000, 'the deadline did not fire');
+});
+
+test('a rejection is a plain no, not silence', async () => {
+  // The browser did answer - by refusing to parse the codec string - so the
+  // next candidate is worth trying.
+  const answer = await askSupported(codec(Promise.reject(new TypeError('bad codec'))), {});
+  assert.equal(answer, false);
+});
+
+test('a class that throws rather than rejecting is a no as well', async () => {
+  const answer = await askSupported({
+    isConfigSupported() { throw new TypeError('nope'); },
+  }, {});
+  assert.equal(answer, false);
+});
+
+test('a browser without the class at all is a no', async () => {
+  assert.equal(await askSupported(undefined, {}), false);
+  assert.equal(await askSupported({}, {}), false);
+});
+
+test('an answer without a supported field is a no', async () => {
+  assert.equal(await askSupported(codec(Promise.resolve({})), {}), false);
+  assert.equal(await askSupported(codec(Promise.resolve(null)), {}), false);
+});

--- a/tools/crop-video/src/support.js
+++ b/tools/crop-video/src/support.js
@@ -8,6 +8,8 @@
  * no demuxer for.
  */
 
+import { askSupported } from './shared/codec-support.js';
+
 /**
  * Candidate H.264 codec strings, best profile/level first. Levels matter: 4.0
  * tops out around 1080p30, so larger frames need 5.1 or better to be accepted.
@@ -40,13 +42,9 @@ export function hasMediaRecorder() {
 /** Whether this browser will decode the configuration a demuxed track reports. */
 export async function canDecode(config) {
   if (!hasWebCodecs()) return false;
-  try {
-    const { supported } = await VideoDecoder.isConfigSupported(config);
-    return Boolean(supported);
-  } catch {
-    // A codec string this browser cannot even parse. Not decodable either.
-    return false;
-  }
+  // A browser that never answers is one that cannot decode, as far as anybody
+  // waiting for this page is concerned.
+  return await askSupported(VideoDecoder, config) === true;
 }
 
 /**
@@ -57,15 +55,17 @@ export async function pickH264Codec({ width, height, framerate, bitrate }) {
   if (!hasWebCodecs()) return null;
 
   for (const codec of H264_CANDIDATES) {
-    try {
-      const { supported } = await VideoEncoder.isConfigSupported({
-        codec, width, height, framerate, bitrate,
-        avc: { format: 'avc' },
-      });
-      if (supported) return codec;
-    } catch {
-      // Malformed-for-this-browser codec string; try the next one.
-    }
+    const supported = await askSupported(VideoEncoder, {
+      codec, width, height, framerate, bitrate,
+      avc: { format: 'avc' },
+    });
+    if (supported) return codec;
+    // A browser that did not answer at all will not answer for the other
+    // eight either, and asking anyway would turn one deadline into nine. See
+    // shared/js/codec-support.js for the build this really happens on.
+    if (supported === null) return null;
+    // Otherwise a plain no - most often a codec string this browser cannot
+    // parse - so try the next one.
   }
   return null;
 }

--- a/tools/crop-video/tool.toml
+++ b/tools/crop-video/tool.toml
@@ -32,7 +32,7 @@ css_parts = ["progress"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.
-js_parts = ["file-picker"]
+js_parts = ["file-picker", "codec-support"]
 # Where a finished result can be carried without being saved first: the row of
 # links shared/handoff.js shows beside the download once there is one. Slugs of
 # tools whose picker takes what this page produces; checked against the tools

--- a/tools/images-to-video/src/support.js
+++ b/tools/images-to-video/src/support.js
@@ -1,5 +1,7 @@
 /** Feature detection for the two encoding paths. */
 
+import { askSupported } from './shared/codec-support.js';
+
 /**
  * Candidate H.264 codec strings, best profile/level first. Levels matter:
  * 4.0 tops out around 1080p30, so larger canvases need 5.1+ to be accepted.
@@ -35,15 +37,17 @@ export async function pickH264Codec({ width, height, framerate, bitrate }) {
   if (!hasWebCodecs()) return null;
 
   for (const codec of H264_CANDIDATES) {
-    try {
-      const { supported } = await VideoEncoder.isConfigSupported({
-        codec, width, height, framerate, bitrate,
-        avc: { format: 'avc' },
-      });
-      if (supported) return codec;
-    } catch {
-      // Malformed-for-this-browser codec string; try the next one.
-    }
+    const supported = await askSupported(VideoEncoder, {
+      codec, width, height, framerate, bitrate,
+      avc: { format: 'avc' },
+    });
+    if (supported) return codec;
+    // A browser that did not answer at all will not answer for the other
+    // eight either, and asking anyway would turn one deadline into nine. See
+    // shared/js/codec-support.js for the build this really happens on.
+    if (supported === null) return null;
+    // Otherwise a plain no - most often a codec string this browser cannot
+    // parse - so try the next one.
   }
   return null;
 }

--- a/tools/images-to-video/tool.toml
+++ b/tools/images-to-video/tool.toml
@@ -32,7 +32,7 @@ css_parts = ["progress"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.
-js_parts = ["file-picker"]
+js_parts = ["file-picker", "codec-support"]
 lastmod = "2026-08-27"
 
 # --- what search engines and chat apps are told ------------------------------

--- a/tools/reverse-video/src/support.js
+++ b/tools/reverse-video/src/support.js
@@ -8,6 +8,8 @@
  * decoding to the <video> element and so accepts anything the browser plays.
  */
 
+import { askSupported } from './shared/codec-support.js';
+
 /**
  * Candidate H.264 codec strings, best profile/level first. Levels matter: 4.0
  * tops out around 1080p30, so larger frames need 5.1 or better to be accepted.
@@ -42,13 +44,9 @@ export function hasEncoder() {
 /** Whether this browser will decode the configuration a demuxed track reports. */
 export async function canDecode(config) {
   if (!hasWebCodecs()) return false;
-  try {
-    const { supported } = await VideoDecoder.isConfigSupported(config);
-    return Boolean(supported);
-  } catch {
-    // A codec string this browser cannot even parse. Not decodable either.
-    return false;
-  }
+  // A browser that never answers is one that cannot decode, as far as anybody
+  // waiting for this page is concerned.
+  return await askSupported(VideoDecoder, config) === true;
 }
 
 /**
@@ -59,15 +57,17 @@ export async function pickH264Codec({ width, height, framerate, bitrate }) {
   if (!hasEncoder()) return null;
 
   for (const codec of H264_CANDIDATES) {
-    try {
-      const { supported } = await VideoEncoder.isConfigSupported({
-        codec, width, height, framerate, bitrate,
-        avc: { format: 'avc' },
-      });
-      if (supported) return codec;
-    } catch {
-      // Malformed-for-this-browser codec string; try the next one.
-    }
+    const supported = await askSupported(VideoEncoder, {
+      codec, width, height, framerate, bitrate,
+      avc: { format: 'avc' },
+    });
+    if (supported) return codec;
+    // A browser that did not answer at all will not answer for the other
+    // eight either, and asking anyway would turn one deadline into nine. See
+    // shared/js/codec-support.js for the build this really happens on.
+    if (supported === null) return null;
+    // Otherwise a plain no - most often a codec string this browser cannot
+    // parse - so try the next one.
   }
   return null;
 }

--- a/tools/reverse-video/tool.toml
+++ b/tools/reverse-video/tool.toml
@@ -32,7 +32,7 @@ css_parts = ["progress"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.
-js_parts = ["file-picker"]
+js_parts = ["file-picker", "codec-support"]
 # Where a finished result can be carried without being saved first: the row of
 # links shared/handoff.js shows beside the download once there is one. Slugs of
 # tools whose picker takes what this page produces; checked against the tools

--- a/tools/timelapse-video/src/support.js
+++ b/tools/timelapse-video/src/support.js
@@ -8,6 +8,8 @@
  * decoding to the <video> element and so accepts anything the browser plays.
  */
 
+import { askSupported } from './shared/codec-support.js';
+
 /**
  * Candidate H.264 codec strings, best profile/level first. Levels matter: 4.0
  * tops out around 1080p30, so larger frames need 5.1 or better to be accepted.
@@ -42,13 +44,9 @@ export function hasEncoder() {
 /** Whether this browser will decode the configuration a demuxed track reports. */
 export async function canDecode(config) {
   if (!hasWebCodecs()) return false;
-  try {
-    const { supported } = await VideoDecoder.isConfigSupported(config);
-    return Boolean(supported);
-  } catch {
-    // A codec string this browser cannot even parse. Not decodable either.
-    return false;
-  }
+  // A browser that never answers is one that cannot decode, as far as anybody
+  // waiting for this page is concerned.
+  return await askSupported(VideoDecoder, config) === true;
 }
 
 /**
@@ -59,15 +57,17 @@ export async function pickH264Codec({ width, height, framerate, bitrate }) {
   if (!hasEncoder()) return null;
 
   for (const codec of H264_CANDIDATES) {
-    try {
-      const { supported } = await VideoEncoder.isConfigSupported({
-        codec, width, height, framerate, bitrate,
-        avc: { format: 'avc' },
-      });
-      if (supported) return codec;
-    } catch {
-      // Malformed-for-this-browser codec string; try the next one.
-    }
+    const supported = await askSupported(VideoEncoder, {
+      codec, width, height, framerate, bitrate,
+      avc: { format: 'avc' },
+    });
+    if (supported) return codec;
+    // A browser that did not answer at all will not answer for the other
+    // eight either, and asking anyway would turn one deadline into nine. See
+    // shared/js/codec-support.js for the build this really happens on.
+    if (supported === null) return null;
+    // Otherwise a plain no - most often a codec string this browser cannot
+    // parse - so try the next one.
   }
   return null;
 }

--- a/tools/timelapse-video/tool.toml
+++ b/tools/timelapse-video/tool.toml
@@ -32,7 +32,7 @@ css_parts = ["progress"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.
-js_parts = ["file-picker"]
+js_parts = ["file-picker", "codec-support"]
 # Where a finished result can be carried without being saved first: the row of
 # links shared/handoff.js shows beside the download once there is one. Slugs of
 # tools whose picker takes what this page produces; checked against the tools

--- a/tools/trim-video/src/support.js
+++ b/tools/trim-video/src/support.js
@@ -8,6 +8,8 @@
  * no demuxer for.
  */
 
+import { askSupported } from './shared/codec-support.js';
+
 /**
  * Candidate H.264 codec strings, best profile/level first. Levels matter: 4.0
  * tops out around 1080p30, so larger frames need 5.1 or better to be accepted.
@@ -40,13 +42,9 @@ export function hasMediaRecorder() {
 /** Whether this browser will decode the configuration a demuxed track reports. */
 export async function canDecode(config) {
   if (!hasWebCodecs()) return false;
-  try {
-    const { supported } = await VideoDecoder.isConfigSupported(config);
-    return Boolean(supported);
-  } catch {
-    // A codec string this browser cannot even parse. Not decodable either.
-    return false;
-  }
+  // A browser that never answers is one that cannot decode, as far as anybody
+  // waiting for this page is concerned.
+  return await askSupported(VideoDecoder, config) === true;
 }
 
 /**
@@ -57,15 +55,17 @@ export async function pickH264Codec({ width, height, framerate, bitrate }) {
   if (!hasWebCodecs()) return null;
 
   for (const codec of H264_CANDIDATES) {
-    try {
-      const { supported } = await VideoEncoder.isConfigSupported({
-        codec, width, height, framerate, bitrate,
-        avc: { format: 'avc' },
-      });
-      if (supported) return codec;
-    } catch {
-      // Malformed-for-this-browser codec string; try the next one.
-    }
+    const supported = await askSupported(VideoEncoder, {
+      codec, width, height, framerate, bitrate,
+      avc: { format: 'avc' },
+    });
+    if (supported) return codec;
+    // A browser that did not answer at all will not answer for the other
+    // eight either, and asking anyway would turn one deadline into nine. See
+    // shared/js/codec-support.js for the build this really happens on.
+    if (supported === null) return null;
+    // Otherwise a plain no - most often a codec string this browser cannot
+    // parse - so try the next one.
   }
   return null;
 }

--- a/tools/trim-video/tool.toml
+++ b/tools/trim-video/tool.toml
@@ -33,7 +33,7 @@ css_parts = ["progress"]
 # Shared modules this tool asks for. The same arrangement as css_parts, and for
 # the same reason: a component more than one tool needs and no tool should own.
 # file-picker brings in the drop zone.
-js_parts = ["file-picker"]
+js_parts = ["file-picker", "codec-support"]
 # Where a finished result can be carried without being saved first: the row of
 # links shared/handoff.js shows beside the download once there is one. Slugs of
 # tools whose picker takes what this page produces; checked against the tools


### PR DESCRIPTION
Press **Create video** on a browser whose `VideoEncoder` never answers, and the page starts a wait that never ends. No progress bar, no error, no second attempt — a button that has visibly been pressed and a page that never says anything again.

Five tools do this: **images-to-video, reverse-video, timelapse-video, crop-video, trim-video**. All five call `pickH264Codec`, which awaits `VideoEncoder.isConfigSupported` inside a loop over nine candidate codec strings.

## The browser it happens on

The WebKit build the QA suite runs against. Its `VideoEncoder.isConfigSupported` is still pending two minutes later, while `VideoDecoder.isConfigSupported` on the same build answers immediately — which is how video-to-gif works there and nothing that encodes does. QA saw it as an export click that had not returned after five minutes.

## The fix

A capability question is not work. Nothing is being encoded while it is outstanding, and a browser that cannot say within two seconds whether it supports H.264 Baseline at 320×240 is not a browser that was about to encode any.

So `shared/js/codec-support.js` asks with a deadline, and no answer is read as no. The tool falls through to the path it already takes when no codec is available, and says so — which is the whole of what these tools promise to do when they cannot do the work.

**Three answers rather than two.** `null` means the browser did not reply, and is worth telling apart from a plain no: a loop over nine codec strings stops at the first silence rather than paying the deadline nine times over, because the silence was about the browser and not about the string it was holding. A rejection stays a plain no — the browser *did* answer, by refusing to parse the codec — so the next candidate is still worth trying.

## What is deliberately not changed

The two `audio.js` files ask `AudioEncoder` the same way and are left alone. `tests/js` imports them directly, so a `./shared/` import would break under `node --test`, and there is no evidence that `AudioEncoder.isConfigSupported` hangs anywhere — the observed fault is the video encoder. Worth revisiting if that changes.

## Verified

- `npm test` — 1,947 pass, including seven new ones for the helper. The one that matters is a promise that never settles: no browser will demonstrate that on demand, and it is one line to write down.
- `python build.py` — clean; `codec-support.js` ships into all five tools.
- The QA suite's `video-more.spec.ts` and `video.spec.ts` on Desktop Chrome, against a local build of this branch — unchanged, as expected where the browser answers in single-digit milliseconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
