### PR TITLE
Take a photograph on the ruler, not only a drawing

### DIFF
--- a/locales/ar/tools/compare-heights.html
+++ b/locales/ar/tools/compare-heights.html
@@ -42,12 +42,12 @@
       <div class="toolbar-actions">
         <button type="button" id="add-person" class="primary">أضِف شخصاً</button>
         <button type="button" id="add-object" class="ghost">أضِف شيئاً</button>
-        <button type="button" id="add-svg" class="ghost">SVG خاص بك</button>
+        <button type="button" id="add-svg" class="ghost">صورة خاصة بك</button>
         <button type="button" id="clear" class="ghost danger">أفرِغ الرسم</button>
         <!-- يشغّله الزرّ الذي فوقه بدل أن يُعرَض: التسمية هنا لأن أيّ عنصر تحكّم يستطيع
              الزائر بلوغه يحتاج اسماً، سواء أكان هو ما نقر عليه أم لا. -->
-        <input type="file" id="svg-file" accept=".svg,image/svg+xml"
-               aria-label="اختر ملف SVG ليوضَع على الرسم" hidden>
+        <input type="file" id="svg-file" accept="image/*,.svg"
+               aria-label="اختر صورة لتوضَع على الرسم" hidden>
       </div>
       <span class="count" id="row-count"></span>
     </div>
@@ -87,13 +87,17 @@
       </select>
     </div>
     <p class="field-summary">
-      يضع <strong>SVG خاص بك</strong> أيّ رسمة على المسطرة &mdash; شعاراً أو
+      يضع <strong>ملف SVG</strong> أيّ رسمة على المسطرة &mdash; شعاراً أو
       مخطّطاً أو قطعة آلة. تُقرأ في هذه الصفحة ولا تذهب إلى أي مكان. ولا يُحتفَظ
       إلا بالأشكال التي فيها: فهي تصل بلونٍ واحد صافٍ تختاره لكلّ صفّ، وكلّ ما
       كان بوسعه بلوغ الشبكة &mdash; صورة مرتبطة أو ورقة أنماط أو خطّ أو نصّ
       برمجي &mdash; يُترَك خلفه بدل أن يُحمَل داخل رسمٍ قد ترسله إلى أحد. أما
       الرسمة المصنوعة من خطوط رفيعة لا من أشكال مملوءة فتخرج لطخةً صمّاء، وتلك
       هي الحالة الوحيدة التي تكون فيها هذه الأداة هي الخطأ.
+    </p>
+
+    <p class="field-summary">
+      <strong>الصورة أو ملف PNG</strong> يوضَع كما هو ويحتفظ بألوانه، فلا يعود لون الصفّ إلا اسماً له. وهو يُقرأ هنا أيضاً ويُعاد رسمه قبل وضعه &mdash; وهذا يحدّ من مقدار ما يضيفه إلى الرسم ويترك بيانات الملف الوصفية خلفه. وما كان شفّافاً يبقى شفّافاً، فالصورة المقصوصة تقف على المسطرة نظيفة، أما الصورة الفوتوغرافية فتأتي بخلفيتها معها، والأفضل قصّها أولاً.
     </p>
 
     <p class="field-summary">
@@ -215,7 +219,7 @@
     <span data-phrase="shape.boy">صبي</span>
     <span data-phrase="shape.girl">فتاة</span>
     <span data-phrase="shape.object">شيء</span>
-    <span data-phrase="shape.upload">SVG خاص بك</span>
+    <span data-phrase="shape.upload">صورة خاصة بك</span>
 
     <span data-phrase="row.shape">شكل الصفّ {n}</span>
     <span data-phrase="row.name">اسم الصفّ {n}</span>
@@ -241,6 +245,9 @@
     <span data-phrase="svg.noshapes">لا شيء يمكن رسمه في ذلك الملف. لا تُبقى إلا الأشكال &mdash; وملف ليس فيه سوى نصوص أو مؤثرات أو صور مرتبطة لا يحوي منها شيئاً.</span>
     <span data-phrase="svg.unreadable">ذلك الملف ليس ملف SVG يمكن قراءته هنا.</span>
     <span data-phrase="svg.toobig">ذلك الملف أكبر من أن يكون شكلاً واحداً. والحد ميغابايتان.</span>
+    <span data-phrase="image.added">أُضيفت. قُرئت الصورة في هذه الصفحة ولم يُرفَع شيء.</span>
+    <span data-phrase="image.unreadable">ذلك الملف ليس صورة يمكن قراءتها هنا.</span>
+    <span data-phrase="image.toobig">تلك الصورة أكبر من اللازم. والحدّ اثنا عشر ميغابايت.</span>
     <span data-phrase="chart.empty">أضِف أحداً، ويظهر الرسم هنا.</span>
     <span data-phrase="chart.noheights">كلّ صفّ يحتاج إلى طول. املأ واحداً ويظهر الرسم هنا.</span>
     <span data-phrase="chart.full">اثنا عشر شكلاً هي أقصى ما يحمله هذا الرسم ويظلّ مقروءاً.</span>

--- a/locales/de/tools/compare-heights.html
+++ b/locales/de/tools/compare-heights.html
@@ -45,13 +45,13 @@
       <div class="toolbar-actions">
         <button type="button" id="add-person" class="primary">Person hinzufügen</button>
         <button type="button" id="add-object" class="ghost">Gegenstand hinzufügen</button>
-        <button type="button" id="add-svg" class="ghost">Eigenes SVG</button>
+        <button type="button" id="add-svg" class="ghost">Eigenes Bild</button>
         <button type="button" id="clear" class="ghost danger">Diagramm leeren</button>
         <!-- Wird vom Button darüber ausgelöst statt angezeigt: Die Beschriftung steht
              hier, weil ein Bedienelement, das ein Besucher erreichen kann, einen
              Namen braucht, ob es das Angeklickte ist oder nicht. -->
-        <input type="file" id="svg-file" accept=".svg,image/svg+xml"
-               aria-label="SVG-Datei auswählen, die auf das Diagramm soll" hidden>
+        <input type="file" id="svg-file" accept="image/*,.svg"
+               aria-label="Bild auswählen, das auf das Diagramm soll" hidden>
       </div>
       <span class="count" id="row-count"></span>
     </div>
@@ -91,7 +91,7 @@
       </select>
     </div>
     <p class="field-summary">
-      <strong>Eigenes SVG</strong> setzt jede beliebige Zeichnung auf den Maßstab
+      <strong>Ein SVG</strong> setzt jede beliebige Zeichnung auf den Maßstab
       &mdash; ein Logo, einen Grundriss, ein Maschinenteil. Sie wird auf dieser
       Seite gelesen und geht nirgendwohin. Behalten werden nur die Formen darin:
       Sie kommt in einer einzigen Volltonfarbe an, die Sie je Zeile wählen, und
@@ -100,6 +100,10 @@
       Diagramm getragen zu werden, das Sie jemandem schicken. Eine Zeichnung aus
       dünnen Linien statt aus gefüllten Formen kommt als einfarbiger Klecks
       heraus, und das ist der eine Fall, in dem dies das falsche Werkzeug ist.
+    </p>
+
+    <p class="field-summary">
+      <strong>Ein Foto oder ein PNG</strong> kommt stattdessen als es selbst auf das Diagramm und behält seine eigenen Farben, sodass die Zeilenfarbe es nur noch benennt. Es wird ebenfalls hier gelesen und vorher neu gezeichnet &mdash; das begrenzt, wie stark es das Diagramm wachsen lässt, und lässt die Metadaten der Datei zurück. Was durchsichtig ist, bleibt durchsichtig: ein Freisteller steht sauber auf dem Maßstab, ein Foto bringt seinen Hintergrund mit, und den schneidet man besser vorher weg.
     </p>
 
     <p class="field-summary">
@@ -230,7 +234,7 @@
     <span data-phrase="shape.boy">Junge</span>
     <span data-phrase="shape.girl">Mädchen</span>
     <span data-phrase="shape.object">Gegenstand</span>
-    <span data-phrase="shape.upload">Eigenes SVG</span>
+    <span data-phrase="shape.upload">Eigenes Bild</span>
 
     <span data-phrase="row.shape">Figur für Zeile {n}</span>
     <span data-phrase="row.name">Name für Zeile {n}</span>
@@ -256,6 +260,9 @@
     <span data-phrase="svg.noshapes">In dieser Datei ist nichts zu zeichnen. Behalten werden nur die Formen &mdash; eine Datei aus lauter Text, Effekten oder verlinkten Bildern hat keine.</span>
     <span data-phrase="svg.unreadable">Diese Datei ist kein SVG, das hier gelesen werden kann.</span>
     <span data-phrase="svg.toobig">Diese Datei ist zu groß für eine einzelne Form. Bei zwei Megabyte ist Schluss.</span>
+    <span data-phrase="image.added">Hinzugefügt. Das Bild wurde auf dieser Seite gelesen, hochgeladen wurde nichts.</span>
+    <span data-phrase="image.unreadable">Diese Datei ist kein Bild, das hier gelesen werden kann.</span>
+    <span data-phrase="image.toobig">Dieses Bild ist zu groß. Bei zwölf Megabyte ist Schluss.</span>
     <span data-phrase="chart.empty">Fügen Sie jemanden hinzu, und das Diagramm erscheint hier.</span>
     <span data-phrase="chart.noheights">Jede Zeile braucht eine Größe. Tragen Sie eine ein, und das Diagramm erscheint hier.</span>
     <span data-phrase="chart.full">Zwölf Figuren sind so viele, wie dieses Diagramm fassen kann und dabei lesbar bleibt.</span>

--- a/locales/es/tools/compare-heights.html
+++ b/locales/es/tools/compare-heights.html
@@ -45,13 +45,13 @@
       <div class="toolbar-actions">
         <button type="button" id="add-person" class="primary">Añadir una persona</button>
         <button type="button" id="add-object" class="ghost">Añadir un objeto</button>
-        <button type="button" id="add-svg" class="ghost">Tu propio SVG</button>
+        <button type="button" id="add-svg" class="ghost">Tu propia imagen</button>
         <button type="button" id="clear" class="ghost danger">Vaciar el gráfico</button>
         <!-- Lo dispara el botón de arriba en vez de mostrarse: la etiqueta está aquí
              porque un control al que un visitante puede llegar necesita un nombre,
              sea o no lo que ha pulsado. -->
-        <input type="file" id="svg-file" accept=".svg,image/svg+xml"
-               aria-label="Elige un archivo SVG para poner en el gráfico" hidden>
+        <input type="file" id="svg-file" accept="image/*,.svg"
+               aria-label="Elige una imagen para poner en el gráfico" hidden>
       </div>
       <span class="count" id="row-count"></span>
     </div>
@@ -91,7 +91,7 @@
       </select>
     </div>
     <p class="field-summary">
-      <strong>Tu propio SVG</strong> pone cualquier dibujo en la regla &mdash;
+      <strong>Un SVG</strong> pone cualquier dibujo en la regla &mdash;
       un logotipo, un plano, una pieza de maquinaria. Se lee en esta página y no
       va a ninguna parte. Solo se conservan las formas que tiene: llega en un
       único color plano que eliges por fila, y todo lo que pudiera alcanzar la
@@ -100,6 +100,10 @@
       quizá le mandes a alguien. Un dibujo hecho de líneas finas en lugar de
       formas rellenas sale como un borrón macizo, que es el único caso en que
       esta es la herramienta equivocada.
+    </p>
+
+    <p class="field-summary">
+      <strong>Una foto o un PNG</strong> va tal cual y conserva sus propios colores, así que el color de la fila solo la nombra. También se lee aquí, y se vuelve a dibujar antes de entrar &mdash; lo que limita cuánto engorda el gráfico y deja atrás los metadatos del archivo. Lo transparente sigue siendo transparente, así que un recorte se apoya limpio en la regla, y una foto trae su fondo consigo, que conviene recortar antes.
     </p>
 
     <p class="field-summary">
@@ -229,7 +233,7 @@
     <span data-phrase="shape.boy">Niño</span>
     <span data-phrase="shape.girl">Niña</span>
     <span data-phrase="shape.object">Objeto</span>
-    <span data-phrase="shape.upload">Tu propio SVG</span>
+    <span data-phrase="shape.upload">Tu propia imagen</span>
 
     <span data-phrase="row.shape">Figura de la fila {n}</span>
     <span data-phrase="row.name">Nombre de la fila {n}</span>
@@ -255,6 +259,9 @@
     <span data-phrase="svg.noshapes">En ese archivo no hay nada que dibujar. Solo se conservan las formas &mdash; un archivo de puro texto, efectos o imágenes enlazadas no tiene ninguna.</span>
     <span data-phrase="svg.unreadable">Ese archivo no es un SVG que esto pueda leer.</span>
     <span data-phrase="svg.toobig">Ese archivo es demasiado grande para ser una sola forma. El límite son dos megabytes.</span>
+    <span data-phrase="image.added">Añadida. La imagen se leyó en esta página y no se subió nada.</span>
+    <span data-phrase="image.unreadable">Ese archivo no es una imagen que esto pueda leer.</span>
+    <span data-phrase="image.toobig">Esa imagen es demasiado grande. El límite son doce megabytes.</span>
     <span data-phrase="chart.empty">Añade a alguien y el gráfico aparecerá aquí.</span>
     <span data-phrase="chart.noheights">Cada fila necesita una altura. Rellena una y el gráfico aparecerá aquí.</span>
     <span data-phrase="chart.full">Doce figuras es todo lo que este gráfico admite sin dejar de leerse.</span>

--- a/locales/fr/tools/compare-heights.html
+++ b/locales/fr/tools/compare-heights.html
@@ -45,13 +45,13 @@
       <div class="toolbar-actions">
         <button type="button" id="add-person" class="primary">Ajouter une personne</button>
         <button type="button" id="add-object" class="ghost">Ajouter un objet</button>
-        <button type="button" id="add-svg" class="ghost">Votre propre SVG</button>
+        <button type="button" id="add-svg" class="ghost">Votre propre image</button>
         <button type="button" id="clear" class="ghost danger">Vider le graphique</button>
         <!-- Déclenché par le bouton ci-dessus plutôt qu'affiché : le libellé est ici
              parce qu'un contrôle qu'un visiteur peut atteindre a besoin d'un nom,
              qu'il soit ou non ce sur quoi il a cliqué. -->
-        <input type="file" id="svg-file" accept=".svg,image/svg+xml"
-               aria-label="Choisir un fichier SVG à mettre sur le graphique" hidden>
+        <input type="file" id="svg-file" accept="image/*,.svg"
+               aria-label="Choisir une image à mettre sur le graphique" hidden>
       </div>
       <span class="count" id="row-count"></span>
     </div>
@@ -91,7 +91,7 @@
       </select>
     </div>
     <p class="field-summary">
-      <strong>Votre propre SVG</strong> pose n'importe quel dessin sur la règle
+      <strong>Un SVG</strong> pose n'importe quel dessin sur la règle
       &mdash; un logo, un plan, une pièce de machine. Il est lu dans cette page
       et ne va nulle part. Seules les formes qu'il contient sont gardées&nbsp;:
       il arrive dans une seule couleur pleine que vous choisissez par ligne, et
@@ -100,6 +100,10 @@
       d'être emporté dans un graphique que vous enverriez à quelqu'un. Un dessin
       fait de traits fins plutôt que de formes pleines ressort en pâté d'un seul
       tenant, et c'est le seul cas où ce n'est pas le bon outil.
+    </p>
+
+    <p class="field-summary">
+      <strong>Une photo ou un PNG</strong> arrive tel quel et garde ses propres couleurs, si bien que la couleur de la ligne ne fait plus que le nommer. Il est lu ici lui aussi, et redessiné avant d'être posé &mdash; ce qui borne ce qu'il ajoute au graphique et laisse derrière lui les métadonnées du fichier. Ce qui est transparent le reste : un détourage se pose proprement sur la règle, tandis qu'une photo apporte son fond avec elle, qu'il vaut mieux recadrer avant.
     </p>
 
     <p class="field-summary">
@@ -231,7 +235,7 @@
     <span data-phrase="shape.boy">Garçon</span>
     <span data-phrase="shape.girl">Fille</span>
     <span data-phrase="shape.object">Objet</span>
-    <span data-phrase="shape.upload">Votre propre SVG</span>
+    <span data-phrase="shape.upload">Votre propre image</span>
 
     <span data-phrase="row.shape">Figure de la ligne {n}</span>
     <span data-phrase="row.name">Nom de la ligne {n}</span>
@@ -257,6 +261,9 @@
     <span data-phrase="svg.noshapes">Il n'y a rien à dessiner dans ce fichier. Seules les formes sont conservées &mdash; un fichier fait uniquement de texte, d'effets ou d'images liées n'en a aucune.</span>
     <span data-phrase="svg.unreadable">Ce fichier n'est pas un SVG lisible ici.</span>
     <span data-phrase="svg.toobig">Ce fichier est trop gros pour une seule forme. La limite est de deux mégaoctets.</span>
+    <span data-phrase="image.added">Ajoutée. L'image a été lue dans cette page et rien n'a été envoyé.</span>
+    <span data-phrase="image.unreadable">Ce fichier n'est pas une image lisible ici.</span>
+    <span data-phrase="image.toobig">Cette image est trop grosse. La limite est de douze mégaoctets.</span>
     <span data-phrase="chart.empty">Ajoutez quelqu'un, et le graphique apparaîtra ici.</span>
     <span data-phrase="chart.noheights">Chaque ligne a besoin d'une taille. Remplissez-en une et le graphique apparaîtra ici.</span>
     <span data-phrase="chart.full">Douze figures, c'est tout ce que ce graphique peut porter en restant lisible.</span>

--- a/locales/hi/tools/compare-heights.html
+++ b/locales/hi/tools/compare-heights.html
@@ -43,12 +43,12 @@
       <div class="toolbar-actions">
         <button type="button" id="add-person" class="primary">एक व्यक्ति जोड़िए</button>
         <button type="button" id="add-object" class="ghost">एक चीज़ जोड़िए</button>
-        <button type="button" id="add-svg" class="ghost">अपनी SVG</button>
+        <button type="button" id="add-svg" class="ghost">अपनी तस्वीर</button>
         <button type="button" id="clear" class="ghost danger">चार्ट खाली कीजिए</button>
         <!-- दिखने के बजाय ऊपर वाले बटन से चलता है: लेबल यहाँ इसलिए है कि जिस नियंत्रण तक कोई
              आगंतुक पहुँच सकता है उसे नाम चाहिए, चाहे उसने उसी पर क्लिक किया हो या नहीं। -->
-        <input type="file" id="svg-file" accept=".svg,image/svg+xml"
-               aria-label="चार्ट पर रखने के लिए एक SVG फ़ाइल चुनिए" hidden>
+        <input type="file" id="svg-file" accept="image/*,.svg"
+               aria-label="चार्ट पर रखने के लिए एक तस्वीर चुनिए" hidden>
       </div>
       <span class="count" id="row-count"></span>
     </div>
@@ -88,7 +88,7 @@
       </select>
     </div>
     <p class="field-summary">
-      <strong>अपनी SVG</strong> किसी भी चित्र को पैमाने पर रख देती है &mdash; एक
+      <strong>कोई SVG</strong> किसी भी चित्र को पैमाने पर रख देती है &mdash; एक
       लोगो, एक नक़्शा, मशीन का कोई हिस्सा। वह इसी पेज में पढ़ी जाती है और कहीं नहीं
       जाती। उसमें से सिर्फ़ आकृतियाँ रखी जाती हैं: वह एक ही भरे हुए रंग में आती है,
       जो आप हर पंक्ति के लिए चुनते हैं, और जो कुछ भी नेटवर्क तक पहुँच सकता था &mdash;
@@ -96,6 +96,10 @@
       चार्ट में जाने के बजाय पीछे छूट जाता है जिसे आप शायद किसी को भेजें। भरी हुई
       आकृतियों के बजाय पतली रेखाओं से बना चित्र एक ठोस धब्बे की तरह निकलेगा, और यही
       वह इकलौता मौक़ा है जब यह ग़लत औज़ार है।
+    </p>
+
+    <p class="field-summary">
+      <strong>कोई फ़ोटो या PNG</strong> जैसी है वैसी ही जाती है और अपने रंग रखती है, इसलिए पंक्ति का रंग सिर्फ़ उसका नाम लिखता है। वह भी यहीं पढ़ी जाती है और रखे जाने से पहले दोबारा बनाई जाती है &mdash; इससे चार्ट कितना भारी होगा यह सीमित रहता है और फ़ाइल का मेटाडेटा पीछे छूट जाता है। जो पारदर्शी है वह पारदर्शी ही रहता है, इसलिए कटी हुई तस्वीर पैमाने पर साफ़ खड़ी होती है, और फ़ोटो अपनी पृष्ठभूमि भी साथ लाती है, जिसे पहले काट देना बेहतर है।
     </p>
 
     <p class="field-summary">
@@ -223,7 +227,7 @@
     <span data-phrase="shape.boy">लड़का</span>
     <span data-phrase="shape.girl">लड़की</span>
     <span data-phrase="shape.object">चीज़</span>
-    <span data-phrase="shape.upload">अपनी SVG</span>
+    <span data-phrase="shape.upload">अपनी तस्वीर</span>
 
     <span data-phrase="row.shape">पंक्ति {n} की आकृति</span>
     <span data-phrase="row.name">पंक्ति {n} का नाम</span>
@@ -249,6 +253,9 @@
     <span data-phrase="svg.noshapes">उस फ़ाइल में बनाने लायक कुछ नहीं है। सिर्फ़ आकृतियाँ रखी जाती हैं &mdash; और जिस फ़ाइल में केवल टेक्स्ट, इफ़ेक्ट या जुड़ी हुई तस्वीरें हों, उसमें वे नहीं होतीं।</span>
     <span data-phrase="svg.unreadable">वह फ़ाइल ऐसी SVG नहीं जो यहाँ पढ़ी जा सके।</span>
     <span data-phrase="svg.toobig">वह फ़ाइल एक आकृति के लिहाज़ से बहुत बड़ी है। सीमा दो मेगाबाइट है।</span>
+    <span data-phrase="image.added">जुड़ गई। तस्वीर इसी पेज में पढ़ी गई और कुछ भी अपलोड नहीं हुआ।</span>
+    <span data-phrase="image.unreadable">वह फ़ाइल ऐसी तस्वीर नहीं जो यहाँ पढ़ी जा सके।</span>
+    <span data-phrase="image.toobig">वह तस्वीर बहुत बड़ी है। सीमा बारह मेगाबाइट है।</span>
     <span data-phrase="chart.empty">किसी को जोड़िए, और चार्ट यहाँ दिख जाएगा।</span>
     <span data-phrase="chart.noheights">हर पंक्ति को एक ऊँचाई चाहिए। एक भर दीजिए, और चार्ट यहाँ दिख जाएगा।</span>
     <span data-phrase="chart.full">बारह आकृतियाँ ही इतनी हैं जितनी यह चार्ट पढ़ने लायक रहते हुए सँभाल सकता है।</span>

--- a/locales/id/tools/compare-heights.html
+++ b/locales/id/tools/compare-heights.html
@@ -45,13 +45,13 @@
       <div class="toolbar-actions">
         <button type="button" id="add-person" class="primary">Tambah orang</button>
         <button type="button" id="add-object" class="ghost">Tambah benda</button>
-        <button type="button" id="add-svg" class="ghost">SVG milik Anda</button>
+        <button type="button" id="add-svg" class="ghost">Gambar milik Anda</button>
         <button type="button" id="clear" class="ghost danger">Kosongkan bagan</button>
         <!-- Dijalankan oleh tombol di atas alih-alih ditampilkan: labelnya ada di sini
              karena kontrol yang bisa dijangkau pengunjung butuh nama, baik itu yang
              mereka klik maupun bukan. -->
-        <input type="file" id="svg-file" accept=".svg,image/svg+xml"
-               aria-label="Pilih berkas SVG untuk ditaruh di bagan" hidden>
+        <input type="file" id="svg-file" accept="image/*,.svg"
+               aria-label="Pilih gambar untuk ditaruh di bagan" hidden>
       </div>
       <span class="count" id="row-count"></span>
     </div>
@@ -91,7 +91,7 @@
       </select>
     </div>
     <p class="field-summary">
-      <strong>SVG milik Anda</strong> menaruh gambar apa pun di penggaris
+      <strong>Sebuah SVG</strong> menaruh gambar apa pun di penggaris
       &mdash; sebuah logo, denah, atau bagian mesin. Ia dibaca di halaman ini
       dan tidak ke mana-mana. Hanya bentuk di dalamnya yang disimpan: ia datang
       sebagai satu warna padat yang Anda pilih per baris, dan apa pun yang bisa
@@ -100,6 +100,10 @@
       Anda kirim ke orang lain. Gambar yang dibuat dari garis tipis, bukan dari
       bentuk terisi, akan keluar sebagai gumpalan padat, dan itulah satu-satunya
       kasus di mana ini alat yang keliru.
+    </p>
+
+    <p class="field-summary">
+      <strong>Foto atau PNG</strong> masuk apa adanya dan menyimpan warnanya sendiri, jadi warna baris hanya menamainya. Berkasnya juga dibaca di sini dan digambar ulang sebelum dipasang &mdash; itu membatasi seberapa berat bagannya jadi, dan meninggalkan metadata berkas. Yang tembus pandang tetap tembus pandang, jadi gambar yang sudah dipotong berdiri bersih di penggaris, sedangkan foto membawa latarnya, yang sebaiknya dipangkas dulu.
     </p>
 
     <p class="field-summary">
@@ -228,7 +232,7 @@
     <span data-phrase="shape.boy">Anak laki-laki</span>
     <span data-phrase="shape.girl">Anak perempuan</span>
     <span data-phrase="shape.object">Benda</span>
-    <span data-phrase="shape.upload">SVG milik Anda</span>
+    <span data-phrase="shape.upload">Gambar milik Anda</span>
 
     <span data-phrase="row.shape">Figur untuk baris {n}</span>
     <span data-phrase="row.name">Nama untuk baris {n}</span>
@@ -254,6 +258,9 @@
     <span data-phrase="svg.noshapes">Tidak ada yang bisa digambar di berkas itu. Hanya bentuknya yang disimpan &mdash; berkas yang isinya cuma teks, efek atau gambar tertaut tidak punya satu pun.</span>
     <span data-phrase="svg.unreadable">Berkas itu bukan SVG yang bisa dibaca di sini.</span>
     <span data-phrase="svg.toobig">Berkas itu terlalu besar untuk satu bentuk. Batasnya dua megabita.</span>
+    <span data-phrase="image.added">Ditambahkan. Gambarnya dibaca di halaman ini dan tidak ada yang diunggah.</span>
+    <span data-phrase="image.unreadable">Berkas itu bukan gambar yang bisa dibaca di sini.</span>
+    <span data-phrase="image.toobig">Gambar itu terlalu besar. Batasnya dua belas megabita.</span>
     <span data-phrase="chart.empty">Tambahkan seseorang, dan bagannya muncul di sini.</span>
     <span data-phrase="chart.noheights">Setiap baris perlu tinggi. Isi satu dan bagannya muncul di sini.</span>
     <span data-phrase="chart.full">Dua belas figur adalah sebanyak yang bisa dimuat bagan ini dan tetap terbaca.</span>

--- a/locales/it/tools/compare-heights.html
+++ b/locales/it/tools/compare-heights.html
@@ -45,13 +45,13 @@
       <div class="toolbar-actions">
         <button type="button" id="add-person" class="primary">Aggiungi una persona</button>
         <button type="button" id="add-object" class="ghost">Aggiungi un oggetto</button>
-        <button type="button" id="add-svg" class="ghost">Il tuo SVG</button>
+        <button type="button" id="add-svg" class="ghost">La tua immagine</button>
         <button type="button" id="clear" class="ghost danger">Svuota il grafico</button>
         <!-- Azionato dal pulsante qui sopra invece che mostrato: l'etichetta sta qui
              perché un controllo che un visitatore può raggiungere ha bisogno di un
              nome, che sia o no la cosa su cui ha cliccato. -->
-        <input type="file" id="svg-file" accept=".svg,image/svg+xml"
-               aria-label="Scegli un file SVG da mettere sul grafico" hidden>
+        <input type="file" id="svg-file" accept="image/*,.svg"
+               aria-label="Scegli un'immagine da mettere sul grafico" hidden>
       </div>
       <span class="count" id="row-count"></span>
     </div>
@@ -91,7 +91,7 @@
       </select>
     </div>
     <p class="field-summary">
-      <strong>Il tuo SVG</strong> mette qualunque disegno sul righello &mdash;
+      <strong>Un SVG</strong> mette qualunque disegno sul righello &mdash;
       un logo, una pianta, un pezzo di macchinario. Viene letto in questa pagina
       e non va da nessuna parte. Si tiene solo quello che c'è dentro come forme:
       arriva in un unico colore pieno che scegli riga per riga, e tutto quello
@@ -100,6 +100,10 @@
       un grafico che magari mandi a qualcuno. Un disegno fatto di linee sottili
       invece che di forme piene esce come una macchia compatta, ed è l'unico
       caso in cui questo è lo strumento sbagliato.
+    </p>
+
+    <p class="field-summary">
+      <strong>Una foto o un PNG</strong> ci va così com'è e tiene i suoi colori, quindi il colore della riga si limita a nominarla. Anche questa viene letta qui, e ridisegnata prima di entrare &mdash; il che limita quanto fa crescere il grafico e lascia indietro i metadati del file. Ciò che è trasparente resta trasparente: un ritaglio sta pulito sul righello, mentre una foto si porta dietro lo sfondo, che conviene tagliare prima.
     </p>
 
     <p class="field-summary">
@@ -228,7 +232,7 @@
     <span data-phrase="shape.boy">Bambino</span>
     <span data-phrase="shape.girl">Bambina</span>
     <span data-phrase="shape.object">Oggetto</span>
-    <span data-phrase="shape.upload">Il tuo SVG</span>
+    <span data-phrase="shape.upload">La tua immagine</span>
 
     <span data-phrase="row.shape">Figura della riga {n}</span>
     <span data-phrase="row.name">Nome della riga {n}</span>
@@ -254,6 +258,9 @@
     <span data-phrase="svg.noshapes">In quel file non c'è niente da disegnare. Si tengono solo le forme &mdash; un file fatto solo di testo, effetti o immagini collegate non ne ha.</span>
     <span data-phrase="svg.unreadable">Quel file non è un SVG leggibile qui.</span>
     <span data-phrase="svg.toobig">Quel file è troppo grande per essere una forma sola. Il limite è due megabyte.</span>
+    <span data-phrase="image.added">Aggiunta. L'immagine è stata letta in questa pagina e non è stato caricato niente.</span>
+    <span data-phrase="image.unreadable">Quel file non è un'immagine leggibile qui.</span>
+    <span data-phrase="image.toobig">Quell'immagine è troppo grande. Il limite è dodici megabyte.</span>
     <span data-phrase="chart.empty">Aggiungi qualcuno e il grafico comparirà qui.</span>
     <span data-phrase="chart.noheights">Ogni riga ha bisogno di un'altezza. Riempine una e il grafico comparirà qui.</span>
     <span data-phrase="chart.full">Dodici figure sono quante ne regge questo grafico restando leggibile.</span>

--- a/locales/ja/tools/compare-heights.html
+++ b/locales/ja/tools/compare-heights.html
@@ -35,12 +35,12 @@
       <div class="toolbar-actions">
         <button type="button" id="add-person" class="primary">人を追加</button>
         <button type="button" id="add-object" class="ghost">ものを追加</button>
-        <button type="button" id="add-svg" class="ghost">自分の SVG</button>
+        <button type="button" id="add-svg" class="ghost">自分の画像</button>
         <button type="button" id="clear" class="ghost danger">図表を空にする</button>
         <!-- 表示するのではなく上のボタンから動かします。ラベルをここに置いているのは、訪問者が
              たどり着ける操作要素には、クリックしたものかどうかによらず名前が要るからです。 -->
-        <input type="file" id="svg-file" accept=".svg,image/svg+xml"
-               aria-label="図表に載せるSVGファイルを選びます" hidden>
+        <input type="file" id="svg-file" accept="image/*,.svg"
+               aria-label="図表に載せる画像を選びます" hidden>
       </div>
       <span class="count" id="row-count"></span>
     </div>
@@ -80,7 +80,11 @@
       </select>
     </div>
     <p class="field-summary">
-      <strong>自分の SVG</strong>は、どんな絵でも目盛りの上に置けます。ロゴでも、間取り図でも、機械の部品でも構いません。ファイルはこのページの中で読まれ、どこにも出ていきません。残るのはその中の図形だけで、行ごとに選んだ一色の塗りとして届きます。ネットワークに手が届きうるもの&mdash;リンクされた画像、スタイルシート、フォント、スクリプト&mdash;は、誰かに送るかもしれない図表の中に運び込まれず、そこに置いていかれます。塗られた図形ではなく細い線で描かれた絵は、一つの塊のしみになって出てきます。この道具が向かないのは、その一点だけです。
+      <strong>SVG</strong>は、どんな絵でも目盛りの上に置けます。ロゴでも、間取り図でも、機械の部品でも構いません。ファイルはこのページの中で読まれ、どこにも出ていきません。残るのはその中の図形だけで、行ごとに選んだ一色の塗りとして届きます。ネットワークに手が届きうるもの&mdash;リンクされた画像、スタイルシート、フォント、スクリプト&mdash;は、誰かに送るかもしれない図表の中に運び込まれず、そこに置いていかれます。塗られた図形ではなく細い線で描かれた絵は、一つの塊のしみになって出てきます。この道具が向かないのは、その一点だけです。
+    </p>
+
+    <p class="field-summary">
+      <strong>写真や PNG</strong> はそのまま載り、自分の色を保ちます。ですから行の色は、その名前を書くだけになります。こちらもこのページの中で読まれ、載せる前に描き直されます&mdash;図表がどれだけ重くなるかはそこで抑えられ、ファイルの付帯情報は置いていかれます。透明なところは透明のままなので、切り抜きは目盛りの上にきれいに立ちますが、写真は背景ごと来ます。先に切っておくのが良いでしょう。
     </p>
 
     <p class="field-summary">
@@ -185,7 +189,7 @@
     <span data-phrase="shape.boy">男の子</span>
     <span data-phrase="shape.girl">女の子</span>
     <span data-phrase="shape.object">もの</span>
-    <span data-phrase="shape.upload">自分の SVG</span>
+    <span data-phrase="shape.upload">自分の画像</span>
 
     <span data-phrase="row.shape">{n}行目の図</span>
     <span data-phrase="row.name">{n}行目の名前</span>
@@ -211,6 +215,9 @@
     <span data-phrase="svg.noshapes">そのファイルには描けるものがありません。残すのは図形だけなので &mdash; 文字や効果、リンクされた画像しかないファイルには何も残りません。</span>
     <span data-phrase="svg.unreadable">そのファイルは、ここで読める SVG ではありません。</span>
     <span data-phrase="svg.toobig">そのファイルは、ひとつの図形にしては大きすぎます。上限は 2 メガバイトです。</span>
+    <span data-phrase="image.added">追加しました。画像はこのページの中で読まれ、何もアップロードしていません。</span>
+    <span data-phrase="image.unreadable">そのファイルは、ここで読める画像ではありません。</span>
+    <span data-phrase="image.toobig">その画像は大きすぎます。上限は 12 メガバイトです。</span>
     <span data-phrase="chart.empty">誰かを追加すると、ここに図表が出ます。</span>
     <span data-phrase="chart.noheights">どの行にも身長が要ります。ひとつ入れると、ここに図表が出ます。</span>
     <span data-phrase="chart.full">12体が、この図表が読めるまま収められる限りです。</span>

--- a/locales/ko/tools/compare-heights.html
+++ b/locales/ko/tools/compare-heights.html
@@ -43,12 +43,12 @@
       <div class="toolbar-actions">
         <button type="button" id="add-person" class="primary">사람 추가</button>
         <button type="button" id="add-object" class="ghost">사물 추가</button>
-        <button type="button" id="add-svg" class="ghost">내 SVG</button>
+        <button type="button" id="add-svg" class="ghost">내 이미지</button>
         <button type="button" id="clear" class="ghost danger">차트 비우기</button>
         <!-- 보이는 대신 위의 버튼이 동작시킵니다. 레이블이 여기 있는 것은, 방문자가 닿을 수 있는
              컨트롤이라면 클릭한 것이든 아니든 이름이 필요하기 때문입니다. -->
-        <input type="file" id="svg-file" accept=".svg,image/svg+xml"
-               aria-label="차트에 올릴 SVG 파일을 고르세요" hidden>
+        <input type="file" id="svg-file" accept="image/*,.svg"
+               aria-label="차트에 올릴 이미지를 고르세요" hidden>
       </div>
       <span class="count" id="row-count"></span>
     </div>
@@ -88,13 +88,17 @@
       </select>
     </div>
     <p class="field-summary">
-      <strong>내 SVG</strong>는 어떤 그림이든 눈금자 위에 올려 줍니다. 로고도, 평면도도,
+      <strong>SVG</strong>는 어떤 그림이든 눈금자 위에 올려 줍니다. 로고도, 평면도도,
       기계 부품도 됩니다. 그림은 이 페이지 안에서 읽히고 어디로도 가지 않습니다. 남는 것은
       그 안의 도형뿐이라, 줄마다 고르신 단색 하나로 들어옵니다. 그리고 네트워크에 닿을 수
       있는 것은 무엇이든 &mdash; 링크된 이미지, 스타일시트, 글꼴, 스크립트 &mdash; 남에게
       보내실 수도 있는 차트 안으로 실려 가지 않고 그 자리에 남습니다. 채워진 도형이 아니라
       가는 선으로 그린 그림은 통짜 얼룩처럼 나오는데, 이 도구가 맞지 않는 경우는 그것
       하나입니다.
+    </p>
+
+    <p class="field-summary">
+      <strong>사진이나 PNG</strong>는 그대로 올라가며 자기 색을 그대로 지닙니다. 그래서 행의 색은 이름을 쓰는 데만 쓰입니다. 이것도 이 페이지 안에서 읽히고, 올리기 전에 다시 그려집니다&mdash;그래서 차트가 얼마나 무거워질지가 여기서 묶이고, 파일의 부가 정보는 남지 않습니다. 투명한 곳은 투명한 채로 남으니 오려낸 그림은 눈금자 위에 깔끔하게 서지만, 사진은 배경까지 함께 옵니다. 미리 잘라 두는 편이 좋습니다.
     </p>
 
     <p class="field-summary">
@@ -216,7 +220,7 @@
     <span data-phrase="shape.boy">남자아이</span>
     <span data-phrase="shape.girl">여자아이</span>
     <span data-phrase="shape.object">사물</span>
-    <span data-phrase="shape.upload">내 SVG</span>
+    <span data-phrase="shape.upload">내 이미지</span>
 
     <span data-phrase="row.shape">{n}번째 줄의 그림</span>
     <span data-phrase="row.name">{n}번째 줄의 이름</span>
@@ -242,6 +246,9 @@
     <span data-phrase="svg.noshapes">그 파일에는 그릴 것이 없습니다. 남기는 것은 도형뿐이라 &mdash; 글자와 효과, 연결된 이미지밖에 없는 파일에는 남을 것이 없습니다.</span>
     <span data-phrase="svg.unreadable">그 파일은 여기서 읽을 수 있는 SVG가 아닙니다.</span>
     <span data-phrase="svg.toobig">그 파일은 도형 하나치고 너무 큽니다. 한도는 2메가바이트입니다.</span>
+    <span data-phrase="image.added">추가했습니다. 이미지는 이 페이지 안에서 읽혔고 아무것도 업로드하지 않았습니다.</span>
+    <span data-phrase="image.unreadable">그 파일은 여기서 읽을 수 있는 이미지가 아닙니다.</span>
+    <span data-phrase="image.toobig">그 이미지는 너무 큽니다. 한도는 12메가바이트입니다.</span>
     <span data-phrase="chart.empty">누군가를 넣으면 차트가 여기에 나타납니다.</span>
     <span data-phrase="chart.noheights">모든 줄에 키가 있어야 합니다. 하나를 채우면 차트가 여기에 나타납니다.</span>
     <span data-phrase="chart.full">열두 개가 이 차트가 읽히는 채로 담을 수 있는 전부입니다.</span>

--- a/locales/nl/tools/compare-heights.html
+++ b/locales/nl/tools/compare-heights.html
@@ -45,13 +45,13 @@
       <div class="toolbar-actions">
         <button type="button" id="add-person" class="primary">Iemand toevoegen</button>
         <button type="button" id="add-object" class="ghost">Een voorwerp toevoegen</button>
-        <button type="button" id="add-svg" class="ghost">Eigen SVG</button>
+        <button type="button" id="add-svg" class="ghost">Eigen afbeelding</button>
         <button type="button" id="clear" class="ghost danger">De grafiek leegmaken</button>
         <!-- Aangestuurd door de knop hierboven in plaats van getoond: het label staat
              hier omdat een besturingselement dat een bezoeker kan bereiken een naam
              nodig heeft, of het nu is waarop geklikt is of niet. -->
-        <input type="file" id="svg-file" accept=".svg,image/svg+xml"
-               aria-label="Kies een SVG-bestand om op de grafiek te zetten" hidden>
+        <input type="file" id="svg-file" accept="image/*,.svg"
+               aria-label="Kies een afbeelding om op de grafiek te zetten" hidden>
       </div>
       <span class="count" id="row-count"></span>
     </div>
@@ -91,7 +91,7 @@
       </select>
     </div>
     <p class="field-summary">
-      <strong>Eigen SVG</strong> zet elke tekening op de meetlat &mdash; een
+      <strong>Een SVG</strong> zet elke tekening op de meetlat &mdash; een
       logo, een plattegrond, een machineonderdeel. Hij wordt in deze pagina
       gelezen en gaat nergens heen. Alleen de vormen erin worden bewaard: hij
       komt aan in één egale kleur die je per regel kiest, en alles wat het
@@ -101,6 +101,10 @@
       tekening van dunne lijnen in plaats van gevulde vormen komt er als één
       massieve klodder uit, en dat is het enige geval waarin dit het verkeerde
       gereedschap is.
+    </p>
+
+    <p class="field-summary">
+      <strong>Een foto of een PNG</strong> gaat er in plaats daarvan als zichzelf op en houdt zijn eigen kleuren, zodat de kleur van de rij hem alleen nog benoemt. Ook die wordt hier gelezen en eerst opnieuw getekend &mdash; dat begrenst hoeveel hij aan de grafiek toevoegt en laat de metadata van het bestand achter. Wat doorzichtig is blijft doorzichtig, dus een uitsnede staat schoon op de meetlat, en een foto neemt zijn achtergrond mee, die je er beter eerst af kunt snijden.
     </p>
 
     <p class="field-summary">
@@ -229,7 +233,7 @@
     <span data-phrase="shape.boy">Jongen</span>
     <span data-phrase="shape.girl">Meisje</span>
     <span data-phrase="shape.object">Voorwerp</span>
-    <span data-phrase="shape.upload">Eigen SVG</span>
+    <span data-phrase="shape.upload">Eigen afbeelding</span>
 
     <span data-phrase="row.shape">Figuur voor regel {n}</span>
     <span data-phrase="row.name">Naam voor regel {n}</span>
@@ -255,6 +259,9 @@
     <span data-phrase="svg.noshapes">In dat bestand valt niets te tekenen. Alleen de vormen worden bewaard &mdash; een bestand met alleen tekst, effecten of gelinkte afbeeldingen heeft er geen.</span>
     <span data-phrase="svg.unreadable">Dat bestand is geen SVG die dit kan lezen.</span>
     <span data-phrase="svg.toobig">Dat bestand is te groot voor één vorm. Twee megabyte is de grens.</span>
+    <span data-phrase="image.added">Toegevoegd. De afbeelding is op deze pagina gelezen en er is niets geüpload.</span>
+    <span data-phrase="image.unreadable">Dat bestand is geen afbeelding die dit kan lezen.</span>
+    <span data-phrase="image.toobig">Die afbeelding is te groot. Twaalf megabyte is de grens.</span>
     <span data-phrase="chart.empty">Voeg iemand toe, en de grafiek verschijnt hier.</span>
     <span data-phrase="chart.noheights">Elke regel heeft een lengte nodig. Vul er een in en de grafiek verschijnt hier.</span>
     <span data-phrase="chart.full">Twaalf figuren is alles wat deze grafiek kan dragen en leesbaar blijven.</span>

--- a/locales/pt/tools/compare-heights.html
+++ b/locales/pt/tools/compare-heights.html
@@ -45,13 +45,13 @@
       <div class="toolbar-actions">
         <button type="button" id="add-person" class="primary">Adicionar uma pessoa</button>
         <button type="button" id="add-object" class="ghost">Adicionar um objeto</button>
-        <button type="button" id="add-svg" class="ghost">Seu próprio SVG</button>
+        <button type="button" id="add-svg" class="ghost">Sua própria imagem</button>
         <button type="button" id="clear" class="ghost danger">Limpar o gráfico</button>
         <!-- Acionado pelo botão acima em vez de exibido: o rótulo está aqui porque um
              controle que um visitante consegue alcançar precisa de um nome, seja ou
              não aquilo em que ele clicou. -->
-        <input type="file" id="svg-file" accept=".svg,image/svg+xml"
-               aria-label="Escolha um arquivo SVG para pôr no gráfico" hidden>
+        <input type="file" id="svg-file" accept="image/*,.svg"
+               aria-label="Escolha uma imagem para pôr no gráfico" hidden>
       </div>
       <span class="count" id="row-count"></span>
     </div>
@@ -91,7 +91,7 @@
       </select>
     </div>
     <p class="field-summary">
-      <strong>Seu próprio SVG</strong> põe qualquer desenho na régua &mdash; um
+      <strong>Um SVG</strong> põe qualquer desenho na régua &mdash; um
       logotipo, uma planta, uma peça de máquina. Ele é lido nesta página e não
       vai a lugar nenhum. Só as formas que ele tem são mantidas: chega numa cor
       chapada só, escolhida por você em cada linha, e tudo o que pudesse
@@ -100,6 +100,10 @@
       dentro de um gráfico que você talvez mande para alguém. Um desenho feito
       de linhas finas em vez de formas preenchidas sai como um borrão maciço, e
       esse é o único caso em que esta é a ferramenta errada.
+    </p>
+
+    <p class="field-summary">
+      <strong>Uma foto ou um PNG</strong> entra como é e mantém as próprias cores, de modo que a cor da linha apenas a nomeia. Ela também é lida aqui e redesenhada antes de entrar &mdash; o que limita o quanto faz o gráfico crescer e deixa para trás os metadados do arquivo. O que é transparente continua transparente, então um recorte fica limpo na régua, e uma foto traz o fundo junto, que convém cortar antes.
     </p>
 
     <p class="field-summary">
@@ -227,7 +231,7 @@
     <span data-phrase="shape.boy">Menino</span>
     <span data-phrase="shape.girl">Menina</span>
     <span data-phrase="shape.object">Objeto</span>
-    <span data-phrase="shape.upload">Seu próprio SVG</span>
+    <span data-phrase="shape.upload">Sua própria imagem</span>
 
     <span data-phrase="row.shape">Figura da linha {n}</span>
     <span data-phrase="row.name">Nome da linha {n}</span>
@@ -253,6 +257,9 @@
     <span data-phrase="svg.noshapes">Nesse arquivo não há nada para desenhar. Só as formas são mantidas &mdash; um arquivo feito só de texto, efeitos ou imagens vinculadas não tem nenhuma.</span>
     <span data-phrase="svg.unreadable">Esse arquivo não é um SVG que isto consiga ler.</span>
     <span data-phrase="svg.toobig">Esse arquivo é grande demais para ser uma forma só. O limite são dois megabytes.</span>
+    <span data-phrase="image.added">Adicionada. A imagem foi lida nesta página e nada foi enviado.</span>
+    <span data-phrase="image.unreadable">Esse arquivo não é uma imagem que isto consiga ler.</span>
+    <span data-phrase="image.toobig">Essa imagem é grande demais. O limite são doze megabytes.</span>
     <span data-phrase="chart.empty">Acrescente alguém e o gráfico aparece aqui.</span>
     <span data-phrase="chart.noheights">Toda linha precisa de uma altura. Preencha uma e o gráfico aparece aqui.</span>
     <span data-phrase="chart.full">Doze figuras é o que este gráfico aguenta continuando legível.</span>

--- a/locales/tr/tools/compare-heights.html
+++ b/locales/tr/tools/compare-heights.html
@@ -43,13 +43,13 @@
       <div class="toolbar-actions">
         <button type="button" id="add-person" class="primary">Kişi ekle</button>
         <button type="button" id="add-object" class="ghost">Nesne ekle</button>
-        <button type="button" id="add-svg" class="ghost">Kendi SVG'niz</button>
+        <button type="button" id="add-svg" class="ghost">Kendi görseliniz</button>
         <button type="button" id="clear" class="ghost danger">Grafiği temizle</button>
         <!-- Gösterilmek yerine yukarıdaki düğmeyle çalıştırılır: etiketi burada, çünkü
              bir ziyaretçinin erişebildiği bir denetimin, tıkladığı şey olsun ya da
              olmasın, bir adı olmalıdır. -->
-        <input type="file" id="svg-file" accept=".svg,image/svg+xml"
-               aria-label="Grafiğe konacak bir SVG dosyası seçin" hidden>
+        <input type="file" id="svg-file" accept="image/*,.svg"
+               aria-label="Grafiğe konacak bir görsel seçin" hidden>
       </div>
       <span class="count" id="row-count"></span>
     </div>
@@ -89,7 +89,7 @@
       </select>
     </div>
     <p class="field-summary">
-      <strong>Kendi SVG'niz</strong> herhangi bir çizimi cetvele koyar &mdash;
+      <strong>Bir SVG</strong> herhangi bir çizimi cetvele koyar &mdash;
       bir logo, bir kat planı, bir makine parçası. Bu sayfada okunur ve hiçbir
       yere gitmez. Yalnızca içindeki biçimler tutulur: her satır için sizin
       seçtiğiniz tek bir düz renkle gelir, ve ağa ulaşabilecek ne varsa &mdash;
@@ -97,6 +97,10 @@
       birine gönderebileceğiniz bir grafiğin içine taşınmak yerine geride
       bırakılır. Dolu biçimler yerine ince çizgilerden yapılmış bir çizim tek
       parça bir leke olarak çıkar; bunun yanlış araç olduğu tek durum da budur.
+    </p>
+
+    <p class="field-summary">
+      <strong>Bir fotoğraf ya da PNG</strong> ise olduğu gibi girer ve kendi renklerini korur; böylece satırın rengi onu yalnızca adlandırır. O da burada okunur ve konmadan önce yeniden çizilir &mdash; bu, grafiği ne kadar büyüteceğini sınırlar ve dosyanın üstverisini geride bırakır. Saydam olan saydam kalır, yani kesilmiş bir görsel cetvelin üstünde temiz durur; fotoğraf ise arka planını da getirir, onu önceden kırpmakta fayda var.
     </p>
 
     <p class="field-summary">
@@ -225,7 +229,7 @@
     <span data-phrase="shape.boy">Erkek çocuk</span>
     <span data-phrase="shape.girl">Kız çocuk</span>
     <span data-phrase="shape.object">Nesne</span>
-    <span data-phrase="shape.upload">Kendi SVG'niz</span>
+    <span data-phrase="shape.upload">Kendi görseliniz</span>
 
     <span data-phrase="row.shape">{n}. satırın figürü</span>
     <span data-phrase="row.name">{n}. satırın adı</span>
@@ -251,6 +255,9 @@
     <span data-phrase="svg.noshapes">O dosyada çizilecek bir şey yok. Yalnızca şekiller tutulur &mdash; sadece metin, efekt ya da bağlantılı görsellerden oluşan bir dosyada hiç yoktur.</span>
     <span data-phrase="svg.unreadable">O dosya, burada okunabilen bir SVG değil.</span>
     <span data-phrase="svg.toobig">O dosya tek bir şekil için fazla büyük. Sınır iki megabayt.</span>
+    <span data-phrase="image.added">Eklendi. Görsel bu sayfada okundu, hiçbir şey yüklenmedi.</span>
+    <span data-phrase="image.unreadable">O dosya, burada okunabilen bir görsel değil.</span>
+    <span data-phrase="image.toobig">O görsel fazla büyük. Sınır on iki megabayt.</span>
     <span data-phrase="chart.empty">Birini ekleyin, grafik burada belirsin.</span>
     <span data-phrase="chart.noheights">Her satırın bir boya ihtiyacı var. Birini doldurun, grafik burada belirsin.</span>
     <span data-phrase="chart.full">On iki figür, bu grafiğin okunur kalarak taşıyabileceği en fazla sayıdır.</span>

--- a/locales/zh-TW/tools/compare-heights.html
+++ b/locales/zh-TW/tools/compare-heights.html
@@ -35,12 +35,12 @@
       <div class="toolbar-actions">
         <button type="button" id="add-person" class="primary">加一個人</button>
         <button type="button" id="add-object" class="ghost">加一件東西</button>
-        <button type="button" id="add-svg" class="ghost">自己的 SVG</button>
+        <button type="button" id="add-svg" class="ghost">自己的圖片</button>
         <button type="button" id="clear" class="ghost danger">清空圖表</button>
         <!-- 不顯示，由上面那個按鈕來驅動：標籤寫在這裡，是因為訪客能夠到的控制元件都需要一個名字，
              不管它是不是他們點的那一個。 -->
-        <input type="file" id="svg-file" accept=".svg,image/svg+xml"
-               aria-label="選擇一個要放到圖上的 SVG 檔案" hidden>
+        <input type="file" id="svg-file" accept="image/*,.svg"
+               aria-label="選擇一個要放到圖上的圖片" hidden>
       </div>
       <span class="count" id="row-count"></span>
     </div>
@@ -80,7 +80,11 @@
       </select>
     </div>
     <p class="field-summary">
-      <strong>自己的 SVG</strong> 能把任何一張圖放到標尺上——一個標誌、一張平面圖、一個機器零件都行。檔案在這個頁面裡讀，哪裡都不去。留下的只有裡面的形狀：它以一種實色進來，顏色由你逐行來挑；而任何夠得著網路的東西——外鏈圖片、樣式表、字型、指令碼——都會被留在原地，不會跟著進到一張你可能發給別人的圖裡。用細線畫的、不是實心形狀的圖，出來會是一團實心的墨塊，這也是這個工具唯一不合適的場合。
+      <strong>SVG</strong> 能把任何一張圖放到標尺上——一個標誌、一張平面圖、一個機器零件都行。檔案在這個頁面裡讀，哪裡都不去。留下的只有裡面的形狀：它以一種實色進來，顏色由你逐行來挑；而任何夠得著網路的東西——外鏈圖片、樣式表、字型、指令碼——都會被留在原地，不會跟著進到一張你可能發給別人的圖裡。用細線畫的、不是實心形狀的圖，出來會是一團實心的墨塊，這也是這個工具唯一不合適的場合。
+    </p>
+
+    <p class="field-summary">
+      <strong>照片或 PNG</strong> 則原樣放上去，保留它自己的顏色，所以那一行的顏色只用來寫名字。它同樣在這個頁面裡讀，放上去之前會重畫一遍&mdash;這既限制了它給圖表添的分量，也把檔案裡的附帶資訊留在了外面。透明的地方仍然透明，所以去背好的圖能乾淨地站在標尺上；照片則連背景一起來，最好先裁掉。
     </p>
 
     <p class="field-summary">
@@ -185,7 +189,7 @@
     <span data-phrase="shape.boy">男孩</span>
     <span data-phrase="shape.girl">女孩</span>
     <span data-phrase="shape.object">物體</span>
-    <span data-phrase="shape.upload">自己的 SVG</span>
+    <span data-phrase="shape.upload">自己的圖片</span>
 
     <span data-phrase="row.shape">第 {n} 行的圖形</span>
     <span data-phrase="row.name">第 {n} 行的名字</span>
@@ -211,6 +215,9 @@
     <span data-phrase="svg.noshapes">那個檔案裡沒有可以畫的東西。只留下形狀 &mdash; 只有文字、效果或連結圖片的檔案，一個形狀也沒有。</span>
     <span data-phrase="svg.unreadable">那個檔案不是這裡讀得懂的 SVG。</span>
     <span data-phrase="svg.toobig">那個檔案要當一個形狀太大了。上限是兩 MB。</span>
+    <span data-phrase="image.added">已加入。圖片在這個頁面裡讀，沒有上傳任何東西。</span>
+    <span data-phrase="image.unreadable">那個檔案不是這裡讀得懂的圖片。</span>
+    <span data-phrase="image.toobig">那張圖片太大了。上限是 12 MB。</span>
     <span data-phrase="chart.empty">加個人，圖表就出現在這裡。</span>
     <span data-phrase="chart.noheights">每一行都得有身高。填一個，圖表就出現在這裡。</span>
     <span data-phrase="chart.full">十二個圖形已經是這張圖表還能讀得清的極限了。</span>

--- a/locales/zh/tools/compare-heights.html
+++ b/locales/zh/tools/compare-heights.html
@@ -35,12 +35,12 @@
       <div class="toolbar-actions">
         <button type="button" id="add-person" class="primary">加一个人</button>
         <button type="button" id="add-object" class="ghost">加一件东西</button>
-        <button type="button" id="add-svg" class="ghost">自己的 SVG</button>
+        <button type="button" id="add-svg" class="ghost">自己的图片</button>
         <button type="button" id="clear" class="ghost danger">清空图表</button>
         <!-- 不显示，由上面那个按钮来驱动：标签写在这里，是因为访客能够到的控件都需要一个名字，
              不管它是不是他们点的那一个。 -->
-        <input type="file" id="svg-file" accept=".svg,image/svg+xml"
-               aria-label="选择一个要放到图上的 SVG 文件" hidden>
+        <input type="file" id="svg-file" accept="image/*,.svg"
+               aria-label="选择一个要放到图上的图片" hidden>
       </div>
       <span class="count" id="row-count"></span>
     </div>
@@ -80,7 +80,11 @@
       </select>
     </div>
     <p class="field-summary">
-      <strong>自己的 SVG</strong> 能把任何一张图放到标尺上——一个标志、一张平面图、一个机器零件都行。文件在这个页面里读，哪儿都不去。留下的只有里面的形状：它以一种实色进来，颜色由你逐行来挑；而任何够得着网络的东西——外链图片、样式表、字体、脚本——都会被留在原地，不会跟着进到一张你可能发给别人的图里。用细线画的、不是实心形状的图，出来会是一团实心的墨块，这也是这个工具唯一不合适的场合。
+      <strong>SVG</strong> 能把任何一张图放到标尺上——一个标志、一张平面图、一个机器零件都行。文件在这个页面里读，哪儿都不去。留下的只有里面的形状：它以一种实色进来，颜色由你逐行来挑；而任何够得着网络的东西——外链图片、样式表、字体、脚本——都会被留在原地，不会跟着进到一张你可能发给别人的图里。用细线画的、不是实心形状的图，出来会是一团实心的墨块，这也是这个工具唯一不合适的场合。
+    </p>
+
+    <p class="field-summary">
+      <strong>照片或 PNG</strong> 则原样放上去，保留它自己的颜色，所以那一行的颜色只用来写名字。它同样在这个页面里读，放上去之前会重画一遍&mdash;这既限制了它给图表添的分量，也把文件里的附带信息留在了外面。透明的地方仍然透明，所以抠好的图能干净地站在标尺上；照片则连背景一起来，最好先裁掉。
     </p>
 
     <p class="field-summary">
@@ -185,7 +189,7 @@
     <span data-phrase="shape.boy">男孩</span>
     <span data-phrase="shape.girl">女孩</span>
     <span data-phrase="shape.object">物体</span>
-    <span data-phrase="shape.upload">自己的 SVG</span>
+    <span data-phrase="shape.upload">自己的图片</span>
 
     <span data-phrase="row.shape">第 {n} 行的图形</span>
     <span data-phrase="row.name">第 {n} 行的名字</span>
@@ -211,6 +215,9 @@
     <span data-phrase="svg.noshapes">那个文件里没有可以画的东西。只留下形状 &mdash; 只有文字、效果或链接图片的文件，一个形状也没有。</span>
     <span data-phrase="svg.unreadable">那个文件不是这里读得懂的 SVG。</span>
     <span data-phrase="svg.toobig">那个文件要当一个形状太大了。上限是两 MB。</span>
+    <span data-phrase="image.added">已加入。图片在这个页面里读，没有上传任何东西。</span>
+    <span data-phrase="image.unreadable">那个文件不是这里读得懂的图片。</span>
+    <span data-phrase="image.toobig">那张图片太大了。上限是 12 MB。</span>
     <span data-phrase="chart.empty">加个人，图表就出现在这里。</span>
     <span data-phrase="chart.noheights">每一行都得有身高。填一个，图表就出现在这里。</span>
     <span data-phrase="chart.full">十二个图形已经是这张图表还能读得清的极限了。</span>

--- a/pages/guides/make-a-height-comparison-chart/body.html
+++ b/pages/guides/make-a-height-comparison-chart/body.html
@@ -149,16 +149,25 @@
     </p>
     <p>
       And when nothing in the menu is the thing you mean,
-      <strong>Add your own SVG</strong>
-      takes a drawing off your machine and puts its actual shape on the ruler
-      &mdash; a product, a vehicle, a building. Two things are worth knowing
-      before you reach for it. It is drawn in <strong>one solid colour</strong>,
-      like everything else on the chart, so a drawing made of thin outlines
-      rather than filled shapes arrives as a blob. And only the shapes are kept:
-      the file is rebuilt out of its paths and circles, and a script, a
-      stylesheet, a font or a linked image is left behind. The file never goes
-      anywhere, but the chart you download does, and it should not carry
-      somebody's server address into it.
+      <strong>Add your own picture</strong>
+      takes a drawing or a photograph off your machine and puts it on the ruler
+      &mdash; a product, a vehicle, a building, or a photo of the thing itself.
+    </p>
+    <p>
+      An <strong>SVG</strong> is drawn in one solid colour, like everything else
+      on the chart, so a drawing made of thin outlines rather than filled shapes
+      arrives as a blob. Only its shapes are kept: the file is rebuilt out of
+      its paths and circles, and a script, a stylesheet, a font or a linked
+      image is left behind. A <strong>photo or a PNG</strong> goes on as itself
+      instead and keeps its own colours &mdash; redrawn here first, which bounds
+      what it adds to the chart and leaves the file's metadata behind.
+      Transparency is kept, so a cut-out stands cleanly and a photo brings its
+      background with it.
+    </p>
+    <p>
+      Neither file goes anywhere. The chart you download does, though, and it
+      should not carry somebody's server address into it &mdash; which is why
+      what ends up in it is shapes and pixels, never a link.
     </p>
 
     <figure class="shot">

--- a/tests/js/compare-heights-chart.test.js
+++ b/tests/js/compare-heights-chart.test.js
@@ -165,6 +165,23 @@ test('an object with no width falls back rather than collapsing', () => {
   assert.ok(Number.isFinite(result.width) && result.width > 0);
 });
 
+test('a picture is drawn straight into the unit box, with no wrapper', () => {
+  // An uploaded raster carries no `inner`: import-image.js writes the <image>
+  // in unit coordinates already, so there is nothing to map out of. The chart
+  // must not invent a <g transform> for it, and must still keep the drawing's
+  // own proportions the way it does for an uploaded drawing.
+  const picture = {
+    id: 'upload', label: 'shape.upload', width: 0.4, inner: null, paths: null,
+    markup: '<image href="data:image/png;base64,AAAA" x="-0.2" y="0" width="0.4" height="1"/>',
+    defaultCm: 0,
+  };
+  const result = draw([figure({ shape: picture, cm: 100, widthCm: 999 })]);
+  assert.match(result.svg, /<image href="data:image\/png;base64,AAAA"/);
+  assert.doesNotMatch(result.svg, /<g transform="scale/, 'no inner group');
+  assert.doesNotMatch(result.svg, /scale\([\d.]+ [\d.]+\)/,
+                      'a picture keeps its own proportions, so one factor');
+});
+
 test('an empty chart does not divide by nothing', () => {
   const result = draw([]);
   assert.ok(result.width > 0 && result.height > 0);

--- a/tests/js/compare-heights-import-image.test.js
+++ b/tests/js/compare-heights-import-image.test.js
@@ -1,0 +1,101 @@
+/**
+ * tools/compare-heights/src/import-image.js - a picture on the ruler.
+ *
+ * The sanitiser next door is a list of what an uploaded SVG may keep. This
+ * module has the opposite job and one rule worth a test file of its own: the
+ * chart is downloaded and sent on, so the `href` it writes must be provably a
+ * picture and not a place. import-svg.js drops every href a stranger's file
+ * has; this one writes an href, so the two have to be able to sit in the same
+ * repository without the second undoing the first.
+ *
+ * The rest is arithmetic that decides how many bytes a chart grows by, which
+ * is the kind of thing that is wrong by a factor of ten and looks fine.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  IMAGE_LIMITS, fit, imageMarkup, nameFromFile,
+} from '../../tools/compare-heights/src/import-image.js';
+
+const PNG = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==';
+
+test('a picture bigger than the bound is brought down to it', () => {
+  const big = fit(4000, 3000);
+  assert.equal(Math.max(big.width, big.height), IMAGE_LIMITS.side);
+  assert.ok(Math.abs(big.width / big.height - 4 / 3) < 0.01, 'and keeps its shape');
+
+  const tall = fit(1000, 5000);
+  assert.equal(Math.max(tall.width, tall.height), IMAGE_LIMITS.side);
+  assert.ok(Math.abs(tall.width / tall.height - 1 / 5) < 0.01);
+});
+
+test('a small picture is left alone rather than blown up', () => {
+  // Enlarging would be more bytes for the same blur, and the chart scales
+  // whatever it is given anyway.
+  assert.deepEqual(fit(120, 90), { width: 120, height: 90 });
+});
+
+test('a picture with no size at all is refused rather than divided by', () => {
+  assert.equal(fit(0, 100), null);
+  assert.equal(fit(100, 0), null);
+  assert.equal(fit(0, 0), null);
+});
+
+test('the markup puts the picture in the unit box every figure lives in', () => {
+  const markup = imageMarkup(PNG, 0.5);
+  // y from 0 at the top of the head to 1 on the ground, x centred on 0 - the
+  // same box a drawn figure gets, which is why chart.js needs no raster case.
+  assert.match(markup, /y="0"/);
+  assert.match(markup, /height="1"/);
+  assert.match(markup, /width="0\.5"/);
+  assert.match(markup, /x="-0\.25"/);
+});
+
+test('the href may only ever be a picture this page encoded', () => {
+  // The whole point of the file. Everything below is a place rather than a
+  // picture, and import-svg.js exists to keep exactly these out of a chart.
+  for (const href of [
+    'https://evil.example/x.png',
+    'http://evil.example/x.png',
+    '//evil.example/x.png',
+    '/local.png',
+    'x.png',
+    'data:text/html;base64,PHNjcmlwdD4=',
+    'data:image/svg+xml;base64,PHN2Zz4=',
+    'data:image/png;base64,AAAA" onload="alert(1)',
+    'data:image/png;base64,AAAA);background:url(https://evil.example',
+    ' data:image/png;base64,AAAA',
+    'DATA:image/png;base64,AAAA',
+    'javascript:alert(1)',
+    '',
+    null,
+    undefined,
+    42,
+  ]) {
+    assert.equal(imageMarkup(href, 1), null, `let through: ${href}`);
+  }
+});
+
+test('a nonsense aspect is refused rather than drawn', () => {
+  for (const aspect of [0, -1, NaN, Infinity, null, undefined, 'wide']) {
+    assert.equal(imageMarkup(PNG, aspect), null, `let through: ${aspect}`);
+  }
+});
+
+test('the markup carries nothing but the picture and its box', () => {
+  const markup = imageMarkup(PNG, 1.25);
+  for (const bad of ['<script', 'xlink', 'style=', 'class=', ' id=', 'filter', 'onload']) {
+    assert.ok(!markup.includes(bad), `markup carries ${bad}`);
+  }
+  assert.ok(markup.startsWith('<image '), markup.slice(0, 20));
+  assert.ok(markup.endsWith('/>'));
+});
+
+test('the row is named from the file, without the extension', () => {
+  assert.equal(nameFromFile('my-bottle.png'), 'my-bottle');
+  assert.equal(nameFromFile('Logo.SVG'), 'Logo');
+  assert.equal(nameFromFile('holiday.jpeg'), 'holiday.jpeg', 'only the two it reads');
+  assert.equal(nameFromFile('x'.repeat(80)).length, 40, 'a name is drawn above a figure');
+});

--- a/tools/compare-heights/README.md
+++ b/tools/compare-heights/README.md
@@ -95,6 +95,33 @@ a row you have not filled in yet is not a mistake. Now that every row arrives
 with a height, an empty one is a box somebody cleared, and a row that will not
 be drawn should say so.
 
+### A picture goes on as itself; a drawing is rebuilt
+
+Two readers sit behind one button, and they have opposite jobs.
+
+`src/import-svg.js` reads a drawing. An SVG is a program, so nothing from the
+file is inserted: a third tree is built from a whitelist, and every `href` in
+the original is dropped, because a chart is downloaded and passed on and must
+not carry a reference to anywhere.
+
+`src/import-image.js` reads a photograph. A raster is not a program and there
+is nothing in it to sanitise — the browser's own decoder does the reading. What
+needs proving there is the other end: this module **writes** an `href`, the same
+attribute the other one drops, so `imageMarkup` refuses anything that is not a
+`data:image/png;base64,` URI of the base64 alphabet and nothing else. The bytes
+are ones this page encoded from a canvas, not the visitor's file passed through.
+
+The picture is redrawn onto a canvas rather than embedded as it arrived, and
+three things fall out of that: the size is bounded, so a twelve-megapixel photo
+cannot make a twenty-megabyte chart; the file's metadata is gone, because none
+of it survives a canvas; and the format is ours, so the string in the markup has
+one shape whatever was opened.
+
+An `<image>` in the chart looks like it should break the download, since
+`src/save.js` rasterises the SVG through a canvas and a tainted canvas cannot be
+read back. It does not: a `data:` URI is inline rather than external. That was
+put to the browser before it was relied on rather than reasoned about.
+
 ### The objects are drawn, and stretched to the numbers
 
 Every preset under *Or add something for scale* used to be a rectangle. Most of
@@ -238,6 +265,7 @@ keeps the canvas untainted so `toBlob` will give the bytes back.
 | `src/figures.js` | the list of figures the menu is built from, each one's default height, and the drawing behind an object preset |
 | `src/objects.js` | the object artwork: each drawing's path data, its measured box, its digest and its licence |
 | `src/import-svg.js` | the whitelist an uploaded SVG is rebuilt from |
+| `src/import-image.js` | the bound an uploaded photograph is redrawn to, and the only href the chart may carry |
 | `src/units.js` | typed height → centimetres, centimetres → written height, and the ruler's spacing and labels |
 | `src/chart.js` | the layout and the SVG, with text measured through a callback |
 | `src/save.js` | the SVG blob, the canvas rasterisation, and the download |

--- a/tools/compare-heights/body.html
+++ b/tools/compare-heights/body.html
@@ -43,13 +43,15 @@
       <div class="toolbar-actions">
         <button type="button" id="add-person" class="primary">Add a person</button>
         <button type="button" id="add-object" class="ghost">Add an object</button>
-        <button type="button" id="add-svg" class="ghost">Add your own SVG</button>
+        <button type="button" id="add-svg" class="ghost">Add your own picture</button>
         <button type="button" id="clear" class="ghost danger">Clear the chart</button>
         <!-- Driven by the button above rather than shown: the label is here
              because a control a visitor can reach needs a name whether or not
-             it is the thing they clicked. -->
-        <input type="file" id="svg-file" accept=".svg,image/svg+xml"
-               aria-label="Choose an SVG file to put on the chart" hidden>
+             it is the thing they clicked. `image/*` rather than a list of
+             types, because whatever the browser can decode is a picture this
+             can draw - it is redrawn as a PNG before it reaches the chart. -->
+        <input type="file" id="svg-file" accept="image/*,.svg"
+               aria-label="Choose a picture to put on the chart" hidden>
       </div>
       <span class="count" id="row-count"></span>
     </div>
@@ -90,14 +92,23 @@
     </div>
 
     <p class="field-summary">
-      <strong>Your own SVG</strong> puts any drawing on the ruler &mdash; a
-      logo, a floor plan, a piece of machinery. It is read in this page and
-      goes nowhere. Only the shapes in it are kept: it arrives as one solid
-      colour you pick per row, and anything that could reach the network
-      &mdash; a linked image, a stylesheet, a font, a script &mdash; is left
-      behind rather than carried into a chart you might send to somebody. A
-      drawing made of thin lines rather than filled shapes will come out as a
-      solid blob, which is the one case where this is the wrong tool.
+      <strong>An SVG</strong> puts any drawing on the ruler &mdash; a logo, a
+      floor plan, a piece of machinery. It is read in this page and goes
+      nowhere. Only the shapes in it are kept: it arrives as one solid colour
+      you pick per row, and anything that could reach the network &mdash; a
+      linked image, a stylesheet, a font, a script &mdash; is left behind
+      rather than carried into a chart you might send to somebody. A drawing
+      made of thin lines rather than filled shapes will come out as a solid
+      blob, which is the one case where this is the wrong tool.
+    </p>
+
+    <p class="field-summary">
+      <strong>A photo or a PNG</strong> goes on as itself instead, keeping its
+      own colours, so the row's colour only names it. It is read here too, and
+      redrawn before it goes on &mdash; which bounds how much it adds to the
+      chart and leaves the file's metadata behind. Whatever is transparent
+      stays transparent, so a cut-out stands on the ruler cleanly, and a photo
+      brings its background with it, which is worth cropping off first.
     </p>
 
     <p class="field-summary">
@@ -225,7 +236,7 @@
     <span data-phrase="shape.boy">Boy</span>
     <span data-phrase="shape.girl">Girl</span>
     <span data-phrase="shape.object">Object</span>
-    <span data-phrase="shape.upload">Your own SVG</span>
+    <span data-phrase="shape.upload">Your own picture</span>
 
     <span data-phrase="row.shape">Figure for row {n}</span>
     <span data-phrase="row.name">Name for row {n}</span>
@@ -251,6 +262,9 @@
     <span data-phrase="svg.noshapes">There is nothing drawable in that file. Only the shapes are kept &mdash; a file of nothing but text, effects or linked images has none.</span>
     <span data-phrase="svg.unreadable">That file is not an SVG this can read.</span>
     <span data-phrase="svg.toobig">That file is too big to be one shape. Two megabytes is the limit.</span>
+    <span data-phrase="image.added">Added. The picture was read in this page and nothing was uploaded.</span>
+    <span data-phrase="image.unreadable">That file is not a picture this can read.</span>
+    <span data-phrase="image.toobig">That picture is too big. Twelve megabytes is the limit.</span>
     <span data-phrase="chart.empty">Add somebody, and the chart appears here.</span>
     <span data-phrase="chart.noheights">Every row needs a height. Fill one in and the chart appears here.</span>
     <span data-phrase="chart.full">Twelve figures is as many as this chart will hold and still be readable.</span>

--- a/tools/compare-heights/src/import-image.js
+++ b/tools/compare-heights/src/import-image.js
@@ -1,0 +1,100 @@
+/**
+ * A picture on the ruler: the raster half of what a visitor can add.
+ *
+ * WHY THIS IS NOT import-svg.js
+ *
+ * An SVG is a program, and that file reads one by building a third tree out of
+ * a whitelist. A PNG is not a program: it is a rectangle of pixels, the
+ * browser's own decoder reads it, and there is nothing in it to sanitise. What
+ * needs care here is the opposite end - what goes OUT.
+ *
+ * A chart is one self-contained SVG that gets downloaded and sent on, and the
+ * one thing it must never carry is a reference to somewhere else. import-svg.js
+ * therefore drops every `href` an uploaded file has. This module writes an
+ * `href`, which is the same attribute, so it has to be provably a different
+ * thing: `imageMarkup` refuses anything that is not a `data:image/png;base64,`
+ * URI of the base64 alphabet and nothing else. The bytes are ones this page
+ * encoded a moment earlier from a canvas - not the visitor's file passed
+ * through - so there is no string in it that came from outside.
+ *
+ * WHY THE PICTURE IS REDRAWN RATHER THAN EMBEDDED AS IT ARRIVED
+ *
+ * Three things fall out of drawing it onto a canvas first and encoding that:
+ *
+ *   * the size is bounded. A chart figure is a few hundred pixels tall in the
+ *     download, and base64 costs a third on top - a 12-megapixel photo carried
+ *     through verbatim would be a 20 MB SVG of which the chart uses a tenth.
+ *   * the metadata is gone. Whatever the file had in it - the camera, the
+ *     place, the colour profile, a comment - is not in a canvas, so it cannot
+ *     be in the chart. Nobody has to think about that again.
+ *   * the format is ours. What is embedded is a PNG this page wrote, whatever
+ *     was opened, so the string in the markup has one shape.
+ *
+ * None of it involves the network, and the file is never read as text.
+ */
+
+export const IMAGE_LIMITS = {
+  // The file on disk. Bigger than the SVG limit because a photograph honestly
+  // is bigger than a drawing, and it is bounded again by `side` below before
+  // any of it reaches the chart.
+  bytes: 12 * 1024 * 1024,
+  // The longest side kept after redrawing. A chart is at most a couple of
+  // thousand pixels tall at 3x, and a figure is a column of that.
+  side: 1400,
+  // Below this in either direction there is no picture to speak of, and the
+  // aspect ratio a chart would take from it is noise.
+  smallest: 2,
+};
+
+/** Only what this page's own canvas produces, and nothing that could be a URL. */
+const PNG_DATA = /^data:image\/png;base64,[A-Za-z0-9+/]+={0,2}$/;
+
+/**
+ * The size to redraw at: the picture's own, unless it is larger than `longest`.
+ *
+ * Never enlarged. A small picture blown up to the bound would be bigger bytes
+ * for the same blur, and the chart scales whatever it is given anyway.
+ */
+export function fit(width, height, longest = IMAGE_LIMITS.side) {
+  // Both sides, not the larger one: a decoder can hand back something 0 by 100,
+  // and rounding that up to a single pixel would put a hairline on the ruler
+  // and call it a picture.
+  if (!(width > 0) || !(height > 0)) return null;
+  const scale = Math.min(1, longest / Math.max(width, height));
+  return {
+    width: Math.max(1, Math.round(width * scale)),
+    height: Math.max(1, Math.round(height * scale)),
+  };
+}
+
+/**
+ * The `<image>` a chart draws, in the unit box every figure lives in.
+ *
+ * y runs 0 to 1 from the top of the head to the ground, x is centred on 0, so
+ * a picture of aspect `w` occupies x from -w/2 to w/2 - the same box a drawn
+ * figure gets, which is why chart.js needs to know nothing about rasters.
+ *
+ * `preserveAspectRatio="none"` is safe precisely because the aspect written
+ * here was measured from the picture: the box is already its shape, so there
+ * is nothing to letterbox and nothing to squash.
+ *
+ * @returns {string|null} null if the href is not one this page made.
+ */
+export function imageMarkup(href, aspect) {
+  if (typeof href !== 'string' || !PNG_DATA.test(href)) return null;
+  if (!(aspect > 0) || !Number.isFinite(aspect)) return null;
+  const w = Math.round(aspect * 1e6) / 1e6;
+  return `<image href="${href}" x="${-w / 2}" y="0" width="${w}" height="1"`
+    + ' preserveAspectRatio="none"/>';
+}
+
+/**
+ * A name for the row, from the file's own.
+ *
+ * The extension goes because it is the one part nobody means as a name, and
+ * the length is cut because a row's name is drawn above a figure a few
+ * centimetres wide.
+ */
+export function nameFromFile(filename) {
+  return String(filename).replace(/\.(png|svg)$/i, '').slice(0, 40);
+}

--- a/tools/compare-heights/src/main.js
+++ b/tools/compare-heights/src/main.js
@@ -6,6 +6,7 @@ import { FONT, chartSvg, isDark } from './chart.js';
 import { format, formatBoth, parseHeight, toInput } from './units.js';
 import { download, svgBlob, svgToPng } from './save.js';
 import { LIMITS, importSvg } from './import-svg.js';
+import { IMAGE_LIMITS, fit, imageMarkup, nameFromFile } from './import-image.js';
 
 const $ = (id) => document.getElementById(id);
 
@@ -159,6 +160,79 @@ async function shapeFromFile(file) {
     shapes: result.shapes,
     name: file.name.replace(/\.svg$/i, '').slice(0, 40),
   };
+}
+
+/**
+ * Read one picture into a shape, or say why not.
+ *
+ * The browser's own decoder does the reading, in `createImageBitmap`, which
+ * runs nothing and resolves nothing: a raster has no references in it to
+ * follow. What comes back is redrawn onto a canvas at a bounded size and
+ * encoded again, so what reaches the chart is a PNG this page wrote - see
+ * import-image.js for why that matters more than the reading does.
+ *
+ * Anything the browser can decode is taken, not only PNG. Refusing a JPEG
+ * would be extra code to make the tool worse: it decodes, it draws, and what
+ * is embedded is a PNG either way.
+ */
+async function shapeFromImage(file) {
+  if (file.size > IMAGE_LIMITS.bytes) return { error: 'image.toobig' };
+
+  let bitmap;
+  try {
+    bitmap = await createImageBitmap(file);
+  } catch {
+    return { error: 'image.unreadable' };
+  }
+
+  const box = fit(bitmap.width, bitmap.height);
+  const tiny = bitmap.width < IMAGE_LIMITS.smallest || bitmap.height < IMAGE_LIMITS.smallest;
+  if (!box || tiny) {
+    bitmap.close?.();
+    return { error: 'image.unreadable' };
+  }
+
+  const canvas = document.createElement('canvas');
+  canvas.width = box.width;
+  canvas.height = box.height;
+  const context = canvas.getContext('2d');
+  context.imageSmoothingQuality = 'high';
+  context.drawImage(bitmap, 0, 0, box.width, box.height);
+  bitmap.close?.();
+
+  const aspect = box.width / box.height;
+  const markup = imageMarkup(canvas.toDataURL('image/png'), aspect);
+  if (!markup) return { error: 'image.unreadable' };
+
+  return {
+    shape: {
+      id: 'upload',
+      label: 'shape.upload',
+      width: aspect,
+      // No `inner`, unlike a drawing: a picture has no coordinates of its own
+      // to be mapped out of, so imageMarkup writes it into the unit box
+      // directly.
+      inner: null,
+      paths: null,
+      markup,
+      raster: true,
+      defaultCm: 0,
+    },
+    name: nameFromFile(file.name),
+  };
+}
+
+/**
+ * Which of the two readers a file goes to.
+ *
+ * An SVG is a program and has to go through the whitelist; everything else is
+ * pixels. A file that lies about which it is can only be wrong in the safe
+ * direction: an SVG named .png is handed to the image decoder, which
+ * rasterises it and runs nothing, and a raster named .svg fails to parse and
+ * is refused.
+ */
+function isVector(file) {
+  return file.type === 'image/svg+xml' || /\.svg$/i.test(file.name);
 }
 
 /* --------------------------------------------------------------------- rows */
@@ -620,7 +694,7 @@ el.svgFile.addEventListener('change', async () => {
   wantsFile = null;
   if (!file) return;
 
-  const result = await shapeFromFile(file);
+  const result = isVector(file) ? await shapeFromFile(file) : await shapeFromImage(file);
   if (result.error) {
     el.inputError.hidden = false;
     el.inputError.textContent = phrase(result.error);
@@ -641,7 +715,9 @@ el.svgFile.addEventListener('change', async () => {
   }
   paintRows();
   draw();
-  note(phrase('svg.added', { shapes: result.shapes }));
+  note(result.shapes === undefined
+    ? phrase('image.added')
+    : phrase('svg.added', { shapes: result.shapes }));
 });
 
 el.clear.addEventListener('click', () => {

--- a/tools/compare-heights/src/save.js
+++ b/tools/compare-heights/src/save.js
@@ -5,9 +5,16 @@
  * to the browser as a blob and painted onto a canvas, so the download cannot
  * disagree with the preview about a colour, a font or where a label sits. That
  * is also what makes it possible with the network unplugged: the chart has no
- * external reference in it - no font file, no image, no stylesheet - so
+ * EXTERNAL reference in it - no font file, no stylesheet, no linked image - so
  * nothing is fetched, the canvas is not tainted, and `toBlob` gives back
  * bytes.
+ *
+ * An uploaded photograph does put an <image> in the chart, which reads like an
+ * exception to that and is not one: its href is a `data:` URI of bytes this
+ * page encoded a moment earlier, so it is the picture itself rather than a
+ * reference to one. The browser was asked directly before this was relied on -
+ * a chart with an embedded raster in it draws, does not taint the canvas, and
+ * still rasterises to a PNG. See src/import-image.js.
  *
  * Image smoothing is left ON here, which is the one place this differs from
  * the same trick in the QR generator: that tool wants hard edges on a grid of

--- a/tools/compare-heights/tool.toml
+++ b/tools/compare-heights/tool.toml
@@ -8,11 +8,14 @@
 #
 # The second tool here whose input is typed rather than dropped, after the QR
 # generator, so it has no [picker] table either. It does take one optional
-# file - an SVG to put a shape of your own on the ruler - and that is a bare
+# file - a picture of your own to put on the ruler - and that is a bare
 # <input type="file"> behind a button rather than the shared picker: the
 # picker draws a drop zone and owns a page's main flow, and here the main flow
-# is still typing. See src/import-svg.js for what happens to the file, which
-# is the part worth reading. What is unusual about it is
+# is still typing. Two readers sit behind it, and both are worth reading:
+# src/import-svg.js, which rebuilds a drawing out of a whitelist because an SVG
+# is a program, and src/import-image.js, which has the opposite job - a raster
+# is only pixels, so what needs proving there is that the href it WRITES can
+# only ever be a picture this page encoded.") What is unusual about it is
 # what the input IS: a list of people's names and how tall each of them is,
 # which is the most personal thing anything on this site is handed and the
 # reason the privacy panel below is written about a list rather than a file.
@@ -64,8 +67,8 @@ og_card = "Two adults, a child and a doorway on one ruler - drawn on your own ma
 
 pledge = """
     A height chart is arithmetic and a drawing: there is no file to send and no
-    service to ask &mdash; and the one file this page will take, an SVG of your
-    own to put on the ruler, is read here and goes nowhere. The man, the woman, the boy and the girl are public-domain
+    service to ask &mdash; and the one file this page will take, a picture of
+    your own to put on the ruler, is read here and goes nowhere. The man, the woman, the boy and the girl are public-domain
     artwork that ships with this page, and the boy and the girl are drawings of
     actual children rather than adults made small &mdash; which is what stops a
     family chart looking wrong in a way nobody can name. Every step of it
@@ -179,7 +182,7 @@ body = """
       fetch and no image to load inside it."""
 
 [[privacy]]
-title = "An SVG you add is read here, and rebuilt rather than trusted."
+title = "A picture you add is read here, and never sent."
 body = """
  The file
       never leaves this page &mdash; it is read with the browser's own
@@ -190,7 +193,15 @@ body = """
       document is left behind rather than carried through. That matters twice
       over, because the chart you download is a file you send to other people:
       anything that survived would be their browser calling a stranger's server,
-      days later, from something this page wrote."""
+      days later, from something this page wrote.
+
+      A photograph or a PNG is not a program and has nothing to rebuild: the
+      browser's own decoder reads it, and it is redrawn onto a canvas here
+      before it goes on the chart. That redrawing is what leaves the file's
+      metadata behind &mdash; the camera, the place, the profile, whatever was
+      in it &mdash; because none of that survives a canvas. What ends up in the
+      chart is a picture this page encoded, written in as data rather than as
+      an address, so the chart still points at nothing."""
 
 [[privacy]]
 title = "The artwork is here, not fetched."
@@ -263,11 +274,12 @@ body = """
 title = "Or put your own drawing on it."
 body = """
  <strong>Add your own
-      SVG</strong> takes a file from your machine and draws its shape at
+      picture</strong> takes a file from your machine and puts it on the ruler at
       whatever height you give it &mdash; the thing to reach for when the chart
-      is about a product, a vehicle or a building rather than a person. It keeps
-      the drawing's own proportions, colours it like any other row, and reads the
-      file here rather than sending it anywhere."""
+      is about a product, a vehicle or a building rather than a person. An SVG
+      is drawn in the row's own colour like every other figure; a photograph or
+      a PNG goes on as itself. Either keeps its own proportions, and either is
+      read here rather than sent anywhere."""
 
 [[howto]]
 title = "Set the ruler to the units your reader thinks in."
@@ -348,23 +360,30 @@ a = """
         requirement to your chart."""
 
 [[faq]]
-q = "Can I put my own drawing on the chart?"
+q = "Can I put my own picture on the chart?"
 a = """
-        Yes &mdash; <strong>Add your own SVG</strong> takes any SVG file and
-        puts its shape on the ruler at whatever height you type: a logo, a floor
-        plan, a piece of machinery, a car. Its proportions are its own, so
-        there is no width to fill in.
+        Yes &mdash; <strong>Add your own picture</strong> takes a drawing or a
+        photograph and puts it on the ruler at whatever height you type: a logo,
+        a floor plan, a piece of machinery, a car, or a photo of the thing
+        itself. Its proportions are its own, so there is no width to fill in.
         <br><br>
-        Two things to know. It is drawn as <strong>one solid colour</strong>,
-        the one that row is set to, because that is what the rest of the chart
-        is &mdash; so a drawing made of thin outlines rather than filled shapes
-        comes out as a blob, and this is the wrong tool for it. And only the
-        <em>shapes</em> are kept: the file is rebuilt from scratch out of paths
-        and rectangles and circles, and anything that could reach the network
-        &mdash; a linked image, a stylesheet, a font, a script &mdash; is left
-        behind. The file itself never goes anywhere; that part is about the
-        chart you download, which is a file you might send to somebody
-        else."""
+        An <strong>SVG</strong> is drawn as one solid colour, the one that row
+        is set to, because that is what the rest of the chart is &mdash; so a
+        drawing made of thin outlines rather than filled shapes comes out as a
+        blob, and this is the wrong tool for it. Only the <em>shapes</em> are
+        kept: the file is rebuilt from scratch out of paths and rectangles and
+        circles, and anything that could reach the network &mdash; a linked
+        image, a stylesheet, a font, a script &mdash; is left behind.
+        <br><br>
+        A <strong>photo or a PNG</strong> goes on as itself and keeps its own
+        colours, so the row's colour only names it. It is redrawn here before it
+        goes on, which bounds how much it adds to the chart and leaves the
+        file's metadata behind. Transparency is kept, so a cut-out stands on the
+        ruler cleanly &mdash; and a photo brings its background with it, which is
+        worth cropping off first.
+        <br><br>
+        Neither file goes anywhere. That matters twice over, because the chart
+        you download is a file you might send to somebody else."""
 
 [[faq]]
 q = "Why is there no toddler or baby?"
@@ -478,7 +497,7 @@ features = [
   "Heights typed as 173, 1.73 m, 5'8\", 68 in or 5 ft 8, with the reading shown back",
   "Centimetres or feet and inches, switched without changing anybody's height",
   "Twenty ready-made objects, seventeen of them drawn: doors, windows, a whiteboard, a vending machine, furniture",
-  "Any SVG of your own on the ruler, rebuilt from its shapes alone",
+  "Any picture of your own on the ruler &mdash; an SVG rebuilt from its shapes, or a photo as it is",
   "A ruler whose spacing is chosen from what the picture can carry",
   "Any background colour, or none, with the ink chosen to stay legible on it",
   "PNG out at any pixel height, and an SVG that prints sharp at any size",


### PR DESCRIPTION
The upload button took an SVG. Most people do not have one — they have a PNG of
the product, a screenshot, a photo of the thing itself. It now takes any picture
the browser can decode, and the SVG path is untouched beside it.

## Pictures

A chart with all four kinds on it: a drawn person, a drawn object, a cut-out PNG
and a photograph.

<img width="2178" height="1352" alt="picture-chart" src="https://github.com/user-attachments/assets/2b2bc8cc-4cb6-44d6-a333-c8fab1adfd07" />

| Before | After |
|---|---|
| <img width="1880" height="918" alt="picture-before" src="https://github.com/user-attachments/assets/e35a097c-716a-4762-888d-03e6bd46b6b4" /> | <img width="1880" height="918" alt="picture-after" src="https://github.com/user-attachments/assets/dd4bcfb3-7154-461e-b844-eca861631049" /> |

## Two readers, with opposite jobs

[`src/import-svg.js`](tools/compare-heights/src/import-svg.js) reads a drawing.
An SVG is a program, so nothing from the file is inserted: a third tree is built
from a whitelist, and **every `href` in the original is dropped**, because a
chart is downloaded and passed on and must not carry a reference to anywhere.

[`src/import-image.js`](tools/compare-heights/src/import-image.js) reads a
photograph. A raster is not a program and there is nothing in it to sanitise —
the browser's own decoder does the reading, and it resolves nothing. What needs
proving is the other end: this module **writes** an `href`, the same attribute
the other one drops. So `imageMarkup` refuses anything that is not a
`data:image/png;base64,` URI of the base64 alphabet and nothing else, the bytes
are ones this page encoded from a canvas rather than the visitor's file passed
through, and
[the test for it](tests/js/compare-heights-import-image.test.js) is a list of
the places a stranger's file might otherwise have pointed at.

## Why the picture is redrawn rather than embedded as it arrived

Three things fall out of drawing it onto a canvas first and encoding that:

- **the size is bounded** — a twelve-megapixel photo cannot make a
  twenty-megabyte chart out of a figure a few hundred pixels tall;
- **the metadata is gone** — camera, place, colour profile, comment; none of it
  survives a canvas, so nobody has to think about that again;
- **the format is ours** — whatever was opened, what is embedded is a PNG this
  page wrote.

## The one thing that looked like it would break

`save.js` rasterises the chart through a canvas, and a tainted canvas cannot be
read back — so an `<image>` in the markup reads like the end of the PNG
download. It is not, because a `data:` URI is inline rather than external, but
that was **put to the browser before it was relied on** rather than reasoned
about:

| Probe | Result |
|---|---|
| SVG with an embedded raster loads as an `<img>` | yes |
| `drawImage` onto a canvas | ok |
| canvas tainted | **no** — `getImageData` works |
| `toBlob` | 6,345 bytes |
| the raster actually painted | `rgba(192,80,122,255)` |

Then again on the real page: chart SVG 41 KB, canvas untainted, PNG out 84 KB.
`save.js`'s docstring said "no image"; it now says no **external** image, and
says why.

## What a reader sees

An SVG still arrives as one flat colour per row. A photo goes on as itself and
keeps its own colours, so the row's colour only names it. Transparency is kept,
so a cut-out stands on the ruler cleanly — and a photo brings its background
with it, which the page says out loud rather than letting somebody find out.

Anything the browser can decode is taken, not only PNG. Refusing a JPEG would
have been extra code to make the tool worse: it decodes, it draws, and what is
embedded is a PNG either way.

## The words moved in fifteen languages, in this commit

The button, the figure menu, the file input's name and the paragraph that
explains it all said "SVG". Changing only the English would have left fourteen
languages describing a button that no longer does what they say — the drift
[#313](https://github.com/A-Box-of-Tools/website/pull/313) and
[#315](https://github.com/A-Box-of-Tools/website/pull/315) were both about. So
the fourteen locale bodies move here: the name becomes each language's word for
a picture, the old paragraph is scoped to the SVG half, one new paragraph covers
the other, and three new phrases carry what the picture half can say.

Driven in German as well as English — `Eigenes Bild`, `accept="image/*,.svg"`,
and *"Hinzugefügt. Das Bild wurde auf dieser Seite gelesen, hochgeladen wurde
nichts."*

## Checks

- `python build.py --out _plain --clean --no-minify` — exit 0, 1353 pages, and
  no locale reported as still in English.
- Whole JavaScript suite: 2,205 tests, 0 failures — 8 of them new.
- `test_build`, `test_phrases`, `test_accessibility`, `test_cards`,
  `test_english_in_js`, `test_duplicates` — 123 tests, OK.
- Driven end to end in a browser: a cut-out PNG, an opaque photo, and an SVG
  (regression) each added, drawn, and rasterised; the live network check stayed
  clean, because a `data:` URI is not a request.
- No CSP change: `img-src` already allowed `data:`.
