### PR TITLE
Let the height chart take a shape out of your own SVG

### DIFF
--- a/pages/guides/make-a-height-comparison-chart/body.html
+++ b/pages/guides/make-a-height-comparison-chart/body.html
@@ -139,6 +139,18 @@
       the whole tool: one rectangle at the real dimensions, one person at their
       real height, and the question answers itself.
     </p>
+    <p>
+      And when a rectangle is not enough, <strong>Add your own SVG</strong>
+      takes a drawing off your machine and puts its actual shape on the ruler
+      &mdash; a product, a vehicle, a building. Two things are worth knowing
+      before you reach for it. It is drawn in <strong>one solid colour</strong>,
+      like everything else on the chart, so a drawing made of thin outlines
+      rather than filled shapes arrives as a blob. And only the shapes are kept:
+      the file is rebuilt out of its paths and circles, and a script, a
+      stylesheet, a font or a linked image is left behind. The file never goes
+      anywhere, but the chart you download does, and it should not carry
+      somebody's server address into it.
+    </p>
 
     <figure class="shot">
       <img src="/screens/make-a-height-comparison-chart/chart.webp" loading="lazy" decoding="async"

--- a/tests/js/compare-heights-import-svg.test.js
+++ b/tests/js/compare-heights-import-svg.test.js
@@ -1,0 +1,197 @@
+/**
+ * tools/compare-heights/src/import-svg.js - what survives an uploaded SVG.
+ *
+ * This is the one module in the tool where being wrong is not a cosmetic
+ * problem. An SVG is a program, and the result of this one is BOTH inserted
+ * into the visitor's own page and downloaded and sent to other people. So the
+ * tests below are mostly a list of things that must not come out the other
+ * side, written one per line so that a future reader can see the policy
+ * without reading the implementation.
+ *
+ * The rule the module is built on is that nothing is inspected for danger:
+ * a new tree is built out of a whitelist, so an attribute is dropped because
+ * it was not asked for rather than because somebody recognised it. These tests
+ * check that rule holds rather than checking a list of known attacks - the
+ * known attacks are here too, but they are the examples, not the point.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  ALLOWED, LIMITS, importSvg, serialise, toPath,
+} from '../../tools/compare-heights/src/import-svg.js';
+
+/** A node, the shape main.js hands over after the browser has parsed the file. */
+const node = (tag, attrs = {}, children = []) => ({ tag, attrs, children });
+const svg = (...children) => node('svg', { viewBox: '0 0 10 10' }, children);
+const out = (tree) => importSvg(tree).markup ?? '';
+
+/* --------------------------------------------------------- what gets through */
+
+test('a path keeps its geometry', () => {
+  const result = importSvg(svg(node('path', { d: 'M0 0L10 10Z' })));
+  assert.equal(result.shapes, 1);
+  assert.match(result.markup, /<path d="M0 0L10 10Z"\/>/);
+});
+
+test('every shape becomes a path, so what ships is one kind of element', () => {
+  const markup = out(svg(
+    node('rect', { x: '1', y: '2', width: '4', height: '6' }),
+    node('circle', { cx: '5', cy: '5', r: '3' }),
+    node('ellipse', { cx: '5', cy: '5', rx: '3', ry: '2' }),
+    node('polygon', { points: '0,0 4,0 4,4' }),
+    node('polyline', { points: '0,0 4,4' }),
+    node('line', { x1: '0', y1: '0', x2: '4', y2: '4' }),
+  ));
+  assert.equal((markup.match(/<path /g) ?? []).length, 6);
+  assert.ok(!/<rect|<circle|<ellipse|<polygon|<polyline|<line/.test(markup));
+});
+
+test('a rounded rectangle keeps its corners', () => {
+  // Squaring them off would be the tool quietly editing somebody's drawing.
+  const d = toPath('rect', { x: '0', y: '0', width: '10', height: '10', rx: '2' });
+  assert.match(d, /A2 2 /);
+  assert.equal(toPath('rect', { x: '0', y: '0', width: '10', height: '10' }),
+               'M0 0h10v10h-10Z');
+});
+
+test('a shape with no size is not a shape', () => {
+  assert.equal(toPath('rect', { width: '0', height: '5' }), null);
+  assert.equal(toPath('circle', { r: '0' }), null);
+  assert.equal(toPath('ellipse', { rx: '4', ry: '0' }), null);
+  assert.equal(toPath('polygon', { points: '' }), null);
+});
+
+test('nesting and transforms survive, because that is where the shape is', () => {
+  const markup = out(svg(node('g', { transform: 'translate(3 4) scale(2)' },
+                               [node('path', { d: 'M0 0h1v1Z' })])));
+  assert.match(markup, /<g transform="translate\(3 4\) scale\(2\)">/);
+  assert.match(markup, /<path d="M0 0h1v1Z"\/>/);
+});
+
+test('fill-rule survives, so a shape with holes keeps them', () => {
+  assert.match(out(svg(node('path', { d: 'M0 0h9v9Z', 'fill-rule': 'evenodd' }))),
+               /fill-rule="evenodd"/);
+  // And a made-up value does not.
+  assert.ok(!out(svg(node('path', { d: 'M0 0h9v9Z', 'fill-rule': 'url(#x)' })))
+    .includes('fill-rule'));
+});
+
+/* ------------------------------------------------------ what does not get out */
+
+test('nothing executable survives', () => {
+  for (const bad of [
+    node('script', {}, []),
+    node('foreignObject', {}, [node('path', { d: 'M0 0h9v9Z' })]),
+    node('a', { href: 'https://example.com' }, [node('path', { d: 'M0 0h9v9Z' })]),
+    node('style', {}, []),
+    node('animate', {}, []),
+    node('set', {}, []),
+  ]) {
+    const markup = out(svg(bad, node('path', { d: 'M1 1h2v2Z' })));
+    // `<` and the name, not the bare name: `a` is a letter in `path`.
+    assert.ok(!markup.includes(`<${bad.tag}`), `${bad.tag} survived`);
+    assert.match(markup, /M1 1h2v2Z/, 'and the real shape beside it still did');
+  }
+});
+
+test('no event handler survives, whatever it is called', () => {
+  const handlers = ['onload', 'onclick', 'onmouseover', 'onbegin', 'onfocusin', 'oncanplay'];
+  const markup = out(svg(node('path',
+    Object.assign({ d: 'M0 0h9v9Z' }, Object.fromEntries(
+      handlers.map((name) => [name, 'alert(1)']))))));
+  for (const name of handlers) assert.ok(!markup.includes(name), `${name} survived`);
+  assert.ok(!markup.includes('alert'));
+});
+
+test('nothing that could fetch survives', () => {
+  // The sharpest one: the chart is downloaded and opened on other machines,
+  // so a reference that lived would be somebody else's browser calling a
+  // stranger's server, days later, from a file this page wrote.
+  const markup = out(svg(
+    node('image', { href: 'https://example.com/x.png', width: '9', height: '9' }),
+    node('use', { href: '#other', 'xlink:href': 'other.svg#x' }),
+    node('path', { d: 'M0 0h9v9Z', href: 'https://example.com', 'xlink:href': 'x' }),
+  ));
+  assert.ok(!markup.includes('href'), 'an href survived');
+  assert.ok(!markup.includes('example.com'));
+  assert.ok(!markup.includes('<image'));
+  assert.ok(!markup.includes('<use'));
+});
+
+test('no styling survives, so nothing can import a stylesheet or a font', () => {
+  const markup = out(svg(node('path', {
+    d: 'M0 0h9v9Z',
+    style: 'fill:url(https://example.com/x)',
+    class: 'whatever',
+    fill: 'url(#gradient)',
+    filter: 'url(#f)',
+    mask: 'url(#m)',
+    'clip-path': 'url(#c)',
+  })));
+  assert.match(markup, /<path d="M0 0h9v9Z"\/>/);
+  for (const gone of ['style', 'class', 'fill=', 'filter', 'mask', 'clip-path', 'url(']) {
+    assert.ok(!markup.includes(gone), `${gone} survived`);
+  }
+});
+
+test('an id does not survive, so nothing in the chart can be referenced', () => {
+  assert.ok(!out(svg(node('path', { d: 'M0 0h9v9Z', id: 'x' }))).includes('id='));
+});
+
+test('a value that is not geometry is dropped even where the name is allowed', () => {
+  // `transform` is on the whitelist and cannot hold a script - but a value
+  // that reaches the page should have been read by something first.
+  const markup = out(svg(node('g', { transform: 'translate(1 2)"><script>x</script><g x="' },
+                              [node('path', { d: 'M0 0h9v9Z' })])));
+  assert.ok(!markup.includes('script'));
+  assert.ok(!markup.includes('transform'), 'the whole value went, not part of it');
+});
+
+test('a path whose d is not path data is dropped', () => {
+  assert.equal(toPath('path', { d: 'M0 0 <script>' }), null);
+  assert.equal(importSvg(svg(node('path', { d: 'javascript:alert(1)' }))).error, 'svg.noshapes');
+});
+
+test('the whitelist is the policy, and it holds no way out', () => {
+  // If a name gets added to ALLOWED in future, this is the test that asks
+  // whether it can carry a URL, a script or a selector.
+  const names = new Set(Object.values(ALLOWED).flat());
+  for (const name of names) {
+    assert.ok(!/href|src|style|class|^id$|filter|mask|clip-path|^on/i.test(name),
+              `${name} should not be on the whitelist`);
+  }
+  assert.ok(!Object.keys(ALLOWED).some((tag) => /script|foreign|image|use|style|a/.test(tag)
+    && tag !== 'path'), 'no executable or fetching element is allowed');
+});
+
+/* ------------------------------------------------------------------ the edges */
+
+test('a file with nothing drawable in it says so rather than drawing nothing', () => {
+  assert.equal(importSvg(svg()).error, 'svg.noshapes');
+  assert.equal(importSvg(svg(node('script', {}, []))).error, 'svg.noshapes');
+  assert.equal(importSvg(null).error, 'svg.noshapes');
+  assert.equal(importSvg(node('html', {}, [])).error, 'svg.noshapes');
+});
+
+test('an empty group does not survive its contents being thrown away', () => {
+  const markup = out(svg(node('g', {}, [node('script', {}, [])]),
+                         node('path', { d: 'M0 0h9v9Z' })));
+  assert.equal((markup.match(/<g/g) ?? []).length, 1, 'only the root wrapper');
+});
+
+test('a file too big to be a shape is refused rather than drawn slowly', () => {
+  const many = Array.from({ length: LIMITS.elements + 50 },
+                          () => node('path', { d: 'M0 0h9v9Z' }));
+  const result = importSvg(svg(...many));
+  assert.ok(result.shapes <= LIMITS.elements, 'the element cap held');
+
+  const huge = node('path', { d: `M0 0${'l1 1'.repeat(LIMITS.path)}Z` });
+  assert.equal(importSvg(svg(huge)).error, 'svg.toobig');
+});
+
+test('what comes out is escaped, so it cannot end an attribute of ours', () => {
+  assert.equal(serialise({ tag: 'path', attrs: { d: 'M0 0"><x' } }),
+               '<path d="M0 0&quot;&gt;&lt;x"/>');
+});

--- a/tools/compare-heights/README.md
+++ b/tools/compare-heights/README.md
@@ -95,6 +95,39 @@ a row you have not filled in yet is not a mistake. Now that every row arrives
 with a height, an empty one is a box somebody cleared, and a row that will not
 be drawn should say so.
 
+### An uploaded SVG is rebuilt, not cleaned up
+
+`src/import-svg.js` is the one module here where being wrong is not cosmetic.
+An SVG is a program: it can carry `<script>`, an `onload=` on any element, a
+`<foreignObject>` holding a whole HTML document, a `<use>` into another file,
+an `<image href="https://…">`, and a stylesheet that imports one. Two things
+make that sharp here:
+
+- the file is read on the visitor's own machine, so anything executable would
+  be executing in their page, with their chart in it;
+- **the result is downloaded and sent to other people.** An `<image href>` that
+  survived would be a chart phoning a stranger's server, open on somebody
+  else's machine, days later. This whole tool is a page-long promise that
+  nothing it makes talks to anything.
+
+So nothing from the file is ever inserted. The browser parses it — `DOMParser`
+on `image/svg+xml`, which builds an inert document and runs nothing — `main.js`
+walks that into plain `{tag, attrs, children}` objects, and `import-svg.js`
+**builds a third tree** containing only the elements and attributes on its
+whitelist. An attribute does not have to be recognised as dangerous to be
+dropped; it is dropped because it was not asked for. That is the only shape of
+this job that stays safe when SVG grows a feature next year.
+
+Everything becomes a `<path>`, so what ships is one element with one attribute
+rather than six of each. `transform` survives — it is numeric and has nowhere
+to put a URL — which is what lets a nested drawing keep its shape without the
+coordinates being rewritten. `fill` does not, both because a row's colour is
+the chart's to choose and because `fill` can hold `url(#…)`.
+
+`tests/js/compare-heights-import-svg.test.js` is mostly a list of things that
+must not come out the other side, one per line, so the policy can be read
+without reading the implementation.
+
 ### There is no dog, and there was
 
 A dog and a cat were built, in profile, standing with the head level with the
@@ -167,6 +200,7 @@ keeps the canvas untainted so `toBlob` will give the bytes back.
 | `vendor/` | the four public-domain files the people came out of, as published, and their licence |
 | `src/traced.js` | those four figures' path data, the box each was measured at, and the transform that puts it in the unit box |
 | `src/figures.js` | the list of figures the menu is built from, and each one's default height |
+| `src/import-svg.js` | the whitelist an uploaded SVG is rebuilt from |
 | `src/units.js` | typed height → centimetres, centimetres → written height, and the ruler's spacing and labels |
 | `src/chart.js` | the layout and the SVG, with text measured through a callback |
 | `src/save.js` | the SVG blob, the canvas rasterisation, and the download |

--- a/tools/compare-heights/body.html
+++ b/tools/compare-heights/body.html
@@ -43,7 +43,13 @@
       <div class="toolbar-actions">
         <button type="button" id="add-person" class="primary">Add a person</button>
         <button type="button" id="add-object" class="ghost">Add an object</button>
+        <button type="button" id="add-svg" class="ghost">Add your own SVG</button>
         <button type="button" id="clear" class="ghost danger">Clear the chart</button>
+        <!-- Driven by the button above rather than shown: the label is here
+             because a control a visitor can reach needs a name whether or not
+             it is the thing they clicked. -->
+        <input type="file" id="svg-file" accept=".svg,image/svg+xml"
+               aria-label="Choose an SVG file to put on the chart" hidden>
       </div>
       <span class="count" id="row-count"></span>
     </div>
@@ -82,6 +88,17 @@
         </optgroup>
       </select>
     </div>
+
+    <p class="field-summary">
+      <strong>Your own SVG</strong> puts any drawing on the ruler &mdash; a
+      logo, a floor plan, a piece of machinery. It is read in this page and
+      goes nowhere. Only the shapes in it are kept: it arrives as one solid
+      colour you pick per row, and anything that could reach the network
+      &mdash; a linked image, a stylesheet, a font, a script &mdash; is left
+      behind rather than carried into a chart you might send to somebody. A
+      drawing made of thin lines rather than filled shapes will come out as a
+      solid blob, which is the one case where this is the wrong tool.
+    </p>
 
     <p class="field-summary">
       A few of these really are fixed: a 20&nbsp;ft shipping container is
@@ -197,6 +214,7 @@
     <span data-phrase="shape.boy">Boy</span>
     <span data-phrase="shape.girl">Girl</span>
     <span data-phrase="shape.object">Object</span>
+    <span data-phrase="shape.upload">Your own SVG</span>
 
     <span data-phrase="row.shape">Figure for row {n}</span>
     <span data-phrase="row.name">Name for row {n}</span>
@@ -218,6 +236,10 @@
     <span data-phrase="height.tooshort">Too short to draw &mdash; 5 cm is the smallest.</span>
     <span data-phrase="height.tootall">Taller than the chart goes &mdash; 12 metres is the limit.</span>
 
+    <span data-phrase="svg.added">Added, drawn from {shapes} shapes in that file. Nothing was uploaded to read it.</span>
+    <span data-phrase="svg.noshapes">There is nothing drawable in that file. Only the shapes are kept &mdash; a file of nothing but text, effects or linked images has none.</span>
+    <span data-phrase="svg.unreadable">That file is not an SVG this can read.</span>
+    <span data-phrase="svg.toobig">That file is too big to be one shape. Two megabytes is the limit.</span>
     <span data-phrase="chart.empty">Add somebody, and the chart appears here.</span>
     <span data-phrase="chart.noheights">Every row needs a height. Fill one in and the chart appears here.</span>
     <span data-phrase="chart.full">Twelve figures is as many as this chart will hold and still be readable.</span>

--- a/tools/compare-heights/src/chart.js
+++ b/tools/compare-heights/src/chart.js
@@ -91,7 +91,7 @@ function columns(figures, scale, font, measure) {
 
   return figures.map((figure) => {
     const height = figure.cm * scale;
-    const drawn = figure.shape.paths
+    const drawn = figure.shape.markup
       ? figure.shape.width * height
       : Math.max((figure.widthCm || figure.cm * 0.6) * scale, 6);
     const name = figure.name ? measure(figure.name, font, 600) : 0;
@@ -192,18 +192,24 @@ export function chartSvg(figures, options, measure) {
     const top = round(groundY - column.height);
     const colour = escape(figure.colour);
 
-    if (figure.shape.paths) {
+    if (figure.shape.markup) {
       const scaled = round(column.height);
       // Two transforms, not one. The outer puts a unit-tall figure where this
-      // column wants it; the inner - which only a traced figure carries - is
-      // what makes that figure unit-tall in the first place, out of whatever
-      // coordinates the artist happened to draw it in. Kept separate so the
-      // vendored path data can stay byte for byte what upstream published.
+      // column wants it; the inner - which a drawn figure carries and a built
+      // one does not - is what makes that figure unit-tall in the first place,
+      // out of whatever coordinates the artist happened to draw it in. Kept
+      // separate so the vendored path data can stay byte for byte what
+      // upstream published, and so an uploaded shape is never rewritten
+      // either.
       const inner = figure.shape.inner
         ? `<g transform="${escape(figure.shape.inner)}">` : '';
+      // `markup` is already markup, and is the only string here that is not
+      // escaped on the way out. For the four figures that ship it is built
+      // from traced.js; for an uploaded one it is whatever survived
+      // import-svg.js, which builds a new tree out of a whitelist rather than
+      // cleaning up the old one. Nothing else may be passed through here.
       parts.push(`<g fill="${colour}" transform="translate(${centre} ${top}) `
-        + `scale(${scaled})">${inner}`
-        + figure.shape.paths.map((d) => `<path d="${d}"/>`).join('')
+        + `scale(${scaled})">${inner}${figure.shape.markup}`
         + `${inner ? '</g>' : ''}</g>`);
     } else {
       parts.push(`<rect x="${round(centre - column.drawn / 2)}" y="${top}" `

--- a/tools/compare-heights/src/figures.js
+++ b/tools/compare-heights/src/figures.js
@@ -58,6 +58,10 @@ export const SHAPES = [
     width: art.width,
     inner: art.inner,
     paths: art.paths,
+    // What the chart actually emits. The four that ship are path data, so it
+    // is built here once; an uploaded shape arrives as markup already, from
+    // import-svg.js, and is the only other thing the chart will draw.
+    markup: art.paths.map((d) => `<path d="${d}"/>`).join(''),
     defaultCm: art.defaultCm,
   })),
   // The rectangle. It carries no paths because its shape is two numbers the
@@ -70,6 +74,7 @@ export const SHAPES = [
     width: 0.6,
     inner: null,
     paths: null,
+    markup: null,
     defaultCm: 0,
   },
 ];

--- a/tools/compare-heights/src/import-svg.js
+++ b/tools/compare-heights/src/import-svg.js
@@ -1,0 +1,239 @@
+/**
+ * Taking a shape out of somebody's SVG, and leaving everything else behind.
+ *
+ * WHY THIS IS A WHITELIST AND NOT A CLEAN-UP
+ *
+ * An SVG is a program. It can carry `<script>`, an `onload=` on any element, a
+ * `<foreignObject>` holding a whole HTML document, a `<use>` pointing into
+ * another file, an `<image href="https://…">` and a stylesheet that imports
+ * one. Two of those matter enormously here:
+ *
+ *   - the file is read on the visitor's own machine, so anything executable in
+ *     it would be executing in their page, with their chart in it;
+ *   - the result is DOWNLOADED and sent to other people. An `<image href>`
+ *     that survived would be a chart that phones a stranger's server open on
+ *     somebody else's machine, days later. This whole tool is one page-long
+ *     promise that nothing here talks to anything.
+ *
+ * So nothing from the file is ever inserted. This module reads a tree of plain
+ * objects, and BUILDS A NEW ONE containing only the handful of elements and
+ * attributes below - geometry and nothing else. An attribute that is not on
+ * the list does not need to be recognised as dangerous to be dropped; it is
+ * dropped because it was not asked for. That is the only shape of this job
+ * that stays safe when SVG grows a new feature next year.
+ *
+ * WHY IT TAKES PLAIN OBJECTS RATHER THAN ELEMENTS
+ *
+ * The parsing is the browser's - `DOMParser` on `image/svg+xml`, which builds
+ * an inert document and runs nothing. main.js walks that into `{tag, attrs,
+ * children}` and hands it here. Keeping the policy away from the DOM is what
+ * lets the tests state it directly: a test that has to build a document to ask
+ * "is `onload` dropped?" is a test nobody writes forty of.
+ */
+
+/**
+ * The elements that may survive, and which of their attributes may come with
+ * them. `transform` is on all of them and is safe: it is a list of numeric
+ * matrix operations with nowhere to put a URL.
+ *
+ * Notably absent: `style` and `class` (a stylesheet can fetch), `id` (nothing
+ * should be able to reference this), `fill` and `stroke` (the chart colours a
+ * figure by its row, and `fill` can hold `url(#…)`), and every form of `href`.
+ */
+export const ALLOWED = {
+  svg: ['viewBox', 'transform'],
+  g: ['transform'],
+  path: ['d', 'transform', 'fill-rule', 'clip-rule'],
+  rect: ['x', 'y', 'width', 'height', 'rx', 'ry', 'transform'],
+  circle: ['cx', 'cy', 'r', 'transform'],
+  ellipse: ['cx', 'cy', 'rx', 'ry', 'transform'],
+  line: ['x1', 'y1', 'x2', 'y2', 'transform'],
+  polyline: ['points', 'transform'],
+  polygon: ['points', 'transform'],
+};
+
+/** Elements whose geometry is worth keeping, as opposed to containers. */
+const SHAPES = new Set(['path', 'rect', 'circle', 'ellipse', 'line', 'polyline', 'polygon']);
+
+/**
+ * Numbers, and the few characters a transform list or a path needs.
+ *
+ * Everything kept is measured against one of these before it is written out.
+ * It is belt and braces over the whitelist - `transform` cannot hold a script
+ * - but a value that reaches the page should have been read by something, and
+ * this is what reads it.
+ */
+const SAFE = {
+  number: /^-?\d*\.?\d+(?:e[-+]?\d+)?$/i,
+  length: /^-?\d*\.?\d+(?:e[-+]?\d+)?(?:px)?$/i,
+  list: /^[\d\s,.eE+-]*$/,
+  path: /^[\sMmZzLlHhVvCcSsQqTtAa\d.,+-eE]*$/,
+  transform: /^[\w\s(),.eE+-]*$/,
+  rule: /^(?:nonzero|evenodd)$/,
+  viewBox: /^[\d\s,.eE+-]*$/,
+};
+
+const CHECK = {
+  d: SAFE.path,
+  points: SAFE.list,
+  transform: SAFE.transform,
+  viewBox: SAFE.viewBox,
+  'fill-rule': SAFE.rule,
+  'clip-rule': SAFE.rule,
+};
+
+/** How much of a file is worth reading. Past this it is not a shape. */
+export const LIMITS = {
+  bytes: 2 * 1024 * 1024,
+  elements: 4000,
+  path: 400000,
+};
+
+const num = (attrs, name, fallback = 0) => {
+  const value = attrs[name];
+  return value !== undefined && SAFE.length.test(String(value).trim())
+    ? Number.parseFloat(value) : fallback;
+};
+
+/**
+ * One shape as path data.
+ *
+ * Everything becomes a `<path>` so that what ships is one kind of element with
+ * one kind of attribute, rather than six of each. A `line` and a `polyline`
+ * are closed on the way through: this tool fills a silhouette in one colour
+ * and never strokes, so an open outline would otherwise vanish.
+ */
+export function toPath(tag, attrs) {
+  const n = (name, fallback) => num(attrs, name, fallback);
+  const points = String(attrs.points ?? '').trim();
+
+  switch (tag) {
+    case 'path':
+      return CHECK.d.test(String(attrs.d ?? '')) ? String(attrs.d ?? '') : null;
+    case 'rect': {
+      const w = n('width');
+      const h = n('height');
+      if (w <= 0 || h <= 0) return null;
+      const x = n('x');
+      const y = n('y');
+      // Rounded corners are kept, because a rounded rectangle that arrived
+      // rounded and came out square is the tool editing somebody's drawing.
+      const rx = Math.min(n('rx', n('ry')), w / 2);
+      const ry = Math.min(n('ry', n('rx')), h / 2);
+      if (rx > 0 && ry > 0) {
+        return `M${x + rx} ${y}H${x + w - rx}A${rx} ${ry} 0 0 1 ${x + w} ${y + ry}`
+          + `V${y + h - ry}A${rx} ${ry} 0 0 1 ${x + w - rx} ${y + h}`
+          + `H${x + rx}A${rx} ${ry} 0 0 1 ${x} ${y + h - ry}`
+          + `V${y + ry}A${rx} ${ry} 0 0 1 ${x + rx} ${y}Z`;
+      }
+      return `M${x} ${y}h${w}v${h}h${-w}Z`;
+    }
+    case 'circle': {
+      const r = n('r');
+      if (r <= 0) return null;
+      const cx = n('cx');
+      const cy = n('cy');
+      return `M${cx - r} ${cy}a${r} ${r} 0 1 0 ${r * 2} 0a${r} ${r} 0 1 0 ${-r * 2} 0Z`;
+    }
+    case 'ellipse': {
+      const rx = n('rx');
+      const ry = n('ry');
+      if (rx <= 0 || ry <= 0) return null;
+      const cx = n('cx');
+      const cy = n('cy');
+      return `M${cx - rx} ${cy}a${rx} ${ry} 0 1 0 ${rx * 2} 0a${rx} ${ry} 0 1 0 ${-rx * 2} 0Z`;
+    }
+    case 'line':
+      return `M${n('x1')} ${n('y1')}L${n('x2')} ${n('y2')}Z`;
+    case 'polyline':
+    case 'polygon':
+      return SAFE.list.test(points) && points ? `M${points}Z` : null;
+    default:
+      return null;
+  }
+}
+
+/** XML-escape an attribute value. */
+const escape = (text) => String(text)
+  .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+  .replace(/"/g, '&quot;');
+
+/**
+ * Rebuild one node, keeping only what is on the list.
+ *
+ * Returns null for anything that is not allowed, has no geometry left, or
+ * holds nothing worth drawing - so a `<g>` full of `<script>` disappears with
+ * its contents rather than becoming an empty group.
+ */
+function rebuild(node, count) {
+  if (!node || typeof node.tag !== 'string') return null;
+  const tag = node.tag.toLowerCase().replace(/^.*:/, '');
+  const allowed = ALLOWED[tag];
+  if (!allowed) return null;
+  if (count.n >= LIMITS.elements) return null;
+  count.n += 1;
+
+  const attrs = {};
+  for (const name of allowed) {
+    const raw = node.attrs?.[name];
+    if (raw === undefined || raw === null) continue;
+    const value = String(raw).trim();
+    if (!value) continue;
+    const check = CHECK[name] ?? SAFE.length;
+    if (!check.test(value)) continue;
+    attrs[name] = value;
+  }
+
+  const children = [];
+  for (const child of node.children ?? []) {
+    const kept = rebuild(child, count);
+    if (kept) children.push(kept);
+  }
+
+  if (SHAPES.has(tag)) {
+    const d = toPath(tag, attrs);
+    if (!d) return null;
+    const kept = { tag: 'path', attrs: { d } };
+    if (attrs.transform) kept.attrs.transform = attrs.transform;
+    if (attrs['fill-rule']) kept.attrs['fill-rule'] = attrs['fill-rule'];
+    if (attrs['clip-rule']) kept.attrs['clip-rule'] = attrs['clip-rule'];
+    return kept;
+  }
+
+  if (!children.length) return null;
+  // The root's own viewBox is not carried: the chart measures the shape it
+  // actually got and scales that, so a viewBox with empty margins in it would
+  // only make the drawing smaller than the box the chart gives it.
+  const wrapper = { tag: tag === 'svg' ? 'g' : 'g', attrs: {}, children };
+  if (attrs.transform) wrapper.attrs.transform = attrs.transform;
+  return wrapper;
+}
+
+/** The kept tree as markup: `g` and `path`, and nothing else. */
+export function serialise(node) {
+  if (!node) return '';
+  const attrs = Object.entries(node.attrs ?? {})
+    .map(([name, value]) => ` ${name}="${escape(value)}"`).join('');
+  if (node.tag === 'path') return `<path${attrs}/>`;
+  return `<g${attrs}>${(node.children ?? []).map(serialise).join('')}</g>`;
+}
+
+/**
+ * A parsed tree in, drawable markup out.
+ *
+ * @param {{tag: string, attrs: object, children: array}} root
+ * @returns {{markup: string, shapes: number}|{error: string}} `error` is a
+ *   phrase key: the words are in the markup, in whatever language the page is.
+ */
+export function importSvg(root) {
+  const count = { n: 0 };
+  const kept = rebuild(root, count);
+  if (!kept) return { error: 'svg.noshapes' };
+
+  const markup = serialise(kept);
+  if (markup.length > LIMITS.path) return { error: 'svg.toobig' };
+
+  const shapes = (markup.match(/<path/g) ?? []).length;
+  if (!shapes) return { error: 'svg.noshapes' };
+  return { markup, shapes };
+}

--- a/tools/compare-heights/src/main.js
+++ b/tools/compare-heights/src/main.js
@@ -5,6 +5,7 @@ import { SHAPES, shapeOf } from './figures.js';
 import { FONT, chartSvg, isDark } from './chart.js';
 import { format, formatBoth, parseHeight, toInput } from './units.js';
 import { download, svgBlob, svgToPng } from './save.js';
+import { LIMITS, importSvg } from './import-svg.js';
 
 const $ = (id) => document.getElementById(id);
 
@@ -14,6 +15,8 @@ const el = {
   rowCount: $('row-count'),
   addPerson: $('add-person'),
   addObject: $('add-object'),
+  addSvg: $('add-svg'),
+  svgFile: $('svg-file'),
   clear: $('clear'),
   preset: $('preset'),
   inputError: $('input-error'),
@@ -81,10 +84,98 @@ function measure(text, fontPx, weight = 400) {
   return gauge.measureText(String(text)).width;
 }
 
+/* ----------------------------------------------------- a shape from a file */
+
+// One off-screen SVG, the same trick chart.js's `measure` uses for text: an
+// uploaded shape is drawn in whatever coordinates its author chose, and the
+// only way to know the box it occupies is to let the browser lay it out.
+const stage = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+stage.setAttribute('aria-hidden', 'true');
+stage.style.cssText = 'position:absolute;left:-9999px;width:1px;height:1px;overflow:hidden';
+
+/**
+ * The parsed document as plain objects, which is all import-svg.js will take.
+ *
+ * Deliberately lossy: it copies the tag and the attributes and nothing else -
+ * no node references, no text, no namespaces. The sanitiser then builds a
+ * third tree from a whitelist, so what reaches the page has been through two
+ * translations that only carry geometry.
+ */
+function plain(element, depth = 0) {
+  if (depth > 40) return null;
+  const attrs = {};
+  for (const attribute of element.attributes ?? []) {
+    attrs[attribute.name.toLowerCase()] = attribute.value;
+  }
+  return {
+    tag: element.tagName,
+    attrs,
+    children: [...element.children].map((child) => plain(child, depth + 1)).filter(Boolean),
+  };
+}
+
+/**
+ * Read one file into a shape, or say why not.
+ *
+ * `DOMParser` on `image/svg+xml` builds an inert document: nothing in the file
+ * runs, no `onload` fires, and no reference in it is resolved. That is the
+ * only place the visitor's file is ever parsed, and nothing from it is
+ * inserted anywhere - see import-svg.js for what is built instead.
+ */
+async function shapeFromFile(file) {
+  if (file.size > LIMITS.bytes) return { error: 'svg.toobig' };
+
+  const text = await file.text();
+  const doc = new DOMParser().parseFromString(text, 'image/svg+xml');
+  if (doc.querySelector('parsererror') || !doc.documentElement) {
+    return { error: 'svg.unreadable' };
+  }
+
+  const result = importSvg(plain(doc.documentElement));
+  if (result.error) return result;
+
+  if (!stage.isConnected) document.body.append(stage);
+  const group = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+  group.innerHTML = result.markup;
+  stage.append(group);
+  const box = group.getBBox();
+  group.remove();
+
+  if (!(box.width > 0) || !(box.height > 0)) return { error: 'svg.noshapes' };
+
+  return {
+    shape: {
+      id: 'upload',
+      label: 'shape.upload',
+      width: box.width / box.height,
+      // The same mapping every drawn figure gets: the artwork's own box onto
+      // the unit box the chart places figures in. The uploaded coordinates are
+      // never rewritten, only wrapped.
+      inner: `scale(${1 / box.height}) translate(${-(box.x + box.width / 2)} ${-box.y})`,
+      paths: null,
+      markup: result.markup,
+      defaultCm: 0,
+    },
+    shapes: result.shapes,
+    name: file.name.replace(/\.svg$/i, '').slice(0, 40),
+  };
+}
+
 /* --------------------------------------------------------------------- rows */
 
 function unit() {
   return el.unit.value;
+}
+
+/**
+ * The figure a row draws.
+ *
+ * An uploaded shape lives on the row rather than in SHAPES, because it is one
+ * visitor's drawing rather than something this tool ships - so every reader of
+ * a row's figure has to come through here rather than through shapeOf().
+ */
+function figureFor(row) {
+  return row.shape === 'upload' && row.art ? row.art : shapeOf(row.shape);
 }
 
 function heightPlaceholder() {
@@ -112,6 +203,9 @@ function addRow(shape, values = {}) {
     height: values.height ?? (start ? toInput(start, unit()) : ''),
     width: values.width ?? '',
     colour: values.colour ?? PALETTE[(rows.length) % PALETTE.length],
+    // An uploaded shape belongs to the row that was given it, not to the menu:
+    // it is one visitor's drawing, not a figure this tool ships.
+    art: values.art ?? null,
   };
 
   row.node = buildRow(row);
@@ -127,19 +221,28 @@ function buildRow(row) {
   const shape = document.createElement('select');
   shape.className = 'row-shape';
   for (const option of SHAPES) shape.append(new Option(phrase(option.label), option.id));
+  if (row.art) shape.append(new Option(phrase('shape.upload'), 'upload'));
   shape.value = row.shape;
   shape.addEventListener('change', () => {
-    const was = shapeOf(row.shape).defaultCm;
+    const was = figureFor(row).defaultCm;
+    // Picking "your own SVG" on a row that has not got one yet is a way of
+    // asking for the file dialog, which is the only place it can come from.
+    if (shape.value === 'upload' && !row.art) {
+      shape.value = row.shape;
+      askForFile(row);
+      return;
+    }
     row.shape = shape.value;
     // Swapping a figure moves the height with it, but only while the height is
     // still the one that arrived with the old figure: a number somebody typed
     // is theirs, and changing the drawing is not a reason to lose it.
-    const now = shapeOf(row.shape).defaultCm;
+    const now = figureFor(row).defaultCm;
     if (now && was && row.height.trim() === toInput(was, unit())) {
       row.height = toInput(now, unit());
       height.value = row.height;
     }
     node.classList.toggle('is-object', row.shape === 'object');
+    node.classList.toggle('is-upload', row.shape === 'upload');
     draw();
   });
 
@@ -202,6 +305,7 @@ function buildRow(row) {
 
   node.append(grip, shape, name, heightCell, width, colour, tools);
   node.classList.toggle('is-object', row.shape === 'object');
+  node.classList.toggle('is-upload', row.shape === 'upload');
 
   // Kept for the renaming pass in paintRows: the aria-labels carry a row
   // number, and every number after a removed row has just changed.
@@ -333,6 +437,7 @@ function paintRows() {
   const full = rows.length >= MOST;
   el.addPerson.disabled = full;
   el.addObject.disabled = full;
+  el.addSvg.disabled = full;
   el.preset.disabled = full;
   el.rowCount.textContent = full ? phrase('chart.full') : '';
 }
@@ -361,9 +466,9 @@ function readRows() {
     reads.textContent = phrase('row.reads', { height: formatBoth(parsed.cm, unit()) });
     reads.className = 'row-reads';
 
-    const shape = shapeOf(row.shape);
+    const shape = figureFor(row);
     let widthCm = 0;
-    if (!shape.paths) {
+    if (!shape.markup) {
       const wide = parseHeight(row.width, unit());
       widthCm = wide.error ? parsed.cm * shape.width : wide.cm;
     }
@@ -480,6 +585,55 @@ el.addObject.addEventListener('click', () => {
   addRow('object');
   paintRows();
   draw();
+});
+
+/**
+ * Which row a pending file is for: a new one, or one already on the chart.
+ *
+ * The input is a single hidden <input type="file"> rather than one per row,
+ * and rather than the shared file picker every other tool here uses. That
+ * picker draws a drop zone and owns the page's main flow; this is an optional
+ * extra on a tool whose input is typed, and a button that opens a dialog is
+ * the whole of what it needs.
+ */
+let wantsFile = null;
+
+function askForFile(row) {
+  wantsFile = row ?? null;
+  el.svgFile.value = '';
+  el.svgFile.click();
+}
+
+el.addSvg.addEventListener('click', () => askForFile(null));
+
+el.svgFile.addEventListener('change', async () => {
+  const file = el.svgFile.files?.[0];
+  const row = wantsFile;
+  wantsFile = null;
+  if (!file) return;
+
+  const result = await shapeFromFile(file);
+  if (result.error) {
+    el.inputError.hidden = false;
+    el.inputError.textContent = phrase(result.error);
+    return;
+  }
+  el.inputError.hidden = true;
+
+  result.shape.defaultCm = 100;
+  if (row) {
+    row.art = result.shape;
+    row.shape = 'upload';
+    if (!row.name.trim()) row.name = result.name;
+    if (!row.height.trim()) row.height = toInput(100, unit());
+  } else {
+    addRow('upload', {
+      art: result.shape, name: result.name, height: toInput(100, unit()),
+    });
+  }
+  paintRows();
+  draw();
+  note(phrase('svg.added', { shapes: result.shapes }));
 });
 
 el.clear.addEventListener('click', () => {

--- a/tools/compare-heights/styles.css
+++ b/tools/compare-heights/styles.css
@@ -193,6 +193,10 @@ body.is-reordering { user-select: none; }
 
 .preset-row { margin-top: 1.1rem; }
 
+/* An uploaded shape has no width to type: its proportions are its own, and
+   stretching somebody's drawing to a number would be the tool redrawing it. */
+.row.is-upload .row-width { visibility: hidden; }
+
 /* The unit sits above the table it changes rather than in a panel of its own:
    it decides what a number typed into any of those boxes means, so it is part
    of the typing rather than part of the picture. */

--- a/tools/compare-heights/tool.toml
+++ b/tools/compare-heights/tool.toml
@@ -7,7 +7,12 @@
 # whole site, the Content-Security-Policy among them, from config/site.toml.
 #
 # The second tool here whose input is typed rather than dropped, after the QR
-# generator, so it has no [picker] table either. What is unusual about it is
+# generator, so it has no [picker] table either. It does take one optional
+# file - an SVG to put a shape of your own on the ruler - and that is a bare
+# <input type="file"> behind a button rather than the shared picker: the
+# picker draws a drop zone and owns a page's main flow, and here the main flow
+# is still typing. See src/import-svg.js for what happens to the file, which
+# is the part worth reading. What is unusual about it is
 # what the input IS: a list of people's names and how tall each of them is,
 # which is the most personal thing anything on this site is handed and the
 # reason the privacy panel below is written about a list rather than a file.
@@ -59,7 +64,8 @@ og_card = "Two adults, a child and a doorway on one ruler - drawn on your own ma
 
 pledge = """
     A height chart is arithmetic and a drawing: there is no file to send and no
-    service to ask. The man, the woman, the boy and the girl are public-domain
+    service to ask &mdash; and the one file this page will take, an SVG of your
+    own to put on the ruler, is read here and goes nowhere. The man, the woman, the boy and the girl are public-domain
     artwork that ships with this page, and the boy and the girl are drawings of
     actual children rather than adults made small &mdash; which is what stops a
     family chart looking wrong in a way nobody can name. Every step of it
@@ -79,9 +85,12 @@ read_first = """
       and <code>vendor/</code> for the four figures and where their artwork came
       from, <code>src/figures.js</code> for the list the menu is built out of,
       <code>src/units.js</code> for how a typed height becomes a number and how
-      the ruler is labelled, <code>src/chart.js</code> for the layout, and
+      the ruler is labelled, <code>src/chart.js</code> for the layout,
       <code>src/save.js</code> for the two downloads &mdash; which are the SVG on
-      screen, and that same SVG painted onto a canvas."""
+      screen, and that same SVG painted onto a canvas &mdash; and
+      <code>src/import-svg.js</code> for the whitelist an uploaded SVG is
+      rebuilt from, which is the one file here where being wrong would
+      matter."""
 
 # --- the written half of the page --------------------------------------------
 
@@ -170,6 +179,20 @@ body = """
       fetch and no image to load inside it."""
 
 [[privacy]]
+title = "An SVG you add is read here, and rebuilt rather than trusted."
+body = """
+ The file
+      never leaves this page &mdash; it is read with the browser's own
+      <code>FileReader</code> and parsed into an inert document that runs
+      nothing. What is drawn is not that file: <code>src/import-svg.js</code>
+      builds a NEW drawing out of a whitelist of shapes and geometry, so a
+      script, a stylesheet, a font, a linked image or a reference to another
+      document is left behind rather than carried through. That matters twice
+      over, because the chart you download is a file you send to other people:
+      anything that survived would be their browser calling a stranger's server,
+      days later, from something this page wrote."""
+
+[[privacy]]
 title = "The artwork is here, not fetched."
 body = """
  All four figures
@@ -235,6 +258,16 @@ body = """
       holds twenty of them, grouped, and every one becomes an ordinary row you
       can type your own numbers over. Objects take a width as well as a height,
       so a door is 203 by 81 rather than a stripe."""
+
+[[howto]]
+title = "Or put your own drawing on it."
+body = """
+ <strong>Add your own
+      SVG</strong> takes a file from your machine and draws its shape at
+      whatever height you give it &mdash; the thing to reach for when the chart
+      is about a product, a vehicle or a building rather than a person. It keeps
+      the drawing's own proportions, colours it like any other row, and reads the
+      file here rather than sending it anywhere."""
 
 [[howto]]
 title = "Set the ruler to the units your reader thinks in."
@@ -313,6 +346,25 @@ a = """
         asks for nothing, which is the point: the artwork ends up inside a picture
         you download, and a licence needing attribution would attach that
         requirement to your chart."""
+
+[[faq]]
+q = "Can I put my own drawing on the chart?"
+a = """
+        Yes &mdash; <strong>Add your own SVG</strong> takes any SVG file and
+        puts its shape on the ruler at whatever height you type: a logo, a floor
+        plan, a piece of machinery, a car. Its proportions are its own, so
+        there is no width to fill in.
+        <br><br>
+        Two things to know. It is drawn as <strong>one solid colour</strong>,
+        the one that row is set to, because that is what the rest of the chart
+        is &mdash; so a drawing made of thin outlines rather than filled shapes
+        comes out as a blob, and this is the wrong tool for it. And only the
+        <em>shapes</em> are kept: the file is rebuilt from scratch out of paths
+        and rectangles and circles, and anything that could reach the network
+        &mdash; a linked image, a stylesheet, a font, a script &mdash; is left
+        behind. The file itself never goes anywhere; that part is about the
+        chart you download, which is a file you might send to somebody
+        else."""
 
 [[faq]]
 q = "Why is there no toddler or baby?"
@@ -419,6 +471,7 @@ features = [
   "Heights typed as 173, 1.73 m, 5'8\", 68 in or 5 ft 8, with the reading shown back",
   "Centimetres or feet and inches, switched without changing anybody's height",
   "Twenty ready-made objects: doors, windows, a whiteboard, a vending machine, a shipping container, furniture",
+  "Any SVG of your own on the ruler, rebuilt from its shapes alone",
   "A ruler whose spacing is chosen from what the picture can carry",
   "Any background colour, or none, with the ink chosen to stay legible on it",
   "PNG out at any pixel height, and an SVG that prints sharp at any size",


### PR DESCRIPTION
**Add your own SVG** puts any drawing on the ruler at whatever height you type —
a logo, a floor plan, a vehicle, a building. It keeps the drawing's own
proportions, so there is no width to fill in; it is coloured like any other row;
the filename becomes the row's name. Picking *Your own SVG* from a row's figure
menu opens the same dialog for that row.

## Pictures

| Before | After |
|---|---|
| `upload-before.png` | `upload-after.png` |

| A chart with an uploaded shape on it |
|---|
| `upload-chart.png` |

The three filenames are placeholders. GitHub's image uploader lives in the web
editor's own session — neither `gh` nor `gh api` can reach it — so the pictures
have to be dropped in by hand. All three were handed over in the session that
opened this PR.

**How to put them in:**

1. On this page, open the **⋯** menu at the top right of the description and
   choose **Edit**.
2. Click into the `Before` cell of the first table and drag `upload-before.png`
   onto it. (The paperclip in the toolbar, or a plain <kbd>Ctrl</kbd>+<kbd>V</kbd>
   of the image, does the same thing.)
3. GitHub uploads it and leaves
   `![upload-before.png](https://github.com/user-attachments/assets/…)` in the
   cell. That markdown **is** the image — delete the `` `upload-before.png` ``
   placeholder sitting next to it.
4. Repeat for the other two cells, then press **Save**.
5. Delete this instruction block once all three images are showing.

## Why the reading is a whitelist and not a clean-up

An SVG is a program. It can carry `<script>`, an `onload=` on any element, a
`<foreignObject>` holding a whole HTML document, a `<use>` pointing into
another file, an `<image href="https://…">` and a stylesheet that imports one.
Two of those matter here, and the second is the sharp one:

- the file is read on the visitor's own machine, so anything executable in it
  would be executing in their page, with their chart in it;
- **the result is downloaded and sent to other people.** An `<image href>` that
  survived would be a chart phoning a stranger's server, open on somebody
  else's machine, days later, out of a file this page wrote. The whole tool is
  one page-long promise that nothing it makes talks to anything.

So nothing from the file is ever inserted. The browser parses it — `DOMParser`
on `image/svg+xml`, which builds an inert document and runs nothing — `main.js`
walks that into plain `{tag, attrs, children}` objects, and
[`src/import-svg.js`](tools/compare-heights/src/import-svg.js) builds a **third
tree** containing only the elements and attributes on its whitelist. An
attribute does not have to be recognised as dangerous to be dropped; it is
dropped because it was not asked for. That is the only shape of this job that
stays safe when SVG grows a feature next year.

Everything becomes a `<path>`, so what ships is one element with one attribute
rather than six of each — and a rounded rectangle keeps its corners rather than
being squared off, because the tool should not quietly edit somebody's drawing.
`transform` survives: it is numeric, has nowhere to put a URL, and is what lets
a nested drawing keep its shape without its coordinates being rewritten. `fill`
does not, both because the row's colour is the chart's to choose and because
`fill` can hold `url(#…)`.

## How it is checked

[`compare-heights-import-svg.test.js`](tests/js/compare-heights-import-svg.test.js)
is 18 cases, mostly a list of things that must not come out the other side, one
per line, so a reader can see the policy without reading the implementation.
One case asserts that the whitelist *itself* holds no name matching
`href|src|style|class|id|filter|mask|clip-path|on*`, so anything added to it
later has to answer that question.

Then driven in a browser against a deliberately hostile file — `<script>`,
`@import`, `<image href>`, `<use href>`, `<foreignObject>`, `onload`,
`onclick`, `fill="url(#g)"`, `id` — carrying two real shapes:

| Check | Result |
|---|---|
| Shapes drawn | 2 |
| Script executed | none — the sentinels were never set |
| Leaks into the produced chart | none of `evil.example`, `<script`, `onload`, `onclick`, `<image`, `<use`, `foreignObject`, `url(#`, `id=`, `@import` |
| PNG still rasterises with it in | yes, 83 KB |
| Empty / unreadable / oversized files | each says which, in its own words |

## The two limits, both said on the page

A drawing arrives as **one solid colour**, like everything else on the chart, so
line art rather than filled shapes comes out as a blob — and the page says that
is the wrong tool for it rather than letting somebody find out. And only the
*shapes* are kept: text, gradients and effects are left behind rather than
approximated.

The file input is a bare `<input type="file">` behind a button rather than the
shared picker. That picker draws a drop zone and owns a page's main flow; here
the main flow is still typing, and this is an optional extra. It carries an
`aria-label` because a control a visitor can reach needs a name whether or not
it is the thing they clicked — which `test_accessibility.py` caught before this
was pushed.

## Checks

- `python build.py --out _plain --clean --no-minify` — exit 0, 1353 pages.
- Whole JavaScript suite: 2,177 tests, 0 failures.
- `test_build`, `test_duplicates`, `test_accessibility`, `test_english_in_js` —
  114 tests, OK.
- The English-in-JavaScript ratchet is unchanged at 4: everything this feature
  says to a visitor is a phrase in the markup.
- No CSP change: reading a file needs nothing, and what is drawn is inline.
