### PR TITLE
Test the MP4 reader, which nothing had ever executed

### DIFF
--- a/tests/js/gif-analyzer-report.test.js
+++ b/tests/js/gif-analyzer-report.test.js
@@ -1,0 +1,402 @@
+/**
+ * tools/gif-analyzer/src/format.js and report.js - the numbers, and the file
+ * somebody pastes into a bug report.
+ *
+ * Two different kinds of risk, in one place because the second is built out of
+ * the first.
+ *
+ * `format.js` exists so that the same quantity reads the same way in the
+ * summary, the byte table and the report. Three copies of "round it unless it
+ * is small" is how a page says 1.0 KB in one row and 1 KB in the next, so the
+ * thresholds are pinned here rather than left to whoever reads the code.
+ *
+ * `report.js` writes a fixed-width table, and the way a fixed-width table fails
+ * is silent: a heading in Japanese occupies two cells per character and one
+ * `String.length` each, so a column padded by length comes out narrow and every
+ * row below it steps sideways. Nothing throws, the file is still produced, and
+ * it is unreadable only to the people whose language did it. So the alignment
+ * tests below measure the built report in cells rather than characters, and one
+ * of them puts the whole thing through a translator that answers in Japanese.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { GifWriter } from '../../tools/gif-maker/src/gif.js';
+import { parseGif } from '../../tools/gif-analyzer/src/gif.js';
+import { budget } from '../../tools/gif-analyzer/src/budget.js';
+import { findings } from '../../tools/gif-analyzer/src/findings.js';
+import { report } from '../../tools/gif-analyzer/src/report.js';
+import {
+  clock, count, delay, fileSize, hex, percent, plural, rate,
+} from '../../tools/gif-analyzer/src/format.js';
+
+/* ------------------------------------------------------------------ format */
+
+test('a file size changes unit where a person would', () => {
+  // The boundaries are the whole content of this function. A byte either side
+  // of each is checked, because an off-by-one here reads as plausible forever.
+  assert.equal(fileSize(0), '0 B');
+  assert.equal(fileSize(1023), '1023 B');
+  assert.equal(fileSize(1024), '1.0 KB');
+  // Under 10 KB keeps a decimal; at 10 KB it stops being worth one.
+  assert.equal(fileSize(10239), '10.0 KB');
+  assert.equal(fileSize(10240), '10 KB');
+  assert.equal(fileSize(1048575), '1024 KB');
+  assert.equal(fileSize(1048576), '1.00 MB');
+  assert.equal(fileSize(10485759), '10.00 MB');
+  assert.equal(fileSize(10485760), '10.0 MB');
+});
+
+test('a delay is written in the only unit a GIF has', () => {
+  // Zero means "as fast as possible" and is written as such rather than as
+  // 0.00, which would read as a measurement.
+  assert.equal(delay(0, say), 'unit.seconds n=0');
+  assert.equal(delay(1, say), 'unit.seconds n=0.01');
+  assert.equal(delay(8, say), 'unit.seconds n=0.08');
+  // Under ten seconds keeps both decimals; at ten it drops to one.
+  assert.equal(delay(999, say), 'unit.seconds n=9.99');
+  assert.equal(delay(1000, say), 'unit.seconds n=10.0');
+  // The longest a 16-bit count of hundredths can express.
+  assert.equal(delay(65535, say), 'unit.seconds n=655.4');
+});
+
+test('a duration becomes minutes and seconds where that reads better', () => {
+  assert.equal(clock(0, say), 'unit.seconds n=0.00');
+  assert.equal(clock(950, say), 'unit.seconds n=9.50');
+  assert.equal(clock(1000, say), 'unit.seconds n=10.0');
+  assert.equal(clock(5999, say), 'unit.seconds n=60.0');
+  assert.equal(clock(6000, say), 'clock.minutes minutes=1 seconds=0.0');
+  assert.equal(clock(9050, say), 'clock.minutes minutes=1 seconds=30.5');
+});
+
+test('a frame rate needs two frames and some time to divide', () => {
+  assert.equal(rate(0, 100), null);
+  assert.equal(rate(1, 100), null);
+  assert.equal(rate(2, 0), null);
+  assert.equal(rate(10, 100), 10);
+  assert.equal(rate(3, 25), 12);
+});
+
+test('a share is rounded without ever rounding away to nothing', () => {
+  // A row that is 0.04% of the file is not 0%: the whole point of the table is
+  // that every byte is somewhere, so a visible row must not read as empty.
+  assert.equal(percent(0), '0%');
+  assert.equal(percent(0.0004), '<0.1%');
+  assert.equal(percent(0.001), '0.1%');
+  assert.equal(percent(0.099), '9.9%');
+  assert.equal(percent(0.1), '10%');
+  assert.equal(percent(1), '100%');
+});
+
+test('a palette entry is hex a person can paste somewhere', () => {
+  const colors = Uint8Array.from([255, 0, 0, 0, 128, 0, 1, 2, 3]);
+  assert.equal(hex(colors, 0), '#FF0000');
+  assert.equal(hex(colors, 1), '#008000');
+  // Single digits are padded, or the string is not a colour.
+  assert.equal(hex(colors, 2), '#010203');
+});
+
+test('one and many are two sentences rather than a suffix', () => {
+  // A language whose plural is not an s on the end has to be able to write
+  // both out, and one with no plural writes the same words twice.
+  assert.equal(plural(1, 'frames', say), 'frames.one n=1');
+  assert.equal(plural(0, 'frames', say), 'frames.many n=0');
+  assert.equal(plural(2, 'frames', say), 'frames.many n=2');
+});
+
+test('a count is grouped the way the reader\'s locale groups it', () => {
+  assert.equal(count(1000), (1000).toLocaleString());
+});
+
+/* ------------------------------------------------------------------ report */
+
+test('the report names the file and everything in it', () => {
+  const text = build(gifOf({ frames: 3, width: 6, height: 4 }));
+
+  assert.ok(text.startsWith('report.title name=example.gif'));
+  // The provenance line is why the file can be pasted anywhere: it says what
+  // made it. Losing it makes the report anonymous.
+  assert.ok(text.includes('report.provenance'));
+  assert.ok(text.includes('report.version'));
+  assert.ok(text.includes('report.frametable'));
+  assert.ok(text.endsWith('\n'));
+});
+
+test('every frame gets exactly one row', () => {
+  const text = build(gifOf({ frames: 5 }));
+  const rows = tableRows(text);
+
+  assert.equal(rows.length, 5);
+  // Numbered from one, because the person reading this is counting pictures.
+  assert.deepEqual(rows.map((row) => row.trim().split(/\s+/)[0]), ['1', '2', '3', '4', '5']);
+});
+
+test('the frame table lines up, header and rows alike', () => {
+  const text = build(gifOf({ frames: 4 }));
+  const header = tableHeader(text);
+
+  // The palette column is left-aligned, so its content starts exactly where
+  // its field does - in the heading, and in every row under it.
+  const wanted = startOf(header, 'column.palette');
+  for (const [index, row] of tableRows(text).entries()) {
+    assert.equal(startOf(row, 'global'), wanted,
+      `frame row ${index + 1} does not line up:\n${header}\n${row}`);
+  }
+});
+
+test('a CJK heading widens its column rather than breaking it', () => {
+  // The failure this exists for. Every heading in front of this column is
+  // wider in cells than it is in characters, so padding counted by length
+  // leaves the header and the rows disagreeing about where the column starts -
+  // and the report is still produced, and still says all the right things.
+  const text = build(gifOf({ frames: 3 }), japanese);
+  const header = tableHeader(text);
+
+  assert.ok(/[぀-ヿ一-鿿]/.test(header), 'the fixture did not translate');
+
+  const wanted = startOf(header, '配色');
+  for (const [index, row] of tableRows(text).entries()) {
+    assert.equal(startOf(row, 'global'), wanted,
+      `frame row ${index + 1} does not line up:\n${header}\n${row}`);
+  }
+});
+
+test('the summary column is as wide as its widest label, in cells', () => {
+  // The label column is sized to the widest label rather than to a fixed
+  // number, so a longer word in another language widens it instead of running
+  // into the value beside it. Every value in the block therefore starts at the
+  // same cell, which is only true if the widening counted cells.
+  const text = build(gifOf({ frames: 2 }), japanese);
+  const block = section(text, 'report.file');
+  const starts = block.map(valueStart);
+
+  assert.ok(block.length >= 5, `the summary block was not found:\n${block.join('\n')}`);
+  // Every line has to be a label and a value with a gap between them. A label
+  // that outgrew its column runs straight into its value and has no gap at
+  // all, so dropping the unreadable lines here would drop the broken ones.
+  assert.ok(starts.every((n) => n !== null),
+    `a label ran into its value:\n${block.join('\n')}`);
+  assert.equal(new Set(starts).size, 1,
+    `values start at ${[...new Set(starts)].join(', ')}:\n${block.join('\n')}`);
+});
+
+test('the byte table adds up to the size of the file', () => {
+  const gif = gifOf({ frames: 4 });
+  const rows = section(build(gif), 'report.budget');
+
+  // The last line of the block is the total, and it is the file's own length.
+  assert.equal(Number(rows.at(-1).trim().split(/\s+/).at(-1)), gif.size);
+});
+
+test('a row worth no bytes is left out, and pixels never are', () => {
+  // A GIF with no local palettes and no metadata has several empty rows. They
+  // are noise in a text report, but "0 bytes of pixels" is a real finding.
+  const rows = section(build(gifOf({ frames: 2 })), 'report.budget');
+
+  assert.ok(rows.some((row) => row.startsWith('budget.pixels.label')));
+  assert.ok(!rows.some((row) => row.startsWith('budget.local.label')),
+    'an empty local-palette row was printed');
+});
+
+test('a share too small to draw still draws one block', () => {
+  // The bar is how the table is read at a glance, so a row with bytes in it
+  // and no bar at all reads as an empty row.
+  const rows = section(build(gifOf({ frames: 6, width: 40, height: 40 })), 'report.budget');
+
+  // Read from the front rather than the back: a row whose bar went missing has
+  // one field fewer, so counting from the end would quietly measure the label
+  // instead and skip the very row this test exists for.
+  let tiny = 0;
+  for (const row of rows.slice(0, -1)) {
+    const parts = row.match(/^\S+\s+(\d+)\s+(\S+)\s*(#*)$/);
+    assert.ok(parts, `unreadable budget row:\n${row}`);
+    const [, bytes, share, bar] = parts;
+    assert.ok(bar.length >= 1, `no bar on a row of ${bytes} bytes (${share}):\n${row}`);
+    if (bar.length === 1 && share !== '100%') tiny += 1;
+  }
+  // And the fixture has to contain such a row, or the assertion above is only
+  // ever checking rows that would have drawn a bar anyway.
+  assert.ok(tiny > 0, 'no row was small enough to round away');
+});
+
+test('a loop count is said three different ways', () => {
+  assert.ok(build(gifOf({ frames: 2, loop: 0 })).includes('loops.forever'));
+  assert.ok(build(gifOf({ frames: 2, loop: 3 })).includes('loops.times n=3'));
+
+  // No Netscape block at all is not the same as looping zero times. The writer
+  // next door always writes one, so the field is cleared here instead of by
+  // hand-assembling a second fixture to carry one absent block.
+  const silent = { ...gifOf({ frames: 2 }), loop: null };
+  assert.ok(report(silent, viewOf(silent), page).includes('report.noloop'));
+});
+
+test('the findings arrive as words rather than as markup', () => {
+  // They are written as HTML for the page. A text file carrying <b> and
+  // &times; is a text file somebody has to clean up before pasting it.
+  const text = build(gifOf({ frames: 3, width: 40, height: 40 }), markup);
+  const block = section(text, 'report.findings').join('\n');
+
+  assert.ok(block.length > 0, 'no findings were reported');
+  assert.ok(!/[<>]/.test(block), `markup survived into the report:\n${block}`);
+  assert.ok(!/&\w+;/.test(block), `an HTML entity survived into the report:\n${block}`);
+  // The entities are replaced by what they meant, not deleted.
+  assert.ok(block.includes('40x40') && block.includes('"here"') && block.includes('&'));
+});
+
+test('a finding\'s body is wrapped to something a comment box will hold', () => {
+  const text = build(gifOf({ frames: 3, width: 40, height: 40 }), longWinded);
+  // Only the findings block is wrapped; the frame table indents its own rows
+  // and they are as wide as the table needs them to be.
+  const wrapped = section(text, 'report.findings').filter((line) => line.startsWith('    '));
+
+  assert.ok(wrapped.length > 1, 'nothing was wrapped');
+  for (const line of wrapped) assert.ok(line.length <= 76, `${line.length} columns: ${line}`);
+});
+
+test('the palette is listed eight colours to a line', () => {
+  const lines = section(build(gifOf({ frames: 2 })), 'report.palette');
+
+  assert.ok(lines.length > 0);
+  for (const line of lines) {
+    const swatches = line.trim().split(/\s+/);
+    assert.ok(swatches.length <= 8, `${swatches.length} swatches on one line`);
+    for (const swatch of swatches) assert.match(swatch, /^#[0-9A-F]{6}$/);
+  }
+});
+
+/* ---------------------------------------------------------------- fixtures */
+
+/** Four colours, deliberately not greyscale so a channel swap would show. */
+const PALETTE = Uint8Array.from([255, 0, 0, 0, 128, 0, 0, 0, 255, 250, 250, 40]);
+
+/** A GIF with n frames, parsed - a real file, written by the tool next door. */
+function gifOf({ frames = 3, width = 6, height = 4, loop = 0 } = {}) {
+  const writer = new GifWriter({ width, height, palette: PALETTE, loop });
+  for (let index = 0; index < frames; index += 1) {
+    writer.addFrame({
+      indices: new Uint8Array(width * height).fill(index % 4),
+      delay: 8 + index,
+    });
+  }
+  return parseGif(writer.finalize());
+}
+
+/**
+ * The view main.js hands the report. `colors` is already a number by the time
+ * it arrives - main.js counts the set - so the decode that produces it is not
+ * repeated here: what is under test on this side is the layout, and the
+ * analyzer's own suite already checks the counting.
+ */
+const viewOf = (gif) => ({
+  name: 'example.gif',
+  budget: budget(gif),
+  findings: findings(gif, {}),
+  colors: 4,
+});
+
+const build = (gif, t = page) => report(gif, viewOf(gif), t);
+
+/**
+ * Stands in for phrase() where what is asserted is the key. The real one reads
+ * the markup; this writes the key and its blanks, because the sentence is
+ * body.html's in fifteen languages.
+ */
+function say(key, values = {}) {
+  const filled = Object.entries(values).map(([k, v]) => `${k}=${v}`).join(' ');
+  return filled ? `${key} ${filled}` : String(key);
+}
+
+/**
+ * The same, except that the handful of keys landing inside a table cell answer
+ * with something the length of a real translation.
+ *
+ * A key written out in full is wider than the column it sits in, and a fixture
+ * that overflows every column cannot say anything about whether the columns
+ * were the right width - which is the whole point of the tests that use this.
+ */
+const CELLS = {
+  'unit.seconds': ({ n }) => `${n}s`,
+  'disposal.unspecified': () => 'none',
+  'disposal.keep': () => 'keep',
+  'disposal.background': () => 'clear',
+  'disposal.restore': () => 'restore',
+  'disposal.reserved': ({ n }) => `reserved ${n}`,
+  'report.globalpalette': () => 'global',
+  'report.localpalette': ({ colours }) => `local ${colours}`,
+  'report.fullcanvas': () => 'full',
+};
+
+const page = (key, values = {}) => (CELLS[key] ? CELLS[key](values) : say(key, values));
+
+/** A translator that answers in Japanese, so the columns are measured in cells. */
+function japanese(key, values = {}) {
+  const words = {
+    'column.index': '番号',
+    'column.at': '位置',
+    'column.size': '大きさ',
+    'column.delay': '待ち時間',
+    'column.disposal': '破棄の方法',
+    'column.palette': '配色',
+    'column.bytes': 'バイト数',
+    'report.version': 'バージョン',
+    'report.canvas': '画面の大きさ',
+    'report.size': 'ファイルの大きさ',
+    'report.frames': 'フレーム数',
+    'report.runsfor': '再生時間',
+    'report.loops': '繰り返し',
+    'report.globalpal': '全体の配色',
+    'report.drawn': '使用色数',
+    'report.background': '背景色',
+  };
+  return words[key] ?? page(key, values);
+}
+
+/** A translator that answers findings in the HTML the page renders. */
+const markup = (key, values = {}) => (String(key).startsWith('find.')
+  ? '<b>A finding</b> about 40&times;40 &amp; friends &ldquo;here&rdquo;'
+  : page(key, values));
+
+/** A translator whose findings are long enough to need wrapping. */
+const longWinded = (key, values = {}) => (String(key).startsWith('find.')
+  ? Array(40).fill('a reasonably long clause about the file').join(' ')
+  : page(key, values));
+
+/* ----------------------------------------------------------------- helpers */
+
+/** How wide a string is in a fixed-width font, counting CJK as two cells. */
+const cells = (text) => [...text].reduce((n, ch) => n
+  + (/[ᄀ-ᅟ⺀-〾ぁ-㏿㐀-䶿一-鿿ꀀ-꓏가-힣豈-﫿︰-﹯＀-｠￠-￦]/.test(ch) ? 2 : 1), 0);
+
+/** The lines of one section, between its rule and the blank line after it. */
+function section(text, heading) {
+  const lines = text.split('\n');
+  const at = lines.findIndex((line) => line.startsWith(heading));
+  assert.ok(at >= 0, `no ${heading} section in the report`);
+  const out = [];
+  for (let i = at + 2; i < lines.length && lines[i] !== ''; i += 1) out.push(lines[i]);
+  return out;
+}
+
+const tableHeader = (text) => section(text, 'report.frametable')[0];
+const tableRows = (text) => section(text, 'report.frametable').slice(1);
+
+/**
+ * How far into a line, in cells, a piece of text starts.
+ *
+ * This is the measurement the whole table rests on. A left-aligned column is
+ * the one worth anchoring to: its content begins exactly where its field
+ * begins, so everything in front of it - including a heading a translator
+ * widened - has to have been counted in cells for the answer to match.
+ */
+function startOf(line, text) {
+  const at = line.indexOf(text);
+  assert.ok(at >= 0, `"${text}" is not in:\n${line}`);
+  return cells(line.slice(0, at));
+}
+
+/** Where the value in a `label  value` line begins, in cells. */
+function valueStart(line) {
+  const parts = line.match(/^(\S+(?: \S+)*?)( {2,})(\S.*)$/);
+  return parts ? cells(parts[1]) + parts[2].length : null;
+}

--- a/tests/js/mp4-demux.test.js
+++ b/tests/js/mp4-demux.test.js
@@ -1,0 +1,749 @@
+/**
+ * The hand-written MP4 reader, in both the copies that exist.
+ *
+ * This is the file that turns somebody else's video into the list every video
+ * tool works from - where each frame is, how big it is, when it is shown, and
+ * whether it can be decoded on its own. Six tools carry a copy, and until now
+ * none of them had a test: the reader was loaded by the suite and never once
+ * executed, which reads as 21% of its lines covered and 0% of its functions.
+ *
+ * An error here does not throw. It hands back a list that is the right length
+ * and the right shape and points at the wrong bytes, and what a person sees is
+ * a still of the wrong moment, or a trim that starts half a second late, or a
+ * frame decoded from the middle of the one before it. So the assertions below
+ * are mostly about arithmetic that has no visible failure mode.
+ *
+ * WHY EVERY TEST RUNS TWICE
+ *
+ * `tests/python/test_duplicates.py` declares two groups for demux.js - one for
+ * crop-video, grab-frame, timelapse-video and video-to-gif, another for
+ * reverse-video and trim-video - which means the copies inside a group are
+ * checked to agree and the two groups are not. They differ: trim-video's copy
+ * carries the display matrix and the sample entry out whole, because a trim
+ * writes them back untouched. Everything under test here is common to both, so
+ * running the suite against one copy from each group is what makes a pass
+ * cover all six rather than four.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  demux as grabFrameDemux,
+  FileWindow as GrabFrameWindow,
+  UnsupportedFile as GrabFrameUnsupported,
+} from '../../tools/grab-frame/src/demux.js';
+import {
+  demux as trimVideoDemux,
+  FileWindow as TrimVideoWindow,
+  UnsupportedFile as TrimVideoUnsupported,
+} from '../../tools/trim-video/src/demux.js';
+
+import {
+  AV1C, AVCC, FTYP, HVCC, VPCC_BODY,
+  asFile, audioEntry, box, fillBytes, fragmentedFile, full, largeBox, mvhd,
+  plainFile, trak, u64be, visualEntry, zeros,
+} from './mp4-fixtures.js';
+import { ascii, concat, u32be } from './helpers.js';
+
+/** One reader from each declared duplicate group. See the header. */
+const READERS = [
+  ['grab-frame', grabFrameDemux, GrabFrameWindow, GrabFrameUnsupported],
+  ['trim-video', trimVideoDemux, TrimVideoWindow, TrimVideoUnsupported],
+];
+
+/** Run one body against both copies, so a divergence between them fails. */
+function forEachReader(name, body) {
+  for (const [tool, demux, FileWindow, UnsupportedFile] of READERS) {
+    test(`${name} [${tool}]`, () => body({ demux, FileWindow, UnsupportedFile }));
+  }
+}
+
+const avc1 = (options = {}) => visualEntry('avc1', { config: box('avcC', AVCC), ...options });
+
+/** The video track most of these files have: six frames at 30 fps on a 600 clock. */
+const VIDEO = {
+  id: 1,
+  entry: avc1(),
+  timescale: 600,
+  duration: 120,
+  sizes: [100, 40, 10, 10, 40, 10],
+  deltas: [[6, 20]],
+  chunkRuns: [[1, 4], [2, 2]],
+  keyframes: [1, 5],
+};
+
+/** Read a fixture, or fail the test with the reason rather than a stack. */
+async function read(demux, bytes) {
+  return demux(asFile(bytes));
+}
+
+/** Assert that reading these bytes is refused, and for the stated reason. */
+async function refuses(demux, UnsupportedFile, bytes, reason) {
+  const error = await read(demux, bytes).then(
+    () => null,
+    (thrown) => thrown,
+  );
+  assert.ok(error, `expected ${reason}, but the file was accepted`);
+  assert.ok(error instanceof UnsupportedFile,
+    `expected UnsupportedFile, got ${error.name}: ${error.message}`);
+  assert.equal(error.reason, reason);
+  return error;
+}
+
+/* ------------------------------------------------------------ sample table */
+
+forEachReader('the sample table becomes one flat list of frames', async ({ demux }) => {
+  const { bytes, layout } = plainFile({ tracks: [VIDEO] });
+  const { video } = await read(demux, bytes);
+
+  assert.equal(video.samples.length, 6);
+  // Against the arithmetic that laid the file out, not a remembered list.
+  assert.deepEqual(video.samples.map((s) => s.offset), layout[0].offsets);
+  assert.deepEqual(video.samples.map((s) => s.size), VIDEO.sizes);
+  assert.deepEqual(video.samples.map((s) => s.dts), [0, 20, 40, 60, 80, 100]);
+});
+
+forEachReader('chunk offsets are read, not assumed to be contiguous', async ({ demux }) => {
+  const { bytes, layout } = plainFile({ tracks: [{ ...VIDEO, chunkGap: 4096 }] });
+  const { video } = await read(demux, bytes);
+
+  // The fixture puts 4 KB of filler between the two chunks. A reader that
+  // walked `mdat` accumulating sizes would put sample 4 immediately after
+  // sample 3 and be exactly one gap out for the rest of the file.
+  const [, second] = [layout[0].offsets[3], layout[0].offsets[4]];
+  assert.equal(second - (layout[0].offsets[3] + 10), 4096);
+  assert.deepEqual(video.samples.map((s) => s.offset), layout[0].offsets);
+});
+
+forEachReader('stsc runs are followed from one chunk to the next', async ({ demux }) => {
+  // One sample in the first chunk and three in each one after it - the shape a
+  // muxer writes when it flushes a keyframe on its own. The earlier fixtures
+  // cannot catch a reader that reads the first `stsc` entry and then stops
+  // consulting the table, because their last run happens to run out of samples
+  // at the same moment. This one does not: staying on the first run gives
+  // seven chunks of one where the file declares three.
+  const { bytes, layout } = plainFile({
+    tracks: [{
+      ...VIDEO,
+      sizes: [90, 30, 30, 30, 25, 25, 25],
+      deltas: [[7, 20]],
+      chunkRuns: [[1, 1], [2, 3]],
+      keyframes: [1],
+    }],
+  });
+  const { video } = await read(demux, bytes);
+
+  assert.equal(video.samples.length, 7);
+  assert.deepEqual(video.samples.map((s) => s.offset), layout[0].offsets);
+});
+
+forEachReader('stss names the keyframes, and nothing else is one', async ({ demux }) => {
+  const { bytes } = plainFile({ tracks: [VIDEO] });
+  const { video } = await read(demux, bytes);
+
+  // stss is 1-based; samples are not. Off by one here is a decode that starts
+  // from a frame that cannot be decoded on its own.
+  assert.deepEqual(video.samples.map((s) => s.isKey),
+    [true, false, false, false, true, false]);
+});
+
+forEachReader('a file with no stss is all keyframes', async ({ demux }) => {
+  const { bytes } = plainFile({ tracks: [{ ...VIDEO, keyframes: null }] });
+  const { video } = await read(demux, bytes);
+  assert.deepEqual(video.samples.map((s) => s.isKey), Array(6).fill(true));
+});
+
+forEachReader('stts runs give a variable frame rate its real times', async ({ demux }) => {
+  // 30 fps for three frames, then 24 - what a phone that got warm writes.
+  const { bytes } = plainFile({
+    tracks: [{ ...VIDEO, deltas: [[3, 20], [3, 25]] }],
+  });
+  const { video } = await read(demux, bytes);
+  assert.deepEqual(video.samples.map((s) => s.dts), [0, 20, 40, 60, 85, 110]);
+});
+
+forEachReader('an stts that runs out early keeps the samples in order', async ({ demux }) => {
+  // Four frames described, six stored. The remaining two must not stack up on
+  // one instant, or "the next frame" stops meaning anything.
+  const { bytes } = plainFile({ tracks: [{ ...VIDEO, deltas: [[4, 20]] }] });
+  const { video } = await read(demux, bytes);
+
+  const times = video.samples.map((s) => s.dts);
+  assert.deepEqual(times.slice(0, 4), [0, 20, 40, 60]);
+  assert.ok(times[4] > times[3] && times[5] > times[4], `not increasing: ${times}`);
+});
+
+forEachReader('ctts is what makes pts differ from dts', async ({ demux }) => {
+  // Stored I P B B P B, watched I B B P B P: the P frames decode before the B
+  // frames that are shown in front of them.
+  const { bytes } = plainFile({
+    tracks: [{
+      ...VIDEO,
+      deltas: [[6, 20]],
+      compositions: [[1, 0], [1, 40], [2, -20], [1, 40], [1, -20]],
+      cttsVersion: 1,
+    }],
+  });
+  const { video } = await read(demux, bytes);
+
+  assert.deepEqual(video.samples.map((s) => s.dts), [0, 20, 40, 60, 80, 100]);
+  assert.deepEqual(video.samples.map((s) => s.pts), [0, 60, 20, 40, 120, 80]);
+});
+
+forEachReader('a version 0 ctts offset is unsigned', async ({ demux }) => {
+  // The same table read as signed would make these negative and reorder the
+  // frames; version 0 has no negative offsets to read.
+  const { bytes } = plainFile({
+    tracks: [{ ...VIDEO, compositions: [[6, 40]], cttsVersion: 0 }],
+  });
+  const { video } = await read(demux, bytes);
+  assert.deepEqual(video.samples.map((s) => s.pts - s.dts), Array(6).fill(40));
+});
+
+forEachReader('a uniform stsz means every sample is that size', async ({ demux }) => {
+  const { bytes, layout } = plainFile({
+    tracks: [{ ...VIDEO, sizes: Array(6).fill(64), uniformSize: 64 }],
+  });
+  const { video } = await read(demux, bytes);
+
+  assert.deepEqual(video.samples.map((s) => s.size), Array(6).fill(64));
+  assert.deepEqual(video.samples.map((s) => s.offset), layout[0].offsets);
+});
+
+forEachReader('co64 carries offsets past four gigabytes', async ({ demux }) => {
+  const { bytes, layout } = plainFile({ tracks: [{ ...VIDEO, wide: true }] });
+  const { video } = await read(demux, bytes);
+  assert.deepEqual(video.samples.map((s) => s.offset), layout[0].offsets);
+});
+
+forEachReader('an mdat with a 64-bit size does not shift the samples', async ({ demux }) => {
+  // The largesize escape puts eight more bytes between the box type and its
+  // payload. A reader that missed them would report every offset eight low.
+  const { bytes, layout } = plainFile({ tracks: [VIDEO], mdatBox: largeBox });
+  const { video } = await read(demux, bytes);
+
+  assert.equal(layout[0].offsets[0], FTYP.length + 16);
+  assert.deepEqual(video.samples.map((s) => s.offset), layout[0].offsets);
+});
+
+/* ----------------------------------------------------------- codec strings */
+
+forEachReader('avcC becomes the string a decoder is configured with', async ({ demux }) => {
+  const { bytes } = plainFile({ tracks: [VIDEO] });
+  const { video } = await read(demux, bytes);
+
+  assert.equal(video.codec, 'avc1.64001f');
+  assert.equal(video.entryType, 'avc1');
+  assert.deepEqual(video.description, AVCC);
+});
+
+forEachReader('avc3 keeps its own prefix', async ({ demux }) => {
+  const { bytes } = plainFile({
+    tracks: [{ ...VIDEO, entry: visualEntry('avc3', { config: box('avcC', AVCC) }) }],
+  });
+  const { video } = await read(demux, bytes);
+  assert.equal(video.codec, 'avc3.64001f');
+});
+
+forEachReader('hvcC is assembled per RFC 6381', async ({ demux }) => {
+  // The compatibility flags are written in reverse bit order and the trailing
+  // zero constraint bytes are dropped. Both are easy to get wrong and produce
+  // a string a browser rejects outright.
+  const { bytes } = plainFile({
+    tracks: [{ ...VIDEO, entry: visualEntry('hvc1', { config: box('hvcC', HVCC) }) }],
+  });
+  const { video } = await read(demux, bytes);
+  assert.equal(video.codec, 'hvc1.1.6.L93.B0');
+});
+
+forEachReader('hev1 keeps its own prefix', async ({ demux }) => {
+  const { bytes } = plainFile({
+    tracks: [{ ...VIDEO, entry: visualEntry('hev1', { config: box('hvcC', HVCC) }) }],
+  });
+  const { video } = await read(demux, bytes);
+  assert.equal(video.codec, 'hev1.1.6.L93.B0');
+});
+
+forEachReader('av1C becomes an av01 string', async ({ demux }) => {
+  const { bytes } = plainFile({
+    tracks: [{ ...VIDEO, entry: visualEntry('av01', { config: box('av1C', AV1C) }) }],
+  });
+  const { video } = await read(demux, bytes);
+  assert.equal(video.codec, 'av01.0.08M.08');
+});
+
+forEachReader('vpcC is read as the full box it is', async ({ demux }) => {
+  // vpcC is the one configuration written with a version and flags in front of
+  // it. Reading it as a plain box shifts every field by four bytes.
+  const { bytes } = plainFile({
+    tracks: [{ ...VIDEO, entry: visualEntry('vp09', { config: full('vpcC', 1, 0, VPCC_BODY) }) }],
+  });
+  const { video } = await read(demux, bytes);
+  assert.equal(video.codec, 'vp09.00.41.08');
+});
+
+/* ---------------------------------------------------------------- rotation */
+
+for (const [rotation, width, height] of [[0, 640, 360], [90, 360, 640], [180, 640, 360], [270, 360, 640]]) {
+  forEachReader(`a ${rotation} degree matrix gives display ${width}x${height}`, async ({ demux }) => {
+    const { bytes } = plainFile({ tracks: [{ ...VIDEO, rotation }] });
+    const { video } = await read(demux, bytes);
+
+    assert.equal(video.rotation, rotation);
+    // The coded size never changes; only what it is presented as does.
+    assert.equal(video.codedWidth, 640);
+    assert.equal(video.codedHeight, 360);
+    assert.equal(video.displayWidth, width);
+    assert.equal(video.displayHeight, height);
+  });
+}
+
+forEachReader('a version 1 tkhd puts the matrix somewhere else', async ({ demux }) => {
+  // v0 and v1 differ only in the width of the times in front of the matrix, so
+  // the reader counts back from the end of the box. A reader counting forward
+  // reads twelve bytes of a timestamp as a rotation.
+  const { bytes } = plainFile({
+    tracks: [{ ...VIDEO, tkhdVersion: 1, rotation: 90 }],
+  });
+  const { video } = await read(demux, bytes);
+
+  assert.equal(video.rotation, 90);
+  assert.equal(video.trackId, 1);
+});
+
+forEachReader('a version 1 mdhd holds a 64-bit duration', async ({ demux }) => {
+  const { bytes } = plainFile({
+    tracks: [{ ...VIDEO, mdhdVersion: 1, timescale: 600, duration: 1800 }],
+  });
+  const { video, duration } = await read(demux, bytes);
+
+  assert.equal(video.timescale, 600);
+  assert.equal(video.duration, 1800);
+  assert.equal(duration, 3);
+});
+
+/* ------------------------------------------------------------------- audio */
+
+forEachReader('the audio track is found and its bytes left alone', async ({ demux }) => {
+  const marker = ascii('an-esds-nothing-here-parses');
+  const sound = audioEntry('mp4a', { channels: 1, sampleRate: 44100, extra: box('esds', marker) });
+
+  const { bytes } = plainFile({
+    tracks: [
+      VIDEO,
+      {
+        id: 2, handler: 'soun', entry: sound, timescale: 44100, duration: 44100,
+        sizes: [50, 50, 50], deltas: [[3, 1024]],
+      },
+    ],
+  });
+  const { video, audio } = await read(demux, bytes);
+
+  assert.equal(video.trackId, 1);
+  assert.equal(audio.trackId, 2);
+  assert.equal(audio.channels, 1);
+  assert.equal(audio.sampleRate, 44100);
+  assert.equal(audio.samples.length, 3);
+  // The whole entry is copied out and written back, so what matters is that it
+  // arrives unchanged - including the box nothing here understands.
+  assert.deepEqual(audio.sampleEntry, sound);
+});
+
+forEachReader('a file with no sound reports none', async ({ demux }) => {
+  const { bytes } = plainFile({ tracks: [VIDEO] });
+  const { audio } = await read(demux, bytes);
+  assert.equal(audio, null);
+});
+
+/* --------------------------------------------------------------- fragments */
+
+/** A fragmented file's video track: no sample tables, defaults in `trex`. */
+const FRAGMENTED_VIDEO = {
+  id: 1, entry: avc1(), timescale: 600, duration: 0,
+  defaultDuration: 20, defaultSize: 30, defaultFlags: 0x10000,
+};
+
+forEachReader('a fragmented file has its tables in the fragments', async ({ demux }) => {
+  const bytes = fragmentedFile({
+    tracks: [FRAGMENTED_VIDEO],
+    fragments: [
+      {
+        runs: [{
+          trackId: 1,
+          baseDecodeTime: 0,
+          firstSampleFlags: 0,
+          samples: [{ size: 100 }, { size: 40 }, { size: 10 }],
+        }],
+      },
+      {
+        runs: [{
+          trackId: 1,
+          baseDecodeTime: 60,
+          firstSampleFlags: 0,
+          samples: [{ size: 80 }, { size: 20 }],
+        }],
+      },
+    ],
+  });
+  const { video, duration } = await read(demux, bytes);
+
+  assert.equal(video.samples.length, 5);
+  assert.deepEqual(video.samples.map((s) => s.size), [100, 40, 10, 80, 20]);
+  // Durations come from trex, which the trun says nothing about.
+  assert.deepEqual(video.samples.map((s) => s.dts), [0, 20, 40, 60, 80]);
+  // The header declared zero; the clock the fragments ended on is the truth.
+  assert.equal(video.duration, 100);
+  assert.equal(duration, 100 / 600);
+});
+
+forEachReader('sample offsets in a fragment are counted from its moof', async ({ demux }) => {
+  const bytes = fragmentedFile({
+    tracks: [FRAGMENTED_VIDEO],
+    fragments: [
+      { runs: [{ trackId: 1, baseDecodeTime: 0, samples: [{ size: 100 }, { size: 40 }] }] },
+      { runs: [{ trackId: 1, baseDecodeTime: 40, samples: [{ size: 70 }] }] },
+    ],
+  });
+  const { video } = await read(demux, bytes);
+
+  const [first, second, third] = video.samples;
+  // Inside a fragment the samples are contiguous...
+  assert.equal(second.offset, first.offset + 100);
+  // ...and the next fragment starts over from its own moof, which is further
+  // along the file than the last sample of the one before it.
+  assert.ok(third.offset > second.offset + 40,
+    `second fragment at ${third.offset} did not clear the first`);
+
+  // What the offsets point at is checked below by reading the bytes back.
+  assert.equal(video.samples.length, 3);
+});
+
+forEachReader('a fragment says which of its samples is a keyframe', async ({ demux }) => {
+  // Bit 16 of the sample flags is "not a sync sample", so first_sample_flags of
+  // 0 makes the opening frame a keyframe and the trex default makes the rest
+  // ordinary. A reader that read the bit the other way up would mark every
+  // frame decodable on its own and seek to the wrong one every time.
+  const bytes = fragmentedFile({
+    tracks: [FRAGMENTED_VIDEO],
+    fragments: [{
+      runs: [{
+        trackId: 1,
+        baseDecodeTime: 0,
+        firstSampleFlags: 0,
+        samples: [{ size: 100 }, { size: 40 }, { size: 10 }, { size: 10 }],
+      }],
+    }],
+  });
+  const { video } = await read(demux, bytes);
+  assert.deepEqual(video.samples.map((s) => s.isKey), [true, false, false, false]);
+});
+
+forEachReader('tfdt moves the clock, and the trun does not have to', async ({ demux }) => {
+  // A fragment that starts at 6000 rather than where the last one stopped is
+  // what a file with a gap in it looks like, and what an appended recording
+  // looks like. The clock has to follow the tfdt, not the running total.
+  const bytes = fragmentedFile({
+    tracks: [FRAGMENTED_VIDEO],
+    fragments: [
+      { runs: [{ trackId: 1, baseDecodeTime: 0, samples: [{ size: 100 }, { size: 40 }] }] },
+      { runs: [{ trackId: 1, baseDecodeTime: 6000, samples: [{ size: 70 }] }] },
+    ],
+  });
+  const { video } = await read(demux, bytes);
+  assert.deepEqual(video.samples.map((s) => s.dts), [0, 20, 6000]);
+});
+
+forEachReader('a trun that states its own durations overrides trex', async ({ demux }) => {
+  const bytes = fragmentedFile({
+    tracks: [FRAGMENTED_VIDEO],
+    fragments: [{
+      runs: [{
+        trackId: 1,
+        baseDecodeTime: 0,
+        samples: [
+          { size: 100, duration: 33, composition: 0 },
+          { size: 40, duration: 33, composition: 66 },
+          { size: 10, duration: 33, composition: 33 },
+        ],
+      }],
+    }],
+  });
+  const { video } = await read(demux, bytes);
+
+  // trex said every sample lasts 20 and is 30 bytes; the trun says otherwise
+  // about both, and the trun is the one that was written last.
+  assert.deepEqual(video.samples.map((s) => s.size), [100, 40, 10]);
+  assert.deepEqual(video.samples.map((s) => s.dts), [0, 33, 66]);
+  assert.deepEqual(video.samples.map((s) => s.pts), [0, 99, 99]);
+});
+
+forEachReader('only a version 1 trun can put a frame before its decode time', async ({ demux }) => {
+  // The same four bytes read as unsigned make a small negative offset into
+  // roughly 4.29 billion, which sorts the frame to the end of the file instead
+  // of one place earlier. Version 0 has no negative offsets to read, so the
+  // reader has to take the version into account rather than the bytes alone.
+  const withVersion = (trunVersion) => fragmentedFile({
+    tracks: [FRAGMENTED_VIDEO],
+    fragments: [{
+      runs: [{
+        trackId: 1,
+        baseDecodeTime: 0,
+        trunVersion,
+        samples: [
+          { size: 100, duration: 33, composition: 0 },
+          { size: 40, duration: 33, composition: 66 },
+          { size: 10, duration: 33, composition: -33 },
+        ],
+      }],
+    }],
+  });
+
+  const signed = await read(demux, withVersion(1));
+  assert.deepEqual(signed.video.samples.map((s) => s.pts), [0, 99, 33]);
+
+  const unsigned = await read(demux, withVersion(0));
+  assert.equal(unsigned.video.samples[2].pts, 66 + 0xffffffff - 32);
+});
+
+forEachReader('an audio track in a fragmented file is picked up too', async ({ demux }) => {
+  const bytes = fragmentedFile({
+    tracks: [
+      FRAGMENTED_VIDEO,
+      {
+        id: 2, handler: 'soun', entry: audioEntry('mp4a'), timescale: 48000, duration: 0,
+        defaultDuration: 1024, defaultSize: 50, defaultFlags: 0,
+      },
+    ],
+    fragments: [{
+      runs: [
+        { trackId: 1, baseDecodeTime: 0, samples: [{ size: 100 }, { size: 40 }] },
+        { trackId: 2, baseDecodeTime: 0, samples: [{ size: 50 }, { size: 50 }] },
+      ],
+    }],
+  });
+  const { video, audio } = await read(demux, bytes);
+
+  assert.equal(video.samples.length, 2);
+  assert.equal(audio.samples.length, 2);
+  assert.deepEqual(audio.samples.map((s) => s.dts), [0, 1024]);
+});
+
+forEachReader('a fragmented file whose audio never appears reports none', async ({ demux }) => {
+  // The moov declares a sound track and no fragment ever carries one, which is
+  // what a recording stopped before the microphone started looks like. An
+  // audio track with an empty sample list would be carried forward as though
+  // there were sound to keep.
+  const bytes = fragmentedFile({
+    tracks: [
+      FRAGMENTED_VIDEO,
+      {
+        id: 2, handler: 'soun', entry: audioEntry('mp4a'), timescale: 48000, duration: 0,
+        defaultDuration: 1024, defaultSize: 50, defaultFlags: 0,
+      },
+    ],
+    fragments: [{ runs: [{ trackId: 1, baseDecodeTime: 0, samples: [{ size: 100 }] }] }],
+  });
+  const { audio, video } = await read(demux, bytes);
+
+  assert.equal(audio, null);
+  assert.equal(video.samples.length, 1);
+});
+
+/* -------------------------------------------------------------- what it is */
+
+forEachReader('the offsets point at the bytes they claim to', async ({ demux, FileWindow }) => {
+  // The whole point of the list. `fillBytes` makes byte n of mdat equal to
+  // n & 0xff, so a sample read back at its own offset names where it came from.
+  const { bytes, layout } = plainFile({ tracks: [VIDEO] });
+  const file = asFile(bytes);
+  const { video } = await read(demux, bytes);
+
+  const window = new FileWindow(file, 1 << 12);
+  const dataStart = layout[0].offsets[0];
+
+  for (const [index, sample] of video.samples.entries()) {
+    const got = await window.read(sample.offset, sample.size);
+    const expected = fillBytes(sample.offset - dataStart + sample.size)
+      .subarray(sample.offset - dataStart);
+    assert.deepEqual(new Uint8Array(got), expected, `sample ${index} read the wrong bytes`);
+  }
+});
+
+/* -------------------------------------------------------------- FileWindow */
+
+forEachReader('FileWindow slides rather than reading the file in', async ({ FileWindow }) => {
+  const data = fillBytes(40_000);
+  const window = new FileWindow(new Blob([data]), 4096);
+
+  assert.deepEqual(new Uint8Array(await window.read(0, 10)), data.subarray(0, 10));
+  // Forward past the end of the window: it moves rather than failing.
+  assert.deepEqual(new Uint8Array(await window.read(30_000, 10)), data.subarray(30_000, 30_010));
+  // Backwards, which a linear walk never does but a seek does.
+  assert.deepEqual(new Uint8Array(await window.read(100, 10)), data.subarray(100, 110));
+  // Bigger than the window itself: the window grows to fit one sample.
+  assert.deepEqual(new Uint8Array(await window.read(0, 9000)), data.subarray(0, 9000));
+});
+
+forEachReader('FileWindow refuses a read that runs off the end', async ({ FileWindow, UnsupportedFile }) => {
+  // A file truncated mid-frame. Returning the short read would hand a decoder
+  // half a frame, which is worse than saying so.
+  const window = new FileWindow(new Blob([fillBytes(1000)]), 4096);
+  await assert.rejects(
+    () => window.read(900, 200),
+    (error) => error instanceof UnsupportedFile && error.reason === 'read.midframe',
+  );
+});
+
+/* ----------------------------------------------------------- what it won't */
+
+forEachReader('something that is not an MP4 at all', async ({ demux, UnsupportedFile }) => {
+  await refuses(demux, UnsupportedFile,
+    concat(ascii('this is not a video, it is a sentence about one')), 'read.notmp4');
+});
+
+forEachReader('an MP4 with no moov', async ({ demux, UnsupportedFile }) => {
+  await refuses(demux, UnsupportedFile,
+    concat(FTYP, box('mdat', fillBytes(64))), 'read.nomoov');
+});
+
+forEachReader('a file whose only track is sound', async ({ demux, UnsupportedFile }) => {
+  const { bytes } = plainFile({
+    tracks: [{
+      id: 1, handler: 'soun', entry: audioEntry('mp4a'), timescale: 48000, duration: 48000,
+      sizes: [50, 50], deltas: [[2, 1024]],
+    }],
+  });
+  await refuses(demux, UnsupportedFile, bytes, 'read.novideo');
+});
+
+forEachReader('an encrypted track, declared as encv', async ({ demux, UnsupportedFile }) => {
+  const { bytes } = plainFile({
+    tracks: [{ ...VIDEO, entry: visualEntry('encv', { config: box('avcC', AVCC) }) }],
+  });
+  await refuses(demux, UnsupportedFile, bytes, 'read.encrypted');
+});
+
+forEachReader('an encrypted track hiding a sinf inside avc1', async ({ demux, UnsupportedFile }) => {
+  // Common encryption leaves the four characters saying avc1 in place and adds
+  // a protection scheme box beside the configuration. Decoding it anyway
+  // produces noise, so a refusal is the honest answer.
+  const { bytes } = plainFile({
+    tracks: [{
+      ...VIDEO,
+      entry: visualEntry('avc1', {
+        config: concat(box('avcC', AVCC), box('sinf', box('frma', ascii('avc1')))),
+      }),
+    }],
+  });
+  await refuses(demux, UnsupportedFile, bytes, 'read.encrypted');
+});
+
+forEachReader('a codec this reader has never heard of', async ({ demux, UnsupportedFile }) => {
+  const { bytes } = plainFile({
+    tracks: [{ ...VIDEO, entry: visualEntry('mjpg', { config: box('jpeC', zeros(8)) }) }],
+  });
+  const error = await refuses(demux, UnsupportedFile, bytes, 'read.unknowncodec');
+  // The four characters travel with the refusal, because the sentence on the
+  // page names the codec and cannot know it in advance.
+  assert.deepEqual(error.values, { type: 'mjpg' });
+});
+
+forEachReader('a known codec with no configuration box', async ({ demux, UnsupportedFile }) => {
+  const { bytes } = plainFile({
+    tracks: [{ ...VIDEO, entry: visualEntry('avc1', { config: null }) }],
+  });
+  const error = await refuses(demux, UnsupportedFile, bytes, 'read.noconfig');
+  assert.deepEqual(error.values, { type: 'avc1' });
+});
+
+forEachReader('an avcC too short to name a codec', async ({ demux, UnsupportedFile }) => {
+  const { bytes } = plainFile({
+    tracks: [{ ...VIDEO, entry: visualEntry('avc1', { config: box('avcC', new Uint8Array([1, 0x64])) }) }],
+  });
+  await refuses(demux, UnsupportedFile, bytes, 'read.avcshort');
+});
+
+forEachReader('an hvcC too short to name a codec', async ({ demux, UnsupportedFile }) => {
+  const { bytes } = plainFile({
+    tracks: [{ ...VIDEO, entry: visualEntry('hvc1', { config: box('hvcC', HVCC.subarray(0, 8)) }) }],
+  });
+  await refuses(demux, UnsupportedFile, bytes, 'read.hevcshort');
+});
+
+forEachReader('the compact sample size table, which is not read', async ({ demux, UnsupportedFile }) => {
+  // stz2 is legal and rare. Saying so beats reading it as an stsz and handing
+  // back sizes that are plausible and wrong.
+  const { bytes } = plainFile({ tracks: [VIDEO] });
+  const patched = renameBox(bytes, 'stsz', 'stz2');
+  await refuses(demux, UnsupportedFile, patched, 'read.compactsizes');
+});
+
+forEachReader('a track with no sample tables', async ({ demux, UnsupportedFile }) => {
+  const { bytes } = plainFile({ tracks: [VIDEO] });
+  await refuses(demux, UnsupportedFile, renameBox(bytes, 'stts', 'free'), 'read.sampletables');
+});
+
+/* ------------------------------------------------------------- broken maps */
+
+forEachReader('a box claiming to run past its parent stops the walk', async ({ demux, UnsupportedFile }) => {
+  // A truncated download. Giving up whatever was read beats throwing, but a
+  // moov whose first box swallows the rest has no tracks left to find.
+  const { bytes } = plainFile({ tracks: [VIDEO] });
+  const patched = bytes.slice();
+  const view = new DataView(patched.buffer);
+  const at = findBoxOffset(patched, 'trak');
+  view.setUint32(at, 0x0fffffff);
+
+  await refuses(demux, UnsupportedFile, patched, 'read.novideo');
+});
+
+forEachReader('a track whose timescale is zero', async ({ demux, UnsupportedFile }) => {
+  // Dividing by it would make every time in the file Infinity, and a timeline
+  // of Infinity draws as an empty strip rather than as an error.
+  const { bytes } = plainFile({ tracks: [{ ...VIDEO, timescale: 0 }] });
+  await refuses(demux, UnsupportedFile, bytes, 'read.notimescale');
+});
+
+/* --------------------------------------------- what only trim-video keeps */
+
+test('trim-video carries the matrix and sample entry out whole', async () => {
+  // Its copy of the reader has one addition: a trim writes the original frames
+  // back untouched, so the boxes describing them have to survive the trip
+  // byte for byte rather than be rebuilt from what was parsed out of them.
+  const entry = avc1();
+  const { bytes } = plainFile({ tracks: [{ ...VIDEO, entry, rotation: 90 }] });
+  const { video } = await trimVideoDemux(asFile(bytes));
+
+  assert.deepEqual(video.sampleEntry, entry);
+  assert.equal(video.matrix.length, 36);
+  assert.equal(video.trackWidth, 640 * 65536);
+  assert.equal(video.trackHeight, 360 * 65536);
+
+  // And the copied matrix is the one that produced the rotation beside it.
+  const view = new DataView(video.matrix.buffer, video.matrix.byteOffset, 36);
+  assert.equal(view.getInt32(0), 0);
+  assert.equal(view.getInt32(4), 0x00010000);
+  assert.equal(video.rotation, 90);
+});
+
+/* ----------------------------------------------------------------- helpers */
+
+/** Where a four-character box type sits in the file, by its first appearance. */
+function findBoxOffset(bytes, type) {
+  const needle = ascii(type);
+  for (let at = 0; at + 4 <= bytes.length; at += 1) {
+    if (needle.every((byte, i) => bytes[at + i] === byte)) return at - 4;
+  }
+  throw new Error(`no ${type} in the fixture`);
+}
+
+/**
+ * Rename a box in place, which is how a fixture asks for a table the reader
+ * does not handle without a second builder for every one of them.
+ */
+function renameBox(bytes, from, to) {
+  const out = bytes.slice();
+  out.set(ascii(to), findBoxOffset(out, from) + 4);
+  return out;
+}

--- a/tests/js/mp4-fixtures.js
+++ b/tests/js/mp4-fixtures.js
@@ -1,0 +1,455 @@
+/**
+ * Building real MP4s to read back.
+ *
+ * The demuxer under test opens files somebody else wrote, so its tests need
+ * files somebody else wrote - or the nearest honest substitute, which is one
+ * assembled here with the tables worked out rather than asserted. A fixture
+ * whose chunk offsets were copied from the reader's own arithmetic would agree
+ * with a broken reader and never touch the case that matters.
+ *
+ * So the offsets here are computed forward from the sample sizes: samples are
+ * laid down in `mdat` back to back in sample order, and a chunk's offset is the
+ * sum of the sizes in front of it. The reader has to arrive at the same numbers
+ * from `stsc`, `stsz` and `stco`, which are three different shapes of the same
+ * fact. Nothing in this file imports the reader.
+ *
+ * The boxes are written the way a muxer writes them rather than the smallest
+ * arrangement the reader would accept: the fixed 78-byte visual sample entry
+ * header, a real display matrix, `mdhd` and `hdlr` where a track keeps them.
+ * A reader that only passes against a stripped-down fixture has not been tested
+ * against anything anybody will actually open.
+ */
+
+import { ascii, concat, u16be, u32be } from './helpers.js';
+
+/* ------------------------------------------------------------ box plumbing */
+
+const u24be = (n) => new Uint8Array([(n >> 16) & 0xff, (n >> 8) & 0xff, n & 0xff]);
+
+/** Two's complement, so a negative matrix entry can be written as one. */
+export const s32be = (n) => u32be(n >>> 0);
+
+export const u64be = (n) => concat(u32be(Math.floor(n / 2 ** 32)), u32be(n >>> 0));
+
+export const zeros = (n) => new Uint8Array(n);
+
+/** size, type, payload - the shape every box in the file has. */
+export function box(type, ...payload) {
+  const body = concat(...payload);
+  return concat(u32be(8 + body.length), ascii(type), body);
+}
+
+/** A box whose first four payload bytes are a version and three flag bytes. */
+export function full(type, version, flags, ...payload) {
+  return box(type, new Uint8Array([version]), u24be(flags), ...payload);
+}
+
+/**
+ * A box written with the 64-bit `largesize` escape: size 1, then the real size
+ * as eight bytes after the type. Files over 4 GB use it for `mdat`, and a
+ * reader that skips the extra eight bytes lands mid-box on everything after it.
+ */
+export function largeBox(type, ...payload) {
+  const body = concat(...payload);
+  return concat(u32be(1), ascii(type), u64be(16 + body.length), body);
+}
+
+/* ------------------------------------------------------------------ matrix */
+
+/**
+ * The 3x3 display matrix, as the nine 16.16 fixed-point values `tkhd` carries.
+ * Only a, b, c and d say anything about rotation; the reader ignores the rest.
+ */
+export function matrix(rotation = 0) {
+  const ONE = 0x00010000;
+  const NEG = -0x00010000;
+  const abcd = {
+    0: [ONE, 0, 0, ONE],
+    90: [0, ONE, NEG, 0],
+    180: [NEG, 0, 0, NEG],
+    270: [0, NEG, ONE, 0],
+  }[rotation];
+  if (!abcd) throw new Error(`no matrix for ${rotation} degrees`);
+
+  const [a, b, c, d] = abcd;
+  // a b u / c d v / x y w, with the bottom right in 2.30 rather than 16.16.
+  return concat(
+    s32be(a), s32be(b), s32be(0),
+    s32be(c), s32be(d), s32be(0),
+    s32be(0), s32be(0), s32be(0x40000000),
+  );
+}
+
+/* ---------------------------------------------------------- configurations */
+
+/**
+ * An avcC naming High profile, level 3.1 - "avc1.64001f". The three bytes after
+ * the configuration version are the whole of what the codec string is made of,
+ * which is why they are the three that are not zero here.
+ */
+export const AVCC = new Uint8Array([
+  1, 0x64, 0x00, 0x1f, 0xff, 0xe1, 0, 4, 0x67, 1, 2, 3, 1, 0, 4, 0x68, 1, 2, 3,
+]);
+
+/**
+ * An hvcC for Main profile, level 3.1 - "hvc1.1.6.L93.B0".
+ *
+ * Byte 1 packs the profile space (0), the tier (0) and the profile (1). Bytes
+ * 2-5 are the compatibility flags, which RFC 6381 writes in reverse bit order:
+ * the 0x60000000 here has to come back as "6". Byte 12 is the level, 93. Bytes
+ * 6-11 are the constraint flags, and only the first is non-zero, so the string
+ * keeps one "B0" and drops the five zeroes behind it.
+ */
+export const HVCC = new Uint8Array([
+  1, 0x01, 0x60, 0x00, 0x00, 0x00, 0xb0, 0, 0, 0, 0, 0, 93,
+]);
+
+/** An av1C for Main profile, level 8, main tier, 8-bit - "av01.0.08M.08". */
+export const AV1C = new Uint8Array([0x81, 0x08, 0x00, 0x00]);
+
+/** A vpcC payload for profile 0, level 41, 8-bit - "vp09.00.41.08". */
+export const VPCC_BODY = new Uint8Array([0, 41, 0x80, 0]);
+
+/* ---------------------------------------------------------- sample entries */
+
+/**
+ * A visual sample entry: six reserved bytes, the data reference index, then the
+ * fixed 78-byte header every one of them carries, then the codec's own box.
+ * The reader looks for the configuration from `entry.body + 78` onwards, so the
+ * header has to be exactly that long.
+ *
+ * `config` is a whole box - `box('avcC', AVCC)`, or `full('vpcC', 1, 0, ...)`
+ * for the one configuration that is written as a full box. Passing the payload
+ * on its own would leave the reader walking the codec's own bytes as though
+ * they were a box header, which is a fixture bug that looks like a reader bug.
+ */
+export function visualEntry(type, { width = 640, height = 360, config = null } = {}) {
+  const header = concat(
+    zeros(6), u16be(1),                       // reserved, data_reference_index
+    u16be(0), u16be(0), zeros(12),            // pre_defined, reserved, pre_defined
+    u16be(width), u16be(height),              // byte 24 and byte 26
+    u32be(0x00480000), u32be(0x00480000),     // 72 dpi, horizontal and vertical
+    u32be(0), u16be(1),                       // reserved, frame_count
+    zeros(32),                                // compressorname
+    u16be(0x0018), u16be(0xffff),             // depth, pre_defined
+  );
+  return box(type, header, ...(config ? [config] : []));
+}
+
+/**
+ * An audio sample entry. The reader reads the channel count and the sample rate
+ * out of it and copies the rest through untouched, so what is inside `extra` is
+ * deliberately not a real esds - the point of the test is that whatever is here
+ * comes back byte for byte.
+ */
+export function audioEntry(type, { channels = 2, sampleRate = 48000, extra = null } = {}) {
+  const header = concat(
+    zeros(6), u16be(1),                       // reserved, data_reference_index
+    zeros(8),                                 // version, revision, vendor
+    u16be(channels), u16be(16),               // byte 16, then the sample size
+    u16be(0), u16be(0),                       // pre_defined, reserved
+    u32be(sampleRate * 65536),                // 16.16, at byte 24
+  );
+  return box(type, header, ...(extra ? [extra] : []));
+}
+
+/* ------------------------------------------------------------ sample table */
+
+/**
+ * The tables that say where the samples are, built from one list of sizes.
+ *
+ * `chunkRuns` is `stsc` as it is actually written - "from this chunk onwards,
+ * this many samples each" - so a file whose last chunk is short is expressed
+ * the way a muxer expresses it rather than by listing every chunk.
+ *
+ * @param {object} spec
+ * @param {number[]} spec.sizes             one entry per sample, in file order
+ * @param {number[][]} spec.deltas          stts runs, as [count, delta] pairs
+ * @param {number[][]} spec.chunkRuns       [firstChunk (1-based), samplesPerChunk]
+ * @param {number[]|null} spec.keyframes    1-based sample numbers, null for no stss
+ * @param {number[][]|null} spec.compositions  ctts runs, as [count, offset] pairs
+ * @param {number} spec.dataStart           where sample 0 sits in the file
+ * @param {number} spec.chunkGap            filler in front of every chunk but the first
+ * @returns {{boxes: Uint8Array, offsets: number[], end: number}}
+ */
+export function sampleTables({
+  sizes,
+  deltas,
+  chunkRuns = [[1, sizes.length]],
+  keyframes = null,
+  compositions = null,
+  cttsVersion = 0,
+  uniformSize = 0,
+  wide = false,
+  chunkGap = 7,
+  dataStart,
+}) {
+  // Which samples fall in which chunk, from the runs. A chunk exists for as
+  // long as there are samples left to put in one.
+  const chunks = [];
+  let sample = 0;
+  let run = 0;
+  while (sample < sizes.length) {
+    while (run + 1 < chunkRuns.length && chunkRuns[run + 1][0] - 1 <= chunks.length) run += 1;
+    const take = [];
+    for (let i = 0; i < chunkRuns[run][1] && sample < sizes.length; i += 1) {
+      take.push(sample);
+      sample += 1;
+    }
+    chunks.push(take);
+  }
+
+  // Lay the chunks down with filler in front of all but the first, so that the
+  // chunk offsets are load-bearing. Samples packed end to end across the whole
+  // file would let a reader that never consulted `stsc` or `stco` at all - one
+  // that just accumulated sizes from the start of `mdat` - agree with every
+  // offset this suite asserts.
+  const starts = new Array(sizes.length);
+  const chunkStarts = [];
+  let at = dataStart;
+  for (const [index, take] of chunks.entries()) {
+    if (index > 0) at += chunkGap;
+    chunkStarts.push(at);
+    for (const which of take) {
+      starts[which] = at;
+      at += sizes[which];
+    }
+  }
+
+  const stts = full('stts', 0, 0, u32be(deltas.length),
+    ...deltas.map(([count, delta]) => concat(u32be(count), u32be(delta))));
+
+  const stsc = full('stsc', 0, 0, u32be(chunkRuns.length),
+    ...chunkRuns.map(([first, per]) => concat(u32be(first), u32be(per), u32be(1))));
+
+  const stsz = uniformSize
+    ? full('stsz', 0, 0, u32be(uniformSize), u32be(sizes.length))
+    : full('stsz', 0, 0, u32be(0), u32be(sizes.length), ...sizes.map(u32be));
+
+  const stco = wide
+    ? full('co64', 0, 0, u32be(chunkStarts.length), ...chunkStarts.map(u64be))
+    : full('stco', 0, 0, u32be(chunkStarts.length), ...chunkStarts.map(u32be));
+
+  const extra = [];
+  if (keyframes) {
+    extra.push(full('stss', 0, 0, u32be(keyframes.length), ...keyframes.map(u32be)));
+  }
+  if (compositions) {
+    extra.push(full('ctts', cttsVersion, 0, u32be(compositions.length),
+      ...compositions.map(([count, offset]) => concat(u32be(count), s32be(offset)))));
+  }
+
+  return { boxes: concat(stts, stsc, stsz, stco, ...extra), offsets: starts, end: at };
+}
+
+/* ------------------------------------------------------------------ tracks */
+
+/**
+ * One `trak`. `tableBoxes` is what `sampleTables` returned, or nothing at all
+ * for a fragmented file, where the tables live in each fragment instead and
+ * `stbl` still has to exist and still has to hold the sample description.
+ */
+export function trak({
+  id = 1,
+  handler = 'vide',
+  timescale = 600,
+  duration = 0,
+  rotation = 0,
+  width = 640,
+  height = 360,
+  entry,
+  tableBoxes = null,
+  mdhdVersion = 0,
+  tkhdVersion = 0,
+}) {
+  const tkhd = tkhdVersion === 1
+    ? full('tkhd', 1, 7,
+      u64be(0), u64be(0), u32be(id), u32be(0), u64be(duration),
+      zeros(8), u16be(0), u16be(0), u16be(0), u16be(0),
+      matrix(rotation), u32be(width * 65536), u32be(height * 65536))
+    : full('tkhd', 0, 7,
+      u32be(0), u32be(0), u32be(id), u32be(0), u32be(duration),
+      zeros(8), u16be(0), u16be(0), u16be(0), u16be(0),
+      matrix(rotation), u32be(width * 65536), u32be(height * 65536));
+
+  const mdhd = mdhdVersion === 1
+    ? full('mdhd', 1, 0, u64be(0), u64be(0), u32be(timescale), u64be(duration),
+      u16be(0x55c4), u16be(0))
+    : full('mdhd', 0, 0, u32be(0), u32be(0), u32be(timescale), u32be(duration),
+      u16be(0x55c4), u16be(0));
+
+  const hdlr = full('hdlr', 0, 0, u32be(0), ascii(handler), zeros(12), ascii('t\0'));
+
+  const stbl = box('stbl',
+    full('stsd', 0, 0, u32be(1), entry),
+    ...(tableBoxes ? [tableBoxes] : []));
+
+  const minf = box('minf',
+    handler === 'vide' ? box('vmhd', zeros(12)) : box('smhd', zeros(8)),
+    box('dinf', full('dref', 0, 0, u32be(1), full('url ', 0, 1))),
+    stbl);
+
+  return box('trak', tkhd, box('mdia', mdhd, hdlr, minf));
+}
+
+/** The movie header. Nothing in the reader looks at it; real files have one. */
+export function mvhd(timescale = 1000, duration = 0, nextTrack = 3) {
+  return full('mvhd', 0, 0,
+    u32be(0), u32be(0), u32be(timescale), u32be(duration),
+    u32be(0x00010000), u16be(0x0100), u16be(0), zeros(8),
+    matrix(0), zeros(24), u32be(nextTrack));
+}
+
+/* ------------------------------------------------------------------- files */
+
+export const FTYP = box('ftyp', ascii('isom'), u32be(512),
+  ascii('isom'), ascii('iso2'), ascii('avc1'), ascii('mp41'));
+
+/** Recognisable filler: byte n of the payload is n, so a slice names itself. */
+export function fillBytes(length) {
+  const out = new Uint8Array(length);
+  for (let i = 0; i < length; i += 1) out[i] = i & 0xff;
+  return out;
+}
+
+/**
+ * A plain file: `ftyp`, then `mdat`, then `moov`.
+ *
+ * `mdat` goes in front so the sample offsets are known before the tables that
+ * name them are built - which is also how a muxer that streams its output has
+ * to write one, and the layout that catches a reader assuming `moov` comes
+ * first. Each track's samples follow the previous track's, in the order given.
+ *
+ * Returns the bytes and, beside them, where each track's samples were actually
+ * put. A test asserting against `layout` is comparing the reader's answer with
+ * the arithmetic that laid the file out, rather than with a list of numbers
+ * somebody copied out of a passing run.
+ *
+ * @returns {{bytes: Uint8Array, layout: {offsets: number[]}[]}}
+ */
+export function plainFile({ tracks, movieDuration = 0, mdatBox = box }) {
+  const dataStart = FTYP.length + (mdatBox === largeBox ? 16 : 8);
+
+  const layout = [];
+  let at = dataStart;
+  const built = tracks.map((spec) => {
+    const table = spec.sizes ? sampleTables({ ...spec, dataStart: at }) : null;
+    layout.push({ offsets: table?.offsets ?? [] });
+    if (table) at = table.end;
+    return trak({ ...spec, tableBoxes: table?.boxes ?? null });
+  });
+
+  return {
+    bytes: concat(
+      FTYP,
+      mdatBox('mdat', fillBytes(at - dataStart)),
+      box('moov', mvhd(1000, movieDuration), ...built),
+    ),
+    layout,
+  };
+}
+
+/** The fixture as the demuxer takes it: something with `size` and `slice`. */
+export const asFile = (bytes) => new Blob([bytes]);
+
+/**
+ * One `traf`: which track, where its clock is, and the samples themselves.
+ *
+ * Only the flags a real writer sets are set. `tfhd` says nothing about the
+ * defaults unless the fixture asks it to, so the values in `trex` are what a
+ * reader has to fall back to - which is the case worth testing, because a
+ * reader that ignores `trex` still produces a plausible-looking list.
+ */
+function traf({
+  trackId,
+  baseDecodeTime = null,
+  tfhdFlags = 0,
+  tfhdExtras = [],
+  samples,
+  sampleFlags = null,
+  firstSampleFlags = null,
+  // A version 0 trun stores composition offsets unsigned, a version 1 trun
+  // signed. Only the second can say a frame is shown before one that decodes
+  // ahead of it, which is why a fixture with B-frames has to ask for it.
+  trunVersion = 0,
+}, dataOffset) {
+  let runFlags = 0x1;                                   // data offset present
+  if (firstSampleFlags !== null) runFlags |= 0x4;
+  if (samples.some((s) => s.duration !== undefined)) runFlags |= 0x100;
+  if (samples.some((s) => s.size !== undefined)) runFlags |= 0x200;
+  if (sampleFlags) runFlags |= 0x400;
+  if (samples.some((s) => s.composition !== undefined)) runFlags |= 0x800;
+
+  const rows = samples.map((sample, index) => concat(
+    ...(runFlags & 0x100 ? [u32be(sample.duration ?? 0)] : []),
+    ...(runFlags & 0x200 ? [u32be(sample.size ?? 0)] : []),
+    ...(runFlags & 0x400 ? [u32be(sampleFlags[index])] : []),
+    ...(runFlags & 0x800 ? [s32be(sample.composition ?? 0)] : []),
+  ));
+
+  return box('traf',
+    full('tfhd', 0, tfhdFlags, u32be(trackId), ...tfhdExtras),
+    ...(baseDecodeTime === null ? [] : [full('tfdt', 1, 0, u64be(baseDecodeTime))]),
+    full('trun', trunVersion, runFlags,
+      u32be(samples.length),
+      s32be(dataOffset),
+      ...(firstSampleFlags !== null ? [u32be(firstSampleFlags)] : []),
+      ...rows));
+}
+
+/** How many bytes of `mdat` a run owns, whether or not its sizes are explicit. */
+function runBytes(run) {
+  if (run.payloadLength !== undefined) return run.payloadLength;
+  return run.samples.reduce((n, sample) => n + (sample.size ?? 0), 0);
+}
+
+/**
+ * A fragmented file: `ftyp`, a `moov` carrying `mvex` and no sample tables at
+ * all, then one `moof` and `mdat` per fragment.
+ *
+ * This is what a browser's own MediaRecorder writes. A `trun`'s sample offsets
+ * are counted from the start of the `moof` that holds it, so each fragment is
+ * assembled once to be measured and again with the offsets that measurement
+ * produced.
+ */
+export function fragmentedFile({ tracks, fragments, movieDuration = 0 }) {
+  const traks = tracks.map((spec) => trak({ ...spec, tableBoxes: null }));
+
+  const trex = tracks.map((spec) => full('trex', 0, 0,
+    u32be(spec.id), u32be(1),
+    u32be(spec.defaultDuration ?? 0),
+    u32be(spec.defaultSize ?? 0),
+    u32be(spec.defaultFlags ?? 0)));
+
+  const moov = box('moov', mvhd(1000, movieDuration), ...traks, box('mvex', ...trex));
+
+  const parts = [FTYP, moov];
+  let sequence = 1;
+
+  for (const fragment of fragments) {
+    const build = (base) => {
+      let cursor = base;
+      return box('moof',
+        full('mfhd', 0, 0, u32be(sequence)),
+        ...fragment.runs.map((run) => {
+          const at = cursor;
+          cursor += runBytes(run);
+          return traf(run, at);
+        }));
+    };
+
+    let moof = build(0);
+    const dataStart = moof.length + 8;
+    moof = build(dataStart);
+    // Every field written above is fixed width, so measuring the moof cannot
+    // have changed its size. If that ever stops being true, say so here rather
+    // than shipping a fixture whose offsets are quietly eight bytes out.
+    if (moof.length + 8 !== dataStart) throw new Error('moof changed size when filled in');
+
+    parts.push(moof, box('mdat', fillBytes(
+      fragment.runs.reduce((n, run) => n + runBytes(run), 0))));
+    sequence += 1;
+  }
+
+  return concat(...parts);
+}

--- a/tests/js/qr-payload.test.js
+++ b/tests/js/qr-payload.test.js
@@ -1,0 +1,257 @@
+/**
+ * tools/qr-barcode/src/payload.js - what actually goes in the code.
+ *
+ * A QR code holds a string. "A Wi-Fi code" is an ordinary code holding a string
+ * in a shape the camera app recognises, so everything that can go wrong here is
+ * a string that looks right and means something else - and none of it throws.
+ *
+ * The case that matters most is escaping. A Wi-Fi password with a semicolon in
+ * it, written out plainly, ends the field early: the phone reads a shorter
+ * password, fails to join, and the person who printed the sign has no way to
+ * tell that from a typo. Every fixture below that carries punctuation carries
+ * the punctuation that ends a field in the format it is going into.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { KINDS, compose, missing } from '../../tools/qr-barcode/src/payload.js';
+
+/**
+ * Stands in for the caller's phrase(). The real one reads the markup; what is
+ * asserted here is which key came back, because the sentence is body.html's in
+ * fifteen languages.
+ */
+const say = (key, values = {}) => {
+  const filled = Object.entries(values).map(([k, v]) => `${k}=${v}`).join(' ');
+  return filled ? `${key} ${filled}` : key;
+};
+
+/* ------------------------------------------------------------------- Wi-Fi */
+
+test('a Wi-Fi payload names the network, the secret and the scheme', () => {
+  assert.equal(
+    compose('wifi', { ssid: 'Cafe', password: 'hunter2', security: 'WPA' }, say),
+    'WIFI:T:WPA;S:Cafe;P:hunter2;;',
+  );
+});
+
+test('a Wi-Fi password keeps every character that would end a field', () => {
+  // Each of these is a separator somewhere in the format. Unescaped, the first
+  // one truncates the password and the network is never joined.
+  const password = 'a;b:c,d"e\\f';
+  const built = compose('wifi', { ssid: 'Cafe', password, security: 'WPA' }, say);
+
+  assert.equal(built, 'WIFI:T:WPA;S:Cafe;P:a\\;b\\:c\\,d\\"e\\\\f;;');
+
+  // And reading it back the way a phone does returns what was typed.
+  assert.equal(unescapeWifi(field(built, 'P')), password);
+});
+
+test('a network name is escaped the same way as the password', () => {
+  const built = compose('wifi', { ssid: 'Bar;Grill', password: 'x', security: 'WPA' }, say);
+  assert.equal(field(built, 'S'), 'Bar\\;Grill');
+  assert.equal(unescapeWifi(field(built, 'S')), 'Bar;Grill');
+});
+
+test('an open network carries no password at all', () => {
+  // Not an empty P field: a phone that sees one may prompt for a key on a
+  // network that has none.
+  const built = compose('wifi', { ssid: 'Cafe', password: 'ignored', security: 'nopass' }, say);
+  assert.equal(built, 'WIFI:T:nopass;S:Cafe;;');
+  assert.ok(!built.includes('ignored'));
+});
+
+test('a Wi-Fi payload with no scheme chosen assumes WPA', () => {
+  const built = compose('wifi', { ssid: 'Cafe', password: 'x', security: '' }, say);
+  assert.equal(field(built, 'T'), 'WPA');
+});
+
+test('a hidden network says so, and a visible one says nothing', () => {
+  const hidden = compose('wifi', { ssid: 'Cafe', password: 'x', security: 'WPA', hidden: true }, say);
+  assert.ok(hidden.includes(';H:true;'));
+
+  const visible = compose('wifi', { ssid: 'Cafe', password: 'x', security: 'WPA', hidden: false }, say);
+  assert.ok(!visible.includes('H:'));
+});
+
+test('a blank Wi-Fi password is left out rather than written empty', () => {
+  const built = compose('wifi', { ssid: 'Cafe', password: '   ', security: 'WPA' }, say);
+  assert.equal(built, 'WIFI:T:WPA;S:Cafe;;');
+});
+
+/* ----------------------------------------------------------------- contact */
+
+test('a contact card is a vCard with the name in both shapes', () => {
+  const built = compose('contact', { first: 'Ada', last: 'Lovelace' }, say);
+  const lines = built.split('\n');
+
+  assert.equal(lines[0], 'BEGIN:VCARD');
+  assert.equal(lines[1], 'VERSION:3.0');
+  // N is family-first and structured; FN is the one a phone shows.
+  assert.ok(lines.includes('N:Lovelace;Ada;;;'));
+  assert.ok(lines.includes('FN:Ada Lovelace'));
+  assert.equal(lines.at(-1), 'END:VCARD');
+});
+
+test('a contact card leaves out every field nobody filled in', () => {
+  const built = compose('contact', { first: 'Ada' }, say);
+  assert.deepEqual(built.split('\n'), [
+    'BEGIN:VCARD', 'VERSION:3.0', 'N:;Ada;;;', 'FN:Ada', 'END:VCARD',
+  ]);
+});
+
+test('a contact card carries the details it was given', () => {
+  const built = compose('contact', {
+    first: 'Ada', last: 'Lovelace', org: 'Analytical Engines',
+    title: 'Mathematician', phone: '+44 20 7946 0000',
+    email: 'ada@example.com', url: 'https://example.com',
+    address: '12 Example Street, London',
+  }, say);
+
+  assert.ok(built.includes('ORG:Analytical Engines'));
+  assert.ok(built.includes('TITLE:Mathematician'));
+  assert.ok(built.includes('TEL;TYPE=CELL:+44 20 7946 0000'));
+  assert.ok(built.includes('EMAIL:ada@example.com'));
+  assert.ok(built.includes('URL:https://example.com'));
+  // One line of address goes in the street slot, with the other six empty.
+  assert.ok(built.includes('ADR:;;12 Example Street\\, London;;;;'));
+});
+
+test('a vCard field escapes its separators and its line breaks', () => {
+  // A comma is a separator in a vCard value, and a raw newline ends the
+  // property - so an address typed across two lines would silently truncate.
+  const built = compose('contact', {
+    first: 'Ada',
+    org: 'Lovelace, Babbage; Co',
+    address: '12 Example Street\nLondon',
+  }, say);
+
+  assert.ok(built.includes('ORG:Lovelace\\, Babbage\\; Co'));
+  assert.ok(built.includes('ADR:;;12 Example Street\\nLondon;;;;'));
+  // The escaped break is two characters, not a real one: the card is still
+  // five lines plus the address line, not six plus one.
+  assert.equal(built.split('\n').filter((line) => line.startsWith('ADR:')).length, 1);
+});
+
+/* ------------------------------------------------------------------- links */
+
+test('an email payload puts the subject and body in the query', () => {
+  const built = compose('email', {
+    to: 'hi@abox.tools', subject: 'Hello there', body: 'Line one\nLine two',
+  }, say);
+
+  assert.equal(built,
+    'mailto:hi@abox.tools?subject=Hello%20there&body=Line%20one%0ALine%20two');
+});
+
+test('an email payload with nothing but an address has no query at all', () => {
+  assert.equal(compose('email', { to: 'hi@abox.tools' }, say), 'mailto:hi@abox.tools');
+});
+
+test('an ampersand in a subject does not start a second parameter', () => {
+  const built = compose('email', { to: 'a@b.c', subject: 'Tea & cake', body: 'x' }, say);
+  assert.ok(built.includes('subject=Tea%20%26%20cake'));
+  // One separator between the two parameters, and no more.
+  assert.equal(built.split('&').length, 2);
+});
+
+test('a text payload is passed through exactly as typed', () => {
+  // Not trimmed: what the box says is what the code holds, and the page shows
+  // the finished string so a stray space is visible rather than guessed at.
+  assert.equal(compose('text', { text: '  https://abox.tools/  ' }, say),
+    '  https://abox.tools/  ');
+});
+
+test('SMS and telephone payloads drop the spaces people type', () => {
+  assert.equal(compose('phone', { number: '+1 555 123 4567' }, say), 'tel:+15551234567');
+  assert.equal(compose('sms', { number: '+1 555 123 4567' }, say), 'SMSTO:+15551234567');
+  assert.equal(compose('sms', { number: '+1 555 123 4567', message: 'on my way' }, say),
+    'SMSTO:+15551234567:on my way');
+});
+
+test('a location payload is a geo URI', () => {
+  assert.equal(compose('location', { latitude: '51.5007', longitude: '-0.1246' }, say),
+    'geo:51.5007,-0.1246');
+});
+
+test('a kind that does not exist is refused, and says which', () => {
+  assert.throws(
+    () => compose('telegram', {}, say),
+    (error) => error instanceof RangeError && error.message === 'payload.nosuch kind=telegram',
+  );
+});
+
+/* ------------------------------------------------------ what is still blank */
+
+test('the required fields are named when they are empty', () => {
+  assert.deepEqual(missing('wifi', {}), ['field.ssid', 'field.security']);
+  assert.deepEqual(missing('location', { latitude: '51.5' }), ['field.longitude']);
+  assert.deepEqual(missing('email', { to: 'hi@abox.tools' }), []);
+});
+
+test('whitespace does not count as filling a field in', () => {
+  assert.deepEqual(missing('phone', { number: '   ' }), ['field.number']);
+});
+
+test('an optional field is never asked for, and neither is a checkbox', () => {
+  // hidden is a checkbox and password is optional; neither can hold up a code.
+  assert.deepEqual(missing('wifi', { ssid: 'Cafe', security: 'WPA' }), []);
+});
+
+test('a contact card needs one detail rather than any particular one', () => {
+  // Every field on the card is optional, so the ordinary rule would accept an
+  // empty card. A card with only a phone number on it is a perfectly good card.
+  assert.deepEqual(missing('contact', {}), ['payload.anydetail']);
+  assert.deepEqual(missing('contact', { phone: '+15551234567' }), []);
+  assert.deepEqual(missing('contact', { first: '  ' }), ['payload.anydetail']);
+});
+
+/* ------------------------------------------------------------- the catalogue */
+
+test('every kind compose handles is offered, and every kind offered composes', () => {
+  const offered = KINDS.map((kind) => kind.id);
+  assert.deepEqual(offered,
+    ['text', 'wifi', 'contact', 'email', 'sms', 'phone', 'location']);
+
+  // A kind in the menu that compose does not know throws at the moment somebody
+  // picks it, which is a blank page rather than a message.
+  for (const kind of offered) {
+    assert.doesNotThrow(() => compose(kind, {}, say), `${kind} did not compose`);
+    assert.doesNotThrow(() => missing(kind, {}), `${kind} could not be checked`);
+  }
+});
+
+test('no kind has two fields with the same id', () => {
+  // Two fields sharing an id means the second input silently overwrites the
+  // first, and the code is built from half of what was typed.
+  for (const kind of KINDS) {
+    const ids = kind.fields.map((field) => field.id);
+    assert.equal(new Set(ids).size, ids.length, `${kind.id} has a repeated field id`);
+  }
+});
+
+test('every select offers a value and a label for it', () => {
+  for (const kind of KINDS) {
+    for (const field of kind.fields.filter((one) => one.type === 'select')) {
+      assert.ok(field.options.length, `${kind.id}.${field.id} has no options`);
+      for (const option of field.options) {
+        assert.equal(option.length, 2, `${kind.id}.${field.id} has a malformed option`);
+      }
+    }
+  }
+});
+
+/* ----------------------------------------------------------------- helpers */
+
+/** Pull one field out of a WIFI: payload the way a reader walks it. */
+function field(payload, key) {
+  const body = payload.replace(/^WIFI:/, '').replace(/;;$/, '');
+  // Split on separators that are not escaped, which is the whole point.
+  const parts = body.match(/(?:\\.|[^;])+/g) ?? [];
+  const found = parts.find((part) => part.startsWith(`${key}:`));
+  return found === undefined ? null : found.slice(key.length + 1);
+}
+
+/** Undo wifiEscape, so a round trip can be asserted rather than a spelling. */
+const unescapeWifi = (value) => value.replace(/\\(.)/g, '$1');


### PR DESCRIPTION
`demux.js` is the file that turns somebody else's video into the list every video tool works from — where each frame is, how big it is, when it is shown, and whether it can be decoded on its own. Six tools carry a copy and none of them had a test.

Coverage read **21.60% of its lines and 0.00% of its functions**: the suite loaded it, transitively through grab-frame's `frames.js`, and never once called into it. No test file in the repository so much as mentioned it.

The contrast with the writer beside it is what makes this worth fixing:

```
crop-video       mp4.js    97.64%
images-to-video  mp4.js    98.65%
trim-video       mp4.js    99.20%
grab-frame       demux.js  21.60%   ← 0.00% of functions
```

The bytes this project produces are checked closely; the bytes it parses — the ones that arrive from strangers — were not checked at all. And an error here does not throw. It hands back a list that is the right length and the right shape and points at the wrong bytes, so what a person sees is a still of the wrong moment, or a trim that starts half a second late.

## What is here

| file | tests | covers |
|---|---|---|
| `tests/js/mp4-fixtures.js` | — | hand-built MP4 writer, plain and fragmented |
| `tests/js/mp4-demux.test.js` | 101 | `demux.js`, both copies |
| `tests/js/qr-payload.test.js` | 25 | `qr-barcode/payload.js` |
| `tests/js/gif-analyzer-report.test.js` | 20 | `gif-analyzer/format.js` and `report.js` |

The suite goes from 1,972 tests to 2,118, and still runs in about ten seconds.

## The fixtures

`mp4-fixtures.js` follows the shape `pdf-fixtures.js` already set: the tables are worked out here rather than asserted, and nothing in it imports the reader — a fixture whose offsets came from the reader's own arithmetic would agree with a broken reader.

Samples are laid down with filler **between the chunks**, so `stco` and `stsc` are load-bearing. Packed end to end, a reader that never consulted either table — one that just accumulated sizes from the start of `mdat` — would agree with every offset the suite asserts.

Both layouts are covered: the plain one with its single table up front, and the fragmented one a browser's own `MediaRecorder` writes, where each `moof` carries its own.

## Why every test runs twice

`tests/python/test_duplicates.py` declares `demux.js` in two groups — crop-video, grab-frame, timelapse-video and video-to-gif in one; reverse-video and trim-video in the other — which means the copies inside a group are checked to agree and the two groups are not. They genuinely differ: trim-video's copy carries the display matrix and the sample entry out whole, because a trim writes them back untouched.

So the suite runs against one copy from each group. That is what makes a pass cover all six tools rather than four.

## The other three modules

Chosen because they are pure, no test had ever loaded them, and a mistake in each is silent:

- **`qr-barcode/payload.js`** — a Wi-Fi password with a semicolon in it, written out plainly, ends the field early: the phone reads a shorter password, fails to join, and whoever printed the sign cannot tell that from a typo.
- **`gif-analyzer/format.js`** — it exists so the same quantity does not read as `1.0 KB` in one row and `1 KB` in the next, so the thresholds are pinned either side.
- **`gif-analyzer/report.js`** — its fixed-width table is padded in cells rather than characters. A Japanese heading is two cells per character and one `String.length` each, so a length-counting pad produces a report that is still correct and unreadable — and only for the languages that did it. One test puts the whole report through a translator that answers in Japanese and measures where the columns start.

## Verification

Every assertion was checked by mutating the source and confirming it fails. Twenty-three mutations in all:

> `stss` off by one · `ctts` read as unsigned · fragment sync bit inverted · hevc compatibility flags left unreversed · matrix counted forward instead of back · `co64` read as 32-bit · `tfdt` ignored · `stsc` runs never advancing · visual entry header 76 rather than 78 · Wi-Fi and vCard escaping removed · `pad` counting characters not cells · zero-byte rows printed anyway · bar rounding small shares away

All caught. The exercise also found **two bugs in the tests themselves** — the byte-table and summary-alignment checks were filtering malformed rows out before asserting on them, silently skipping exactly the rows they existed to catch. Both fixed, then re-verified.

## Result

```
demux.js  |  98.71 |  85.83 |  100.00   (grab-frame)
demux.js  |  98.76 |  85.83 |  100.00   (trim-video)
```

| tool | before | after |
|---|---|---|
| grab-frame | 36.8% | **75.5%** |
| trim-video | 44.9% | **62.2%** |
| gif-analyzer | 76.5% | **92.7%** |
| qr-barcode | 77.8% | **89.3%** |
| all logic lines | 71.0% | **73.3%** |

`payload.js` and `format.js` are at 100% of lines, branches and functions; `report.js` at 94.6% of lines and 100% of functions.

## Before and after

Nothing visible to a visitor changes — no file under `tools/`, `shared/`, `locales/` or `config/` is touched, and this adds no page and alters no sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
