### PR TITLE
Dress the footer's marks on the pages that are not tools

### DIFF
--- a/shared/site.css
+++ b/shared/site.css
@@ -766,6 +766,62 @@ footer {
 
 .footer-brand p { margin: 0.55rem 0 0; max-width: 34ch; }
 
+/* "Get in touch" is the one column that is a row: three marks side by side
+   rather than three lines of text. It is still a <ul>, because it is still a
+   list of links and a screen reader should hear how many there are - only the
+   direction it runs in changes.
+
+   The targets are 2.25rem square with the drawing at 1.05rem inside them, which
+   is the smallest the guidance allows a touch target to be and is a good deal
+   larger than the one-line links above them. A row of icons is the easiest
+   thing in a footer to miss with a thumb.
+
+   Named through `.footer-col ul` rather than on its own, because that is the
+   rule it is overriding and that rule is the more specific of the two: a bare
+   `.footer-marks` loses its margin and its gap to it silently, and the row
+   still looks almost right. */
+.footer-col ul.footer-marks {
+  grid-auto-flow: column;
+  justify-content: start;
+  gap: 0.25rem;
+  /* Half the difference between the target and the drawing inside it, taken
+     back off the left, so the first mark's edge lines up with the heading
+     above it and with the column of links to its left. Without it the row
+     starts a tenth of an inch in from everything else in the footer, which is
+     the kind of thing nobody can name and everybody can see. Logical, so that
+     the pull is on whichever side the row starts from - in Arabic that is the
+     right, and `margin-left` there widens the gap it was meant to close. */
+  margin-inline-start: -0.6rem;
+}
+
+.footer-marks a {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 8px;
+  color: var(--text-dim);
+}
+
+.footer-marks a:hover,
+.footer-marks a:focus-visible {
+  color: var(--accent);
+  background: var(--surface-2);
+  text-decoration: none;   /* the underline the other footer links get has
+                              nothing to underline here */
+}
+
+/* Filled, not stroked, unlike every other drawing on the site: two of the three
+   are other people's logos and those are published as solid shapes. The
+   envelope is drawn to match them rather than the site, so the row reads as one
+   set. */
+.footer-mark {
+  width: 1.05rem;
+  height: 1.05rem;
+  fill: currentColor;
+}
+
 footer p { margin: 0.35rem 0; }
 footer a { color: var(--accent); text-decoration: none; }
 footer a:hover { text-decoration: underline; }

--- a/tests/python/test_duplicates.py
+++ b/tests/python/test_duplicates.py
@@ -81,6 +81,7 @@ name to being either grouped or listed below with a reason.
 import collections
 import itertools
 import pathlib
+import re
 import unittest
 
 from buildlib import minify
@@ -246,6 +247,55 @@ class Coverage(unittest.TestCase):
                         (TOOLS / tool / 'src' / module).is_file(),
                         f'tools/{tool}/src/{module} is declared here and is '
                         f'not on disk')
+
+
+# The two stylesheets. `.footer-*` is not a module and could not be declared
+# above, but it is the same failure in another language: one footer partial,
+# rendered on every page in the site, and two hand-kept copies of the rules
+# that dress it - shared/site.css for the hub, the guides and the prose pages,
+# shared/css/tool-frame.css for the thirty-six tools.
+#
+# Every simple selector in a group has to mention the footer for the group to
+# count here. That is not fussiness: `main, .topbar, ..., footer` sets the page
+# width, and the list either side of `footer` is legitimately different in the
+# two sheets, because a tool page and a hub page are not made of the same parts.
+FOOTER_SHEETS = ('shared/site.css', 'shared/css/tool-frame.css')
+RULE = re.compile(r'([^{}]+)\{([^{}]*)\}')
+COMMENT = re.compile(r'/\*.*?\*/', re.S)
+
+
+def footer_rules(path):
+    """The footer rules of one sheet, as {selectors: declarations}, whitespace
+    and comments normalised away."""
+    css = COMMENT.sub('', (ROOT / path).read_text(encoding='utf-8'))
+    rules = {}
+    for group, body in RULE.findall(css):
+        parts = [' '.join(part.split()) for part in group.split(',')]
+        if all('footer' in part for part in parts):
+            rules[', '.join(parts)] = ' '.join(body.split())
+    return rules
+
+
+class TheFooterInBothSheets(unittest.TestCase):
+    """The footer is one partial and has to look like one thing.
+
+    This is here because it drifted: the row of marks under "Get in touch" was
+    written into the tool sheet and not the other, so it was checked on a tool
+    page, looked right, and shipped as three enormous unstyled logos down the
+    side of every page that is not a tool. Nothing in the build could say so -
+    a stylesheet missing a rule is not an error, it is a page.
+    """
+
+    def test_the_two_sheets_dress_the_footer_the_same(self):
+        site, frame = (footer_rules(path) for path in FOOTER_SHEETS)
+        for selector in sorted(set(site) | set(frame)):
+            with self.subTest(selector=selector):
+                self.assertEqual(
+                    site.get(selector), frame.get(selector),
+                    f'{selector}: the two sheets disagree. The footer is one '
+                    f'partial on every page, so a rule added to '
+                    f'{FOOTER_SHEETS[1]} belongs in {FOOTER_SHEETS[0]} too, '
+                    f'and identically.')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Follows #299, and fixes what it broke on every page that is not a tool.

The row of marks under "Get in touch" was written into
`shared/css/tool-frame.css` and nowhere else. That sheet dresses the thirty-six
tool pages; `shared/site.css` dresses the hub, the guides, the roadmap, the 404
and the five prose pages. #299 was checked on a tool page, looked right, and
left everywhere else showing three logos at their natural size, stacked down the
column in black.

## Before / After

The hub's footer, from a build of `main` as it stands and a build of this
branch:

| Before (`main`) | After |
|---|---|
| <img width="2400" height="2642" alt="hub-before" src="https://github.com/user-attachments/assets/ed133648-bdbc-4629-8e21-633e62ce33e0" /> | <img width="2400" height="2588" alt="hub-after" src="https://github.com/user-attachments/assets/859b1ea1-db53-4d5b-b87e-1ae51b87986d" /> |

## Why nothing caught it

A stylesheet missing a rule is not an error, it is a page. The build writes it,
the link check passes, and the only signal is somebody looking at a page nobody
thought to look at — which is exactly how it was found.

So the copy is now declared, the way the duplicated JavaScript modules already
are. `tests/python/test_duplicates.py` reads the footer rules out of both sheets
and fails if they disagree; it passes here and fails on `main`. The comparison
is by selector and declarations, with comments and whitespace normalised away,
and it skips any group whose selectors are not all about the footer —
`main, .topbar, …, footer` sets the page width, and the list either side of
`footer` is legitimately different between a tool page and a hub page.

That file exists for this shape of bug: one thing, two copies, a fix applied to
one of them. It only knew about JavaScript until now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
