### PR TITLE
Wire the privacy toggle compare-heights forgot

### DIFF
--- a/tools/compare-heights/src/main.js
+++ b/tools/compare-heights/src/main.js
@@ -537,6 +537,19 @@ for (const control of [el.order, el.showRuler, el.showNames, el.background,
 
 /* ------------------------------------------------------ the live network check */
 
+/* ------------------------------------------------- privacy panel + offline */
+
+// The header's toggle, which every other tool on the site wires and this one
+// did not. The panel it opens is the live network check - the page's own
+// evidence for the claim it makes - so a toggle that does nothing is the one
+// control here it is worst to leave dead. It went unnoticed because nothing
+// throws: the elements are looked up, the listener is simply never added.
+el.privacyToggle.addEventListener('click', () => {
+  const open = el.privacyPanel.hidden;
+  el.privacyPanel.hidden = !open;
+  el.privacyToggle.setAttribute('aria-expanded', String(open));
+});
+
 // Google's ad and measurement scripts, and the donate button's. They are the
 // price of the site being free, they are loaded without the visitor asking, and
 // none of them is handed anything typed into this page - so they are reported


### PR DESCRIPTION
The header's privacy toggle does nothing on `/compare-heights/`.

`el.privacyToggle` and `el.privacyPanel` are looked up at the top of `main.js` and then never used again — the listener every other tool adds was never written. Nothing throws, so nothing said so: the click lands, and the page ignores it.

The panel it opens is that page's **live network check** — the evidence for the claim the page makes, on a tool whose input is a list of people and how tall each of them is. That makes it the worst control on the page to leave dead.

Three lines, the same three every other tool has.

## How it surfaced

The QA suite's generic `tool-pages.spec.ts` check caught it on all four browser projects the night the tool shipped. That check exists for exactly this: the things every tool page owes a visitor, verified on every tool page, so a new one cannot quietly skip one.

## Verified

`tool-pages.spec.ts -g compare-heights` against a local build of this branch — 8 passed on Desktop Chrome and Desktop Safari, where the privacy-panel test had been failing. `npm test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)