### PR TITLE
Give "Get in touch" an account to reach, and marks to reach it by

### DIFF
--- a/buildlib/site.py
+++ b/buildlib/site.py
@@ -357,9 +357,12 @@ def hub_jsonld(site, tools):
                 'url': site['contact_url'],
                 'availableLanguage': 'en',
             },
-            # The repository. `sameAs` is for the same entity somewhere else,
-            # which is exactly what it is: the site is that repository, built.
-            'sameAs': [site['source_url']],
+            # The repository and the account. `sameAs` is for the same entity
+            # somewhere else, which is exactly what both are: the site is that
+            # repository, built, and that account, posting. It is the only
+            # place the two are claimed to be one publisher rather than three
+            # addresses that happen to share a name.
+            'sameAs': [site['source_url'], site['x_url']],
         },
         {
             '@type': 'CollectionPage',

--- a/config/site.toml
+++ b/config/site.toml
@@ -18,6 +18,12 @@ source_url = "https://github.com/A-Box-of-Tools/website"
 source_label = "github.com/A-Box-of-Tools/website"
 contact_email = "hi@abox.tools"
 
+# The account the site posts from. It is here rather than in the footer markup
+# because it is the same fact twice: the link a reader follows, and the `sameAs`
+# a search engine reads off the Organization node to decide that the profile and
+# the site are one publisher. Two copies of a handle is one that gets renamed.
+x_url = "https://x.com/aboxtools"
+
 # The version is deliberately NOT here. It is a git tag, worked out by the
 # deploy from what the change touched - see buildlib/version.py and "The
 # version" in CLAUDE.md. It lived on this line until it was noticed that
@@ -619,7 +625,15 @@ footer_tools = "Tools"
 footer_site = "This site"
 footer_contact = "Get in touch"
 footer_sitemap = "Sitemap"
+
+# The three links under "Get in touch" are drawn rather than written - a
+# repository, an account and an address are things a reader recognises by their
+# marks - so these two lines are no longer the words on screen. They are the
+# accessible names: what a screen reader announces, and what the tooltip says.
+# That is why they still have to be translated, and why each names where it
+# goes rather than saying "GitHub" or "X", which a link already looks like.
 footer_source = "Read the code on GitHub"
+footer_x = "abox.tools on X"
 
 # The three lines that carry a link inside a sentence. The <a> is part of the
 # translated string on purpose: which words are the link, and where in the

--- a/locales/ar/locale.toml
+++ b/locales/ar/locale.toml
@@ -392,6 +392,7 @@ footer_site = "هذا الموقع"
 footer_contact = "تواصل معنا"
 footer_sitemap = "خريطة الموقع"
 footer_source = "اقرأ الشيفرة المصدرية على GitHub"
+footer_x = "abox.tools على X"
 
 guarantees_note = """
     لا شيء من هذا عليك تصديقه دون تحقق.

--- a/locales/de/locale.toml
+++ b/locales/de/locale.toml
@@ -414,6 +414,7 @@ footer_site = "Diese Seite"
 footer_contact = "Kontakt"
 footer_sitemap = "Sitemap"
 footer_source = "Den Quellcode auf GitHub lesen"
+footer_x = "abox.tools auf X"
 
 guarantees_note = """
     Nichts davon müssen Sie uns glauben.

--- a/locales/es/locale.toml
+++ b/locales/es/locale.toml
@@ -360,6 +360,7 @@ footer_site = "Este sitio"
 footer_contact = "Contacto"
 footer_sitemap = "Mapa del sitio"
 footer_source = "Leer el código en GitHub"
+footer_x = "abox.tools en X"
 
 guarantees_note = """
     Nada de esto hay que creérselo.

--- a/locales/fr/locale.toml
+++ b/locales/fr/locale.toml
@@ -378,6 +378,7 @@ footer_site = "Ce site"
 footer_contact = "Nous écrire"
 footer_sitemap = "Plan du site"
 footer_source = "Lire le code sur GitHub"
+footer_x = "abox.tools sur X"
 
 guarantees_note = """
     Rien de tout cela n'est à croire sur parole.

--- a/locales/hi/locale.toml
+++ b/locales/hi/locale.toml
@@ -271,6 +271,7 @@ footer_site = "यह साइट"
 footer_contact = "संपर्क करें"
 footer_sitemap = "साइटमैप"
 footer_source = "GitHub पर कोड पढ़ें"
+footer_x = "X पर abox.tools"
 
 guarantees_note = """
     इनमें से किसी भी बात को भरोसे पर मानने की ज़रूरत नहीं।

--- a/locales/id/locale.toml
+++ b/locales/id/locale.toml
@@ -383,6 +383,7 @@ footer_site = "Situs ini"
 footer_contact = "Hubungi kami"
 footer_sitemap = "Peta situs"
 footer_source = "Baca kode sumber di GitHub"
+footer_x = "abox.tools di X"
 
 guarantees_note = """
     Anda tidak perlu memercayai semua itu begitu saja.

--- a/locales/it/locale.toml
+++ b/locales/it/locale.toml
@@ -355,6 +355,7 @@ footer_site = "Questo sito"
 footer_contact = "Contatti"
 footer_sitemap = "Mappa del sito"
 footer_source = "Leggi il codice su GitHub"
+footer_x = "abox.tools su X"
 
 guarantees_note = """
     Niente di tutto questo va preso per buono.

--- a/locales/ja/locale.toml
+++ b/locales/ja/locale.toml
@@ -256,6 +256,7 @@ footer_site = "このサイト"
 footer_contact = "お問い合わせ"
 footer_sitemap = "サイトマップ"
 footer_source = "GitHubでコードを読む"
+footer_x = "abox.toolsのXアカウント"
 
 guarantees_note = """
     以上のどれも、鵜呑みにする必要はありません。\

--- a/locales/ko/locale.toml
+++ b/locales/ko/locale.toml
@@ -393,6 +393,7 @@ footer_site = "이 사이트"
 footer_contact = "문의"
 footer_sitemap = "사이트맵"
 footer_source = "GitHub에서 코드 보기"
+footer_x = "abox.tools X 계정"
 
 guarantees_note = """
     셋 중 어느 것도 그냥 믿으실 필요는 없습니다.

--- a/locales/nl/locale.toml
+++ b/locales/nl/locale.toml
@@ -363,6 +363,7 @@ footer_site = "Deze site"
 footer_contact = "Contact"
 footer_sitemap = "Sitemap"
 footer_source = "Lees de code op GitHub"
+footer_x = "abox.tools op X"
 
 guarantees_note = """
     Je hoeft daar niets van op ons woord aan te nemen.

--- a/locales/pt/locale.toml
+++ b/locales/pt/locale.toml
@@ -355,6 +355,7 @@ footer_site = "Este site"
 footer_contact = "Fale com a gente"
 footer_sitemap = "Mapa do site"
 footer_source = "Ler o código no GitHub"
+footer_x = "abox.tools no X"
 
 guarantees_note = """
     Nada disso você precisa aceitar na fé.

--- a/locales/tr/locale.toml
+++ b/locales/tr/locale.toml
@@ -373,6 +373,7 @@ footer_site = "Bu site"
 footer_contact = "Bize ulaşın"
 footer_sitemap = "Site haritası"
 footer_source = "Kaynak kodu GitHub'da okuyun"
+footer_x = "X'te abox.tools"
 
 guarantees_note = """
     Bunların hiçbirine güvenmeniz gerekmez.

--- a/locales/zh-TW/locale.toml
+++ b/locales/zh-TW/locale.toml
@@ -234,6 +234,7 @@ footer_site = "本站"
 footer_contact = "聯絡我們"
 footer_sitemap = "網站地圖"
 footer_source = "在 GitHub 上讀程式碼"
+footer_x = "abox.tools 的 X 帳號"
 
 guarantees_note = """
     上面這些不用你信。

--- a/locales/zh/locale.toml
+++ b/locales/zh/locale.toml
@@ -255,6 +255,7 @@ footer_site = "本站"
 footer_contact = "联系我们"
 footer_sitemap = "站点地图"
 footer_source = "在 GitHub 上读代码"
+footer_x = "abox.tools 的 X 账号"
 
 guarantees_note = """
     上面这些不用你信。

--- a/shared/css/tool-frame.css
+++ b/shared/css/tool-frame.css
@@ -1189,6 +1189,62 @@ footer {
 
 .footer-brand p { margin: 0.55rem 0 0; max-width: 34ch; }
 
+/* "Get in touch" is the one column that is a row: three marks side by side
+   rather than three lines of text. It is still a <ul>, because it is still a
+   list of links and a screen reader should hear how many there are - only the
+   direction it runs in changes.
+
+   The targets are 2.25rem square with the drawing at 1.05rem inside them, which
+   is the smallest the guidance allows a touch target to be and is a good deal
+   larger than the one-line links above them. A row of icons is the easiest
+   thing in a footer to miss with a thumb.
+
+   Named through `.footer-col ul` rather than on its own, because that is the
+   rule it is overriding and that rule is the more specific of the two: a bare
+   `.footer-marks` loses its margin and its gap to it silently, and the row
+   still looks almost right. */
+.footer-col ul.footer-marks {
+  grid-auto-flow: column;
+  justify-content: start;
+  gap: 0.25rem;
+  /* Half the difference between the target and the drawing inside it, taken
+     back off the left, so the first mark's edge lines up with the heading
+     above it and with the column of links to its left. Without it the row
+     starts a tenth of an inch in from everything else in the footer, which is
+     the kind of thing nobody can name and everybody can see. Logical, so that
+     the pull is on whichever side the row starts from - in Arabic that is the
+     right, and `margin-left` there widens the gap it was meant to close. */
+  margin-inline-start: -0.6rem;
+}
+
+.footer-marks a {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 8px;
+  color: var(--text-dim);
+}
+
+.footer-marks a:hover,
+.footer-marks a:focus-visible {
+  color: var(--accent);
+  background: var(--surface-2);
+  text-decoration: none;   /* the underline the other footer links get has
+                              nothing to underline here */
+}
+
+/* Filled, not stroked, unlike every other drawing on the site: two of the three
+   are other people's logos and those are published as solid shapes. The
+   envelope is drawn to match them rather than the site, so the row reads as one
+   set. */
+.footer-mark {
+  width: 1.05rem;
+  height: 1.05rem;
+  fill: currentColor;
+}
+
 footer p { margin: 0.35rem 0; }
 footer a { color: var(--accent); text-decoration: none; }
 footer a:hover { text-decoration: underline; }

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -56,15 +56,52 @@
       </ul>
     </div>
 
+    <!--
+      The one column that is drawn rather than written. A repository, an account
+      and an address are recognised by their marks in a way that no other link
+      here is, and three sentences stacked in a column - "Read the code on
+      GitHub", a handle, an email address - were three lines saying the same
+      thing three times. The marks fit on one row.
+
+      Each link still carries the sentence, as `aria-label` for a screen reader
+      and `title` for a pointer, so nothing is lost by not being able to see the
+      drawing. The <svg>s are hidden from the accessibility tree rather than
+      labelled themselves: the name belongs on the link, which is the thing that
+      is focused and announced.
+
+      The two brand marks are their owners' - GitHub's Octicon and X's logo -
+      and are drawn here as those companies publish them, because a redrawn
+      logo is a wrong logo. They are outside shared/icons/ for that reason: that
+      folder is Lucide's, byte for byte, and is checkable against it.
+    -->
     <div class="footer-col">
       <strong>{{ ui.footer_contact }}</strong>
-      <ul>
+      <ul class="footer-marks">
         <li>
-          <a href="{{ site.source_url }}" target="_blank" rel="noopener noreferrer">
-            {{ ui.footer_source }}
+          <a href="{{ site.source_url }}" target="_blank" rel="noopener noreferrer"
+             aria-label="{{ ui.footer_source | e }}" title="{{ ui.footer_source | e }}">
+            <svg class="footer-mark" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+              <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13 -.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66 .07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15 -.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.65 7.65 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8 8 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/>
+            </svg>
           </a>
         </li>
-        <li><a href="mailto:{{ site.contact_email }}">{{ site.contact_email }}</a></li>
+        <li>
+          <a href="{{ site.x_url }}" target="_blank" rel="noopener noreferrer"
+             aria-label="{{ ui.footer_x | e }}" title="{{ ui.footer_x | e }}">
+            <svg class="footer-mark" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24h-6.657l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231 5.45-6.231Zm-1.161 17.52h1.833L7.084 4.126H5.117l11.966 15.644Z"/>
+            </svg>
+          </a>
+        </li>
+        <li>
+          <a href="mailto:{{ site.contact_email }}"
+             aria-label="{{ site.contact_email | e }}" title="{{ site.contact_email | e }}">
+            <svg class="footer-mark" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path d="M2.4 6.7A1.8 1.8 0 0 1 4.1 5.5h15.8a1.8 1.8 0 0 1 1.7 1.2L12 12.6Z"/>
+              <path d="M2 8.5 12 14.5l10-6V17a1.8 1.8 0 0 1-1.8 1.8H3.8A1.8 1.8 0 0 1 2 17Z"/>
+            </svg>
+          </a>
+        </li>
       </ul>
     </div>
   </div>

--- a/tests/python/test_site.py
+++ b/tests/python/test_site.py
@@ -34,6 +34,7 @@ SITE = {'domain': 'https://example.test/', 'name': 'Site', 'lang': 'en',
         'contact_url': 'https://example.test/contact/',
         'contact_email': 'hi@example.test',
         'source_url': 'https://example.test/source',
+        'x_url': 'https://x.example.test/site',
         'publisher': {'region': 'Ontario', 'country': 'CA',
                       'contact_slug': 'contact'},
         'guides': {'slug': 'guides', 'heading': 'Guides',
@@ -356,7 +357,8 @@ class StructuredData(unittest.TestCase):
         self.assertEqual(org['address']['addressRegion'], 'Ontario')
         self.assertEqual(org['contactPoint']['url'],
                          'https://example.test/contact/')
-        self.assertEqual(org['sameAs'], ['https://example.test/source'])
+        self.assertEqual(org['sameAs'], ['https://example.test/source',
+                                         'https://x.example.test/site'])
 
     def test_the_hub_lists_the_tools_in_order(self):
         tools = [{'name': 'A', 'url': 'https://example.test/a/'},


### PR DESCRIPTION
The footer's fourth column carried two links, and neither looked like the thing
it led to: **Read the code on GitHub** and **hi@abox.tools**, stacked, in a
footer whose other three columns are also stacked links. A repository, an
account and an address are the three things here a reader already recognises by
their marks, so they are drawn now and the row fits on one line.

The account is the new part — [x.com/aboxtools](https://x.com/aboxtools), which
the site posts from and which nothing here linked to.

## Before / After

| Before | After |
|---|---|
| <img width="432" height="230" alt="get-in-touch-before" src="https://github.com/user-attachments/assets/772077d7-8fca-476b-b55d-7bf1e1d2f11a" /> | <img width="450" height="208" alt="get-in-touch-after" src="https://github.com/user-attachments/assets/9ae8f339-374e-4c40-abfc-f1c3f41cc556" /> |

And the two the English shot cannot show — the row flipped for Arabic, and the
same row in the dark palette:

| Arabic (RTL) | Dark |
|---|---|
| <img width="450" height="208" alt="get-in-touch-ar" src="https://github.com/user-attachments/assets/ef93cbd6-dd89-486c-9bb0-b29691511dfb" /> | <img width="450" height="208" alt="get-in-touch-dark" src="https://github.com/user-attachments/assets/d48a480e-c467-4e49-a725-a5f33930769e" /> |


## What is in the diff

- **`templates/partials/footer.html`** — the column's two text links become
  three icon links. GitHub's Octicon and X's own logo, drawn as their owners
  publish them; the envelope drawn solid to match, so the row reads as one set.
  Each `<a>` keeps the sentence as `aria-label` and `title`; each `<svg>` is
  `aria-hidden`, because the name belongs on the link that is focused and
  announced.
- **`config/site.toml`** — a new `x_url`, and `ui.footer_x` as that link's
  accessible name. The handle is in the config rather than the markup because it
  is the same fact twice: the link a reader follows, and the `sameAs` below.
- **`locales/*/locale.toml`** — `footer_x` in all fourteen languages. The labels
  are no longer the words on screen, but they are still the words a screen
  reader reads out, so they are still translated.
- **`buildlib/site.py`** — the profile joins `sameAs` on the `Organization`
  node, which is exactly what that field is for: the same publisher, somewhere
  else. Fixture and assertion updated in `tests/python/test_site.py`.
- **`shared/css/tool-frame.css`** — the row: 2.25rem targets with a 1.05rem mark
  centred in each, a hover and focus tint, and the pull that lines the first
  mark up with the heading above it.

Two details the pictures do not show, both recorded in comments beside the code:

- the row is named through `.footer-col ul.footer-marks` rather than a bare
  `.footer-marks`, because the rule it overrides is the more specific of the two
  and a bare class loses its margin and its gap to it silently — and still looks
  almost right;
- the pull is `margin-inline-start`, so in Arabic it comes off the right.
  `margin-left` there widens the gap it was written to close.

## Verification

`python build.py --out _plain --clean --no-minify` exits 0, which is the part
that matters for a change in the shared frame: it means no `complete = true`
locale is missing the new string and no link check regressed. The X link and its
translated label are on all 1,305 pages.

The Contact page is deliberately untouched. It still describes "the two ways
in", email and the issue tracker, which is what it means — the account is
somewhere to follow, not a third support channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
