### PR TITLE
Keep an ad inside the screen it is shown on

### DIFF
--- a/shared/css/tool-frame.css
+++ b/shared/css/tool-frame.css
@@ -1616,6 +1616,23 @@ footer a:hover { text-decoration: underline; }
 ins.adsbygoogle { display: block; }
 ins.adsbygoogle[data-ad-status="unfilled"] { display: none !important; }
 
+/* And no wider than the screen, whatever arrives in it.
+
+   A creative wider than the phone it is on makes the whole document scroll
+   sideways, which is a page that rubber-bands under the thumb for a reason
+   the reader cannot see and cannot fix. The QA suite caught /base64/ eight
+   pixels over on both phone projects; it does not reproduce where the slot
+   comes back unfilled, which is what points at the creative rather than the
+   page.
+
+   What arrives in the slot is not this site's to choose, but how much room it
+   is allowed to take is. `max-width` is what Google's own guidance asks for on
+   a responsive unit; `overflow-x: clip` is the belt to that brace, and `clip`
+   rather than `hidden` so the slot does not become a scroll container and drag
+   the other axis to `auto` with it. */
+ins.adsbygoogle { max-width: 100%; overflow-x: clip; }
+
+
 :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 
 /* ---------------------------------------------------------------- handoff */

--- a/shared/site.css
+++ b/shared/site.css
@@ -1096,6 +1096,23 @@ footer a:hover { text-decoration: underline; }
 ins.adsbygoogle { display: block; }
 ins.adsbygoogle[data-ad-status="unfilled"] { display: none !important; }
 
+/* And no wider than the screen, whatever arrives in it.
+
+   A creative wider than the phone it is on makes the whole document scroll
+   sideways, which is a page that rubber-bands under the thumb for a reason
+   the reader cannot see and cannot fix. The QA suite caught /base64/ eight
+   pixels over on both phone projects; it does not reproduce where the slot
+   comes back unfilled, which is what points at the creative rather than the
+   page.
+
+   What arrives in the slot is not this site's to choose, but how much room it
+   is allowed to take is. `max-width` is what Google's own guidance asks for on
+   a responsive unit; `overflow-x: clip` is the belt to that brace, and `clip`
+   rather than `hidden` so the slot does not become a scroll container and drag
+   the other axis to `auto` with it. */
+ins.adsbygoogle { max-width: 100%; overflow-x: clip; }
+
+
 :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 
 /* ---- the language menu on a phone -------------------------------------- */


### PR DESCRIPTION
The QA suite found `/base64/` **eight pixels wider than the viewport on both phone projects** — a page that rubber-bands sideways under the thumb for a reason the reader can neither see nor fix.

## It does not reproduce here, and that is the evidence

Measured against production at 0, 3, 6 and 10 seconds on both mobile engines: zero overflow. The slot comes back **unfilled** on this machine, and the rule two lines up hides it. Where a creative actually arrives, nothing bounds its width — and both phone engines seeing the same eight pixels is one creative, not two layouts.

## The change

What arrives in that slot is not this site's to choose. How much room it is allowed to take is.

```css
ins.adsbygoogle { max-width: 100%; overflow-x: clip; }
```

`max-width` is what Google's own guidance asks for on a responsive unit. `overflow-x: clip` is the belt to that brace — `clip` rather than `hidden`, so the slot does not become a scroll container and drag the other axis to `auto` with it.

Both stylesheets, because the hub and the tool frame each carry their own copy of the two `ins.adsbygoogle` rules.

## Verified

`python build.py` clean, the rule present in `dist/site.css`. `responsive.spec.ts` on both phone projects against a local build: 32 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)