### PR TITLE
Say the SVG upload's five sentences in the other fourteen languages

### DIFF
--- a/locales/ar/tools/compare-heights.html
+++ b/locales/ar/tools/compare-heights.html
@@ -192,6 +192,7 @@
     <span data-phrase="shape.boy">صبي</span>
     <span data-phrase="shape.girl">فتاة</span>
     <span data-phrase="shape.object">شيء</span>
+    <span data-phrase="shape.upload">SVG خاص بك</span>
 
     <span data-phrase="row.shape">شكل الصفّ {n}</span>
     <span data-phrase="row.name">اسم الصفّ {n}</span>
@@ -213,6 +214,10 @@
     <span data-phrase="height.tooshort">أقصر من أن يُرسَم &mdash; 5 سم هو الأصغر.</span>
     <span data-phrase="height.tootall">أطول مما يبلغه الرسم &mdash; الحدّ 12 متراً.</span>
 
+    <span data-phrase="svg.added">أُضيف، ومرسوم من {shapes} شكلاً في ذلك الملف. ولم يُرفَع شيء لقراءته.</span>
+    <span data-phrase="svg.noshapes">لا شيء يمكن رسمه في ذلك الملف. لا تُبقى إلا الأشكال &mdash; وملف ليس فيه سوى نصوص أو مؤثرات أو صور مرتبطة لا يحوي منها شيئاً.</span>
+    <span data-phrase="svg.unreadable">ذلك الملف ليس ملف SVG يمكن قراءته هنا.</span>
+    <span data-phrase="svg.toobig">ذلك الملف أكبر من أن يكون شكلاً واحداً. والحد ميغابايتان.</span>
     <span data-phrase="chart.empty">أضِف أحداً، ويظهر الرسم هنا.</span>
     <span data-phrase="chart.noheights">كلّ صفّ يحتاج إلى طول. املأ واحداً ويظهر الرسم هنا.</span>
     <span data-phrase="chart.full">اثنا عشر شكلاً هي أقصى ما يحمله هذا الرسم ويظلّ مقروءاً.</span>

--- a/locales/de/tools/compare-heights.html
+++ b/locales/de/tools/compare-heights.html
@@ -201,6 +201,7 @@
     <span data-phrase="shape.boy">Junge</span>
     <span data-phrase="shape.girl">Mädchen</span>
     <span data-phrase="shape.object">Gegenstand</span>
+    <span data-phrase="shape.upload">Eigenes SVG</span>
 
     <span data-phrase="row.shape">Figur für Zeile {n}</span>
     <span data-phrase="row.name">Name für Zeile {n}</span>
@@ -222,6 +223,10 @@
     <span data-phrase="height.tooshort">Zu klein zum Zeichnen &mdash; 5 cm ist das Kleinste.</span>
     <span data-phrase="height.tootall">Größer, als das Diagramm reicht &mdash; bei 12 Metern ist Schluss.</span>
 
+    <span data-phrase="svg.added">Hinzugefügt, gezeichnet aus {shapes} Formen in dieser Datei. Zum Lesen wurde nichts hochgeladen.</span>
+    <span data-phrase="svg.noshapes">In dieser Datei ist nichts zu zeichnen. Behalten werden nur die Formen &mdash; eine Datei aus lauter Text, Effekten oder verlinkten Bildern hat keine.</span>
+    <span data-phrase="svg.unreadable">Diese Datei ist kein SVG, das hier gelesen werden kann.</span>
+    <span data-phrase="svg.toobig">Diese Datei ist zu groß für eine einzelne Form. Bei zwei Megabyte ist Schluss.</span>
     <span data-phrase="chart.empty">Fügen Sie jemanden hinzu, und das Diagramm erscheint hier.</span>
     <span data-phrase="chart.noheights">Jede Zeile braucht eine Größe. Tragen Sie eine ein, und das Diagramm erscheint hier.</span>
     <span data-phrase="chart.full">Zwölf Figuren sind so viele, wie dieses Diagramm fassen kann und dabei lesbar bleibt.</span>

--- a/locales/es/tools/compare-heights.html
+++ b/locales/es/tools/compare-heights.html
@@ -200,6 +200,7 @@
     <span data-phrase="shape.boy">Niño</span>
     <span data-phrase="shape.girl">Niña</span>
     <span data-phrase="shape.object">Objeto</span>
+    <span data-phrase="shape.upload">Tu propio SVG</span>
 
     <span data-phrase="row.shape">Figura de la fila {n}</span>
     <span data-phrase="row.name">Nombre de la fila {n}</span>
@@ -221,6 +222,10 @@
     <span data-phrase="height.tooshort">Demasiado bajo para dibujarlo &mdash; 5 cm es lo mínimo.</span>
     <span data-phrase="height.tootall">Más alto de lo que llega el gráfico &mdash; el límite son 12 metros.</span>
 
+    <span data-phrase="svg.added">Añadido, dibujado a partir de {shapes} formas de ese archivo. No se ha subido nada para leerlo.</span>
+    <span data-phrase="svg.noshapes">En ese archivo no hay nada que dibujar. Solo se conservan las formas &mdash; un archivo de puro texto, efectos o imágenes enlazadas no tiene ninguna.</span>
+    <span data-phrase="svg.unreadable">Ese archivo no es un SVG que esto pueda leer.</span>
+    <span data-phrase="svg.toobig">Ese archivo es demasiado grande para ser una sola forma. El límite son dos megabytes.</span>
     <span data-phrase="chart.empty">Añade a alguien y el gráfico aparecerá aquí.</span>
     <span data-phrase="chart.noheights">Cada fila necesita una altura. Rellena una y el gráfico aparecerá aquí.</span>
     <span data-phrase="chart.full">Doce figuras es todo lo que este gráfico admite sin dejar de leerse.</span>

--- a/locales/fr/tools/compare-heights.html
+++ b/locales/fr/tools/compare-heights.html
@@ -202,6 +202,7 @@
     <span data-phrase="shape.boy">Garçon</span>
     <span data-phrase="shape.girl">Fille</span>
     <span data-phrase="shape.object">Objet</span>
+    <span data-phrase="shape.upload">Votre propre SVG</span>
 
     <span data-phrase="row.shape">Figure de la ligne {n}</span>
     <span data-phrase="row.name">Nom de la ligne {n}</span>
@@ -223,6 +224,10 @@
     <span data-phrase="height.tooshort">Trop petit pour être dessiné &mdash; 5 cm est le minimum.</span>
     <span data-phrase="height.tootall">Plus grand que ne va le graphique &mdash; la limite est de 12 mètres.</span>
 
+    <span data-phrase="svg.added">Ajouté, dessiné à partir de {shapes} formes de ce fichier. Rien n'a été envoyé pour le lire.</span>
+    <span data-phrase="svg.noshapes">Il n'y a rien à dessiner dans ce fichier. Seules les formes sont conservées &mdash; un fichier fait uniquement de texte, d'effets ou d'images liées n'en a aucune.</span>
+    <span data-phrase="svg.unreadable">Ce fichier n'est pas un SVG lisible ici.</span>
+    <span data-phrase="svg.toobig">Ce fichier est trop gros pour une seule forme. La limite est de deux mégaoctets.</span>
     <span data-phrase="chart.empty">Ajoutez quelqu'un, et le graphique apparaîtra ici.</span>
     <span data-phrase="chart.noheights">Chaque ligne a besoin d'une taille. Remplissez-en une et le graphique apparaîtra ici.</span>
     <span data-phrase="chart.full">Douze figures, c'est tout ce que ce graphique peut porter en restant lisible.</span>

--- a/locales/hi/tools/compare-heights.html
+++ b/locales/hi/tools/compare-heights.html
@@ -197,6 +197,7 @@
     <span data-phrase="shape.boy">लड़का</span>
     <span data-phrase="shape.girl">लड़की</span>
     <span data-phrase="shape.object">चीज़</span>
+    <span data-phrase="shape.upload">अपनी SVG</span>
 
     <span data-phrase="row.shape">पंक्ति {n} की आकृति</span>
     <span data-phrase="row.name">पंक्ति {n} का नाम</span>
@@ -218,6 +219,10 @@
     <span data-phrase="height.tooshort">बनाने के लिए बहुत छोटा &mdash; 5 cm सबसे कम है।</span>
     <span data-phrase="height.tootall">चार्ट जहाँ तक जाता है उससे ऊँचा &mdash; 12 मीटर सीमा है।</span>
 
+    <span data-phrase="svg.added">जुड़ गया &mdash; उस फ़ाइल की {shapes} आकृतियों से बना। इसे पढ़ने के लिए कुछ भी अपलोड नहीं हुआ।</span>
+    <span data-phrase="svg.noshapes">उस फ़ाइल में बनाने लायक कुछ नहीं है। सिर्फ़ आकृतियाँ रखी जाती हैं &mdash; और जिस फ़ाइल में केवल टेक्स्ट, इफ़ेक्ट या जुड़ी हुई तस्वीरें हों, उसमें वे नहीं होतीं।</span>
+    <span data-phrase="svg.unreadable">वह फ़ाइल ऐसी SVG नहीं जो यहाँ पढ़ी जा सके।</span>
+    <span data-phrase="svg.toobig">वह फ़ाइल एक आकृति के लिहाज़ से बहुत बड़ी है। सीमा दो मेगाबाइट है।</span>
     <span data-phrase="chart.empty">किसी को जोड़िए, और चार्ट यहाँ दिख जाएगा।</span>
     <span data-phrase="chart.noheights">हर पंक्ति को एक ऊँचाई चाहिए। एक भर दीजिए, और चार्ट यहाँ दिख जाएगा।</span>
     <span data-phrase="chart.full">बारह आकृतियाँ ही इतनी हैं जितनी यह चार्ट पढ़ने लायक रहते हुए सँभाल सकता है।</span>

--- a/locales/id/tools/compare-heights.html
+++ b/locales/id/tools/compare-heights.html
@@ -200,6 +200,7 @@
     <span data-phrase="shape.boy">Anak laki-laki</span>
     <span data-phrase="shape.girl">Anak perempuan</span>
     <span data-phrase="shape.object">Benda</span>
+    <span data-phrase="shape.upload">SVG milik Anda</span>
 
     <span data-phrase="row.shape">Figur untuk baris {n}</span>
     <span data-phrase="row.name">Nama untuk baris {n}</span>
@@ -221,6 +222,10 @@
     <span data-phrase="height.tooshort">Terlalu pendek untuk digambar &mdash; 5 cm yang paling kecil.</span>
     <span data-phrase="height.tootall">Lebih tinggi daripada jangkauan bagan &mdash; batasnya 12 meter.</span>
 
+    <span data-phrase="svg.added">Ditambahkan, digambar dari {shapes} bentuk di berkas itu. Tidak ada yang diunggah untuk membacanya.</span>
+    <span data-phrase="svg.noshapes">Tidak ada yang bisa digambar di berkas itu. Hanya bentuknya yang disimpan &mdash; berkas yang isinya cuma teks, efek atau gambar tertaut tidak punya satu pun.</span>
+    <span data-phrase="svg.unreadable">Berkas itu bukan SVG yang bisa dibaca di sini.</span>
+    <span data-phrase="svg.toobig">Berkas itu terlalu besar untuk satu bentuk. Batasnya dua megabita.</span>
     <span data-phrase="chart.empty">Tambahkan seseorang, dan bagannya muncul di sini.</span>
     <span data-phrase="chart.noheights">Setiap baris perlu tinggi. Isi satu dan bagannya muncul di sini.</span>
     <span data-phrase="chart.full">Dua belas figur adalah sebanyak yang bisa dimuat bagan ini dan tetap terbaca.</span>

--- a/locales/it/tools/compare-heights.html
+++ b/locales/it/tools/compare-heights.html
@@ -199,6 +199,7 @@
     <span data-phrase="shape.boy">Bambino</span>
     <span data-phrase="shape.girl">Bambina</span>
     <span data-phrase="shape.object">Oggetto</span>
+    <span data-phrase="shape.upload">Il tuo SVG</span>
 
     <span data-phrase="row.shape">Figura della riga {n}</span>
     <span data-phrase="row.name">Nome della riga {n}</span>
@@ -220,6 +221,10 @@
     <span data-phrase="height.tooshort">Troppo basso per disegnarlo &mdash; 5 cm è il minimo.</span>
     <span data-phrase="height.tootall">Più alto di dove arriva il grafico &mdash; il limite è 12 metri.</span>
 
+    <span data-phrase="svg.added">Aggiunto, disegnato da {shapes} forme di quel file. Per leggerlo non è stato caricato niente.</span>
+    <span data-phrase="svg.noshapes">In quel file non c'è niente da disegnare. Si tengono solo le forme &mdash; un file fatto solo di testo, effetti o immagini collegate non ne ha.</span>
+    <span data-phrase="svg.unreadable">Quel file non è un SVG leggibile qui.</span>
+    <span data-phrase="svg.toobig">Quel file è troppo grande per essere una forma sola. Il limite è due megabyte.</span>
     <span data-phrase="chart.empty">Aggiungi qualcuno e il grafico comparirà qui.</span>
     <span data-phrase="chart.noheights">Ogni riga ha bisogno di un'altezza. Riempine una e il grafico comparirà qui.</span>
     <span data-phrase="chart.full">Dodici figure sono quante ne regge questo grafico restando leggibile.</span>

--- a/locales/ja/tools/compare-heights.html
+++ b/locales/ja/tools/compare-heights.html
@@ -172,6 +172,7 @@
     <span data-phrase="shape.boy">男の子</span>
     <span data-phrase="shape.girl">女の子</span>
     <span data-phrase="shape.object">もの</span>
+    <span data-phrase="shape.upload">自分の SVG</span>
 
     <span data-phrase="row.shape">{n}行目の図</span>
     <span data-phrase="row.name">{n}行目の名前</span>
@@ -193,6 +194,10 @@
     <span data-phrase="height.tooshort">小さすぎて描けません。5 cmが下限です。</span>
     <span data-phrase="height.tootall">図表の範囲より高すぎます。12メートルまでです。</span>
 
+    <span data-phrase="svg.added">追加しました。そのファイルの {shapes} 個の図形から描いています。読み取るために何もアップロードしていません。</span>
+    <span data-phrase="svg.noshapes">そのファイルには描けるものがありません。残すのは図形だけなので &mdash; 文字や効果、リンクされた画像しかないファイルには何も残りません。</span>
+    <span data-phrase="svg.unreadable">そのファイルは、ここで読める SVG ではありません。</span>
+    <span data-phrase="svg.toobig">そのファイルは、ひとつの図形にしては大きすぎます。上限は 2 メガバイトです。</span>
     <span data-phrase="chart.empty">誰かを追加すると、ここに図表が出ます。</span>
     <span data-phrase="chart.noheights">どの行にも身長が要ります。ひとつ入れると、ここに図表が出ます。</span>
     <span data-phrase="chart.full">12体が、この図表が読めるまま収められる限りです。</span>

--- a/locales/ko/tools/compare-heights.html
+++ b/locales/ko/tools/compare-heights.html
@@ -193,6 +193,7 @@
     <span data-phrase="shape.boy">남자아이</span>
     <span data-phrase="shape.girl">여자아이</span>
     <span data-phrase="shape.object">사물</span>
+    <span data-phrase="shape.upload">내 SVG</span>
 
     <span data-phrase="row.shape">{n}번째 줄의 그림</span>
     <span data-phrase="row.name">{n}번째 줄의 이름</span>
@@ -214,6 +215,10 @@
     <span data-phrase="height.tooshort">그리기에 너무 작습니다 &mdash; 5 cm가 가장 작습니다.</span>
     <span data-phrase="height.tootall">차트가 닿는 것보다 큽니다 &mdash; 12미터가 한계입니다.</span>
 
+    <span data-phrase="svg.added">추가했습니다. 그 파일의 도형 {shapes}개로 그렸습니다. 읽으려고 아무것도 업로드하지 않았습니다.</span>
+    <span data-phrase="svg.noshapes">그 파일에는 그릴 것이 없습니다. 남기는 것은 도형뿐이라 &mdash; 글자와 효과, 연결된 이미지밖에 없는 파일에는 남을 것이 없습니다.</span>
+    <span data-phrase="svg.unreadable">그 파일은 여기서 읽을 수 있는 SVG가 아닙니다.</span>
+    <span data-phrase="svg.toobig">그 파일은 도형 하나치고 너무 큽니다. 한도는 2메가바이트입니다.</span>
     <span data-phrase="chart.empty">누군가를 넣으면 차트가 여기에 나타납니다.</span>
     <span data-phrase="chart.noheights">모든 줄에 키가 있어야 합니다. 하나를 채우면 차트가 여기에 나타납니다.</span>
     <span data-phrase="chart.full">열두 개가 이 차트가 읽히는 채로 담을 수 있는 전부입니다.</span>

--- a/locales/nl/tools/compare-heights.html
+++ b/locales/nl/tools/compare-heights.html
@@ -199,6 +199,7 @@
     <span data-phrase="shape.boy">Jongen</span>
     <span data-phrase="shape.girl">Meisje</span>
     <span data-phrase="shape.object">Voorwerp</span>
+    <span data-phrase="shape.upload">Eigen SVG</span>
 
     <span data-phrase="row.shape">Figuur voor regel {n}</span>
     <span data-phrase="row.name">Naam voor regel {n}</span>
@@ -220,6 +221,10 @@
     <span data-phrase="height.tooshort">Te klein om te tekenen &mdash; 5 cm is het kleinste.</span>
     <span data-phrase="height.tootall">Langer dan de grafiek reikt &mdash; 12 meter is de grens.</span>
 
+    <span data-phrase="svg.added">Toegevoegd, getekend uit {shapes} vormen in dat bestand. Er is niets geüpload om het te lezen.</span>
+    <span data-phrase="svg.noshapes">In dat bestand valt niets te tekenen. Alleen de vormen worden bewaard &mdash; een bestand met alleen tekst, effecten of gelinkte afbeeldingen heeft er geen.</span>
+    <span data-phrase="svg.unreadable">Dat bestand is geen SVG die dit kan lezen.</span>
+    <span data-phrase="svg.toobig">Dat bestand is te groot voor één vorm. Twee megabyte is de grens.</span>
     <span data-phrase="chart.empty">Voeg iemand toe, en de grafiek verschijnt hier.</span>
     <span data-phrase="chart.noheights">Elke regel heeft een lengte nodig. Vul er een in en de grafiek verschijnt hier.</span>
     <span data-phrase="chart.full">Twaalf figuren is alles wat deze grafiek kan dragen en leesbaar blijven.</span>

--- a/locales/pt/tools/compare-heights.html
+++ b/locales/pt/tools/compare-heights.html
@@ -199,6 +199,7 @@
     <span data-phrase="shape.boy">Menino</span>
     <span data-phrase="shape.girl">Menina</span>
     <span data-phrase="shape.object">Objeto</span>
+    <span data-phrase="shape.upload">Seu próprio SVG</span>
 
     <span data-phrase="row.shape">Figura da linha {n}</span>
     <span data-phrase="row.name">Nome da linha {n}</span>
@@ -220,6 +221,10 @@
     <span data-phrase="height.tooshort">Baixo demais para desenhar &mdash; 5 cm é o mínimo.</span>
     <span data-phrase="height.tootall">Mais alto do que o gráfico vai &mdash; o limite é 12 metros.</span>
 
+    <span data-phrase="svg.added">Adicionado, desenhado a partir de {shapes} formas desse arquivo. Nada foi enviado para lê-lo.</span>
+    <span data-phrase="svg.noshapes">Nesse arquivo não há nada para desenhar. Só as formas são mantidas &mdash; um arquivo feito só de texto, efeitos ou imagens vinculadas não tem nenhuma.</span>
+    <span data-phrase="svg.unreadable">Esse arquivo não é um SVG que isto consiga ler.</span>
+    <span data-phrase="svg.toobig">Esse arquivo é grande demais para ser uma forma só. O limite são dois megabytes.</span>
     <span data-phrase="chart.empty">Acrescente alguém e o gráfico aparece aqui.</span>
     <span data-phrase="chart.noheights">Toda linha precisa de uma altura. Preencha uma e o gráfico aparece aqui.</span>
     <span data-phrase="chart.full">Doze figuras é o que este gráfico aguenta continuando legível.</span>

--- a/locales/tr/tools/compare-heights.html
+++ b/locales/tr/tools/compare-heights.html
@@ -198,6 +198,7 @@
     <span data-phrase="shape.boy">Erkek çocuk</span>
     <span data-phrase="shape.girl">Kız çocuk</span>
     <span data-phrase="shape.object">Nesne</span>
+    <span data-phrase="shape.upload">Kendi SVG'niz</span>
 
     <span data-phrase="row.shape">{n}. satırın figürü</span>
     <span data-phrase="row.name">{n}. satırın adı</span>
@@ -219,6 +220,10 @@
     <span data-phrase="height.tooshort">Çizilemeyecek kadar kısa &mdash; en küçüğü 5 cm.</span>
     <span data-phrase="height.tootall">Grafiğin çıktığından daha uzun &mdash; sınır 12 metre.</span>
 
+    <span data-phrase="svg.added">Eklendi, o dosyadaki {shapes} şekilden çizildi. Okumak için hiçbir şey yüklenmedi.</span>
+    <span data-phrase="svg.noshapes">O dosyada çizilecek bir şey yok. Yalnızca şekiller tutulur &mdash; sadece metin, efekt ya da bağlantılı görsellerden oluşan bir dosyada hiç yoktur.</span>
+    <span data-phrase="svg.unreadable">O dosya, burada okunabilen bir SVG değil.</span>
+    <span data-phrase="svg.toobig">O dosya tek bir şekil için fazla büyük. Sınır iki megabayt.</span>
     <span data-phrase="chart.empty">Birini ekleyin, grafik burada belirsin.</span>
     <span data-phrase="chart.noheights">Her satırın bir boya ihtiyacı var. Birini doldurun, grafik burada belirsin.</span>
     <span data-phrase="chart.full">On iki figür, bu grafiğin okunur kalarak taşıyabileceği en fazla sayıdır.</span>

--- a/locales/zh-TW/tools/compare-heights.html
+++ b/locales/zh-TW/tools/compare-heights.html
@@ -172,6 +172,7 @@
     <span data-phrase="shape.boy">男孩</span>
     <span data-phrase="shape.girl">女孩</span>
     <span data-phrase="shape.object">物體</span>
+    <span data-phrase="shape.upload">自己的 SVG</span>
 
     <span data-phrase="row.shape">第 {n} 行的圖形</span>
     <span data-phrase="row.name">第 {n} 行的名字</span>
@@ -193,6 +194,10 @@
     <span data-phrase="height.tooshort">太矮畫不出來——最小 5 cm。</span>
     <span data-phrase="height.tootall">比圖表能到的還高——上限是 12 米。</span>
 
+    <span data-phrase="svg.added">已加入，用那個檔案裡的 {shapes} 個形狀畫成。為了讀它，沒有上傳任何東西。</span>
+    <span data-phrase="svg.noshapes">那個檔案裡沒有可以畫的東西。只留下形狀 &mdash; 只有文字、效果或連結圖片的檔案，一個形狀也沒有。</span>
+    <span data-phrase="svg.unreadable">那個檔案不是這裡讀得懂的 SVG。</span>
+    <span data-phrase="svg.toobig">那個檔案要當一個形狀太大了。上限是兩 MB。</span>
     <span data-phrase="chart.empty">加個人，圖表就出現在這裡。</span>
     <span data-phrase="chart.noheights">每一行都得有身高。填一個，圖表就出現在這裡。</span>
     <span data-phrase="chart.full">十二個圖形已經是這張圖表還能讀得清的極限了。</span>

--- a/locales/zh/tools/compare-heights.html
+++ b/locales/zh/tools/compare-heights.html
@@ -172,6 +172,7 @@
     <span data-phrase="shape.boy">男孩</span>
     <span data-phrase="shape.girl">女孩</span>
     <span data-phrase="shape.object">物体</span>
+    <span data-phrase="shape.upload">自己的 SVG</span>
 
     <span data-phrase="row.shape">第 {n} 行的图形</span>
     <span data-phrase="row.name">第 {n} 行的名字</span>
@@ -193,6 +194,10 @@
     <span data-phrase="height.tooshort">太矮画不出来——最小 5 cm。</span>
     <span data-phrase="height.tootall">比图表能到的还高——上限是 12 米。</span>
 
+    <span data-phrase="svg.added">已加入，用那个文件里的 {shapes} 个形状画成。为了读它，没有上传任何东西。</span>
+    <span data-phrase="svg.noshapes">那个文件里没有可以画的东西。只留下形状 &mdash; 只有文字、效果或链接图片的文件，一个形状也没有。</span>
+    <span data-phrase="svg.unreadable">那个文件不是这里读得懂的 SVG。</span>
+    <span data-phrase="svg.toobig">那个文件要当一个形状太大了。上限是两 MB。</span>
     <span data-phrase="chart.empty">加个人，图表就出现在这里。</span>
     <span data-phrase="chart.noheights">每一行都得有身高。填一个，图表就出现在这里。</span>
     <span data-phrase="chart.full">十二个图形已经是这张图表还能读得清的极限了。</span>


### PR DESCRIPTION
`main` has been failing `test_phrases` since the translations for this tool and
the SVG upload landed in either order, and it is failing on `main` right now —
[#312](https://github.com/A-Box-of-Tools/website/pull/312) is blocked behind it
rather than the cause of it.

[#309](https://github.com/A-Box-of-Tools/website/pull/309) added five keys to
`tools/compare-heights/body.html`: the figure menu's *Your own SVG*, and the
four things the page says when a file cannot be used. The locale bodies were
translated from the version before that, so they do not have them — and a key
with no translation renders as **the key itself**. In fourteen languages the
figure menu has `shape.upload` in it and an oversized file is answered with
`svg.toobig`.

Nothing is wrong with either change. They simply could not see each other: one
added phrases, the other translated a body that did not have them yet, and
whichever merged second was never rebuilt against the first.

## What is here

The five phrases in all fourteen languages, inserted next to the keys they
belong with — `shape.upload` after `shape.object`, the four `svg.*` beside
`chart.empty`.

**Each is on one line.** A translated sentence that wraps in the source arrives
with a visible hole in it once the minifier has been through, and CJK falls into
that every time; the two Chinese files and the Japanese and Korean ones are the
reason to say so out loud rather than trust it.

**The register is each file's own**, not a house style imposed on them: *Sie* in
German, *tu* in Italian and Spanish, *vous* in French, *você* in Portuguese, the
polite imperative Hindi already uses, ます in Japanese, 습니다 in Korean.

## Checks

- `test_phrases` — was failing on `main`, now 3 tests OK.
- `test_build` — 94 tests OK.
- `python build.py --out _plain --clean --no-minify` — exit 0, 1353 pages, and
  spot-checked in the built output: `自分の SVG`, `自己的 SVG`, `SVG خاص بك`,
  `Eigenes SVG`, `Votre propre SVG`.
- No CRLF, no wrapped phrase, no duplicate key.

Nothing visible changes for an English reader, so there are no before-and-after
pictures: the diff is fourteen files gaining five `<span data-phrase>` lines
each.
