### PR TITLE
Name what the copied modules are, instead of counting them wrong

### DIFF
--- a/.claude/skills/tool-development/SKILL.md
+++ b/.claude/skills/tool-development/SKILL.md
@@ -225,9 +225,9 @@ While iterating on one tool, scope the build instead:
 python build.py --only <slug> --locale en --quiet
 ```
 
-Seconds rather than a couple of minutes, because it does not write the other
-thirty-five tools or the fifteen languages' worth of guides. The page it writes
-is byte for byte the page a full build writes, so it is worth looking at; what
+Seconds rather than a couple of minutes, because it does not write any tool but
+the one named, or the fifteen languages' worth of guides. The page it writes is
+byte for byte the page a full build writes, so it is worth looking at; what
 it does not write is everything that lists other pages — hub, guides, roadmap,
 404, sitemap, feeds — and it does not check links, since every link out of the
 scope would report broken. Run the full command above before calling the change

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,8 @@ the site that has not been built. Change one half of this and change the other,
 or the site asks to be indexed and refuses in the same breath.
 
 **Some modules are deliberately copied, and must stay in step.** The MP4
-reader is in five tools and the writer in two, because the rule above blocks
+reader is copied into every tool that reads frames out of a video file, and
+the writer into every tool that writes one, because the rule above blocks
 sharing them. `tests/python/test_duplicates.py` declares which copies must
 agree and fails if they drift, comparing tokens so each copy keeps its own
 comments. Fix one copy and it will tell you about the others; add a new copy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ node screenshots/capture.mjs [<guide>]            # the guides' screenshots
 **Scope the build while you are working on one tool.** The third line above is
 the loop: a full build writes about twelve hundred pages in fifteen languages
 and takes a couple of minutes, and `--only` cuts that to seconds by not writing
-the other thirty-five tools. The pages it writes are byte for byte the pages a
+any tool but the one named. The pages it writes are byte for byte the pages a
 full build writes — that is tested — so what you look at is what ships. What it
 does **not** write is anything that lists other pages: the hub, the guides, the
 roadmap, the 404, the sitemap and the feeds are skipped and links are not

--- a/buildlib/icons.py
+++ b/buildlib/icons.py
@@ -13,7 +13,7 @@ trust.
 
 Lucide is ISC, which asks that the notice travel with the copies - so
 shared/icons/LICENSE is the file that came with them, and it is why the folder
-is one directory rather than thirty-six files loose in shared/.
+is one directory rather than a scatter of files loose in shared/.
 
 WHY THE WRAPPER IS DROPPED AT ALL
 
@@ -35,8 +35,8 @@ from . import site as sitelib
 WRAPPER = re.compile(r'\A\s*<svg\b[^>]*>(?P<inner>.*)</svg>\s*\Z', re.S)
 
 # Two or more spaces, or a newline and its indent: upstream pretty-prints one
-# element per line, and inside a page that is thirty-six icons' worth of
-# whitespace saying nothing.
+# element per line, and inside a page holding an icon for every tool that is a
+# lot of whitespace saying nothing.
 GAPS = re.compile(r'\s*\n\s*')
 
 
@@ -71,8 +71,8 @@ def inner(root, name):
 def load_all(root, names):
     """Every icon the site needs, worked out once.
 
-    One dict for the whole build rather than a read per page: the same thirty-six
-    drawings are placed on the hub, on every tool page's header, and on the four
+    One dict for the whole build rather than a read per page: the same drawings
+    are placed on the hub, on every tool page's header, and on the four
     neighbour tiles at the foot of each of them, in fifteen languages. Reading
     them off the disk each time would be about sixty thousand file opens for
     eighteen kilobytes of geometry.

--- a/buildlib/version.py
+++ b/buildlib/version.py
@@ -89,7 +89,7 @@ NEW_TOOL = re.compile(r'^tools/([^/]+)/tool\.toml$')
 TAG = re.compile(r'^(\d+)\.(\d+)\.(\d+)$')
 
 #: Where counting starts when there is no version tag yet. 1.0.0 rather than a
-#: number worked backwards from the thirty-six tools already here, because a
+#: number worked backwards from the tools already here, because a
 #: version is a promise about what happens next and inventing a history for it
 #: would be neither true nor useful.
 FIRST = (1, 0, 0)

--- a/docs/prose-pages.md
+++ b/docs/prose-pages.md
@@ -52,7 +52,7 @@ is not fussiness. The slug is translated in every locale — `ueber-diese-seite`
 `chi-siamo`, `소개` — so deriving one from the other would have worked in
 English and quietly stopped working in the other fourteen languages.
 
-Why the kind exists at all: a site carrying thirty-six tools that never says who
+Why the kind exists at all: a site carrying dozens of tools that never says who
 made any of them reads as nobody's. Every claim on every tool page is a claim
 somebody is making, and a reader deciding whether to believe it is entitled to
 know who, and why. It is also the first thing an ad network's review looks for,

--- a/tests/python/test_accessibility.py
+++ b/tests/python/test_accessibility.py
@@ -208,7 +208,7 @@ class FrameRules(unittest.TestCase):
         `.encoded summary:hover` and a `:focus-visible` on the same base has to
         exist in the same file. It reads the source rather than the build for
         the reason the rules above do - the built CSS is minified and one
-        stylesheet per tool, so a gap would report thirty-six times or not at
+        stylesheet per tool, so a gap would report once per tool or not at
         all.
         """
         state = re.compile(r':(?:hover|focus-visible)')

--- a/tests/python/test_duplicates.py
+++ b/tests/python/test_duplicates.py
@@ -3,14 +3,15 @@ The modules that exist as more than one copy, and have to stay in step.
 
 WHY THERE ARE COPIES AT ALL
 
-The MP4 reader is about seven hundred lines of box parsing and it sits in five
-tools. The obvious answer is shared/js/, and it is not available: a shared
-module is copied into a tool at build time, at src/shared/, so a source file
-importing one cannot be loaded outside a build - and the JavaScript tests
-import tool modules straight off the disk with no build in front of them. Every
-tool that reads MP4 reaches the reader from a leaf module that has tests
-(grab-frame's frames.js, trim-video's copy.js), so moving it would trade those
-tests for the deduplication. See "Shared parts" in README.md.
+The MP4 reader is about seven hundred lines of box parsing and it sits in every
+tool that reads frames out of a video file. The obvious answer is shared/js/,
+and it is not available: a shared module is copied into a tool at build time,
+at src/shared/, so a source file importing one cannot be loaded outside a
+build - and the JavaScript tests import tool modules straight off the disk with
+no build in front of them. Every one of those tools reaches the reader from a
+leaf module that has tests (grab-frame's frames.js, trim-video's copy.js), so
+moving it would trade those tests for the deduplication. See "Shared parts" in
+README.md.
 
 WHAT THIS ENFORCES INSTEAD
 
@@ -24,8 +25,8 @@ files of the same name whose tokens are equal are a copy, and one that is not
 declared fails. It has to work that way round, because a module copied into a
 second tool arrives under a name of its author's choosing - and a file the
 declarations have never heard of is exactly the one nobody will think to add.
-The name alone proves nothing in the other direction: thirty-six tools have a
-main.js and no two of them are the same file.
+The name alone proves nothing in the other direction: every tool has a main.js
+and no two of them are the same file.
 
 Comments are not compared. Each copy explains itself in terms of the tool it
 sits in, and that is correct - `minify.tokenize_js` drops comments, so what is
@@ -72,7 +73,7 @@ The groups are deliberate, not accidental:
     them - a broken cross-reference table, a stream whose /Length lies - is a
     repair all three want.
 
-Adding a sixth copy of one of these, or a new duplicated module, means adding
+Adding another copy of one of these, or a new duplicated module, means adding
 it here. `test_identical_copies_are_declared` finds it on disk and fails until
 it is, and `test_every_copy_is_declared` then holds the other copies of that
 name to being either grouped or listed below with a reason.
@@ -203,7 +204,7 @@ class Coverage(unittest.TestCase):
         So this one starts from disk. Two files with the same name whose token
         streams are equal are a copy by any reading, and have to sit in a group
         that keeps them in step. Nothing is inferred from the name alone -
-        thirty-six tools have a main.js and no two of them are the same file.
+        every tool has a main.js and no two of them are the same file.
         """
         by_name = collections.defaultdict(list)
         for path in sorted(TOOLS.glob('*/src/*.js')):
@@ -253,7 +254,7 @@ class Coverage(unittest.TestCase):
 # above, but it is the same failure in another language: one footer partial,
 # rendered on every page in the site, and two hand-kept copies of the rules
 # that dress it - shared/site.css for the hub, the guides and the prose pages,
-# shared/css/tool-frame.css for the thirty-six tools.
+# shared/css/tool-frame.css for the tool pages.
 #
 # Every simple selector in a group has to mention the footer for the group to
 # count here. That is not fussiness: `main, .topbar, ..., footer` sets the page


### PR DESCRIPTION
Hand-written counts in this repo's prose had gone stale as tools shipped, and none of them survives contact with the tree. Two commits: the duplication notes first, then the rest of the prose that names a count.

| said | is |
|---|---|
| `test_duplicates.py`: "thirty-six tools have a main.js", twice | 40 tool directories, 40 `main.js` |
| `test_duplicates.py`: "shared/css/tool-frame.css for the thirty-six tools" | the same 40 |
| `test_duplicates.py`: the MP4 reader "sits in five tools" | 6 copies of `demux.js` — crop-video, grab-frame, reverse-video, timelapse-video, trim-video, video-to-gif |
| `CLAUDE.md`: "The MP4 reader is in five tools and the writer in two" | 6 readers as above; 5 copies of `mp4.js` — crop-video, images-to-video, reverse-video, timelapse-video, trim-video |
| `CLAUDE.md`: `--only` skips "the other thirty-five tools" | the other 39 |
| `buildlib/icons.py`: "the same thirty-six drawings" | one per tool, so 40 |
| `buildlib/icons.py`: "thirty-six files loose in shared/" | `shared/icons` holds 37 `.svg` — this pair had drifted with the icons, not the tools |
| `tests/python/test_accessibility.py`: "a gap would report thirty-six times" | once per tool |
| `docs/prose-pages.md`, `.claude/skills/tool-development/SKILL.md` | both sized the site by a stale number |
| `buildlib/version.py`: "the thirty-six tools already here" | history, but reads as current |

The docstring's closing "adding a **sixth** copy of one of these" counted on from the stale five, so it was wrong twice over — six copies of `demux.js` already exist. It now says "another copy".

## Why the numbers are mostly gone rather than corrected

A corrected count is a count that goes stale on the next tool, and these had been wrong for four tools' worth of shipping without anything noticing. So where the number was incidental to the point, the point is now stated without it:

- what the coverage test cannot infer from a filename is that **every** tool has a `main.js` and no two are the same file — thirty-six was never the argument;
- the reason the reader cannot move to `shared/js/` is that **every tool that reads frames out of a video file** carries a copy;
- a gap in a per-tool stylesheet reports **once per tool**; `--only` skips **every tool but the one named**; the footer rules dress **the tool pages**; the icons folder is one directory rather than **a scatter** of files.

The exact list of copies stays in `GROUPS`, where `test_identical_copies_are_declared` checks it against disk on every run. That is the copy of this information that cannot drift in silence.

## One claim worth a reviewer's eye

"Every tool that reads frames out of a video file" is narrower than it reads, and it was checked rather than assumed. `extract-audio-from-video` and `edit-audio` open a video and never demux it (they go through `decodeAudioData`), and `qr-barcode-reader` takes frames off a live camera rather than a file — so the six tools carrying `demux.js` are exactly the ones the sentence describes, and "every tool that reads a video" would have been false.

## Testing

Prose only: no test logic, no `GROUPS`/`SINGLETONS` changes, no behaviour, and no page the build writes — so there is nothing visible to photograph. A scoped build was run to prove `build.py` and `buildlib/icons.py` still import and run after the comment edits; the suites were left to CI, per CLAUDE.md.

## The two counts this does not touch

`build.py`'s own pair — "thirty-five of the thirty-six tools" in the scoped-build docstring, and "thirty-five thirty-sixths" over the minify cache — travel with #307, which edits that file to give the About page a live count.

Everything else that names a number is history and is meant to: the thirty-seven deploys of 27 August in `CLAUDE.md` and `docs/deploying.md`, the roadmap bug that "rendered name - desc thirty-seven times", and `icons.py`'s "about sixty thousand file opens", which is an estimate rather than a count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
