### PR TITLE
Stop accusing a page of being broken while it is still loading

### DIFF
--- a/shared/css/tool-frame.css
+++ b/shared/css/tool-frame.css
@@ -104,6 +104,51 @@ main, .topbar, .crumbs, .privacy, .pledge, .faq, .tool-next, footer {
   color: var(--text);
 }
 
+/* Five seconds of a page doing nothing, and then the notice - not before.
+
+   It cannot be added when the trouble is noticed, because the code that would
+   add it is the code that did not run: it is in the page from the start and
+   main.js removes it on the way past. So every visitor whose page is perfectly
+   fine used to watch it flash by while the module was still on its way, which
+   is what it looks like from the outside - a red error, on a page that then
+   works. Visitors reported it as a bug, and they were right to.
+
+   A page served over http boots in a fraction of a second, so nobody whose
+   page is coming ever waits long enough to see this. A page opened straight
+   out of a folder never boots at all, and its reader waits five seconds for
+   the explanation - the cheaper half of the trade, and they are already
+   looking at something broken.
+
+   Collapsed rather than `display: none` because the reveal is an animation and
+   `display` in a keyframe is recent enough that an older browser would hide
+   the notice for ever - and an older browser refusing modern syntax is one of
+   the ways a page arrives here in the first place. Every property below
+   animates everywhere.
+
+   Nothing here moves: the duration is zero and the delay is the whole
+   mechanism, so this is not one of the animations that belongs in a
+   prefers-reduced-motion switch-off. */
+#boot-warning {
+  overflow: hidden;
+  max-height: 0;
+  margin-top: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+  border-width: 0;
+  animation: boot-warning-late 0s linear 5s forwards;
+}
+
+@keyframes boot-warning-late {
+  to {
+    overflow: visible;
+    max-height: 100vh;
+    margin-top: 1.5rem;
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+    border-width: 1px;
+  }
+}
+
 .boot-warning strong { color: var(--danger); }
 .boot-warning p { margin: 0.5rem 0; font-size: 0.9rem; }
 

--- a/templates/tool.html
+++ b/templates/tool.html
@@ -133,11 +133,16 @@
 {% include "partials/lang-notice.html" %}
 
 <!--
-  Visible by default and removed by main.js once it boots. If the scripts never
-  run - opening this file straight from disk blocks ES modules, and so does a
-  CSP or network failure - this stays on screen and explains why. Without it the
-  page looks fine, the file picker still opens (that part is pure HTML), and
-  nothing at all happens when you choose {{ tool.words.choose }}.
+  In the page from the start and removed by main.js once it boots. If the
+  scripts never run - opening this file straight from disk blocks ES modules,
+  and so does a CSP or network failure - nothing removes it and it explains
+  why. Without it the page looks fine, the file picker still opens (that part
+  is pure HTML), and nothing at all happens when you choose
+  {{ tool.words.choose }}.
+
+  It is in the page but not on screen: shared/css/tool-frame.css keeps it
+  collapsed for the first five seconds, so a page whose module is merely on its
+  way is never accused of being broken.
 -->
 <div id="boot-warning" class="boot-warning">
   <strong>{{ ui.tool.boot_title }}</strong>

--- a/tests/python/test_build.py
+++ b/tests/python/test_build.py
@@ -231,6 +231,69 @@ class DownloadHooks(unittest.TestCase):
         self.assertRegex(body, r'id="save-edits"[^>]*data-download')
 
 
+class BootNotice(unittest.TestCase):
+    """The notice about a page whose code never started, and when it shows.
+
+    It has to be in the markup from the start, because the code that would add
+    it is the code that did not run - so every page carried a red error at
+    first paint and removed it a tenth of a second later, when main.js got
+    there. A visitor reported that as a bug, and from the outside it is
+    indistinguishable from a page that broke and recovered.
+
+    What stops it is a delay in shared/css/tool-frame.css: the notice is
+    collapsed when the page paints, and an animation with a delay and no
+    duration reveals it, so it arrives only on a page that really is not
+    coming. Both halves are checked here because either alone is wrong - the
+    markup without the CSS is the flash again, and the CSS without a notice to
+    reveal is nothing at all.
+    """
+
+    def setUp(self):
+        self.template = (ROOT / 'templates' / 'tool.html').read_text(encoding='utf-8')
+        self.css = (ROOT / 'shared' / 'css' / 'tool-frame.css').read_text(encoding='utf-8')
+        found = re.search(r'#boot-warning\s*\{([^}]*)\}', self.css)
+        self.assertIsNotNone(found, 'shared/css/tool-frame.css: no #boot-warning rule')
+        self.rule = found.group(1)
+
+    def test_the_notice_is_in_the_page_the_build_writes(self):
+        self.assertIn('id="boot-warning"', self.template)
+
+    def test_it_is_collapsed_when_the_page_paints(self):
+        self.assertRegex(self.rule, r'max-height:\s*0',
+                         'the notice is on screen at first paint again')
+
+    def test_a_delay_and_not_a_duration_is_what_reveals_it(self):
+        """Nothing moves: the reveal is a jump, some seconds in.
+
+        Read out of the shorthand rather than compared to it whole, so that
+        changing how long the page is given is not a test failure. Removing the
+        wait is, because a page that is merely slow is not a page that failed.
+        """
+        animation = re.search(r'animation:\s*([^;]+);', self.rule)
+        self.assertIsNotNone(animation, 'nothing reveals the notice')
+        name, *rest = animation.group(1).split()
+        times = [word for word in rest if re.fullmatch(r'[\d.]+m?s', word)]
+        self.assertEqual(len(times), 2, f'expected a duration and a delay, got {rest}')
+        duration, delay = times
+        self.assertEqual(float(duration.rstrip('ms')), 0,
+                         'the reveal is a jump, not a fade')
+        self.assertGreater(float(delay.rstrip('s')), 1, 'a page is accused too soon')
+        self.assertIn('forwards', rest, 'the notice would take itself away again')
+        self.assertRegex(self.css, r'@keyframes\s+' + re.escape(name) + r'\s*\{',
+                         f'{name} is named but never written')
+
+    def test_what_it_collapses_is_what_the_reveal_puts_back(self):
+        """A property zeroed and never restored is a notice nobody can read."""
+        name = re.search(r'animation:\s*(\S+)', self.rule).group(1)
+        frames = self.css.split('@keyframes ' + name, 1)[1].split('\n}')[0]
+        for prop in dict(re.findall(r'([a-z-]+):\s*([^;]+);', self.rule)):
+            if prop == 'animation':
+                continue
+            with self.subTest(property=prop):
+                self.assertIn(f'{prop}:', frames,
+                              f'{prop} is collapsed and never restored')
+
+
 class BuildTheSite(unittest.TestCase):
     """A whole plain build, into a temporary directory.
 


### PR DESCRIPTION
Feedback from [a V2EX thread about the site](https://www.v2ex.com/t/1238149): a
red "This page's code did not start." appears the moment a tool page opens and
disappears again a moment later. The reporter attached a screenshot of an Image
Resizer page that was in no trouble whatsoever.

They are right, and it is on every tool page in every language. The notice has
to be in the markup from the start, because the code that would add it is the
code that did not run — `main.js` removes it on the way past. So the page paints
with a red error on it and takes it off once the module arrives. Caught at 120ms
on a page served from localhost, with nothing wrong with it at all, it looks
exactly like the screenshot in the thread.

`shared/css/tool-frame.css` now collapses it when the page paints and reveals it
with an animation that has a five second delay and no duration:

- **served over http** — the module boots in a fraction of a second and removes
  the notice long before the delay is up, so nobody whose page is coming ever
  sees it;
- **opened straight out of a folder** — nothing boots, nothing removes it, and
  it arrives five seconds in. The reader waits five seconds for an explanation
  of something they are already looking at, which is the cheaper half of the
  trade;
- **a CSP or a network failure on http** — same, which is the other case the
  notice was written for.

Collapsed rather than `display: none` because the reveal is an animation, and
`display` in a keyframe is recent enough that an older browser would hide the
notice for ever — and an older browser refusing modern syntax is one of the ways
a page ends up needing it. Every property in the keyframe animates everywhere.
Nothing moves, so it is deliberately not in a `prefers-reduced-motion`
switch-off.

`tests/python/test_build.py` gains a `BootNotice` class over both halves: the
notice is in the markup, the CSS collapses it, the reveal is a delay rather than
a duration, and every property collapsed is a property the keyframe puts back.
Removing the delay fails it.

## Verified

A full `python build.py --clean` — 1278 pages, links checked. Then, in headless
Edge against the built site:

| moment | before | after |
|---|---|---|
| healthy page, 120ms | notice on screen, 200px tall | present, `max-height: 0`, 0px |
| healthy page, 2.5s | removed by main.js | removed by main.js |
| `src/main.js` removed, 1s | notice on screen | present, 0px |
| `src/main.js` removed, 6.5s | notice on screen | notice on screen, 200px |

And the case it exists for: `index.html` opened over `file://` shows nothing at
one second and the notice at six and a half. Checked in `zh` at 390×844 (the
notice reveals whole, no clipping, the shell command scrolls inside its own box)
and in `ar` (RTL) on the desktop layout.

## Before / after

| Before | After |
|---|---|
| `boot-notice-before.png` | `boot-notice-after.png` |

Both are `/resize-image/` served over http, photographed 120ms after navigation
— the same moment, the same page, one with the red notice and one without. A
third file, `boot-notice-after-dead.png`, is the same page with `src/main.js`
removed at 6.5 seconds: the notice still arrives when it is true.

The filenames are placeholders. GitHub's image uploader lives in the web
editor's own session — neither `gh` nor `gh api` can reach it — so the pictures
have to be dropped in by hand. All three files were handed over in the session
that opened this PR.

**How to put them in:**

1. On this page, open the **⋯** menu at the top right of the description and
   choose **Edit**.
2. Click into the `Before` cell of the table above and drag
   `boot-notice-before.png` onto it. (The paperclip in the toolbar, or a plain
   <kbd>Ctrl</kbd>+<kbd>V</kbd> of the image, does the same thing.)
3. GitHub uploads it and leaves
   `![boot-notice-before.png](https://github.com/user-attachments/assets/…)` in
   the cell. That markdown **is** the image — delete the
   `` `boot-notice-before.png` `` placeholder sitting next to it.
4. Repeat in the `After` cell with `boot-notice-after.png`, and drop
   `boot-notice-after-dead.png` under the table if it is worth showing, then
   press **Save**.
5. Delete this instruction block once the images are showing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
