### PR TITLE
Share the small helpers: sizes, durations, the error line, the downloads and the media probes

### DIFF
--- a/docs/adding-a-tool.md
+++ b/docs/adding-a-tool.md
@@ -109,6 +109,10 @@ A component more than one tool needs, and that no tool should own, lives under
 | `shared/js/qr-tables.js` | `js_parts = ["qr-tables"]` | the QR specification's tables and the arithmetic around them, for the writer and the reader alike |
 | `shared/js/pdf-page-writer.js` | `js_parts = ["pdf-page-writer"]` | a PDF writer for putting pictures on pages; not the quartet's rewriter |
 | `shared/js/video-support.js` | `js_parts = ["video-support"]` | what this browser will decode, encode and record; imports `codec-support` |
+| `shared/js/format.js` | `js_parts = ["format"]` | sizes, durations and the m:ss.mmm clock as words, in the tiers and decimals the tool names |
+| `shared/js/message-box.js` | `js_parts = ["message-box"]` | the error line under the drop zone, or any line that is either saying something or hidden |
+| `shared/js/download.js` | `js_parts = ["download"]` | a download that starts now, or a link that follows the latest result |
+| `shared/js/media.js` | `js_parts = ["media"]` | what the browser makes of a file: a video's size and length, a picture's size |
 | `shared/js/phrases.js` | nothing — every tool gets it | the words, read off the page |
 | `shared/js/trust.js` | nothing — every tool gets it | the live network check and the offline line |
 

--- a/locales/ar/tools/trim-video.html
+++ b/locales/ar/tools/trim-video.html
@@ -264,8 +264,8 @@
     <span data-phrase="size.kb">{n} ك.بايت</span>
     <span data-phrase="size.mb">{n} م.بايت</span>
     <span data-phrase="size.gb">{n} ج.بايت</span>
-    <span data-phrase="dur.minutes">{m} د {s} ث</span>
-    <span data-phrase="dur.seconds">{s} ث</span>
+    <span data-phrase="time.minutes">{minutes} د {seconds} ث</span>
+    <span data-phrase="time.seconds">{n} ث</span>
     <span data-phrase="clip.mark">علِّم هذا الفيديو</span>
     <span data-phrase="clip.segments.one">جزء واحد</span>
     <span data-phrase="clip.segments.many">{n} أجزاء</span>

--- a/locales/de/tools/trim-video.html
+++ b/locales/de/tools/trim-video.html
@@ -273,8 +273,8 @@
     <span data-phrase="size.kb">{n} KB</span>
     <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="size.gb">{n} GB</span>
-    <span data-phrase="dur.minutes">{m}m {s}s</span>
-    <span data-phrase="dur.seconds">{s}s</span>
+    <span data-phrase="time.minutes">{minutes}m {seconds}s</span>
+    <span data-phrase="time.seconds">{n}s</span>
     <span data-phrase="clip.mark">Dieses Video markieren</span>
     <span data-phrase="clip.segments.one">1 Abschnitt</span>
     <span data-phrase="clip.segments.many">{n} Abschnitte</span>

--- a/locales/es/tools/trim-video.html
+++ b/locales/es/tools/trim-video.html
@@ -271,8 +271,8 @@
     <span data-phrase="size.kb">{n} KB</span>
     <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="size.gb">{n} GB</span>
-    <span data-phrase="dur.minutes">{m}m {s}s</span>
-    <span data-phrase="dur.seconds">{s}s</span>
+    <span data-phrase="time.minutes">{minutes}m {seconds}s</span>
+    <span data-phrase="time.seconds">{n}s</span>
     <span data-phrase="clip.mark">Marcar este vídeo</span>
     <span data-phrase="clip.segments.one">1 trozo</span>
     <span data-phrase="clip.segments.many">{n} trozos</span>

--- a/locales/fr/tools/trim-video.html
+++ b/locales/fr/tools/trim-video.html
@@ -273,8 +273,8 @@
     <span data-phrase="size.kb">{n} Ko</span>
     <span data-phrase="size.mb">{n} Mo</span>
     <span data-phrase="size.gb">{n} Go</span>
-    <span data-phrase="dur.minutes">{m}m {s}s</span>
-    <span data-phrase="dur.seconds">{s}s</span>
+    <span data-phrase="time.minutes">{minutes}m {seconds}s</span>
+    <span data-phrase="time.seconds">{n}s</span>
     <span data-phrase="clip.mark">Marquer cette vidéo</span>
     <span data-phrase="clip.segments.one">1 passage</span>
     <span data-phrase="clip.segments.many">{n} passages</span>

--- a/locales/hi/tools/trim-video.html
+++ b/locales/hi/tools/trim-video.html
@@ -269,8 +269,8 @@
     <span data-phrase="size.kb">{n} KB</span>
     <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="size.gb">{n} GB</span>
-    <span data-phrase="dur.minutes">{m}m {s}s</span>
-    <span data-phrase="dur.seconds">{s}s</span>
+    <span data-phrase="time.minutes">{minutes}m {seconds}s</span>
+    <span data-phrase="time.seconds">{n}s</span>
     <span data-phrase="clip.mark">इस वीडियो पर निशान लगाइए</span>
     <span data-phrase="clip.segments.one">1 हिस्सा</span>
     <span data-phrase="clip.segments.many">{n} हिस्से</span>

--- a/locales/id/tools/trim-video.html
+++ b/locales/id/tools/trim-video.html
@@ -278,8 +278,8 @@
     <span data-phrase="size.kb">{n} KB</span>
     <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="size.gb">{n} GB</span>
-    <span data-phrase="dur.minutes">{m}m {s}d</span>
-    <span data-phrase="dur.seconds">{s}d</span>
+    <span data-phrase="time.minutes">{minutes}m {seconds}d</span>
+    <span data-phrase="time.seconds">{n}d</span>
     <span data-phrase="clip.mark">Tandai video ini</span>
     <span data-phrase="clip.segments.one">1 segmen</span>
     <span data-phrase="clip.segments.many">{n} segmen</span>

--- a/locales/it/tools/trim-video.html
+++ b/locales/it/tools/trim-video.html
@@ -270,8 +270,8 @@
     <span data-phrase="size.kb">{n} KB</span>
     <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="size.gb">{n} GB</span>
-    <span data-phrase="dur.minutes">{m}m {s}s</span>
-    <span data-phrase="dur.seconds">{s}s</span>
+    <span data-phrase="time.minutes">{minutes}m {seconds}s</span>
+    <span data-phrase="time.seconds">{n}s</span>
     <span data-phrase="clip.mark">Segna questo video</span>
     <span data-phrase="clip.segments.one">1 segmento</span>
     <span data-phrase="clip.segments.many">{n} segmenti</span>

--- a/locales/ja/tools/trim-video.html
+++ b/locales/ja/tools/trim-video.html
@@ -248,8 +248,8 @@
     <span data-phrase="size.kb">{n} KB</span>
     <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="size.gb">{n} GB</span>
-    <span data-phrase="dur.minutes">{m}分{s}秒</span>
-    <span data-phrase="dur.seconds">{s}秒</span>
+    <span data-phrase="time.minutes">{minutes}分{seconds}秒</span>
+    <span data-phrase="time.seconds">{n}秒</span>
     <span data-phrase="clip.mark">この動画に印をつける</span>
     <span data-phrase="clip.segments.one">区間1つ</span>
     <span data-phrase="clip.segments.many">区間{n}つ</span>

--- a/locales/ko/tools/trim-video.html
+++ b/locales/ko/tools/trim-video.html
@@ -261,8 +261,8 @@
     <span data-phrase="size.kb">{n} KB</span>
     <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="size.gb">{n} GB</span>
-    <span data-phrase="dur.minutes">{m}분 {s}초</span>
-    <span data-phrase="dur.seconds">{s}초</span>
+    <span data-phrase="time.minutes">{minutes}분 {seconds}초</span>
+    <span data-phrase="time.seconds">{n}초</span>
     <span data-phrase="clip.mark">이 영상에 표시하기</span>
     <span data-phrase="clip.segments.one">구간 1개</span>
     <span data-phrase="clip.segments.many">구간 {n}개</span>

--- a/locales/nl/tools/trim-video.html
+++ b/locales/nl/tools/trim-video.html
@@ -271,8 +271,8 @@
     <span data-phrase="size.kb">{n} KB</span>
     <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="size.gb">{n} GB</span>
-    <span data-phrase="dur.minutes">{m}m {s}s</span>
-    <span data-phrase="dur.seconds">{s}s</span>
+    <span data-phrase="time.minutes">{minutes}m {seconds}s</span>
+    <span data-phrase="time.seconds">{n}s</span>
     <span data-phrase="clip.mark">Deze video markeren</span>
     <span data-phrase="clip.segments.one">1 segment</span>
     <span data-phrase="clip.segments.many">{n} segmenten</span>

--- a/locales/pt/tools/trim-video.html
+++ b/locales/pt/tools/trim-video.html
@@ -269,8 +269,8 @@
     <span data-phrase="size.kb">{n} KB</span>
     <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="size.gb">{n} GB</span>
-    <span data-phrase="dur.minutes">{m}m {s}s</span>
-    <span data-phrase="dur.seconds">{s}s</span>
+    <span data-phrase="time.minutes">{minutes}m {seconds}s</span>
+    <span data-phrase="time.seconds">{n}s</span>
     <span data-phrase="clip.mark">Marcar este vídeo</span>
     <span data-phrase="clip.segments.one">1 trecho</span>
     <span data-phrase="clip.segments.many">{n} trechos</span>

--- a/locales/tr/tools/trim-video.html
+++ b/locales/tr/tools/trim-video.html
@@ -274,8 +274,8 @@
     <span data-phrase="size.kb">{n} KB</span>
     <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="size.gb">{n} GB</span>
-    <span data-phrase="dur.minutes">{m}d {s}sn</span>
-    <span data-phrase="dur.seconds">{s}sn</span>
+    <span data-phrase="time.minutes">{minutes}d {seconds}sn</span>
+    <span data-phrase="time.seconds">{n}sn</span>
     <span data-phrase="clip.mark">Bu videoyu işaretle</span>
     <span data-phrase="clip.segments.one">1 parça</span>
     <span data-phrase="clip.segments.many">{n} parça</span>

--- a/locales/zh-TW/tools/trim-video.html
+++ b/locales/zh-TW/tools/trim-video.html
@@ -255,8 +255,8 @@
     <span data-phrase="size.kb">{n} KB</span>
     <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="size.gb">{n} GB</span>
-    <span data-phrase="dur.minutes">{m} 分 {s} 秒</span>
-    <span data-phrase="dur.seconds">{s} 秒</span>
+    <span data-phrase="time.minutes">{minutes} 分 {seconds} 秒</span>
+    <span data-phrase="time.seconds">{n} 秒</span>
     <span data-phrase="clip.mark">標記這個影片</span>
     <span data-phrase="clip.segments.one">1 個段落</span>
     <span data-phrase="clip.segments.many">{n} 個段落</span>

--- a/locales/zh/tools/trim-video.html
+++ b/locales/zh/tools/trim-video.html
@@ -255,8 +255,8 @@
     <span data-phrase="size.kb">{n} KB</span>
     <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="size.gb">{n} GB</span>
-    <span data-phrase="dur.minutes">{m} 分 {s} 秒</span>
-    <span data-phrase="dur.seconds">{s} 秒</span>
+    <span data-phrase="time.minutes">{minutes} 分 {seconds} 秒</span>
+    <span data-phrase="time.seconds">{n} 秒</span>
     <span data-phrase="clip.mark">标记这个视频</span>
     <span data-phrase="clip.segments.one">1 个段落</span>
     <span data-phrase="clip.segments.many">{n} 个段落</span>

--- a/shared/js/download.js
+++ b/shared/js/download.js
@@ -1,0 +1,73 @@
+/**
+ * Handing a result to the browser as a file, with no server to fetch it from.
+ *
+ * GENERATED INTO EACH TOOL. This file lives at shared/js/download.js and the
+ * build copies it to <tool>/src/shared/download.js for the tools that ask for
+ * it with `js_parts = ["download", ...]`. It imports nothing.
+ *
+ * Two shapes, because tools want two things:
+ *
+ *   saveBlob(blob, name)   a download that starts now: the ZIP a button just
+ *                          built, the PNG a chart was drawn into.
+ *   downloadLink(link)     a link on the page that points at the latest
+ *                          result until there is a newer one or none; the
+ *                          formatter pages move it on every keystroke.
+ *
+ * Both hold an object URL, and an object URL is a reference the page owns
+ * until it says otherwise: the blob behind it cannot be collected until it is
+ * revoked. So the link revokes the last one before it points at the next, and
+ * the one-shot download revokes late - revoking at once can cancel a download
+ * that has not started yet in some browsers, and a minute is long after the
+ * browser has opened the blob for itself.
+ */
+
+/**
+ * Start a download of `blob` under `name`. Nothing leaves the machine.
+ *
+ * @param {Blob} blob
+ * @param {string} name  what the file will be called
+ */
+export function saveBlob(blob, name) {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = name;
+  link.rel = 'noopener';
+  // In the document while it is clicked: some browsers have ignored a
+  // synthetic click on a link that was not.
+  document.body.append(link);
+  link.click();
+  link.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 60_000);
+}
+
+/**
+ * A download link that follows the result.
+ *
+ * @param {HTMLAnchorElement} link  the link on the page, hidden until there
+ *   is something to offer
+ * @param {string} [type]  the MIME type a string is wrapped in; a Blob is
+ *   offered as it is
+ * @returns {{offer: (content: string|Blob, name: string) => void, clear: () => void}}
+ */
+export function downloadLink(link, type = 'text/plain;charset=utf-8') {
+  let url = null;
+  const clear = () => {
+    if (url) URL.revokeObjectURL(url);
+    url = null;
+    link.hidden = true;
+  };
+  return {
+    /** Point the link at `content`, or hide it when there is nothing. */
+    offer(content, name) {
+      clear();
+      if (content === '') return;
+      url = URL.createObjectURL(
+        content instanceof Blob ? content : new Blob([content], { type }));
+      link.href = url;
+      link.download = name;
+      link.hidden = false;
+    },
+    clear,
+  };
+}

--- a/shared/js/format.js
+++ b/shared/js/format.js
@@ -1,0 +1,112 @@
+/**
+ * Sizes and durations as words, through the caller's phrase().
+ *
+ * GENERATED INTO EACH TOOL. This file lives at shared/js/format.js and the
+ * build copies it to <tool>/src/shared/format.js for the tools that ask for
+ * it with `js_parts = ["format", ...]`. It imports nothing.
+ *
+ * Twenty-three tools carried a byte formatter of their own, and between them
+ * those twenty-three were eleven different formatters: some had a tier below
+ * a kilobyte and some started at "0 KB", some gave kilobytes a decimal and
+ * some did not, some had a gigabyte tier, and two keys were in use for the
+ * bytes tier. None of those differences is a decision anybody recorded, but
+ * every one is a number a visitor can see, so this file does not pick a
+ * winner. Each function takes the caller's `phrase` and a `style` naming the
+ * tiers and the decimals, and every tool's output is what it was before: the
+ * differences are one line in each tool instead of six, where a pass that
+ * wants to unify them can read them side by side.
+ *
+ * KB and MB mean 1024 and 1024*1024 throughout, which is what a file manager
+ * shows on every platform except macOS, and what people mean by "about 3 MB".
+ */
+
+const KB = 1024;
+const MB = KB * 1024;
+const GB = MB * 1024;
+
+const pad = (n) => String(n).padStart(2, '0');
+
+/**
+ * A size as a phrase: "512 bytes", "4.5 KB", "1.2 MB".
+ *
+ * @param {number} n  bytes
+ * @param {(key: string, values?: object) => string} t  the caller's phrase()
+ * @param {object} [style]
+ * @param {string} [style.under]  the key below a kilobyte, taking {n}; leave
+ *   it out and kilobytes start at zero, "0 KB" included
+ * @param {number|'auto'} [style.kb=0]  decimals in kilobytes; 'auto' is one
+ *   below 10 KB and none above, where a tenth stops being a difference
+ * @param {number} [style.mb=1]  decimals in megabytes
+ * @param {string} [style.gb]  the key from a gigabyte up, taking {n} to two
+ *   decimals; leave it out and megabytes carry on
+ * @returns {string}
+ */
+export function sizeText(n, t, { under, kb = 0, mb = 1, gb } = {}) {
+  // An estimate can be NaN or negative before there is a file to measure;
+  // nothing about that is worth showing beyond a zero.
+  const size = Number.isFinite(n) && n > 0 ? n : 0;
+  if (under && size < KB) return t(under, { n: Math.round(size) });
+  if (size < MB) {
+    const decimals = kb === 'auto' ? (size < 10 * KB ? 1 : 0) : kb;
+    return t('size.kb', { n: (size / KB).toFixed(decimals) });
+  }
+  if (gb && size >= GB) return t(gb, { n: (size / GB).toFixed(2) });
+  return t('size.mb', { n: (size / MB).toFixed(mb) });
+}
+
+/**
+ * A duration as a phrase: "4.2s", "12s", "3m 05s" - and "2h 14m" for the
+ * tools that name an hours key.
+ *
+ * The keys are `time.seconds` with {n}, `time.minutes` with {minutes} and a
+ * two-digit {seconds}, and the caller's hours key with {hours} and a
+ * two-digit {minutes}.
+ *
+ * @param {number} seconds
+ * @param {(key: string, values?: object) => string} t  the caller's phrase()
+ * @param {object} [style]
+ * @param {string} [style.hours]  the key from an hour up; leave it out and
+ *   minutes carry on past sixty
+ * @param {number|'auto'} [style.decimals='auto']  decimals below a minute: a
+ *   fixed count, or 'auto' for one under ten seconds and none from there,
+ *   which is where a tenth stops being something a person can see
+ * @returns {string}
+ */
+export function durationText(seconds, t, { hours, decimals = 'auto' } = {}) {
+  const whole = Math.max(0, Math.round(seconds));
+  if (hours && whole >= 3600) {
+    return t(hours, {
+      hours: Math.floor(whole / 3600),
+      minutes: pad(Math.floor((whole % 3600) / 60)),
+    });
+  }
+  const minutes = Math.floor(whole / 60);
+  if (minutes) return t('time.minutes', { minutes, seconds: pad(whole % 60) });
+  const n = decimals === 'auto'
+    ? (seconds < 10 ? seconds.toFixed(1) : whole)
+    : seconds.toFixed(decimals);
+  return t('time.seconds', { n });
+}
+
+/**
+ * m:ss.mmm, or h:mm:ss.mmm past an hour: short enough to read, exact enough
+ * to type back into the field it came from. No phrase, because there are no
+ * words in it.
+ *
+ * Rounded to milliseconds once, before it is taken apart. Flooring the
+ * seconds and rounding the fraction separately writes 3.9996 as `0:03.1000`,
+ * four digits in a three-digit field, which parses back as 3.1 - so a mark
+ * that was only ever shown would move nine tenths of a second the moment
+ * somebody edited the row beside it.
+ *
+ * @param {number} seconds
+ * @returns {string}
+ */
+export function clockText(seconds) {
+  const total = Math.round(Math.max(0, seconds || 0) * 1000);
+  const whole = Math.floor(total / 1000);
+  const hours = Math.floor(whole / 3600);
+  const minutes = Math.floor((whole % 3600) / 60);
+  const tail = `${pad(whole % 60)}.${String(total % 1000).padStart(3, '0')}`;
+  return hours ? `${hours}:${pad(minutes)}:${tail}` : `${minutes}:${tail}`;
+}

--- a/shared/js/media.js
+++ b/shared/js/media.js
@@ -1,0 +1,68 @@
+/**
+ * What the browser makes of a file it is asked to open: a video's size and
+ * length through a <video>, a picture's size through an <img>.
+ *
+ * GENERATED INTO EACH TOOL. This file lives at shared/js/media.js and the
+ * build copies it to <tool>/src/shared/media.js for the tools that ask for it
+ * with `js_parts = ["media", ...]`. It imports nothing.
+ *
+ * Six video tools carried openInPlayer and three image tools carried
+ * measureImage, each identical to the others, until the tests could follow a
+ * `./shared/` import (tests/js/resolve-shared.mjs).
+ *
+ * Both resolve rather than reject, with `ok: false` or null for a file the
+ * browser would not open: the callers ask this question to decide which path
+ * to take - the exact one that reads the file itself, or the fallback that
+ * leaves the reading to the browser - and "no" is an answer, not a failure.
+ */
+
+/**
+ * Hand `url` to a <video> and wait for it to say what it found.
+ *
+ * Fifteen seconds is the cap because a browser that cannot open a file does
+ * not always say so: a container it half understands can sit in `loading`
+ * indefinitely, and a page that waited on it would never get to the message.
+ *
+ * @param {HTMLVideoElement} video
+ * @param {string} url  an object URL for the file
+ * @returns {Promise<{ok: boolean, width: number, height: number, duration: number}>}
+ */
+export function openInPlayer(video, url) {
+  return new Promise((resolve) => {
+    const done = (result) => {
+      clearTimeout(timer);
+      video.removeEventListener('loadedmetadata', ok);
+      video.removeEventListener('error', bad);
+      resolve(result);
+    };
+    const ok = () => done({
+      ok: video.videoWidth > 0 && video.videoHeight > 0,
+      width: video.videoWidth,
+      height: video.videoHeight,
+      duration: Number.isFinite(video.duration) ? video.duration : 0,
+    });
+    const bad = () => done({ ok: false, width: 0, height: 0, duration: 0 });
+
+    const timer = setTimeout(bad, 15000);
+    video.addEventListener('loadedmetadata', ok, { once: true });
+    video.addEventListener('error', bad, { once: true });
+    video.src = url;
+    video.load();
+  });
+}
+
+/**
+ * The pixel size of the picture at `url`, or null if the browser will not
+ * decode it.
+ *
+ * @param {string} url
+ * @returns {Promise<{width: number, height: number}|null>}
+ */
+export function measureImage(url) {
+  return new Promise((resolve) => {
+    const img = new Image();
+    img.onload = () => resolve({ width: img.naturalWidth, height: img.naturalHeight });
+    img.onerror = () => resolve(null);
+    img.src = url;
+  });
+}

--- a/shared/js/message-box.js
+++ b/shared/js/message-box.js
@@ -1,0 +1,42 @@
+/**
+ * A line on the page that is either saying something or hidden.
+ *
+ * GENERATED INTO EACH TOOL. This file lives at shared/js/message-box.js and
+ * the build copies it to <tool>/src/shared/message-box.js for the tools that
+ * ask for it with `js_parts = ["message-box", ...]`. It imports nothing.
+ *
+ * Every tool has an error line under its drop zone, most have a second one
+ * under the controls, and the PDF tools have a note beside the file they
+ * opened. Showing one is two statements and clearing it is the same two the
+ * other way round, and thirty-five tools had written that pair between two
+ * and four times each - sixty-odd copies of the same four lines, differing
+ * only in which element they named. So the element is named once, here, and
+ * a tool keeps the names its call sites already use:
+ *
+ *   const { show: showError, clear: clearError } = messageBox(el.error);
+ *
+ * `hidden` rather than a class, because the frame's stylesheet gives `.error`
+ * its look and `[hidden]` its absence, and a box with an empty string in it
+ * would still be a box.
+ */
+
+/**
+ * @param {HTMLElement} element  the line, hidden until there is something to say
+ * @param {object} [options]
+ * @param {() => void} [options.onShow]  run after each message is shown; the
+ *   formatter pages use it to say that the result panel is empty
+ * @returns {{show: (message: string) => void, clear: () => void}}
+ */
+export function messageBox(element, { onShow } = {}) {
+  return {
+    show(message) {
+      element.textContent = message;
+      element.hidden = false;
+      onShow?.();
+    },
+    clear() {
+      element.textContent = '';
+      element.hidden = true;
+    },
+  };
+}

--- a/shared/js/phrases.js
+++ b/shared/js/phrases.js
@@ -82,3 +82,21 @@ export function phrase(key, values = {}) {
   return text.replace(/\{(\w+)\}/g, (whole, name) => (
     name in values ? String(values[name]) : whole));
 }
+
+/**
+ * Values for a phrase, with any that are phrases themselves resolved first.
+ *
+ * A module too deep to reach the DOM returns a key and lets the caller look it
+ * up (see above), and when its answer is a sentence with a blank in it, what
+ * fills the blank is sometimes another key: "could not read it: {reason}",
+ * where the reason is the reader's own. So a value that is a `{key, values}`
+ * pair is looked up here, and everything else - a number, a file name, a
+ * string already in the visitor's language - passes through as it is.
+ *
+ * @param {Record<string, unknown>} [values]
+ * @returns {Record<string, unknown>}
+ */
+export function fill(values = {}) {
+  return Object.fromEntries(Object.entries(values)
+    .map(([name, value]) => [name, value?.key ? phrase(value.key, value.values) : value]));
+}

--- a/tests/js/download.test.js
+++ b/tests/js/download.test.js
@@ -1,0 +1,97 @@
+/**
+ * shared/js/download.js - handing a result to the browser as a file.
+ *
+ * What matters here is the bookkeeping around object URLs, which is the part
+ * that goes wrong silently: a URL never revoked keeps its blob alive for the
+ * life of the page, and one revoked too soon cancels the download it was for.
+ * So `URL` is a stub that counts, `document` is the least it takes to click a
+ * link, and the clock is the test runner's.
+ */
+
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { saveBlob, downloadLink } from '../../shared/js/download.js';
+
+/** A URL and a document that record what was done to them. */
+function browser() {
+  const made = [];
+  const revoked = [];
+  const links = [];
+  globalThis.URL.createObjectURL = (blob) => {
+    made.push(blob);
+    return `blob:${made.length}`;
+  };
+  globalThis.URL.revokeObjectURL = (url) => revoked.push(url);
+  globalThis.document = {
+    createElement(tag) {
+      const link = { tag, clicks: 0, click() { this.clicks += 1; }, remove() { this.inDocument = false; } };
+      links.push(link);
+      return link;
+    },
+    body: { append(link) { link.inDocument = true; } },
+  };
+  return { made, revoked, links };
+}
+
+test('saveBlob clicks a link in the document and revokes its URL a minute later', () => {
+  mock.timers.enable({ apis: ['setTimeout'] });
+  const { made, revoked, links } = browser();
+  const blob = new Blob(['hello']);
+
+  saveBlob(blob, 'hello.txt');
+
+  assert.equal(made[0], blob);
+  assert.equal(links.length, 1);
+  assert.equal(links[0].href, 'blob:1');
+  assert.equal(links[0].download, 'hello.txt');
+  assert.equal(links[0].rel, 'noopener');
+  assert.equal(links[0].clicks, 1);
+  assert.equal(links[0].inDocument, false, 'removed again once clicked');
+  assert.deepEqual(revoked, [], 'not revoked before the download can start');
+  mock.timers.tick(60_000);
+  assert.deepEqual(revoked, ['blob:1']);
+  mock.timers.reset();
+});
+
+test('a download link points at the latest text and lets go of the last', () => {
+  const { made, revoked } = browser();
+  const link = { hidden: true };
+  const download = downloadLink(link);
+
+  download.offer('one', 'a.txt');
+  assert.equal(link.href, 'blob:1');
+  assert.equal(link.download, 'a.txt');
+  assert.equal(link.hidden, false);
+  assert.equal(made[0].type, 'text/plain;charset=utf-8');
+
+  download.offer('two', 'b.txt');
+  assert.equal(link.href, 'blob:2');
+  assert.deepEqual(revoked, ['blob:1']);
+});
+
+test('an empty result hides the link, and so does clearing', () => {
+  const { revoked } = browser();
+  const link = { hidden: true };
+  const download = downloadLink(link);
+
+  download.offer('one', 'a.txt');
+  download.offer('', 'a.txt');
+  assert.equal(link.hidden, true);
+  assert.deepEqual(revoked, ['blob:1']);
+
+  download.offer('two', 'b.txt');
+  download.clear();
+  assert.equal(link.hidden, true);
+  assert.deepEqual(revoked, ['blob:1', 'blob:2']);
+  download.clear();
+  assert.deepEqual(revoked, ['blob:1', 'blob:2'], 'nothing to revoke twice');
+});
+
+test('a Blob is offered as it is, whatever type the link was made for', () => {
+  const { made } = browser();
+  const link = { hidden: true };
+  const svg = new Blob(['<svg/>'], { type: 'image/svg+xml' });
+  downloadLink(link).offer(svg, 'picture.svg');
+  assert.equal(made[0], svg);
+});

--- a/tests/js/format.test.js
+++ b/tests/js/format.test.js
@@ -1,0 +1,87 @@
+/**
+ * shared/js/format.js - sizes and durations as words.
+ *
+ * The file replaced eleven byte formatters and seven duration formatters that
+ * agreed on the arithmetic and disagreed on the tiers and the decimals, and
+ * its contract is that a tool naming its old choices in a `style` gets its old
+ * output. So the cases below are the tiers, one at a time, with the numbers
+ * each tier showed before - and the two rounding traps that were the point of
+ * writing a formatter carefully the first time.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { sizeText, durationText, clockText } from '../../shared/js/format.js';
+
+const KB = 1024;
+const MB = KB * 1024;
+const GB = MB * 1024;
+
+/** A phrase() that shows which key was asked for and what it was given. */
+const t = (key, values) => `${key}:${Object.values(values).join('/')}`;
+
+test('sizes: kilobytes from zero when there is no bytes key', () => {
+  // The video tools' style: a file under a kilobyte is "0 KB", by design.
+  const style = { kb: 0, mb: 1, gb: 'size.gb' };
+  assert.equal(sizeText(0, t, style), 'size.kb:0');
+  assert.equal(sizeText(3 * KB, t, style), 'size.kb:3');
+  assert.equal(sizeText(1.5 * MB, t, style), 'size.mb:1.5');
+  assert.equal(sizeText(2 * GB, t, style), 'size.gb:2.00');
+});
+
+test('sizes: a bytes tier under whichever key the tool has', () => {
+  assert.equal(sizeText(512, t, { under: 'size.bytes' }), 'size.bytes:512');
+  assert.equal(sizeText(512, t, { under: 'size.b' }), 'size.b:512');
+  assert.equal(sizeText(KB, t, { under: 'size.b' }), 'size.kb:1');
+});
+
+test("sizes: 'auto' kilobytes keep a decimal below ten", () => {
+  const style = { kb: 'auto', mb: 2 };
+  assert.equal(sizeText(1.5 * KB, t, style), 'size.kb:1.5');
+  assert.equal(sizeText(10 * KB, t, style), 'size.kb:10');
+  assert.equal(sizeText(20.4 * KB, t, style), 'size.kb:20');
+  assert.equal(sizeText(1.25 * MB, t, style), 'size.mb:1.25');
+});
+
+test('sizes: megabytes carry on when there is no gigabyte key', () => {
+  assert.equal(sizeText(2 * GB, t, { mb: 2 }), 'size.mb:2048.00');
+  assert.equal(sizeText(2 * GB, t, { mb: 1, gb: 'size.gb' }), 'size.gb:2.00');
+});
+
+test('sizes: an estimate that is not a number yet is a zero', () => {
+  // merge-pdf and compress-pdf format sizes they have not finished working
+  // out; "NaN KB" is not a size.
+  assert.equal(sizeText(NaN, t, { under: 'size.bytes' }), 'size.bytes:0');
+  assert.equal(sizeText(-40, t, { under: 'size.bytes' }), 'size.bytes:0');
+  assert.equal(sizeText(Infinity, t, {}), 'size.kb:0');
+});
+
+test('durations: a decimal below ten seconds, whole seconds from there', () => {
+  assert.equal(durationText(4.24, t), 'time.seconds:4.2');
+  assert.equal(durationText(12.6, t), 'time.seconds:13');
+  assert.equal(durationText(65, t), 'time.minutes:1/05');
+  assert.equal(durationText(-3, t), 'time.seconds:-3.0');
+});
+
+test('durations: a fixed count of decimals where the tool asks for one', () => {
+  assert.equal(durationText(4.24, t, { decimals: 2 }), 'time.seconds:4.24');
+  assert.equal(durationText(12.6, t, { decimals: 1 }), 'time.seconds:12.6');
+});
+
+test('durations: hours only for the tool that has a key for them', () => {
+  assert.equal(durationText(3725, t, { hours: 'time.hours' }), 'time.hours:1/02');
+  assert.equal(durationText(3725, t), 'time.minutes:62/05');
+  assert.equal(durationText(3599.4, t, { hours: 'time.hours' }), 'time.minutes:59/59');
+});
+
+test('the clock rounds to a millisecond once, before it is taken apart', () => {
+  assert.equal(clockText(0), '0:00.000');
+  assert.equal(clockText(83.5), '1:23.500');
+  assert.equal(clockText(3725.25), '1:02:05.250');
+  // Flooring the seconds and rounding the fraction separately wrote this as
+  // 0:03.1000, which parses back as 3.1.
+  assert.equal(clockText(3.9996), '0:04.000');
+  assert.equal(clockText(-2), '0:00.000');
+  assert.equal(clockText(undefined), '0:00.000');
+});

--- a/tests/js/media.test.js
+++ b/tests/js/media.test.js
@@ -1,0 +1,67 @@
+/**
+ * shared/js/media.js - what the browser makes of a file it is asked to open.
+ *
+ * The <video> is an EventTarget with the four properties the module reads,
+ * and `load()` is what decides how the browser answers - metadata, an error,
+ * or nothing at all, which is the case the timeout exists for.
+ */
+
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { openInPlayer, measureImage } from '../../shared/js/media.js';
+
+/** A <video> whose load() answers as told. */
+function player(answer, { width = 0, height = 0, duration = NaN } = {}) {
+  const video = new EventTarget();
+  Object.assign(video, { videoWidth: width, videoHeight: height, duration });
+  video.load = () => {
+    if (answer) queueMicrotask(() => video.dispatchEvent(new Event(answer)));
+  };
+  return video;
+}
+
+test('a file the browser opens comes back with its size and length', async () => {
+  const video = player('loadedmetadata', { width: 640, height: 360, duration: 12.5 });
+  const found = await openInPlayer(video, 'blob:1');
+  assert.deepEqual(found, { ok: true, width: 640, height: 360, duration: 12.5 });
+  assert.equal(video.src, 'blob:1');
+});
+
+test('metadata without a picture in it is not ok, and an unknown length is zero', async () => {
+  // An audio-only file opens, reports a duration and has no frame to show.
+  const video = player('loadedmetadata', { duration: Infinity });
+  assert.deepEqual(await openInPlayer(video, 'blob:1'),
+    { ok: false, width: 0, height: 0, duration: 0 });
+});
+
+test('a file the browser refuses is an answer, not a rejection', async () => {
+  assert.deepEqual(await openInPlayer(player('error'), 'blob:1'),
+    { ok: false, width: 0, height: 0, duration: 0 });
+});
+
+test('a browser that never answers is given fifteen seconds', async () => {
+  mock.timers.enable({ apis: ['setTimeout'] });
+  const pending = openInPlayer(player(null), 'blob:1');
+  mock.timers.tick(15000);
+  assert.deepEqual(await pending, { ok: false, width: 0, height: 0, duration: 0 });
+  mock.timers.reset();
+});
+
+test('a picture is measured, and one that will not decode is null', async () => {
+  globalThis.Image = class {
+    set src(url) {
+      queueMicrotask(() => {
+        if (url === 'blob:good') {
+          this.naturalWidth = 4032;
+          this.naturalHeight = 3024;
+          this.onload();
+        } else {
+          this.onerror();
+        }
+      });
+    }
+  };
+  assert.deepEqual(await measureImage('blob:good'), { width: 4032, height: 3024 });
+  assert.equal(await measureImage('blob:bad'), null);
+});

--- a/tests/js/message-box.test.js
+++ b/tests/js/message-box.test.js
@@ -1,0 +1,50 @@
+/**
+ * shared/js/message-box.js - a line that is either saying something or hidden.
+ *
+ * Four lines of code, sixty-odd copies before this file; the test is here so
+ * that the one copy cannot quietly become a fifth variant. The element is a
+ * plain object, because `textContent` and `hidden` are all the module touches.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { messageBox } from '../../shared/js/message-box.js';
+
+const line = () => ({ textContent: '', hidden: true });
+
+test('showing puts the message in the element and unhides it', () => {
+  const element = line();
+  const box = messageBox(element);
+  box.show('That is not a PDF.');
+  assert.equal(element.textContent, 'That is not a PDF.');
+  assert.equal(element.hidden, false);
+});
+
+test('clearing empties the element and hides it', () => {
+  const element = line();
+  const box = messageBox(element);
+  box.show('That is not a PDF.');
+  box.clear();
+  assert.equal(element.textContent, '');
+  assert.equal(element.hidden, true);
+});
+
+test('the pair can be pulled apart under the names a tool already uses', () => {
+  const element = line();
+  const { show: showError, clear: clearError } = messageBox(element);
+  showError('no');
+  assert.equal(element.hidden, false);
+  clearError();
+  assert.equal(element.hidden, true);
+});
+
+test('onShow runs after the message is on the page, and not on clear', () => {
+  const element = line();
+  const seen = [];
+  const box = messageBox(element, { onShow: () => seen.push(element.textContent) });
+  box.show('first');
+  box.clear();
+  box.show('second');
+  assert.deepEqual(seen, ['first', 'second']);
+});

--- a/tests/js/phrases.test.js
+++ b/tests/js/phrases.test.js
@@ -16,7 +16,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { phrase } from '../../shared/js/phrases.js';
+import { phrase, fill } from '../../shared/js/phrases.js';
 import { readingLabel } from '../../shared/js/file-picker.js';
 
 const SELECTOR = /^#(phrases|frame-phrases) \[data-phrase="(.+)"\]$/;
@@ -99,3 +99,13 @@ test('readingLabel picks the singular for one file and the plural for any other'
     assert.equal(readingLabel(0), 'Reading 0 files');
     assert.equal(readingLabel(12), 'Reading 12 files');
   });
+
+test('fill looks up the values that are keys and leaves the rest alone', () => {
+  // A leaf that cannot reach the page hands back {key, values} for the part
+  // of its answer that is a sentence; the number and the name are not.
+  page({ tool: { 'read.short': 'only {n} bytes of it' } });
+  assert.deepEqual(
+    fill({ reason: { key: 'read.short', values: { n: 3 } }, name: 'a.pdf', count: 0 }),
+    { reason: 'only 3 bytes of it', name: 'a.pdf', count: 0 });
+  assert.deepEqual(fill(), {});
+});

--- a/tools/base64/src/main.js
+++ b/tools/base64/src/main.js
@@ -1,6 +1,9 @@
 /** UI wiring and application state. */
 
 import { phrase } from './shared/phrases.js';
+import { sizeText } from './shared/format.js';
+import { downloadLink } from './shared/download.js';
+import { messageBox } from './shared/message-box.js';
 import { wireFilePicker } from './shared/file-picker.js';
 import { CODECS, codecById, CodecError } from './encode.js';
 import { SAMPLES } from './samples.js';
@@ -25,9 +28,14 @@ const el = {
   privacyPanel: $('privacy-panel'),
 };
 
+const { show: showError, clear: clearError } = messageBox(el.error, {
+  onShow: () => { el.resultNote.textContent = phrase('result.none'); },
+});
+const download = downloadLink(el.download);
+const humanBytes = (n) => sizeText(n, phrase, { under: 'size.b', kb: 1, mb: 2 });
+
 /** The text of the last successful result, for the copy and download buttons. */
 let result = null;
-let downloadUrl = null;
 
 /* --------------------------------------------------------------- the menu */
 
@@ -164,22 +172,7 @@ function show(text, note, name) {
   el.resultNote.textContent = note;
   result = { text, name };
   el.copy.disabled = text === '';
-  offerDownload(text, name);
-}
-
-/**
- * The download is a blob: URL made in this page from a string that was already
- * in this page. Nothing is uploaded to produce it and nothing is fetched to
- * serve it.
- */
-function offerDownload(text, name) {
-  if (downloadUrl) URL.revokeObjectURL(downloadUrl);
-  downloadUrl = null;
-  if (text === '') { el.download.hidden = true; return; }
-  downloadUrl = URL.createObjectURL(new Blob([text], { type: 'text/plain;charset=utf-8' }));
-  el.download.href = downloadUrl;
-  el.download.download = name;
-  el.download.hidden = false;
+  download.offer(text, name);
 }
 
 el.copy.addEventListener('click', async () => {
@@ -203,32 +196,13 @@ el.copy.addEventListener('click', async () => {
 function clearResult() {
   el.output.textContent = '';
   el.copy.disabled = true;
-  el.download.hidden = true;
+  download.clear();
   result = null;
-  if (downloadUrl) URL.revokeObjectURL(downloadUrl);
-  downloadUrl = null;
-}
-
-function showError(message) {
-  el.error.textContent = message;
-  el.error.hidden = false;
-  el.resultNote.textContent = phrase('result.none');
-}
-
-function clearError() {
-  el.error.hidden = true;
-  el.error.textContent = '';
 }
 
 /* ----------------------------------------------------------------- wording */
 
 const pickedDirection = () => document.querySelector('input[name="direction"]:checked').value;
-
-function humanBytes(bytes) {
-  if (bytes < 1024) return phrase('size.b', { n: bytes });
-  if (bytes < 1024 * 1024) return phrase('size.kb', { n: (bytes / 1024).toFixed(1) });
-  return phrase('size.mb', { n: (bytes / (1024 * 1024)).toFixed(2) });
-}
 
 /* ------------------------------------------------- privacy panel + offline */
 

--- a/tools/base64/tool.toml
+++ b/tools/base64/tool.toml
@@ -40,7 +40,7 @@ roadmap_group = "beyond"
 
 # Shared modules this tool asks for. file-picker brings in the drop zone, which
 # is here for the file that is easier to drop than to open, select all and copy.
-js_parts = ["file-picker"]
+js_parts = ["file-picker", "message-box", "download", "format"]
 lastmod = "2026-08-30"
 
 # --- what search engines and chat apps are told ------------------------------

--- a/tools/compare-heights/src/main.js
+++ b/tools/compare-heights/src/main.js
@@ -1,10 +1,11 @@
 /** UI wiring and application state. */
 
 import { phrase } from './shared/phrases.js';
+import { saveBlob } from './shared/download.js';
 import { SHAPES, objectShape, shapeOf } from './figures.js';
 import { FONT, chartSvg, isDark } from './chart.js';
 import { format, formatBoth, parseHeight, toInput } from './units.js';
-import { download, svgBlob, svgToPng } from './save.js';
+import { svgBlob, svgToPng } from './save.js';
 import { LIMITS, importSvg } from './import-svg.js';
 import { IMAGE_LIMITS, fit, imageMarkup, nameFromFile } from './import-image.js';
 
@@ -625,14 +626,14 @@ function note(text, bad = false) {
 
 el.downloadSvg.addEventListener('click', () => {
   if (!current) return note(phrase('save.nothing'), true);
-  download(svgBlob(current.svg), 'height-chart.svg');
+  saveBlob(svgBlob(current.svg), 'height-chart.svg');
   return note(phrase('save.done'));
 });
 
 el.downloadPng.addEventListener('click', async () => {
   if (!current) return note(phrase('save.nothing'), true);
   try {
-    download(await svgToPng(current.svg, current), 'height-chart.png');
+    saveBlob(await svgToPng(current.svg, current), 'height-chart.png');
     return note(phrase('save.done'));
   } catch (error) {
     return note(phrase('save.failed', { detail: phrase(error.message) }), true);

--- a/tools/compare-heights/src/save.js
+++ b/tools/compare-heights/src/save.js
@@ -63,17 +63,3 @@ export async function svgToPng(svg, size, multiple = 1) {
   }
 }
 
-/** Hand a blob to the browser as a download. Nothing leaves the machine. */
-export function download(blob, name) {
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement('a');
-  link.href = url;
-  link.download = name;
-  link.rel = 'noopener';
-  document.body.append(link);
-  link.click();
-  link.remove();
-  // Revoked on a later turn of the event loop: revoking it at once can beat
-  // the download starting in some browsers.
-  setTimeout(() => URL.revokeObjectURL(url), 1000);
-}

--- a/tools/compare-heights/tool.toml
+++ b/tools/compare-heights/tool.toml
@@ -106,6 +106,10 @@ card = """
             centimetres or feet and inches &mdash; and download it as a PNG or
             an SVG."""
 
+# Shared modules this tool asks for, copied into it at src/shared/ by the
+# build: download hands the chart to the browser as a file.
+js_parts = ["download"]
+
 # The nouns this tool uses for the things it works on. They appear in the boot
 # warning, the pledge line and the analytics comment, which is why they are a
 # setting rather than three copies of the same word in three files.

--- a/tools/compress-image/src/main.js
+++ b/tools/compress-image/src/main.js
@@ -1,6 +1,9 @@
 /** UI wiring and application state. */
 
 import { phrase } from './shared/phrases.js';
+import { measureImage } from './shared/media.js';
+import { saveBlob } from './shared/download.js';
+import { messageBox } from './shared/message-box.js';
 import {
   decode, encodableTypes, release, FORMATS, JPEG, PNG, WEBP, READABLE,
 } from './codecs.js';
@@ -56,6 +59,8 @@ const el = {
   privacyToggle: $('privacy-toggle'),
   privacyPanel: $('privacy-panel'),
 };
+
+const { show: showLoadError, clear: clearLoadError } = messageBox(el.loadError);
 
 /**
  * @typedef {object} Item
@@ -121,7 +126,7 @@ async function addFiles(files) {
 
       // The thumbnail decode doubles as the measurement, so the picture is
       // read once here and not again until it is actually compressed.
-      item.size = await measure(item.thumbUrl);
+      item.size = await measureImage(item.thumbUrl);
       if (!item.size) {
         URL.revokeObjectURL(item.thumbUrl);
         failures.push(phrase('load.undecodable', { name: file.name }));
@@ -146,16 +151,6 @@ async function addFiles(files) {
 function isImage(file) {
   if (!file.type) return /\.(jpe?g|png|webp|gif|bmp|avif)$/i.test(file.name);
   return READABLE.includes(file.type) || file.type.startsWith('image/');
-}
-
-/** Read a picture's pixel size without keeping the decoded image around. */
-function measure(url) {
-  return new Promise((resolve) => {
-    const img = new Image();
-    img.onload = () => resolve({ width: img.naturalWidth, height: img.naturalHeight });
-    img.onerror = () => resolve(null);
-    img.src = url;
-  });
 }
 
 
@@ -773,29 +768,7 @@ function comparePanel(result, resultUrl) {
   return panel;
 }
 
-/** Hand a blob to the browser's downloads. */
-function saveBlob(blob, name) {
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement('a');
-  link.href = url;
-  link.download = name;
-  link.click();
-  // Revoked late: revoking immediately can cancel a download that has not
-  // started yet in some browsers.
-  setTimeout(() => URL.revokeObjectURL(url), 60000);
-}
-
 /* ------------------------------------------------------------------ errors */
-
-function showLoadError(message) {
-  el.loadError.textContent = message;
-  el.loadError.hidden = false;
-}
-
-function clearLoadError() {
-  el.loadError.textContent = '';
-  el.loadError.hidden = true;
-}
 
 /* ------------------------------------------------- privacy panel + offline */
 

--- a/tools/compress-image/tool.toml
+++ b/tools/compress-image/tool.toml
@@ -32,7 +32,7 @@ css_parts = ["file-list", "progress"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.
-js_parts = ["file-picker", "zip", "crc32"]
+js_parts = ["file-picker", "zip", "crc32", "message-box", "download", "media"]
 lastmod = "2026-08-27"
 
 # --- what search engines and chat apps are told ------------------------------

--- a/tools/compress-pdf/src/main.js
+++ b/tools/compress-pdf/src/main.js
@@ -1,6 +1,7 @@
 /** UI wiring and application state. */
 
 import { phrase } from './shared/phrases.js';
+import { messageBox } from './shared/message-box.js';
 import {
   compressDocument, describeSettings, PRESETS,
 } from './compress.js';
@@ -52,6 +53,9 @@ const el = {
   privacyToggle: $('privacy-toggle'),
   privacyPanel: $('privacy-panel'),
 };
+
+const { show: showLoadError } = messageBox(el.loadError);
+const { show: note } = messageBox(el.loadNote);
 
 /**
  * @typedef {object} Loaded
@@ -183,16 +187,6 @@ function emptyInventory() {
   el.breakdownBar.hidden = true;
   el.breakdownList.replaceChildren();
   el.inventoryNotes.textContent = '';
-}
-
-function showLoadError(text) {
-  el.loadError.textContent = text;
-  el.loadError.hidden = false;
-}
-
-function note(text) {
-  el.loadNote.textContent = text;
-  el.loadNote.hidden = false;
 }
 
 el.clearFile.addEventListener('click', () => {

--- a/tools/compress-pdf/tool.toml
+++ b/tools/compress-pdf/tool.toml
@@ -34,7 +34,7 @@ css_parts = ["progress"]
 # travel together, because the reader and the writer import the other two;
 # the merger and the redactor ask for the same four. This tool carried its own
 # copy of them until the tests learned to follow a ./shared/ import.
-js_parts = ["file-picker", "pdf-objects", "pdf-filters", "pdf-reader", "pdf-writer"]
+js_parts = ["file-picker", "pdf-objects", "pdf-filters", "pdf-reader", "pdf-writer", "message-box"]
 lastmod = "2026-08-27"
 
 # --- what search engines and chat apps are told ------------------------------

--- a/tools/crop-video/src/main.js
+++ b/tools/crop-video/src/main.js
@@ -1,6 +1,9 @@
 /** UI wiring and application state. */
 
-import { phrase } from './shared/phrases.js';
+import { phrase, fill } from './shared/phrases.js';
+import { sizeText, durationText } from './shared/format.js';
+import { openInPlayer } from './shared/media.js';
+import { messageBox } from './shared/message-box.js';
 import { wireFilePicker } from './shared/file-picker.js';
 import { demux, UnsupportedFile } from './shared/mp4-reader.js';
 import { cropExact, grabFrame, decoderConfig, averageFps } from './transcode.js';
@@ -77,6 +80,10 @@ const el = {
   privacyPanel: $('privacy-panel'),
 };
 
+const { show: showError, clear: clearError } = messageBox(el.error);
+const formatBytes = (n) => sizeText(n, phrase, { kb: 0, mb: 1, gb: 'size.gb' });
+const formatDuration = (seconds) => durationText(seconds, phrase);
+
 /** @type {File|null} */
 let file = null;
 let objectUrl = null;
@@ -126,35 +133,6 @@ const picker = wireFilePicker({
 
 
 /* ------------------------------------------------------------------ loading */
-
-/**
- * Ask the <video> element to open the file, and report what it made of it.
- * A browser that will not play a format still says so quickly, so this is also
- * the test for whether the recording path is available at all.
- */
-function openInPlayer(video, url) {
-  return new Promise((resolve) => {
-    const done = (result) => {
-      clearTimeout(timer);
-      video.removeEventListener('loadedmetadata', ok);
-      video.removeEventListener('error', bad);
-      resolve(result);
-    };
-    const ok = () => done({
-      ok: video.videoWidth > 0 && video.videoHeight > 0,
-      width: video.videoWidth,
-      height: video.videoHeight,
-      duration: Number.isFinite(video.duration) ? video.duration : 0,
-    });
-    const bad = () => done({ ok: false, width: 0, height: 0, duration: 0 });
-
-    const timer = setTimeout(bad, 15000);
-    video.addEventListener('loadedmetadata', ok, { once: true });
-    video.addEventListener('error', bad, { once: true });
-    video.src = url;
-    video.load();
-  });
-}
 
 async function loadFile(picked) {
   if (exporting) return;
@@ -580,27 +558,6 @@ function updateSummary() {
 
 /* ------------------------------------------------------------------ export */
 
-/**
- * An error's blanks, with any that are themselves a phrase resolved.
- *
- * transcode.js names the size it will not encode; the reader's sentence is
- * built here, where a phrase can be read.
- */
-function fill(values = {}) {
-  return Object.fromEntries(Object.entries(values)
-    .map(([name, value]) => [name, value?.key ? phrase(value.key, value.values) : value]));
-}
-
-function showError(message) {
-  el.error.textContent = message;
-  el.error.hidden = false;
-}
-
-function clearError() {
-  el.error.hidden = true;
-  el.error.textContent = '';
-}
-
 function setProgress({ phase, done, total, realtime }) {
   const fraction = total > 0 ? Math.min(1, done / total) : 0;
   el.progressBar.style.width = `${(fraction * 100).toFixed(1)}%`;
@@ -629,28 +586,12 @@ function outputFilename(extension) {
   return `${base}-cropped.${extension}`;
 }
 
-function formatBytes(bytes) {
-  if (bytes < 1024 * 1024) return phrase('size.kb', { n: (bytes / 1024).toFixed(0) });
-  if (bytes < 1024 * 1024 * 1024) {
-    return phrase('size.mb', { n: (bytes / 1024 / 1024).toFixed(1) });
-  }
-  return phrase('size.gb', { n: (bytes / 1024 / 1024 / 1024).toFixed(2) });
-}
-
 /** A moment in the clip, written the way a person reads it. */
 function clockTime(seconds) {
   const whole = Math.max(0, seconds);
   const minutes = Math.floor(whole / 60);
   const rest = whole - minutes * 60;
   return `${minutes}:${rest.toFixed(3).padStart(6, '0')}`;
-}
-
-function formatDuration(seconds) {
-  const whole = Math.max(0, Math.round(seconds));
-  const minutes = Math.floor(whole / 60);
-  return minutes
-    ? phrase('time.minutes', { minutes, seconds: String(whole % 60).padStart(2, '0') })
-    : phrase('time.seconds', { n: seconds < 10 ? seconds.toFixed(1) : whole });
 }
 
 async function runExport() {

--- a/tools/crop-video/tool.toml
+++ b/tools/crop-video/tool.toml
@@ -32,7 +32,7 @@ css_parts = ["progress"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.
-js_parts = ["file-picker", "codec-support", "mp4-reader", "video-support"]
+js_parts = ["file-picker", "codec-support", "mp4-reader", "video-support", "message-box", "media", "format"]
 # Where a finished result can be carried without being saved first: the row of
 # links shared/handoff.js shows beside the download once there is one. Slugs of
 # tools whose picker takes what this page produces; checked against the tools

--- a/tools/dicom-viewer/src/main.js
+++ b/tools/dicom-viewer/src/main.js
@@ -1,6 +1,7 @@
 /** UI wiring and application state. */
 
 import { phrase } from './shared/phrases.js';
+import { messageBox } from './shared/message-box.js';
 import { wireFilePicker, readingLabel } from './shared/file-picker.js';
 import { PIXEL_DATA, parseDataset, parseFile, walk } from './dicom.js';
 import { describe, formatTag } from './dictionary.js';
@@ -81,6 +82,8 @@ const el = {
   tagRows: $('tag-rows'),
   showMore: $('show-more'),
 };
+
+const { show: showError } = messageBox(el.loadError);
 
 /**
  * What a field with nothing in it shows.
@@ -1225,11 +1228,6 @@ function save(blob, name) {
 }
 
 /* ------------------------------------------------------------------ messages */
-
-function showError(message) {
-  el.loadError.textContent = message;
-  el.loadError.hidden = false;
-}
 
 function hideError() {
   el.loadError.hidden = true;

--- a/tools/dicom-viewer/tool.toml
+++ b/tools/dicom-viewer/tool.toml
@@ -41,7 +41,7 @@ roadmap_group = "images"
 # Shared modules this tool asks for. file-picker brings in the drop zone; it is
 # set to accept many files because a CT is three hundred of them and dropping a
 # folder is the only sane way to open one.
-js_parts = ["file-picker"]
+js_parts = ["file-picker", "message-box"]
 lastmod = "2026-08-27"
 
 # --- what search engines and chat apps are told ------------------------------

--- a/tools/document-scanner/src/main.js
+++ b/tools/document-scanner/src/main.js
@@ -1,6 +1,7 @@
 /** UI wiring and application state. */
 
 import { phrase } from './shared/phrases.js';
+import { messageBox } from './shared/message-box.js';
 import { readingLabel, wireFilePicker } from './shared/file-picker.js';
 import { makeZip } from './shared/zip.js';
 import { WORKING_EDGE, findPageQuad } from './detect.js';
@@ -71,6 +72,8 @@ const el = {
   privacyToggle: $('privacy-toggle'),
   privacyPanel: $('privacy-panel'),
 };
+
+const { show: showError, clear: clearError } = messageBox(el.loadError);
 
 /**
  * How large the photograph is kept for the editor.
@@ -778,16 +781,6 @@ function show(blob, name, facts) {
 }
 
 /* ------------------------------------------------------------------ errors */
-
-function showError(message) {
-  el.loadError.textContent = message;
-  el.loadError.hidden = false;
-}
-
-function clearError() {
-  el.loadError.textContent = '';
-  el.loadError.hidden = true;
-}
 
 /* --------------------------------------------------------------- the wiring */
 

--- a/tools/document-scanner/tool.toml
+++ b/tools/document-scanner/tool.toml
@@ -28,7 +28,7 @@ roadmap_group = "documents"
 # Shared modules this tool asks for. file-picker brings in the drop zone; zip is
 # for saving several pages as pictures rather than as a document, and needs crc32
 # beside it because the archive stores a checksum per entry.
-js_parts = ["file-picker", "zip", "crc32", "pdf-page-writer"]
+js_parts = ["file-picker", "zip", "crc32", "pdf-page-writer", "message-box"]
 # Where a finished result can be carried without being saved first: the row of
 # links shared/handoff.js shows beside the download once there is one. Slugs of
 # tools whose picker takes what this page produces; checked against the tools

--- a/tools/edit-audio/src/main.js
+++ b/tools/edit-audio/src/main.js
@@ -1,6 +1,8 @@
 /** UI wiring and application state. */
 
 import { phrase } from './shared/phrases.js';
+import { sizeText } from './shared/format.js';
+import { messageBox } from './shared/message-box.js';
 import { wireFilePicker } from './shared/file-picker.js';
 import { decodeAudio, UnreadableFile } from './shared/audio-decode.js';
 import { render, lengthAfter } from './edit.js';
@@ -53,6 +55,9 @@ const el = {
   privacyToggle: $('privacy-toggle'),
   privacyPanel: $('privacy-panel'),
 };
+
+const { show: showError, clear: clearError } = messageBox(el.error);
+const formatBytes = (n) => sizeText(n, phrase, { under: 'size.b', kb: 1, mb: 1, gb: 'size.gb' });
 
 /** @type {File|null} */
 let file = null;
@@ -399,16 +404,6 @@ window.addEventListener('resize', () => {
 
 /* ---------------------------------------------------------------- reporting */
 
-function showError(message) {
-  el.error.textContent = message;
-  el.error.hidden = false;
-}
-
-function clearError() {
-  el.error.hidden = true;
-  el.error.textContent = '';
-}
-
 function clearResult() {
   el.result.hidden = true;
   el.resultAudio.removeAttribute('src');
@@ -452,15 +447,6 @@ function formatDuration(seconds) {
   return hours
     ? `${hours}:${String(minutes).padStart(2, '0')}:${shown}`
     : `${minutes}:${shown}`;
-}
-
-function formatBytes(bytes) {
-  if (bytes < 1024) return phrase('size.b', { n: bytes });
-  if (bytes < 1024 * 1024) return phrase('size.kb', { n: (bytes / 1024).toFixed(1) });
-  if (bytes < 1024 * 1024 * 1024) {
-    return phrase('size.mb', { n: (bytes / (1024 * 1024)).toFixed(1) });
-  }
-  return phrase('size.gb', { n: (bytes / (1024 * 1024 * 1024)).toFixed(2) });
 }
 
 /* ------------------------------------------------- privacy panel + offline */

--- a/tools/edit-audio/tool.toml
+++ b/tools/edit-audio/tool.toml
@@ -32,7 +32,7 @@ css_parts = ["progress"]
 # Shared modules this tool asks for. The same arrangement as css_parts, and for
 # the same reason: a component more than one tool needs and no tool should own.
 # file-picker brings in the drop zone.
-js_parts = ["file-picker", "audio-decode", "samplerate", "wav"]
+js_parts = ["file-picker", "audio-decode", "samplerate", "wav", "message-box", "format"]
 # Where a finished result can be carried without being saved first: the row of
 # links shared/handoff.js shows beside the download once there is one. Slugs of
 # tools whose picker takes what this page produces; checked against the tools

--- a/tools/exif-editor/src/main.js
+++ b/tools/exif-editor/src/main.js
@@ -1,6 +1,9 @@
 /** UI wiring and application state. */
 
 import { phrase } from './shared/phrases.js';
+import { measureImage } from './shared/media.js';
+import { saveBlob } from './shared/download.js';
+import { messageBox } from './shared/message-box.js';
 import { wireFilePicker, readingLabel } from './shared/file-picker.js';
 import { makeZip } from './shared/zip.js';
 import { readImage, readBytes, serialize, exifBytes, outputType, KIND_NAMES } from './container.js';
@@ -50,6 +53,8 @@ const el = {
   privacyToggle: $('privacy-toggle'),
   privacyPanel: $('privacy-panel'),
 };
+
+const { show: showLoadError, clear: clearLoadError } = messageBox(el.loadError);
 
 /**
  * @typedef {object} Item
@@ -114,7 +119,7 @@ async function addFiles(files) {
 
       // One decode, used twice: it draws the thumbnail, and its dimensions are
       // what a WebP with no extended header needs before metadata can be added.
-      const dims = await measure(item.thumbUrl);
+      const dims = await measureImage(item.thumbUrl);
       if (dims && item.doc) item.doc.canvas = dims;
 
       if (item.ok) normalizeExif(item);
@@ -179,16 +184,6 @@ function normalizeExif(item) {
   item.exifUnreadable = Boolean(item.exif && !item.exif.ok && item.meta.exif);
   item.exifError = item.exifUnreadable ? item.exif.error : null;
   if (!item.exif?.ok) item.exif = emptyExif();
-}
-
-/** Read a picture's pixel size without keeping the decoded image around. */
-function measure(url) {
-  return new Promise((resolve) => {
-    const img = new Image();
-    img.onload = () => resolve({ width: img.naturalWidth, height: img.naturalHeight });
-    img.onerror = () => resolve(null);
-    img.src = url;
-  });
 }
 
 
@@ -1097,18 +1092,6 @@ function showResults(results) {
   };
 }
 
-/** Hand a blob to the browser's downloads. */
-function saveBlob(blob, name) {
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement('a');
-  link.href = url;
-  link.download = name;
-  link.click();
-  // Revoked late: revoking immediately can cancel a download that has not
-  // started yet in some browsers.
-  setTimeout(() => URL.revokeObjectURL(url), 60000);
-}
-
 el.saveEdits.addEventListener('click', () => {
   const item = selected();
   if (!item) return;
@@ -1150,16 +1133,6 @@ el.revertEdits.addEventListener('click', async () => {
 });
 
 /* ------------------------------------------------------------------ errors */
-
-function showLoadError(message) {
-  el.loadError.textContent = message;
-  el.loadError.hidden = false;
-}
-
-function clearLoadError() {
-  el.loadError.textContent = '';
-  el.loadError.hidden = true;
-}
 
 function showEditError(message) {
   el.editError.textContent = message;

--- a/tools/exif-editor/tool.toml
+++ b/tools/exif-editor/tool.toml
@@ -36,7 +36,7 @@ css_parts = ["file-list"]
 # batch of cleaned files comes back in, and crc32 is the checksum both it and
 # the PNG writer need. This tool carried its own copy of those two until the
 # tests learned to follow a ./shared/ import (tests/js/resolve-shared.mjs).
-js_parts = ["file-picker", "zip", "crc32"]
+js_parts = ["file-picker", "zip", "crc32", "message-box", "download", "media"]
 lastmod = "2026-08-27"
 
 # --- what search engines and chat apps are told ------------------------------

--- a/tools/extract-audio-from-video/src/main.js
+++ b/tools/extract-audio-from-video/src/main.js
@@ -1,6 +1,8 @@
 /** UI wiring and application state. */
 
 import { phrase } from './shared/phrases.js';
+import { sizeText } from './shared/format.js';
+import { messageBox } from './shared/message-box.js';
 import { wireFilePicker } from './shared/file-picker.js';
 import { decodeAudio, UnreadableFile } from './shared/audio-decode.js';
 import { writeWav } from './shared/wav.js';
@@ -30,6 +32,9 @@ const el = {
   privacyToggle: $('privacy-toggle'),
   privacyPanel: $('privacy-panel'),
 };
+
+const { show: showError, clear: clearError } = messageBox(el.error);
+const humanBytes = (n) => sizeText(n, phrase, { under: 'size.bytes', kb: 1, mb: 1 });
 
 /**
  * The decoded sound, and the name it came in under. Held so that changing the
@@ -153,22 +158,6 @@ function clearResult() {
 function say(error) {
   if (error instanceof UnreadableFile) return phrase(error.message);
   return error?.message ? phrase(error.message) : String(error);
-}
-
-function showError(message) {
-  el.error.textContent = message;
-  el.error.hidden = false;
-}
-
-function clearError() {
-  el.error.hidden = true;
-  el.error.textContent = '';
-}
-
-function humanBytes(bytes) {
-  if (bytes < 1024) return phrase('size.bytes', { n: bytes });
-  if (bytes < 1024 * 1024) return phrase('size.kb', { n: (bytes / 1024).toFixed(1) });
-  return phrase('size.mb', { n: (bytes / (1024 * 1024)).toFixed(1) });
 }
 
 /** m:ss, or h:mm:ss once there is an hour of it. */

--- a/tools/extract-audio-from-video/tool.toml
+++ b/tools/extract-audio-from-video/tool.toml
@@ -72,7 +72,7 @@ roadmap_group = "audio"
 css_parts = ["progress"]
 
 # Shared modules this tool asks for. file-picker brings in the drop zone.
-js_parts = ["file-picker", "audio-decode", "samplerate", "wav"]
+js_parts = ["file-picker", "audio-decode", "samplerate", "wav", "message-box", "format"]
 # Where a finished result can be carried without being saved first: the row of
 # links shared/handoff.js shows beside the download once there is one. The sound
 # out of a video is very often wanted shorter, or louder, which is the next two

--- a/tools/gif-analyzer/src/main.js
+++ b/tools/gif-analyzer/src/main.js
@@ -1,6 +1,7 @@
 /** UI wiring and application state. */
 
-import { phrase } from './shared/phrases.js';
+import { phrase, fill } from './shared/phrases.js';
+import { messageBox } from './shared/message-box.js';
 import { wireFilePicker, readingLabel } from './shared/file-picker.js';
 import { DISPOSALS, NotAGif, frameData, parseGif } from './gif.js';
 import { lzwDecode } from './lzw.js';
@@ -62,6 +63,8 @@ const el = {
   privacyToggle: $('privacy-toggle'),
   privacyPanel: $('privacy-panel'),
 };
+
+const { show: showError } = messageBox(el.loadError);
 
 /**
  * How much of a file is drawn rather than merely measured.
@@ -349,19 +352,6 @@ function renderFindings(list) {
     item.append(mark, body);
     el.findings.append(item);
   }
-}
-
-/**
- * A finding's blanks, with any that are themselves a phrase resolved.
- *
- * gif.js quotes the reader's account of a truncation inside its own
- * sentence, and names what a file that is not a GIF appears to be inside
- * its refusal. Both are phrases, and a key dropped into a blank would reach
- * the page as the key, so the inner one is resolved on the way in.
- */
-function fill(values = {}) {
-  return Object.fromEntries(Object.entries(values)
-    .map(([name, value]) => [name, value?.key ? phrase(value.key, value.values) : value]));
 }
 
 /* ------------------------------------------------------------ the budget */
@@ -660,11 +650,6 @@ el.copyReport.addEventListener('click', async () => {
 });
 
 /* ------------------------------------------------------------- the frame */
-
-function showError(message) {
-  el.loadError.textContent = message;
-  el.loadError.hidden = false;
-}
 
 function hideError() {
   el.loadError.hidden = true;

--- a/tools/gif-analyzer/tool.toml
+++ b/tools/gif-analyzer/tool.toml
@@ -33,7 +33,7 @@ roadmap_group = "gif"
 # Shared modules this tool asks for. The same arrangement as css_parts, and for
 # the same reason: a component more than one tool needs and no tool should own.
 # file-picker brings in the drop zone.
-js_parts = ["file-picker"]
+js_parts = ["file-picker", "message-box"]
 lastmod = "2026-08-27"
 
 # --- what search engines and chat apps are told ------------------------------

--- a/tools/gif-maker/src/main.js
+++ b/tools/gif-maker/src/main.js
@@ -1,6 +1,8 @@
 /** UI wiring and application state. */
 
 import { phrase } from './shared/phrases.js';
+import { sizeText, durationText } from './shared/format.js';
+import { messageBox } from './shared/message-box.js';
 import { wireFilePicker, readingLabel } from './shared/file-picker.js';
 import {
   loadImages, releaseItem, sortItems, moveItem, decodeFull,
@@ -60,6 +62,10 @@ const el = {
   privacyToggle: $('privacy-toggle'),
   privacyPanel: $('privacy-panel'),
 };
+
+const { show: showError, clear: clearError } = messageBox(el.error);
+const formatBytes = (n) => sizeText(n, phrase, { kb: 0, mb: 1 });
+const formatDuration = (seconds) => durationText(seconds, phrase, { decimals: 2 });
 
 /** @type {object[]} */
 let items = [];
@@ -459,15 +465,6 @@ function syncSettingControls() {
 /** The dash a summary row shows when there is nothing to summarise. */
 const EMPTY = '\u2014';
 
-function formatDuration(seconds) {
-  const whole = Math.round(seconds);
-  const mins = Math.floor(whole / 60);
-  const secs = whole % 60;
-  return mins
-    ? phrase('time.minutes', { minutes: mins, seconds: String(secs).padStart(2, '0') })
-    : phrase('time.seconds', { n: seconds.toFixed(2) });
-}
-
 function updateSummary() {
   if (!items.length) {
     el.sumFrames.textContent = EMPTY;
@@ -559,16 +556,6 @@ for (const input of settingsInputs) {
 
 /* ------------------------------------------------------------------ export */
 
-function showError(message) {
-  el.error.textContent = message;
-  el.error.hidden = false;
-}
-
-function clearError() {
-  el.error.hidden = true;
-  el.error.textContent = '';
-}
-
 function setProgress({ phase, done, total }) {
   const fraction = total > 0 ? Math.min(1, done / total) : 0;
   el.progressBar.style.width = `${(fraction * 100).toFixed(1)}%`;
@@ -593,11 +580,6 @@ function outputFilename() {
     String(now.getDate()).padStart(2, '0'),
   ].join('-');
   return `animation-${stamp}.gif`;
-}
-
-function formatBytes(bytes) {
-  if (bytes < 1024 * 1024) return phrase('size.kb', { n: (bytes / 1024).toFixed(0) });
-  return phrase('size.mb', { n: (bytes / 1024 / 1024).toFixed(1) });
 }
 
 async function runExport() {

--- a/tools/gif-maker/tool.toml
+++ b/tools/gif-maker/tool.toml
@@ -32,7 +32,7 @@ css_parts = ["progress"]
 # Shared modules this tool asks for. The same arrangement as css_parts, and for
 # the same reason: a component more than one tool needs and no tool should own.
 # file-picker brings in the drop zone.
-js_parts = ["file-picker"]
+js_parts = ["file-picker", "message-box", "format"]
 # Where a finished result can be carried without being saved first: the row of
 # links shared/handoff.js shows beside the download once there is one. Slugs of
 # tools whose picker takes what this page produces; checked against the tools

--- a/tools/grab-frame/src/main.js
+++ b/tools/grab-frame/src/main.js
@@ -1,6 +1,10 @@
 /** UI wiring and application state. */
 
-import { phrase } from './shared/phrases.js';
+import { phrase, fill } from './shared/phrases.js';
+import { sizeText, durationText } from './shared/format.js';
+import { openInPlayer } from './shared/media.js';
+import { saveBlob } from './shared/download.js';
+import { messageBox } from './shared/message-box.js';
 import { wireFilePicker } from './shared/file-picker.js';
 import { demux, UnsupportedFile } from './shared/mp4-reader.js';
 import { FrameReader, decodeSeries, frameNear, seriesFrames } from './frames.js';
@@ -66,6 +70,10 @@ const el = {
   privacyPanel: $('privacy-panel'),
 };
 
+const { show: showError, clear: clearError } = messageBox(el.error);
+const formatBytes = (n) => sizeText(n, phrase, { kb: 0, mb: 1, gb: 'size.gb' });
+const formatDuration = (seconds) => durationText(seconds, phrase);
+
 /** @type {File|null} */
 let file = null;
 let objectUrl = null;
@@ -122,35 +130,6 @@ const picker = wireFilePicker({
 });
 
 /* ----------------------------------------------------------------- loading */
-
-/**
- * Ask the <video> element to open the file, and report what it made of it.
- * A browser that will not play a format still says so quickly, so this is also
- * the test for whether the playback path is available at all.
- */
-function openInPlayer(video, url) {
-  return new Promise((resolve) => {
-    const done = (result) => {
-      clearTimeout(timer);
-      video.removeEventListener('loadedmetadata', ok);
-      video.removeEventListener('error', bad);
-      resolve(result);
-    };
-    const ok = () => done({
-      ok: video.videoWidth > 0 && video.videoHeight > 0,
-      width: video.videoWidth,
-      height: video.videoHeight,
-      duration: Number.isFinite(video.duration) ? video.duration : 0,
-    });
-    const bad = () => done({ ok: false, width: 0, height: 0, duration: 0 });
-
-    const timer = setTimeout(bad, 15000);
-    video.addEventListener('loadedmetadata', ok, { once: true });
-    video.addEventListener('error', bad, { once: true });
-    video.src = url;
-    video.load();
-  });
-}
 
 async function loadFile(picked) {
   if (working) return;
@@ -685,16 +664,6 @@ el.downloadAll.addEventListener('click', async () => {
   }
 });
 
-/** Hand a blob to the browser's downloads and let go of it afterwards. */
-function saveBlob(blob, name) {
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement('a');
-  link.href = url;
-  link.download = name;
-  link.click();
-  setTimeout(() => URL.revokeObjectURL(url), 60_000);
-}
-
 /* ------------------------------------------------------------- the grabbing */
 
 /** The frame on screen, at its full size, ready to encode. */
@@ -850,43 +819,6 @@ function setProgress({ done, total, step }) {
     total: total.toLocaleString(),
     percent: Math.round(fraction * 100),
   });
-}
-
-/**
- * An error's blanks, with any that are themselves a phrase resolved.
- *
- * still.js names the format it could not write; the reader's sentence is
- * built here, where a phrase can be read.
- */
-function fill(values = {}) {
-  return Object.fromEntries(Object.entries(values)
-    .map(([name, value]) => [name, value?.key ? phrase(value.key, value.values) : value]));
-}
-
-function showError(message) {
-  el.error.textContent = message;
-  el.error.hidden = false;
-}
-
-function clearError() {
-  el.error.hidden = true;
-  el.error.textContent = '';
-}
-
-function formatBytes(bytes) {
-  if (bytes < 1024 * 1024) return phrase('size.kb', { n: (bytes / 1024).toFixed(0) });
-  if (bytes < 1024 * 1024 * 1024) {
-    return phrase('size.mb', { n: (bytes / 1024 / 1024).toFixed(1) });
-  }
-  return phrase('size.gb', { n: (bytes / 1024 / 1024 / 1024).toFixed(2) });
-}
-
-function formatDuration(seconds) {
-  const whole = Math.max(0, Math.round(seconds));
-  const minutes = Math.floor(whole / 60);
-  return minutes
-    ? phrase('time.minutes', { minutes, seconds: String(whole % 60).padStart(2, '0') })
-    : phrase('time.seconds', { n: seconds < 10 ? seconds.toFixed(1) : whole });
 }
 
 window.addEventListener('beforeunload', (event) => {

--- a/tools/grab-frame/tool.toml
+++ b/tools/grab-frame/tool.toml
@@ -32,7 +32,7 @@ css_parts = ["progress"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.
-js_parts = ["file-picker", "zip", "crc32", "mp4-reader"]
+js_parts = ["file-picker", "zip", "crc32", "mp4-reader", "message-box", "download", "media", "format"]
 lastmod = "2026-09-02"
 
 # --- what search engines and chat apps are told ------------------------------

--- a/tools/hash-checksum/src/main.js
+++ b/tools/hash-checksum/src/main.js
@@ -1,6 +1,7 @@
 /** UI wiring and application state. */
 
 import { phrase } from './shared/phrases.js';
+import { messageBox } from './shared/message-box.js';
 import { wireFilePicker, readingLabel } from './shared/file-picker.js';
 import { ALGORITHMS, ORDER, Stopped, Unreadable, hashFile } from './hash.js';
 import { algorithmsIn, readExpected, verdict } from './expected.js';
@@ -37,6 +38,8 @@ const el = {
   privacyToggle: $('privacy-toggle'),
   privacyPanel: $('privacy-panel'),
 };
+
+const { show: showError } = messageBox(el.loadError);
 
 /** The five checkboxes, by the algorithm they turn on. */
 const boxes = new Map(
@@ -368,11 +371,6 @@ el.downloadChecksums.addEventListener('click', () => {
 });
 
 /* ------------------------------------------------------------- the frame */
-
-function showError(message) {
-  el.loadError.textContent = message;
-  el.loadError.hidden = false;
-}
 
 function hideError() {
   el.loadError.hidden = true;

--- a/tools/hash-checksum/tool.toml
+++ b/tools/hash-checksum/tool.toml
@@ -38,7 +38,7 @@ roadmap_group = "beyond"
 css_parts = ["progress"]
 
 # Shared modules this tool asks for. file-picker brings in the drop zone.
-js_parts = ["file-picker"]
+js_parts = ["file-picker", "message-box"]
 lastmod = "2026-08-27"
 
 # --- what search engines and chat apps are told ------------------------------

--- a/tools/heic-to-jpg/src/files.js
+++ b/tools/heic-to-jpg/src/files.js
@@ -1,14 +1,9 @@
 /** Names and sizes, as words a person would use. */
 
 import { FORMATS } from './codecs.js';
+import { sizeText } from './shared/format.js';
 
-/** KB and MB here mean 1024 and 1024*1024, which is what a file manager shows
- *  on every platform except macOS, and what people mean by "about 3 MB". */
-export function bytes(n, t) {
-  if (n < 1024) return t('size.bytes', { n });
-  if (n < 1024 * 1024) return t('size.kb', { n: (n / 1024).toFixed(n < 10240 ? 1 : 0) });
-  return t('size.mb', { n: (n / (1024 * 1024)).toFixed(2) });
-}
+export const bytes = (n, t) => sizeText(n, t, { under: 'size.bytes', kb: 'auto', mb: 2 });
 
 /** "4032 × 3024", with a real multiplication sign. */
 export function dimensions(width, height) {

--- a/tools/heic-to-jpg/src/main.js
+++ b/tools/heic-to-jpg/src/main.js
@@ -1,6 +1,8 @@
 /** UI wiring and application state. */
 
 import { phrase } from './shared/phrases.js';
+import { saveBlob } from './shared/download.js';
+import { messageBox } from './shared/message-box.js';
 import { encodePixels, encodableTypes, FORMATS, JPEG, PNG, WEBP } from './codecs.js';
 import { heifBrand, isAvif, readExif } from './boxes.js';
 import { describeExif, fitsInJpeg, uprightExif, withExif } from './exif.js';
@@ -40,6 +42,8 @@ const el = {
   privacyToggle: $('privacy-toggle'),
   privacyPanel: $('privacy-panel'),
 };
+
+const { show: showLoadError, clear: clearLoadError } = messageBox(el.loadError);
 
 /**
  * How much of a file is read when it is added to the list.
@@ -564,29 +568,7 @@ function describe(result) {
   return phrase('out.line', { list: parts.reduce((a, b) => phrase('join.dot', { a, b })) });
 }
 
-/** Hand a blob to the browser's downloads. */
-function saveBlob(blob, name) {
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement('a');
-  link.href = url;
-  link.download = name;
-  link.click();
-  // Revoked late: revoking immediately can cancel a download that has not
-  // started yet in some browsers.
-  setTimeout(() => URL.revokeObjectURL(url), 60000);
-}
-
 /* ------------------------------------------------------------------ errors */
-
-function showLoadError(message) {
-  el.loadError.textContent = message;
-  el.loadError.hidden = false;
-}
-
-function clearLoadError() {
-  el.loadError.textContent = '';
-  el.loadError.hidden = true;
-}
 
 /* ------------------------------------------------- privacy panel + offline */
 

--- a/tools/heic-to-jpg/tool.toml
+++ b/tools/heic-to-jpg/tool.toml
@@ -33,7 +33,7 @@ roadmap_group = "images"
 # more than one tool needs and that no tool should own.
 css_parts = ["file-list", "progress"]
 # Shared modules this tool asks for. file-picker brings in the drop zone.
-js_parts = ["file-picker", "zip", "crc32"]
+js_parts = ["file-picker", "zip", "crc32", "message-box", "download", "format"]
 lastmod = "2026-08-27"
 
 # --- what search engines and chat apps are told ------------------------------

--- a/tools/id-photo/src/main.js
+++ b/tools/id-photo/src/main.js
@@ -1,6 +1,7 @@
 /** UI wiring and application state. */
 
 import { phrase } from './shared/phrases.js';
+import { messageBox } from './shared/message-box.js';
 import {
   SPECS, backgroundOf, pixelLabel, portalBytes, portalPixels, printLabel,
   specById, specsByCountry, trim, withCustom,
@@ -86,6 +87,8 @@ const el = {
   privacyToggle: $('privacy-toggle'),
   privacyPanel: $('privacy-panel'),
 };
+
+const { show: showLoadError, clear: clearLoadError } = messageBox(el.loadError);
 
 /** The custom fields, by the key withCustom() reads them under. */
 const CUSTOM_FIELDS = {
@@ -818,16 +821,6 @@ function showProgress(fraction, label) {
 }
 
 /* ------------------------------------------------------------------ errors */
-
-function showLoadError(message) {
-  el.loadError.textContent = message;
-  el.loadError.hidden = false;
-}
-
-function clearLoadError() {
-  el.loadError.textContent = '';
-  el.loadError.hidden = true;
-}
 
 /* ------------------------------------------------- privacy panel + offline */
 

--- a/tools/id-photo/tool.toml
+++ b/tools/id-photo/tool.toml
@@ -29,7 +29,7 @@ roadmap_group = "images"
 css_parts = ["progress"]
 
 # Shared modules this tool asks for. file-picker brings in the drop zone.
-js_parts = ["file-picker"]
+js_parts = ["file-picker", "message-box"]
 lastmod = "2026-08-27"
 
 # --- what search engines and chat apps are told ------------------------------

--- a/tools/image-to-data-uri/src/files.js
+++ b/tools/image-to-data-uri/src/files.js
@@ -1,12 +1,7 @@
 /** Sizes, counts and the one judgement this tool is in a position to make. */
+import { sizeText } from './shared/format.js';
 
-/** KB and MB mean 1024 and 1024*1024 here, which is what a file manager shows
- *  on every platform except macOS. */
-export function bytes(n, t) {
-  if (n < 1024) return t('size.b', { n });
-  if (n < 1024 * 1024) return t('size.kb', { n: (n / 1024).toFixed(n < 10240 ? 1 : 0) });
-  return t('size.mb', { n: (n / (1024 * 1024)).toFixed(2) });
-}
+export const bytes = (n, t) => sizeText(n, t, { under: 'size.b', kb: 'auto', mb: 2 });
 
 /** "1,204,556" - a character count is read, not compared, so it gets commas. */
 export function count(n) {

--- a/tools/image-to-data-uri/src/main.js
+++ b/tools/image-to-data-uri/src/main.js
@@ -1,6 +1,7 @@
 /** UI wiring and application state. */
 
 import { phrase } from './shared/phrases.js';
+import { messageBox } from './shared/message-box.js';
 import { base64DataUri, svgDataUri } from './encode.js';
 import { sniff, extensionType } from './sniff.js';
 import { metadata } from './metadata.js';
@@ -33,6 +34,8 @@ const el = {
   privacyToggle: $('privacy-toggle'),
   privacyPanel: $('privacy-panel'),
 };
+
+const { show: showLoadError, clear: clearLoadError } = messageBox(el.loadError);
 
 /**
  * @typedef {object} Item
@@ -475,16 +478,6 @@ function saveText(text, name) {
 }
 
 /* ------------------------------------------------------------------ errors */
-
-function showLoadError(message) {
-  el.loadError.textContent = message;
-  el.loadError.hidden = false;
-}
-
-function clearLoadError() {
-  el.loadError.textContent = '';
-  el.loadError.hidden = true;
-}
 
 /* ------------------------------------------------- privacy panel + offline */
 

--- a/tools/image-to-data-uri/tool.toml
+++ b/tools/image-to-data-uri/tool.toml
@@ -33,7 +33,7 @@ css_parts = ["file-list"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.
-js_parts = ["file-picker"]
+js_parts = ["file-picker", "message-box", "format"]
 lastmod = "2026-08-27"
 
 # --- what search engines and chat apps are told ------------------------------

--- a/tools/image-to-ico/src/files.js
+++ b/tools/image-to-ico/src/files.js
@@ -5,13 +5,9 @@
  * words cannot live in this file: src/ is copied byte for byte into every
  * language. See shared/js/phrases.js.
  */
+import { sizeText } from './shared/format.js';
 
-/** File sizes. Nothing here is measured against a limit, so ordinary rounding. */
-export function bytes(n, t) {
-  if (n < 1024) return t('size.bytes', { n });
-  if (n < 1024 * 1024) return t('size.kb', { n: (n / 1024).toFixed(n < 10240 ? 1 : 0) });
-  return t('size.mb', { n: (n / (1024 * 1024)).toFixed(2) });
-}
+export const bytes = (n, t) => sizeText(n, t, { under: 'size.bytes', kb: 'auto', mb: 2 });
 
 /** "16 × 16", with a real multiplication sign. */
 export const dimensions = (width, height) => `${width} × ${height}`;

--- a/tools/image-to-ico/src/main.js
+++ b/tools/image-to-ico/src/main.js
@@ -1,6 +1,7 @@
 /** UI wiring and application state. */
 
 import { phrase } from './shared/phrases.js';
+import { messageBox } from './shared/message-box.js';
 import { writeIco, dibEntry, readIcoDirectory } from './ico.js';
 import { writeIcns, readIcnsElements, ICNS_TYPES, ICNS_SIZES } from './icns.js';
 import { PRESETS, SIZES, WHY, presetById, storageFor, dibBytes } from './sizes.js';
@@ -64,6 +65,8 @@ const el = {
   privacyToggle: $('privacy-toggle'),
   privacyPanel: $('privacy-panel'),
 };
+
+const { show: showLoadError, clear: clearLoadError } = messageBox(el.loadError);
 
 /**
  * @typedef {object} Item
@@ -1001,16 +1004,6 @@ for (const box of [el.wantIco, el.wantIcns, el.wantPack]) {
 }
 
 /* ------------------------------------------------------------------ errors */
-
-function showLoadError(message) {
-  el.loadError.textContent = message;
-  el.loadError.hidden = false;
-}
-
-function clearLoadError() {
-  el.loadError.textContent = '';
-  el.loadError.hidden = true;
-}
 
 /* ------------------------------------------------- privacy panel + offline */
 

--- a/tools/image-to-ico/tool.toml
+++ b/tools/image-to-ico/tool.toml
@@ -32,7 +32,7 @@ css_parts = ["file-list", "progress"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.
-js_parts = ["file-picker", "zip", "crc32"]
+js_parts = ["file-picker", "zip", "crc32", "message-box", "format"]
 lastmod = "2026-08-27"
 
 # --- what search engines and chat apps are told ------------------------------

--- a/tools/image-to-svg/src/main.js
+++ b/tools/image-to-svg/src/main.js
@@ -1,6 +1,7 @@
 /** UI wiring and application state. */
 
 import { phrase } from './shared/phrases.js';
+import { downloadLink } from './shared/download.js';
 import { readingLabel, wireFilePicker } from './shared/file-picker.js';
 import { maskFromImage } from './mask.js';
 import { subjectMask } from './subject.js';
@@ -66,6 +67,8 @@ const el = {
   tooBig: $('too-big'),
 };
 
+const download = downloadLink(el.download);
+
 /**
  * What a preview may cost, and what a click may.
  *
@@ -103,7 +106,6 @@ let outPath = null;       // out.d as a Path2D, parsed once rather than per fram
 let overwhelming = false;
 let bgSamples = [];
 let hover = { ...NOTHING };
-let downloadUrl = null;
 
 const view = new Viewport({
   hosts: [el.stagePicture, el.stageSvg],
@@ -504,12 +506,8 @@ function sizeText(bytes) {
 }
 
 function offerDownload() {
-  if (downloadUrl) URL.revokeObjectURL(downloadUrl);
-  const blob = new Blob([out.svg], { type: 'image/svg+xml' });
-  downloadUrl = URL.createObjectURL(blob);
-  el.download.href = downloadUrl;
-  el.download.download = phrase('save.name', { stem: picture.stem });
-  el.download.hidden = false;
+  download.offer(new Blob([out.svg], { type: 'image/svg+xml' }),
+    phrase('save.name', { stem: picture.stem }));
 }
 
 function showSamples() {

--- a/tools/image-to-svg/tool.toml
+++ b/tools/image-to-svg/tool.toml
@@ -42,7 +42,7 @@ roadmap_group = "images"
 css_parts = []
 # Shared modules this tool asks for. file-picker brings in the drop zone;
 # phrases arrives on its own, for every tool.
-js_parts = ["file-picker"]
+js_parts = ["file-picker", "download"]
 lastmod = "2026-09-01"
 
 # --- what search engines and chat apps are told ------------------------------

--- a/tools/images-to-pdf/src/main.js
+++ b/tools/images-to-pdf/src/main.js
@@ -1,6 +1,8 @@
 /** UI wiring and application state. */
 
 import { phrase } from './shared/phrases.js';
+import { sizeText } from './shared/format.js';
+import { messageBox } from './shared/message-box.js';
 import { wireFilePicker, readingLabel } from './shared/file-picker.js';
 import { loadImages, releaseItem, rotateItem, sortItems, moveItem } from './images.js';
 import { layoutPage, seenSize, PAGE_SIZES } from './layout.js';
@@ -69,6 +71,10 @@ const el = {
   privacyToggle: $('privacy-toggle'),
   privacyPanel: $('privacy-panel'),
 };
+
+const { show: showError, clear: clearError } = messageBox(el.error);
+const { show: showLoadError, clear: clearLoadError } = messageBox(el.loadError);
+const formatBytes = (n) => sizeText(n, phrase, { under: 'size.b', kb: 0, mb: 1 });
 
 /** The chosen pictures, in page order. */
 let items = [];
@@ -586,33 +592,7 @@ function trim(value) {
   return String(Math.round(Number(value) * 10) / 10);
 }
 
-function formatBytes(bytes) {
-  if (bytes < 1024) return phrase('size.b', { n: bytes });
-  if (bytes < 1024 * 1024) return phrase('size.kb', { n: (bytes / 1024).toFixed(0) });
-  return phrase('size.mb', { n: (bytes / (1024 * 1024)).toFixed(1) });
-}
-
 /* ------------------------------------------------------------------ export */
-
-function showError(message) {
-  el.error.textContent = message;
-  el.error.hidden = false;
-}
-
-function clearError() {
-  el.error.textContent = '';
-  el.error.hidden = true;
-}
-
-function showLoadError(message) {
-  el.loadError.textContent = message;
-  el.loadError.hidden = false;
-}
-
-function clearLoadError() {
-  el.loadError.textContent = '';
-  el.loadError.hidden = true;
-}
 
 /** Drop a finished PDF, because the settings or the pages have moved on. */
 function clearResult() {

--- a/tools/images-to-pdf/tool.toml
+++ b/tools/images-to-pdf/tool.toml
@@ -32,7 +32,7 @@ css_parts = ["progress"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.
-js_parts = ["file-picker", "pdf-page-writer"]
+js_parts = ["file-picker", "pdf-page-writer", "message-box", "format"]
 # Where a finished result can be carried without being saved first: the row of
 # links shared/handoff.js shows beside the download once there is one. Slugs of
 # tools whose picker takes what this page produces; checked against the tools

--- a/tools/images-to-video/src/main.js
+++ b/tools/images-to-video/src/main.js
@@ -1,6 +1,8 @@
 /** UI wiring and application state. */
 
 import { phrase } from './shared/phrases.js';
+import { sizeText, durationText } from './shared/format.js';
+import { messageBox } from './shared/message-box.js';
 import { wireFilePicker, readingLabel } from './shared/file-picker.js';
 import { loadImages, decodeFull, releaseItem, sortItems, moveItem } from './images.js';
 import { drawFrame, resolveOutputSize } from './compose.js';
@@ -60,6 +62,10 @@ const el = {
   privacyToggle: $('privacy-toggle'),
   privacyPanel: $('privacy-panel'),
 };
+
+const { show: showError, clear: clearError } = messageBox(el.error);
+const formatBytes = (n) => sizeText(n, phrase, { kb: 0, mb: 1 });
+const formatDuration = (seconds) => durationText(seconds, phrase, { decimals: 1 });
 
 /** @type {object[]} */
 let items = [];
@@ -126,7 +132,6 @@ async function addFiles(files) {
 
 
 /* ------------------------------------------------------------ web addresses */
-
 
 // The importer itself is shared - src/shared/url-import.js, brought in by
 // [picker.urls] in this tool's tool.toml. What stays here is the one part that
@@ -555,15 +560,6 @@ function syncCustomControls() {
 /** The dash a summary row shows when there is nothing to summarise. */
 const EMPTY = '\u2014';
 
-function formatDuration(seconds) {
-  const whole = Math.round(seconds);
-  const mins = Math.floor(whole / 60);
-  const secs = whole % 60;
-  return mins
-    ? phrase('time.minutes', { minutes: mins, seconds: String(secs).padStart(2, '0') })
-    : phrase('time.seconds', { n: seconds.toFixed(1) });
-}
-
 function updateSummary() {
   if (!items.length) {
     el.sumImages.textContent = EMPTY;
@@ -679,16 +675,6 @@ function initFormatNote() {
 
 /* ------------------------------------------------------------------ export */
 
-function showError(message) {
-  el.error.textContent = message;
-  el.error.hidden = false;
-}
-
-function clearError() {
-  el.error.hidden = true;
-  el.error.textContent = '';
-}
-
 function setProgress({ phase, done, total, realtime }) {
   const fraction = total > 0 ? Math.min(1, done / total) : 0;
   el.progressBar.style.width = `${(fraction * 100).toFixed(1)}%`;
@@ -720,11 +706,6 @@ function outputFilename(extension) {
     String(now.getDate()).padStart(2, '0'),
   ].join('-');
   return `slideshow-${stamp}.${extension}`;
-}
-
-function formatBytes(bytes) {
-  if (bytes < 1024 * 1024) return phrase('size.kb', { n: (bytes / 1024).toFixed(0) });
-  return phrase('size.mb', { n: (bytes / 1024 / 1024).toFixed(1) });
 }
 
 async function runExport() {

--- a/tools/images-to-video/tool.toml
+++ b/tools/images-to-video/tool.toml
@@ -32,7 +32,7 @@ css_parts = ["progress"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.
-js_parts = ["file-picker", "codec-support", "mp4-muxer"]
+js_parts = ["file-picker", "codec-support", "mp4-muxer", "message-box", "format"]
 lastmod = "2026-08-27"
 
 # --- what search engines and chat apps are told ------------------------------

--- a/tools/json-formatter/src/main.js
+++ b/tools/json-formatter/src/main.js
@@ -1,6 +1,9 @@
 /** UI wiring and application state. */
 
-import { phrase } from './shared/phrases.js';
+import { phrase, fill } from './shared/phrases.js';
+import { sizeText } from './shared/format.js';
+import { downloadLink } from './shared/download.js';
+import { messageBox } from './shared/message-box.js';
 import { wireFilePicker } from './shared/file-picker.js';
 import { LANGUAGES, languageById, formatText, detectLanguage } from './format.js';
 import { CONVERSIONS, conversionById } from './convert.js';
@@ -40,11 +43,16 @@ const el = {
   privacyPanel: $('privacy-panel'),
 };
 
+const { show: showError, clear: clearError } = messageBox(el.error, {
+  onShow: () => { el.resultNote.textContent = phrase('out.empty'); },
+});
+const download = downloadLink(el.download);
+const humanBytes = (n) => sizeText(n, phrase, { under: 'size.bytes', kb: 1, mb: 2 });
+
 /** Which of the two jobs is on screen. */
 let mode = 'format';
 /** The text of the last successful result, for the copy and download buttons. */
 let result = null;
-let downloadUrl = null;
 
 /* ------------------------------------------------------------- the menu */
 
@@ -258,22 +266,7 @@ function show(text, note, name) {
   el.resultNote.textContent = note;
   result = { text, name };
   el.copy.disabled = text === '';
-  offerDownload(text, name);
-}
-
-/**
- * The download is a blob: URL made in this page from a string that was already
- * in this page. Nothing is uploaded to produce it and nothing is fetched to
- * serve it.
- */
-function offerDownload(text, name) {
-  if (downloadUrl) URL.revokeObjectURL(downloadUrl);
-  downloadUrl = null;
-  if (text === '') { el.download.hidden = true; return; }
-  downloadUrl = URL.createObjectURL(new Blob([text], { type: 'text/plain;charset=utf-8' }));
-  el.download.href = downloadUrl;
-  el.download.download = name;
-  el.download.hidden = false;
+  download.offer(text, name);
 }
 
 el.copy.addEventListener('click', async () => {
@@ -297,10 +290,8 @@ el.copy.addEventListener('click', async () => {
 function clearResult() {
   el.output.textContent = '';
   el.copy.disabled = true;
-  el.download.hidden = true;
+  download.clear();
   result = null;
-  if (downloadUrl) URL.revokeObjectURL(downloadUrl);
-  downloadUrl = null;
 }
 
 /**
@@ -316,9 +307,6 @@ function clearResult() {
  * cannot find, so it still reads as itself.
  */
 function say(error) {
-  const fill = (values = {}) => Object.fromEntries(Object.entries(values)
-    .map(([name, value]) => [name, value?.key ? phrase(value.key, value.values) : value]));
-
   if (error?.name === 'ParseError') {
     return phrase('parse.at', {
       reason: phrase(error.reason, fill(error.values)),
@@ -329,26 +317,9 @@ function say(error) {
   return error?.message ? phrase(error.message, fill(error.values)) : String(error);
 }
 
-function showError(message) {
-  el.error.textContent = message;
-  el.error.hidden = false;
-  el.resultNote.textContent = phrase('out.empty');
-}
-
-function clearError() {
-  el.error.hidden = true;
-  el.error.textContent = '';
-}
-
 /* ----------------------------------------------------------------- wording */
 
 const indentString = () => (el.indent.value === 'tab' ? '\t' : ' '.repeat(Number(el.indent.value)));
-
-function humanBytes(bytes) {
-  if (bytes < 1024) return phrase('size.bytes', { n: bytes });
-  if (bytes < 1024 * 1024) return phrase('size.kb', { n: (bytes / 1024).toFixed(1) });
-  return phrase('size.mb', { n: (bytes / (1024 * 1024)).toFixed(2) });
-}
 
 /* ------------------------------------------------- privacy panel + offline */
 

--- a/tools/json-formatter/tool.toml
+++ b/tools/json-formatter/tool.toml
@@ -35,7 +35,7 @@ roadmap_group = "beyond"
 
 # Shared modules this tool asks for. file-picker brings in the drop zone, which
 # is here for the file that is easier to drop than to open, select all and copy.
-js_parts = ["file-picker", "parse-errors", "parse-json", "parse-yaml", "parse-xml"]
+js_parts = ["file-picker", "parse-errors", "parse-json", "parse-yaml", "parse-xml", "message-box", "download", "format"]
 lastmod = "2026-09-02"
 
 # --- what search engines and chat apps are told ------------------------------

--- a/tools/merge-pdf/src/format.js
+++ b/tools/merge-pdf/src/format.js
@@ -4,15 +4,9 @@
  * Both take `t`, the caller's `phrase`. src/ is copied byte for byte into
  * every language, so a word written here is English at fourteen addresses.
  */
+import { sizeText } from './shared/format.js';
 
-/** KB and MB mean 1024 and 1024*1024, which is what a file manager shows and
- *  what people mean when they say "under 5 MB". */
-export function bytes(n, t) {
-  if (!Number.isFinite(n) || n < 0) return t('size.bytes', { n: 0 });
-  if (n < 1024) return t('size.bytes', { n: Math.round(n) });
-  if (n < 1024 * 1024) return t('size.kb', { n: (n / 1024).toFixed(n < 10240 ? 1 : 0) });
-  return t('size.mb', { n: (n / (1024 * 1024)).toFixed(2) });
-}
+export const bytes = (n, t) => sizeText(n, t, { under: 'size.bytes', kb: 'auto', mb: 2 });
 
 /**
  * "1 page", "14 pages", said the same way everywhere.

--- a/tools/merge-pdf/src/main.js
+++ b/tools/merge-pdf/src/main.js
@@ -1,6 +1,7 @@
 /** UI wiring and application state. */
 
 import { phrase } from './shared/phrases.js';
+import { messageBox } from './shared/message-box.js';
 import { readSource } from './assemble.js';
 import { bytes, count as countOf, shortName } from './format.js';
 import { sizeLabel } from './pages.js';
@@ -62,6 +63,9 @@ const el = {
   privacyToggle: $('privacy-toggle'),
   privacyPanel: $('privacy-panel'),
 };
+
+const { show: showLoadError } = messageBox(el.loadError);
+const { show: note } = messageBox(el.loadNote);
 
 /**
  * The files chosen, in the order they were chosen.
@@ -160,16 +164,6 @@ function messageFor(error) {
   if (error?.name === 'AbortError') return phrase('read.cancelled');
   return phrase('read.unreadable',
     { detail: phrase(error?.message ?? String(error), error?.values) });
-}
-
-function showLoadError(text) {
-  el.loadError.textContent = text;
-  el.loadError.hidden = false;
-}
-
-function note(text) {
-  el.loadNote.textContent = text;
-  el.loadNote.hidden = false;
 }
 
 /* ------------------------------------------------------------- the sources */

--- a/tools/merge-pdf/tool.toml
+++ b/tools/merge-pdf/tool.toml
@@ -36,7 +36,7 @@ css_parts = ["progress"]
 # reader and the writer import the other two; the compressor and the redactor
 # ask for the same four. This tool carried its own copy of all six until the
 # tests learned to follow a ./shared/ import (tests/js/resolve-shared.mjs).
-js_parts = ["file-picker", "zip", "crc32", "pdf-objects", "pdf-filters", "pdf-reader", "pdf-writer"]
+js_parts = ["file-picker", "zip", "crc32", "pdf-objects", "pdf-filters", "pdf-reader", "pdf-writer", "message-box", "format"]
 # Where a finished result can be carried without being saved first: the row of
 # links shared/handoff.js shows beside the download once there is one. Slugs of
 # tools whose picker takes what this page produces; checked against the tools

--- a/tools/qr-barcode/src/main.js
+++ b/tools/qr-barcode/src/main.js
@@ -1,12 +1,13 @@
 /** UI wiring and application state. */
 
 import { phrase } from './shared/phrases.js';
+import { saveBlob } from './shared/download.js';
 import { KINDS, compose, missing } from './payload.js';
 import { makeQr } from './qr.js';
 import { capacityFor } from './qr-encode.js';
 import { SYMBOLOGIES, makeBarcode } from './barcode.js';
 import {
-  barcodeSvg, download, qrSvg, sizeOfSvg, svgToPng,
+  barcodeSvg, qrSvg, sizeOfSvg, svgToPng,
 } from './render.js';
 
 const $ = (id) => document.getElementById(id);
@@ -352,14 +353,14 @@ function baseName() {
 
 el.downloadSvg.addEventListener('click', () => {
   if (!current) return;
-  download(new Blob([current.svg], { type: 'image/svg+xml' }), `${baseName()}.svg`);
+  saveBlob(new Blob([current.svg], { type: 'image/svg+xml' }), `${baseName()}.svg`);
   el.downloadNote.textContent = phrase('save.done');
 });
 
 el.downloadPng.addEventListener('click', async () => {
   if (!current) return;
   try {
-    download(await svgToPng(current.svg), `${baseName()}.png`);
+    saveBlob(await svgToPng(current.svg), `${baseName()}.png`);
     el.downloadNote.textContent = phrase('save.done');
   } catch (error) {
     // render.js throws a key; a browser that failed for its own reasons throws

--- a/tools/qr-barcode/src/render.js
+++ b/tools/qr-barcode/src/render.js
@@ -166,17 +166,3 @@ export async function svgToPng(svg, multiple = 1) {
   }
 }
 
-/** Hand a blob to the browser as a download. Nothing leaves the machine. */
-export function download(blob, name) {
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement('a');
-  link.href = url;
-  link.download = name;
-  link.rel = 'noopener';
-  document.body.append(link);
-  link.click();
-  link.remove();
-  // Revoked on the next turn of the event loop: revoking it immediately can
-  // beat the download starting in some browsers.
-  setTimeout(() => URL.revokeObjectURL(url), 1000);
-}

--- a/tools/qr-barcode/tool.toml
+++ b/tools/qr-barcode/tool.toml
@@ -27,7 +27,7 @@ category = "text-codes-and-passwords"
 # Which group on the roadmap this tool joins, by the id in config/planned.toml.
 # It sits at the top of that group as a link, above the names still to be built.
 roadmap_group = "beyond"
-js_parts = ["qr-tables"]
+js_parts = ["qr-tables", "download"]
 lastmod = "2026-08-27"
 
 # --- what search engines and chat apps are told ------------------------------

--- a/tools/redact-image/src/main.js
+++ b/tools/redact-image/src/main.js
@@ -1,6 +1,7 @@
 /** UI wiring and application state. */
 
 import { phrase } from './shared/phrases.js';
+import { messageBox } from './shared/message-box.js';
 import { MIN_SIZE, clampRect } from './regions.js';
 import { applyRegions } from './redact.js';
 import { Preview } from './preview.js';
@@ -49,6 +50,8 @@ const el = {
   privacyToggle: $('privacy-toggle'),
   privacyPanel: $('privacy-panel'),
 };
+
+const { show: showLoadError, clear: clearLoadError } = messageBox(el.loadError);
 
 /**
  * @typedef {object} Picture
@@ -481,16 +484,6 @@ function showResult(blob, format) {
 }
 
 /* ------------------------------------------------------------------ errors */
-
-function showLoadError(message) {
-  el.loadError.textContent = message;
-  el.loadError.hidden = false;
-}
-
-function clearLoadError() {
-  el.loadError.textContent = '';
-  el.loadError.hidden = true;
-}
 
 /* ------------------------------------------------- privacy panel + offline */
 

--- a/tools/redact-image/tool.toml
+++ b/tools/redact-image/tool.toml
@@ -28,7 +28,7 @@ roadmap_group = "images"
 # Shared modules this tool asks for. file-picker brings in the drop zone; the
 # list of boxes underneath the picture is this tool's own, because it is a list
 # of rectangles rather than a list of files.
-js_parts = ["file-picker"]
+js_parts = ["file-picker", "message-box"]
 lastmod = "2026-08-27"
 
 # --- what search engines and chat apps are told ------------------------------

--- a/tools/redact-pdf/src/main.js
+++ b/tools/redact-pdf/src/main.js
@@ -17,6 +17,7 @@
  */
 
 import { phrase } from './shared/phrases.js';
+import { messageBox } from './shared/message-box.js';
 import { bytes as humanBytes, outName, tally } from './format.js';
 import {
   contextOf, FINDERS, findPattern, findTerm, glyphsIn, mergeRanges, wordsOf,
@@ -84,6 +85,8 @@ const el = {
   privacyToggle: $('privacy-toggle'),
   privacyPanel: $('privacy-panel'),
 };
+
+const { show: note } = messageBox(el.loadNote);
 
 /** How many rows of matches are drawn. Everything found is still acted on;
  *  this is only what a person is asked to scroll through. */
@@ -186,11 +189,6 @@ function reset() {
 function fail(text) {
   el.loadError.textContent = text;
   el.loadError.hidden = false;
-}
-
-function note(text) {
-  el.loadNote.textContent = text;
-  el.loadNote.hidden = false;
 }
 
 /** Yield to the browser, so that a hundred-page document does not freeze the

--- a/tools/redact-pdf/tool.toml
+++ b/tools/redact-pdf/tool.toml
@@ -40,7 +40,7 @@ css_parts = ["progress"]
 # travel together, because the reader and the writer import the other two;
 # the compressor and the merger ask for the same four. Everything this tool
 # does to a page's drawing instructions is its own and stays in src/.
-js_parts = ["file-picker", "pdf-objects", "pdf-filters", "pdf-reader", "pdf-writer"]
+js_parts = ["file-picker", "pdf-objects", "pdf-filters", "pdf-reader", "pdf-writer", "message-box"]
 lastmod = "2026-09-01"
 
 # --- what search engines and chat apps are told ------------------------------

--- a/tools/resize-image/src/files.js
+++ b/tools/resize-image/src/files.js
@@ -8,13 +8,9 @@
  */
 
 import { FORMATS } from './codecs.js';
+import { sizeText } from './shared/format.js';
 
-/** File sizes. Nothing here is read against a limit, so ordinary rounding. */
-export function bytes(n, t) {
-  if (n < 1024) return t('size.bytes', { n });
-  if (n < 1024 * 1024) return t('size.kb', { n: (n / 1024).toFixed(n < 10240 ? 1 : 0) });
-  return t('size.mb', { n: (n / (1024 * 1024)).toFixed(2) });
-}
+export const bytes = (n, t) => sizeText(n, t, { under: 'size.bytes', kb: 'auto', mb: 2 });
 
 /** "4032 × 3024", with a real multiplication sign. */
 export function dimensions(width, height) {

--- a/tools/resize-image/src/main.js
+++ b/tools/resize-image/src/main.js
@@ -1,6 +1,9 @@
 /** UI wiring and application state. */
 
 import { phrase } from './shared/phrases.js';
+import { measureImage } from './shared/media.js';
+import { saveBlob } from './shared/download.js';
+import { messageBox } from './shared/message-box.js';
 import {
   decode, encodableTypes, keepFormat, release, render as renderImage,
   FORMATS, JPEG, PNG, WEBP, READABLE,
@@ -102,6 +105,8 @@ const el = {
   privacyPanel: $('privacy-panel'),
 };
 
+const { show: showLoadError, clear: clearLoadError } = messageBox(el.loadError);
+
 /**
  * @typedef {object} Item
  * @property {number} id
@@ -202,7 +207,7 @@ async function addFiles(files) {
 
       // The thumbnail decode doubles as the measurement, so the picture is
       // read once here and not again until it is actually processed.
-      item.size = await measure(item.thumbUrl);
+      item.size = await measureImage(item.thumbUrl);
       if (!item.size) {
         URL.revokeObjectURL(item.thumbUrl);
         failures.push(phrase('load.undecodable', { name: file.name }));
@@ -232,16 +237,6 @@ async function addFiles(files) {
 function isImage(file) {
   if (!file.type) return /\.(jpe?g|png|webp|gif|bmp|avif)$/i.test(file.name);
   return READABLE.includes(file.type) || file.type.startsWith('image/');
-}
-
-/** Read a picture's pixel size without keeping the decoded image around. */
-function measure(url) {
-  return new Promise((resolve) => {
-    const img = new Image();
-    img.onload = () => resolve({ width: img.naturalWidth, height: img.naturalHeight });
-    img.onerror = () => resolve(null);
-    img.src = url;
-  });
 }
 
 function removeItem(id) {
@@ -1240,29 +1235,7 @@ el.viewer.addEventListener('close', () => {
   el.viewerImage.removeAttribute('src');
 });
 
-/** Hand a blob to the browser's downloads. */
-function saveBlob(blob, name) {
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement('a');
-  link.href = url;
-  link.download = name;
-  link.click();
-  // Revoked late: revoking immediately can cancel a download that has not
-  // started yet in some browsers.
-  setTimeout(() => URL.revokeObjectURL(url), 60000);
-}
-
 /* ------------------------------------------------------------------ errors */
-
-function showLoadError(message) {
-  el.loadError.textContent = message;
-  el.loadError.hidden = false;
-}
-
-function clearLoadError() {
-  el.loadError.textContent = '';
-  el.loadError.hidden = true;
-}
 
 /* ------------------------------------------------- privacy panel + offline */
 

--- a/tools/resize-image/tool.toml
+++ b/tools/resize-image/tool.toml
@@ -32,7 +32,7 @@ css_parts = ["file-list", "progress"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.
-js_parts = ["file-picker", "zip", "crc32"]
+js_parts = ["file-picker", "zip", "crc32", "message-box", "download", "media", "format"]
 lastmod = "2026-08-27"
 
 # --- what search engines and chat apps are told ------------------------------

--- a/tools/reverse-video/src/main.js
+++ b/tools/reverse-video/src/main.js
@@ -1,6 +1,9 @@
 /** UI wiring and application state. */
 
 import { phrase } from './shared/phrases.js';
+import { sizeText, durationText } from './shared/format.js';
+import { openInPlayer } from './shared/media.js';
+import { messageBox } from './shared/message-box.js';
 import { wireFilePicker } from './shared/file-picker.js';
 import { demux, UnsupportedFile } from './shared/mp4-reader.js';
 import { reverseExact, decoderConfig } from './reverse.js';
@@ -56,6 +59,10 @@ const el = {
   privacyPanel: $('privacy-panel'),
 };
 
+const { show: showError, clear: clearError } = messageBox(el.error);
+const formatBytes = (n) => sizeText(n, phrase, { kb: 0, mb: 1, gb: 'size.gb' });
+const formatDuration = (seconds) => durationText(seconds, phrase);
+
 /** @type {File|null} */
 let file = null;
 let objectUrl = null;
@@ -105,35 +112,6 @@ const picker = wireFilePicker({
 });
 
 /* ------------------------------------------------------------------ loading */
-
-/**
- * Ask a <video> element to open the file, and report what it made of it.
- * A browser that will not play a format still says so quickly, so this is also
- * the test for whether the playback path is available at all.
- */
-function openInPlayer(video, url) {
-  return new Promise((resolve) => {
-    const done = (result) => {
-      clearTimeout(timer);
-      video.removeEventListener('loadedmetadata', ok);
-      video.removeEventListener('error', bad);
-      resolve(result);
-    };
-    const ok = () => done({
-      ok: video.videoWidth > 0 && video.videoHeight > 0,
-      width: video.videoWidth,
-      height: video.videoHeight,
-      duration: Number.isFinite(video.duration) ? video.duration : 0,
-    });
-    const bad = () => done({ ok: false, width: 0, height: 0, duration: 0 });
-
-    const timer = setTimeout(bad, 15000);
-    video.addEventListener('loadedmetadata', ok, { once: true });
-    video.addEventListener('error', bad, { once: true });
-    video.src = url;
-    video.load();
-  });
-}
 
 async function loadFile(picked) {
   if (exporting) return;
@@ -358,16 +336,6 @@ el.keepAudio.addEventListener('change', updateAudioNote);
 
 /* ------------------------------------------------------------------ export */
 
-function showError(message) {
-  el.error.textContent = message;
-  el.error.hidden = false;
-}
-
-function clearError() {
-  el.error.hidden = true;
-  el.error.textContent = '';
-}
-
 function setProgress({ phase, done, total }) {
   const fraction = total > 0 ? Math.min(1, done / total) : 0;
 
@@ -397,22 +365,6 @@ function setProgress({ phase, done, total }) {
 function outputFilename(extension) {
   const base = (file?.name ?? 'video').replace(/\.[^.]+$/, '');
   return `${base}-reversed.${extension}`;
-}
-
-function formatBytes(bytes) {
-  if (bytes < 1024 * 1024) return phrase('size.kb', { n: (bytes / 1024).toFixed(0) });
-  if (bytes < 1024 * 1024 * 1024) {
-    return phrase('size.mb', { n: (bytes / 1024 / 1024).toFixed(1) });
-  }
-  return phrase('size.gb', { n: (bytes / 1024 / 1024 / 1024).toFixed(2) });
-}
-
-function formatDuration(seconds) {
-  const whole = Math.max(0, Math.round(seconds));
-  const minutes = Math.floor(whole / 60);
-  return minutes
-    ? phrase('time.minutes', { minutes, seconds: String(whole % 60).padStart(2, '0') })
-    : phrase('time.seconds', { n: seconds < 10 ? seconds.toFixed(1) : whole });
 }
 
 async function runExport() {

--- a/tools/reverse-video/tool.toml
+++ b/tools/reverse-video/tool.toml
@@ -32,7 +32,7 @@ css_parts = ["progress"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.
-js_parts = ["file-picker", "codec-support", "mp4-reader", "mp4-writer", "video-support"]
+js_parts = ["file-picker", "codec-support", "mp4-reader", "mp4-writer", "video-support", "message-box", "media", "format"]
 # Where a finished result can be carried without being saved first: the row of
 # links shared/handoff.js shows beside the download once there is one. Slugs of
 # tools whose picker takes what this page produces; checked against the tools

--- a/tools/split-gif/src/frames.js
+++ b/tools/split-gif/src/frames.js
@@ -13,6 +13,9 @@
  * have - and what the two files beside this one are - is the GIF reader that
  * gets the pixels out in the first place.
  */
+import { sizeText } from './shared/format.js';
+
+export const formatBytes = (n, t) => sizeText(n, t, { under: 'size.b', kb: 'auto', mb: 1 });
 
 /** Frame thumbnails on the page are drawn no larger than this, in pixels. */
 const THUMB_MAX = 168;
@@ -152,15 +155,6 @@ export function timingList(sourceName, gif, rows, t) {
   }
 
   return `${lines.join('\n')}\n`;
-}
-
-/** A byte count in the units a person reads. */
-export function formatBytes(bytes, t) {
-  if (bytes < 1024) return t('size.b', { n: bytes });
-  if (bytes < 1024 * 1024) {
-    return t('size.kb', { n: (bytes / 1024).toFixed(bytes < 10240 ? 1 : 0) });
-  }
-  return t('size.mb', { n: (bytes / (1024 * 1024)).toFixed(1) });
 }
 
 /** Seconds, written short: 0.08s, 1.2s, 12s. */

--- a/tools/split-gif/src/main.js
+++ b/tools/split-gif/src/main.js
@@ -1,6 +1,7 @@
 /** UI wiring and application state. */
 
 import { phrase } from './shared/phrases.js';
+import { messageBox } from './shared/message-box.js';
 import { wireFilePicker } from './shared/file-picker.js';
 import { decodeGif, GifFormatError, playedDelay, totalDuration } from './gif.js';
 import { GifCanvas, flatten, parseColour, patchPixels } from './compose.js';
@@ -50,6 +51,8 @@ const el = {
   privacyToggle: $('privacy-toggle'),
   privacyPanel: $('privacy-panel'),
 };
+
+const { show: showError, clear: clearError } = messageBox(el.error);
 
 /** @type {File|null} */
 let file = null;
@@ -585,16 +588,6 @@ function hideProgress() {
   el.progress.hidden = true;
   el.progressBar.style.width = '0%';
   el.progressLabel.textContent = '';
-}
-
-function showError(message) {
-  el.error.textContent = message;
-  el.error.hidden = false;
-}
-
-function clearError() {
-  el.error.hidden = true;
-  el.error.textContent = '';
 }
 
 /** Let go of everything the last file left behind. */

--- a/tools/split-gif/tool.toml
+++ b/tools/split-gif/tool.toml
@@ -32,7 +32,7 @@ css_parts = ["progress"]
 # Shared modules this tool asks for. The same arrangement as css_parts, and for
 # the same reason: a component more than one tool needs and no tool should own.
 # file-picker brings in the drop zone.
-js_parts = ["file-picker", "zip", "crc32"]
+js_parts = ["file-picker", "zip", "crc32", "message-box", "format"]
 lastmod = "2026-08-27"
 
 # --- what search engines and chat apps are told ------------------------------

--- a/tools/stack-images/src/main.js
+++ b/tools/stack-images/src/main.js
@@ -9,6 +9,7 @@
  */
 
 import { phrase } from './shared/phrases.js';
+import { messageBox } from './shared/message-box.js';
 import { wireFilePicker, readingLabel } from './shared/file-picker.js';
 import { SCALES, outputSize, planRun, scaleThatFits } from './plan.js';
 
@@ -65,6 +66,8 @@ const el = {
   privacyToggle: $('privacy-toggle'),
   privacyPanel: $('privacy-panel'),
 };
+
+const { show: showError } = messageBox(el.error);
 
 /** @type {{file: File, info: object|null, thumb: string|null, ok: boolean}[]} */
 let frames = [];
@@ -586,11 +589,6 @@ function finishRun() {
   el.cancel.hidden = true;
   el.progress.hidden = true;
   render();
-}
-
-function showError(message) {
-  el.error.textContent = message;
-  el.error.hidden = false;
 }
 
 /* ------------------------------------------------------------------ events */

--- a/tools/stack-images/tool.toml
+++ b/tools/stack-images/tool.toml
@@ -32,7 +32,7 @@ css_parts = ["progress"]
 # Shared modules this tool asks for. Only the drop zone: the list underneath it
 # is this tool's own, because a row in it carries what was found inside a RAW
 # file rather than what the operating system said about the file.
-js_parts = ["file-picker"]
+js_parts = ["file-picker", "message-box"]
 # Where a finished result can be carried without being saved first: the row of
 # links shared/handoff.js shows beside the download once there is one. Slugs of
 # tools whose picker takes what this page produces; checked against the tools

--- a/tools/svg-to-image/src/files.js
+++ b/tools/svg-to-image/src/files.js
@@ -1,16 +1,7 @@
 /** Names, sizes and counts, as words a person would use. */
+import { sizeText } from './shared/format.js';
 
-/** File sizes. Nothing here is measured against a limit, so ordinary rounding.
- *
- * B rather than the word, for the same reason KB and MB are symbols: the word
- * is English - octets in French, バイト in Japanese - and this module cannot
- * reach the markup a translation would live in. The symbol is the same in
- * every language the site is written in. */
-export function bytes(n, t) {
-  if (n < 1024) return t('size.b', { n });
-  if (n < 1024 * 1024) return t('size.kb', { n: (n / 1024).toFixed(n < 10240 ? 1 : 0) });
-  return t('size.mb', { n: (n / (1024 * 1024)).toFixed(2) });
-}
+export const bytes = (n, t) => sizeText(n, t, { under: 'size.b', kb: 'auto', mb: 2 });
 
 /** "512 × 512", with a real multiplication sign. */
 export const dimensions = (width, height) => `${width} × ${height}`;

--- a/tools/svg-to-image/src/main.js
+++ b/tools/svg-to-image/src/main.js
@@ -1,6 +1,7 @@
 /** UI wiring and application state. */
 
-import { phrase } from './shared/phrases.js';
+import { phrase, fill } from './shared/phrases.js';
+import { messageBox } from './shared/message-box.js';
 import {
   decodeSvgText, intrinsicSize, looksLikeSvg,
 } from './svg.js';
@@ -60,6 +61,8 @@ const el = {
   privacyToggle: $('privacy-toggle'),
   privacyPanel: $('privacy-panel'),
 };
+
+const { show: showLoadError, clear: clearLoadError } = messageBox(el.loadError);
 
 /** Which panel of size fields belongs to which mode. */
 const FIELDS = {
@@ -326,17 +329,6 @@ function renderList() {
     row.append(wrap, remove);
     el.fileList.append(row);
   }
-}
-
-/**
- * A refusal's blanks, with any that are themselves a phrase resolved.
- *
- * sizing.js says how many megapixels inside a sentence about the limit, and
- * the word for a megapixel is not English everywhere either.
- */
-function fill(values = {}) {
-  return Object.fromEntries(Object.entries(values)
-    .map(([name, value]) => [name, value?.key ? phrase(value.key, value.values) : value]));
 }
 
 function renderNotes() {
@@ -670,16 +662,6 @@ for (const [group, key] of [[$('scale-presets'), 'scale'], [$('width-presets'), 
 }
 
 /* ------------------------------------------------------------------ errors */
-
-function showLoadError(message) {
-  el.loadError.textContent = message;
-  el.loadError.hidden = false;
-}
-
-function clearLoadError() {
-  el.loadError.textContent = '';
-  el.loadError.hidden = true;
-}
 
 /* ------------------------------------------------- privacy panel + offline */
 

--- a/tools/svg-to-image/tool.toml
+++ b/tools/svg-to-image/tool.toml
@@ -32,7 +32,7 @@ css_parts = ["file-list", "progress"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.
-js_parts = ["file-picker", "zip", "crc32"]
+js_parts = ["file-picker", "zip", "crc32", "message-box", "format"]
 lastmod = "2026-08-27"
 
 # --- what search engines and chat apps are told ------------------------------

--- a/tools/text-diff/src/main.js
+++ b/tools/text-diff/src/main.js
@@ -1,6 +1,8 @@
 /** UI wiring and application state. */
 
 import { phrase } from './shared/phrases.js';
+import { downloadLink } from './shared/download.js';
+import { messageBox } from './shared/message-box.js';
 import { wireFilePicker, readingLabel } from './shared/file-picker.js';
 import { compareText, alignRows, diffWords, formatUnified } from './diff.js';
 import { SAMPLES } from './samples.js';
@@ -31,9 +33,13 @@ const el = {
   privacyPanel: $('privacy-panel'),
 };
 
+const { show: showError, clear: clearError } = messageBox(el.error, {
+  onShow: () => { el.resultNote.textContent = phrase('result.failed'); },
+});
+const download = downloadLink(el.download);
+
 /** The patch of the last comparison, for the copy and download buttons. */
 let result = null;
-let downloadUrl = null;
 
 /** What the Copy button says at rest, read off the button rather than written
  *  here, so that the word it goes back to after "Copied" is the translated one
@@ -193,7 +199,7 @@ function runDiff(aText, bText) {
   const patch = formatUnified(ops, { aLabel: 'original', bLabel: 'changed' });
   result = { text: patch, name: 'changes.patch' };
   el.copy.disabled = patch === '';
-  offerDownload(patch, 'changes.patch');
+  download.offer(patch, 'changes.patch');
 
   if (stats.identical) {
     el.resultNote.textContent = phrase('result.identical');
@@ -339,21 +345,6 @@ function side(text, words, where, marked) {
 
 /* -------------------------------------------------------------- the result */
 
-/**
- * The download is a blob: URL made in this page from a string that was already
- * in this page. Nothing is uploaded to produce it and nothing is fetched to
- * serve it.
- */
-function offerDownload(text, name) {
-  if (downloadUrl) URL.revokeObjectURL(downloadUrl);
-  downloadUrl = null;
-  if (text === '') { el.download.hidden = true; return; }
-  downloadUrl = URL.createObjectURL(new Blob([text], { type: 'text/plain;charset=utf-8' }));
-  el.download.href = downloadUrl;
-  el.download.download = name;
-  el.download.hidden = false;
-}
-
 el.copy.addEventListener('click', async () => {
   if (!result) return;
   try {
@@ -375,21 +366,8 @@ el.copy.addEventListener('click', async () => {
 function clearResult() {
   el.diffView.replaceChildren();
   el.copy.disabled = true;
-  el.download.hidden = true;
+  download.clear();
   result = null;
-  if (downloadUrl) URL.revokeObjectURL(downloadUrl);
-  downloadUrl = null;
-}
-
-function showError(message) {
-  el.error.textContent = message;
-  el.error.hidden = false;
-  el.resultNote.textContent = phrase('result.failed');
-}
-
-function clearError() {
-  el.error.hidden = true;
-  el.error.textContent = '';
 }
 
 /* ----------------------------------------------------------------- wording */

--- a/tools/text-diff/tool.toml
+++ b/tools/text-diff/tool.toml
@@ -38,7 +38,7 @@ roadmap_group = "beyond"
 # Shared modules this tool asks for. file-picker brings in the drop zone, which
 # is here for the two files that are easier to drop than to open, select all
 # and copy - twice.
-js_parts = ["file-picker"]
+js_parts = ["file-picker", "message-box", "download"]
 lastmod = "2026-08-30"
 
 # --- what search engines and chat apps are told ------------------------------

--- a/tools/timelapse-video/src/main.js
+++ b/tools/timelapse-video/src/main.js
@@ -1,6 +1,9 @@
 /** UI wiring and application state. */
 
-import { phrase } from './shared/phrases.js';
+import { phrase, fill } from './shared/phrases.js';
+import { sizeText, durationText } from './shared/format.js';
+import { openInPlayer } from './shared/media.js';
+import { messageBox } from './shared/message-box.js';
 import { wireFilePicker } from './shared/file-picker.js';
 import { demux, UnsupportedFile } from './shared/mp4-reader.js';
 import { timelapseByDecoding, previewFrame, decoderConfig, averageFps } from './decode.js';
@@ -71,6 +74,10 @@ const el = {
   privacyPanel: $('privacy-panel'),
 };
 
+const { show: showError, clear: clearError } = messageBox(el.error);
+const formatBytes = (n) => sizeText(n, phrase, { kb: 0, mb: 1, gb: 'size.gb' });
+const formatDuration = (seconds) => durationText(seconds, phrase, { hours: 'time.hours' });
+
 /** @type {File|null} */
 let file = null;
 let objectUrl = null;
@@ -104,38 +111,6 @@ const picker = wireFilePicker({
 });
 
 /* ----------------------------------------------------------------- loading */
-
-/**
- * Ask the <video> element to open the file, and report what it made of it.
- *
- * This says the container was parsed, and nothing more. Whether a frame can
- * actually be decoded out of it is a separate question, asked by
- * `firstFrameLands` below - see the note there for why the two are not the
- * same question.
- */
-function openInPlayer(video, url) {
-  return new Promise((resolve) => {
-    const done = (result) => {
-      clearTimeout(timer);
-      video.removeEventListener('loadedmetadata', ok);
-      video.removeEventListener('error', bad);
-      resolve(result);
-    };
-    const ok = () => done({
-      ok: video.videoWidth > 0 && video.videoHeight > 0,
-      width: video.videoWidth,
-      height: video.videoHeight,
-      duration: Number.isFinite(video.duration) ? video.duration : 0,
-    });
-    const bad = () => done({ ok: false, width: 0, height: 0, duration: 0 });
-
-    const timer = setTimeout(bad, 15000);
-    video.addEventListener('loadedmetadata', ok, { once: true });
-    video.addEventListener('error', bad, { once: true });
-    video.src = url;
-    video.load();
-  });
-}
 
 /**
  * How long to wait for the probe frame before giving up on the file.
@@ -529,27 +504,6 @@ function updateSummary() {
 
 /* ------------------------------------------------------------------ export */
 
-function showError(message) {
-  el.error.textContent = message;
-  el.error.hidden = false;
-}
-
-function clearError() {
-  el.error.hidden = true;
-  el.error.textContent = '';
-}
-
-/**
- * An error's blanks, with any that are themselves a phrase resolved.
- *
- * playback.js quotes what the player said inside its own sentence. Both are
- * phrases, and a key dropped into a blank would reach the page as the key.
- */
-function fill(values = {}) {
-  return Object.fromEntries(Object.entries(values)
-    .map(([name, value]) => [name, value?.key ? phrase(value.key, value.values) : value]));
-}
-
 /** An error whose message is a phrase key; showError resolves it. */
 const said = (key, values = {}) => Object.assign(new Error(key), { values });
 
@@ -573,28 +527,6 @@ function setProgress({ phase, done, total }) {
 function outputFilename() {
   const base = (file?.name ?? 'video').replace(/\.[^.]+$/, '');
   return `${base}-timelapse.mp4`;
-}
-
-function formatBytes(bytes) {
-  if (bytes < 1024 * 1024) return phrase('size.kb', { n: (bytes / 1024).toFixed(0) });
-  if (bytes < 1024 * 1024 * 1024) {
-    return phrase('size.mb', { n: (bytes / 1024 / 1024).toFixed(1) });
-  }
-  return phrase('size.gb', { n: (bytes / 1024 / 1024 / 1024).toFixed(2) });
-}
-
-function formatDuration(seconds) {
-  const whole = Math.max(0, Math.round(seconds));
-  const hours = Math.floor(whole / 3600);
-  const minutes = Math.floor((whole % 3600) / 60);
-  if (hours) {
-    return phrase('time.hours', { hours, minutes: String(minutes).padStart(2, '0') });
-  }
-  if (minutes) {
-    return phrase('time.minutes',
-      { minutes, seconds: String(whole % 60).padStart(2, '0') });
-  }
-  return phrase('time.seconds', { n: seconds < 10 ? seconds.toFixed(1) : whole });
 }
 
 /** The interval, in the unit that makes it readable rather than always in seconds. */

--- a/tools/timelapse-video/tool.toml
+++ b/tools/timelapse-video/tool.toml
@@ -32,7 +32,7 @@ css_parts = ["progress"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.
-js_parts = ["file-picker", "codec-support", "mp4-reader", "mp4-muxer", "video-support"]
+js_parts = ["file-picker", "codec-support", "mp4-reader", "mp4-muxer", "video-support", "message-box", "media", "format"]
 # Where a finished result can be carried without being saved first: the row of
 # links shared/handoff.js shows beside the download once there is one. Slugs of
 # tools whose picker takes what this page produces; checked against the tools

--- a/tools/trim-audio/src/main.js
+++ b/tools/trim-audio/src/main.js
@@ -1,6 +1,8 @@
 /** UI wiring and application state. */
 
 import { phrase } from './shared/phrases.js';
+import { sizeText } from './shared/format.js';
+import { messageBox } from './shared/message-box.js';
 import { wireFilePicker } from './shared/file-picker.js';
 import { decodeAudio, UnreadableFile } from './shared/audio-decode.js';
 import {
@@ -79,6 +81,9 @@ const el = {
   privacyToggle: $('privacy-toggle'),
   privacyPanel: $('privacy-panel'),
 };
+
+const { show: showError, clear: clearError } = messageBox(el.error);
+const formatBytes = (n) => sizeText(n, phrase, { under: 'size.b', kb: 1, mb: 1, gb: 'size.gb' });
 
 /** @type {File|null} */
 let file = null;
@@ -834,16 +839,6 @@ window.addEventListener('resize', () => {
 
 /* ---------------------------------------------------------------- reporting */
 
-function showError(message) {
-  el.error.textContent = message;
-  el.error.hidden = false;
-}
-
-function clearError() {
-  el.error.hidden = true;
-  el.error.textContent = '';
-}
-
 function clearResult() {
   el.result.hidden = true;
   el.resultAudio.removeAttribute('src');
@@ -857,15 +852,6 @@ function clearResult() {
 const channelWord = (count) => (count <= 2
   ? phrase(count === 1 ? 'channels.mono' : 'channels.stereo')
   : phrase('channels.many', { n: count }));
-
-function formatBytes(bytes) {
-  if (bytes < 1024) return phrase('size.b', { n: bytes });
-  if (bytes < 1024 * 1024) return phrase('size.kb', { n: (bytes / 1024).toFixed(1) });
-  if (bytes < 1024 * 1024 * 1024) {
-    return phrase('size.mb', { n: (bytes / (1024 * 1024)).toFixed(1) });
-  }
-  return phrase('size.gb', { n: (bytes / (1024 * 1024 * 1024)).toFixed(2) });
-}
 
 /* ------------------------------------------------- privacy panel + offline */
 

--- a/tools/trim-audio/src/timeline.js
+++ b/tools/trim-audio/src/timeline.js
@@ -27,32 +27,16 @@
 
 import { drawWaveform } from './waveform.js';
 
+import { clockText as formatTime } from './shared/format.js';
+
+/** m:ss.mmm - the one clock every timeline here shows; shared/js/format.js says why it rounds once. */
+export { formatTime };
+
 /** The shortest part a drag will leave behind. */
 const MIN_SEGMENT = 0.02;
 
 function clamp(value, low, high) {
   return Math.max(low, Math.min(high, value));
-}
-
-/**
- * mm:ss.mmm, which is short enough to read and exact enough to type back.
- *
- * Rounded to milliseconds once, before it is taken apart: flooring the seconds
- * and rounding the fraction separately writes 3.9996 as `0:03.1000`, which is
- * four digits in a three-digit field and parses back as 3.1. This label is not
- * only read - it is what a row's time box is filled with, so a number that
- * cannot be read back is a mark that moves nine tenths of a second when
- * somebody edits the row beside it.
- */
-export function formatTime(seconds) {
-  const total = Math.round(Math.max(0, seconds || 0) * 1000);
-  const whole = Math.floor(total / 1000);
-  const hours = Math.floor(whole / 3600);
-  const minutes = Math.floor((whole % 3600) / 60);
-  const tail = `${String(whole % 60).padStart(2, '0')}.${String(total % 1000).padStart(3, '0')}`;
-  return hours
-    ? `${hours}:${String(minutes).padStart(2, '0')}:${tail}`
-    : `${minutes}:${tail}`;
 }
 
 /**

--- a/tools/trim-audio/tool.toml
+++ b/tools/trim-audio/tool.toml
@@ -40,7 +40,7 @@ css_parts = ["progress"]
 # Shared modules this tool asks for. The same arrangement as css_parts, and for
 # the same reason: a component more than one tool needs and no tool should own.
 # file-picker brings in the drop zone.
-js_parts = ["file-picker", "audio-decode", "samplerate", "wav"]
+js_parts = ["file-picker", "audio-decode", "samplerate", "wav", "message-box", "format"]
 # Where a finished result can be carried without being saved first: the row of
 # links shared/handoff.js shows beside the download once there is one. Slugs of
 # tools whose picker takes what this page produces; checked against the tools

--- a/tools/trim-video/body.html
+++ b/tools/trim-video/body.html
@@ -266,8 +266,8 @@
     <span data-phrase="size.kb">{n} KB</span>
     <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="size.gb">{n} GB</span>
-    <span data-phrase="dur.minutes">{m}m {s}s</span>
-    <span data-phrase="dur.seconds">{s}s</span>
+    <span data-phrase="time.minutes">{minutes}m {seconds}s</span>
+    <span data-phrase="time.seconds">{n}s</span>
     <span data-phrase="clip.mark">Mark this video</span>
     <span data-phrase="clip.segments.one">1 segment</span>
     <span data-phrase="clip.segments.many">{n} segments</span>

--- a/tools/trim-video/src/main.js
+++ b/tools/trim-video/src/main.js
@@ -1,6 +1,9 @@
 /** UI wiring and application state. */
 
 import { phrase } from './shared/phrases.js';
+import { sizeText, durationText } from './shared/format.js';
+import { openInPlayer } from './shared/media.js';
+import { messageBox } from './shared/message-box.js';
 import { wireFilePicker, readingLabel } from './shared/file-picker.js';
 import { demux, UnsupportedFile } from './shared/mp4-reader.js';
 import { joinByCopy, estimateJoinCopy } from './copy.js';
@@ -92,6 +95,10 @@ const el = {
   privacyPanel: $('privacy-panel'),
 };
 
+const { show: showError, clear: clearError } = messageBox(el.error);
+const formatBytes = (n) => sizeText(n, phrase, { kb: 0, mb: 1, gb: 'size.gb' });
+const formatDuration = (seconds) => durationText(seconds, phrase);
+
 /**
  * The videos, in the order they will be joined, each holding its own list of
  * marked segments.
@@ -154,36 +161,6 @@ async function addFiles(files) {
   describeSelection();
   renderClips();
   updateMethodOptions();
-}
-
-/**
- * Ask a <video> element to open the file, and report what it made of it.
- *
- * A browser that will not play a format still says so quickly, so this is also
- * the test for whether the recording path is available at all.
- */
-function openInPlayer(video, url) {
-  return new Promise((resolve) => {
-    const done = (result) => {
-      clearTimeout(timer);
-      video.removeEventListener('loadedmetadata', ok);
-      video.removeEventListener('error', bad);
-      resolve(result);
-    };
-    const ok = () => done({
-      ok: video.videoWidth > 0 && video.videoHeight > 0,
-      width: video.videoWidth,
-      height: video.videoHeight,
-      duration: Number.isFinite(video.duration) ? video.duration : 0,
-    });
-    const bad = () => done({ ok: false, width: 0, height: 0, duration: 0 });
-
-    const timer = setTimeout(bad, 15000);
-    video.addEventListener('loadedmetadata', ok, { once: true });
-    video.addEventListener('error', bad, { once: true });
-    video.src = url;
-    video.load();
-  });
 }
 
 async function addClip(file) {
@@ -1128,16 +1105,6 @@ function updateSummary() {
  */
 const sentences = (said) => said.reduce((a, b) => phrase('join.sentences', { a, b }));
 
-function showError(message) {
-  el.error.textContent = message;
-  el.error.hidden = false;
-}
-
-function clearError() {
-  el.error.hidden = true;
-  el.error.textContent = '';
-}
-
 function setProgress({ phase, done, total, realtime }) {
   const fraction = total > 0 ? Math.min(1, done / total) : 0;
   el.progressBar.style.width = `${(fraction * 100).toFixed(1)}%`;
@@ -1169,22 +1136,6 @@ function setProgress({ phase, done, total, realtime }) {
 function outputFilename(extension) {
   const base = (clips[0]?.name ?? 'video').replace(/\.[^.]+$/, '');
   return `${base}-cut.${extension}`;
-}
-
-function formatBytes(bytes) {
-  if (bytes < 1024 * 1024) return phrase('size.kb', { n: (bytes / 1024).toFixed(0) });
-  if (bytes < 1024 * 1024 * 1024) {
-    return phrase('size.mb', { n: (bytes / 1024 / 1024).toFixed(1) });
-  }
-  return phrase('size.gb', { n: (bytes / 1024 / 1024 / 1024).toFixed(2) });
-}
-
-function formatDuration(seconds) {
-  const whole = Math.max(0, Math.round(seconds));
-  const minutes = Math.floor(whole / 60);
-  return minutes
-    ? phrase('dur.minutes', { m: minutes, s: String(whole % 60).padStart(2, '0') })
-    : phrase('dur.seconds', { s: seconds < 10 ? seconds.toFixed(1) : whole });
 }
 
 async function runExport() {

--- a/tools/trim-video/src/timeline.js
+++ b/tools/trim-video/src/timeline.js
@@ -23,6 +23,11 @@
  * the file; it is handed times and hands times back.
  */
 
+import { clockText as formatTime } from './shared/format.js';
+
+/** m:ss.mmm - the one clock every timeline here shows; shared/js/format.js says why it rounds once. */
+export { formatTime };
+
 /** The shortest segment a drag will leave behind. */
 const MIN_SEGMENT = 0.05;
 
@@ -32,27 +37,6 @@ const MAX_TICKS = 400;
 
 function clamp(value, low, high) {
   return Math.max(low, Math.min(high, value));
-}
-
-/**
- * mm:ss.mmm, which is short enough to read and exact enough to type back.
- *
- * Rounded to milliseconds once, before it is taken apart: flooring the seconds
- * and rounding the fraction separately writes 3.9996 as `0:03.1000`, which is
- * four digits in a three-digit field and parses back as 3.1. This label is not
- * only read - it is what a row's time box is filled with, so a number that
- * cannot be read back is a mark that moves nine tenths of a second when
- * somebody edits the row beside it.
- */
-export function formatTime(seconds) {
-  const total = Math.round(Math.max(0, seconds || 0) * 1000);
-  const whole = Math.floor(total / 1000);
-  const hours = Math.floor(whole / 3600);
-  const minutes = Math.floor((whole % 3600) / 60);
-  const tail = `${String(whole % 60).padStart(2, '0')}.${String(total % 1000).padStart(3, '0')}`;
-  return hours
-    ? `${hours}:${String(minutes).padStart(2, '0')}:${tail}`
-    : `${minutes}:${tail}`;
 }
 
 /**

--- a/tools/trim-video/tool.toml
+++ b/tools/trim-video/tool.toml
@@ -33,7 +33,7 @@ css_parts = ["progress"]
 # Shared modules this tool asks for. The same arrangement as css_parts, and for
 # the same reason: a component more than one tool needs and no tool should own.
 # file-picker brings in the drop zone.
-js_parts = ["file-picker", "codec-support", "mp4-reader", "mp4-writer", "video-support"]
+js_parts = ["file-picker", "codec-support", "mp4-reader", "mp4-writer", "video-support", "message-box", "media", "format"]
 # Where a finished result can be carried without being saved first: the row of
 # links shared/handoff.js shows beside the download once there is one. Slugs of
 # tools whose picker takes what this page produces; checked against the tools

--- a/tools/video-to-gif/src/main.js
+++ b/tools/video-to-gif/src/main.js
@@ -1,6 +1,9 @@
 /** UI wiring and application state. */
 
 import { phrase } from './shared/phrases.js';
+import { sizeText } from './shared/format.js';
+import { openInPlayer } from './shared/media.js';
+import { messageBox } from './shared/message-box.js';
 import { wireFilePicker } from './shared/file-picker.js';
 import { demux, UnsupportedFile } from './shared/mp4-reader.js';
 import { framesByDecoding, framesByPlaying, decoderConfig } from './frames.js';
@@ -71,6 +74,9 @@ const el = {
   privacyPanel: $('privacy-panel'),
 };
 
+const { show: showError, clear: clearError } = messageBox(el.error);
+const formatBytes = (n) => sizeText(n, phrase, { kb: 0, mb: 1, gb: 'size.gb' });
+
 /**
  * How long a section the tool starts you off with when the clip is longer.
  *
@@ -132,35 +138,6 @@ const picker = wireFilePicker({
 });
 
 /* ----------------------------------------------------------------- loading */
-
-/**
- * Ask the <video> element to open the file, and report what it made of it.
- * A browser that will not play a format still says so quickly, so this is also
- * the test for whether the player path is available at all.
- */
-function openInPlayer(video, url) {
-  return new Promise((resolve) => {
-    const done = (result) => {
-      clearTimeout(timer);
-      video.removeEventListener('loadedmetadata', ok);
-      video.removeEventListener('error', bad);
-      resolve(result);
-    };
-    const ok = () => done({
-      ok: video.videoWidth > 0 && video.videoHeight > 0,
-      width: video.videoWidth,
-      height: video.videoHeight,
-      duration: Number.isFinite(video.duration) ? video.duration : 0,
-    });
-    const bad = () => done({ ok: false, width: 0, height: 0, duration: 0 });
-
-    const timer = setTimeout(bad, 15000);
-    video.addEventListener('loadedmetadata', ok, { once: true });
-    video.addEventListener('error', bad, { once: true });
-    video.src = url;
-    video.load();
-  });
-}
 
 async function loadFile(picked) {
   if (exporting) return;
@@ -474,16 +451,6 @@ function updateSummary() {
 
 /* ------------------------------------------------------------------ export */
 
-function showError(message) {
-  el.error.textContent = message;
-  el.error.hidden = false;
-}
-
-function clearError() {
-  el.error.hidden = true;
-  el.error.textContent = '';
-}
-
 function setProgress({ phase, done, total }) {
   // Reading the frames is most of the wait on the player path and about half of
   // it on the reader path, so the bar gives it the first two thirds rather than
@@ -502,14 +469,6 @@ function setProgress({ phase, done, total }) {
 function outputFilename() {
   const base = (file?.name ?? 'video').replace(/\.[^.]+$/, '');
   return `${base}.gif`;
-}
-
-function formatBytes(bytes) {
-  if (bytes < 1024 * 1024) return phrase('size.kb', { n: (bytes / 1024).toFixed(0) });
-  if (bytes < 1024 * 1024 * 1024) {
-    return phrase('size.mb', { n: (bytes / 1024 / 1024).toFixed(1) });
-  }
-  return phrase('size.gb', { n: (bytes / 1024 / 1024 / 1024).toFixed(2) });
 }
 
 async function runExport() {

--- a/tools/video-to-gif/src/range.js
+++ b/tools/video-to-gif/src/range.js
@@ -11,24 +11,13 @@
  * or touches the video element: it is handed times and it hands times back.
  */
 
+/** m:ss.mmm - the one clock every timeline here shows; shared/js/format.js says why it rounds once. */
+export { clockText as formatTime } from './shared/format.js';
+
 /** The shortest section a drag will leave behind. */
 const MIN_SECTION = 0.1;
 
 const clamp = (value, low, high) => Math.max(low, Math.min(high, value));
-
-/** mm:ss.mmm - short enough to read, exact enough to type back. */
-export function formatTime(seconds) {
-  const safe = Math.max(0, seconds || 0);
-  const whole = Math.floor(safe);
-  const hours = Math.floor(whole / 3600);
-  const minutes = Math.floor((whole % 3600) / 60);
-  const rest = whole % 60;
-  const millis = Math.round((safe - whole) * 1000);
-  const tail = `${String(rest).padStart(2, '0')}.${String(millis).padStart(3, '0')}`;
-  return hours
-    ? `${hours}:${String(minutes).padStart(2, '0')}:${tail}`
-    : `${minutes}:${tail}`;
-}
 
 /**
  * The reverse: "1:23.5", "83.5" and "0:01:23.500" all mean the same instant.

--- a/tools/video-to-gif/tool.toml
+++ b/tools/video-to-gif/tool.toml
@@ -32,7 +32,7 @@ css_parts = ["progress"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.
-js_parts = ["file-picker", "mp4-reader"]
+js_parts = ["file-picker", "mp4-reader", "message-box", "media", "format"]
 # Where a finished result can be carried without being saved first: the row of
 # links shared/handoff.js shows beside the download once there is one. Slugs of
 # tools whose picker takes what this page produces; checked against the tools

--- a/tools/xml-formatter/src/main.js
+++ b/tools/xml-formatter/src/main.js
@@ -1,6 +1,9 @@
 /** UI wiring and application state. */
 
-import { phrase } from './shared/phrases.js';
+import { phrase, fill } from './shared/phrases.js';
+import { sizeText } from './shared/format.js';
+import { downloadLink } from './shared/download.js';
+import { messageBox } from './shared/message-box.js';
 import { wireFilePicker } from './shared/file-picker.js';
 import { parseXml, printXml } from './shared/parse-xml.js';
 import { CONVERSIONS, conversionById } from './convert.js';
@@ -35,11 +38,16 @@ const el = {
   privacyPanel: $('privacy-panel'),
 };
 
+const { show: showError, clear: clearError } = messageBox(el.error, {
+  onShow: () => { el.resultNote.textContent = phrase('out.empty'); },
+});
+const download = downloadLink(el.download);
+const humanBytes = (n) => sizeText(n, phrase, { under: 'size.bytes', kb: 1, mb: 2 });
+
 /** Which of the two jobs is on screen. */
 let mode = 'format';
 /** The text of the last successful result, for the copy and download buttons. */
 let result = null;
-let downloadUrl = null;
 
 /* ---------------------------------------------------------------- the menu */
 
@@ -234,22 +242,7 @@ function show(text, note, name) {
   el.resultNote.textContent = note;
   result = { text, name };
   el.copy.disabled = text === '';
-  offerDownload(text, name);
-}
-
-/**
- * The download is a blob: URL made in this page from a string that was already
- * in this page. Nothing is uploaded to produce it and nothing is fetched to
- * serve it.
- */
-function offerDownload(text, name) {
-  if (downloadUrl) URL.revokeObjectURL(downloadUrl);
-  downloadUrl = null;
-  if (text === '') { el.download.hidden = true; return; }
-  downloadUrl = URL.createObjectURL(new Blob([text], { type: 'text/plain;charset=utf-8' }));
-  el.download.href = downloadUrl;
-  el.download.download = name;
-  el.download.hidden = false;
+  download.offer(text, name);
 }
 
 el.copy.addEventListener('click', async () => {
@@ -273,10 +266,8 @@ el.copy.addEventListener('click', async () => {
 function clearResult() {
   el.output.textContent = '';
   el.copy.disabled = true;
-  el.download.hidden = true;
+  download.clear();
   result = null;
-  if (downloadUrl) URL.revokeObjectURL(downloadUrl);
-  downloadUrl = null;
 }
 
 /**
@@ -292,9 +283,6 @@ function clearResult() {
  * cannot find, so it still reads as itself.
  */
 function say(error) {
-  const fill = (values = {}) => Object.fromEntries(Object.entries(values)
-    .map(([name, value]) => [name, value?.key ? phrase(value.key, value.values) : value]));
-
   if (error?.name === 'ParseError') {
     return phrase('parse.at', {
       reason: phrase(error.reason, fill(error.values)),
@@ -305,26 +293,9 @@ function say(error) {
   return error?.message ? phrase(error.message, fill(error.values)) : String(error);
 }
 
-function showError(message) {
-  el.error.textContent = message;
-  el.error.hidden = false;
-  el.resultNote.textContent = phrase('out.empty');
-}
-
-function clearError() {
-  el.error.hidden = true;
-  el.error.textContent = '';
-}
-
 /* ----------------------------------------------------------------- wording */
 
 const indentString = () => (el.indent.value === 'tab' ? '\t' : ' '.repeat(Number(el.indent.value)));
-
-function humanBytes(bytes) {
-  if (bytes < 1024) return phrase('size.bytes', { n: bytes });
-  if (bytes < 1024 * 1024) return phrase('size.kb', { n: (bytes / 1024).toFixed(1) });
-  return phrase('size.mb', { n: (bytes / (1024 * 1024)).toFixed(2) });
-}
 
 /* ------------------------------------------------- privacy panel + offline */
 

--- a/tools/xml-formatter/tool.toml
+++ b/tools/xml-formatter/tool.toml
@@ -56,7 +56,7 @@ roadmap_group = "beyond"
 
 # Shared modules this tool asks for. file-picker brings in the drop zone, which
 # is here for the file that is easier to drop than to open, select all and copy.
-js_parts = ["file-picker", "parse-errors", "parse-json", "parse-xml"]
+js_parts = ["file-picker", "parse-errors", "parse-json", "parse-xml", "message-box", "download", "format"]
 lastmod = "2026-09-02"
 
 # --- what search engines and chat apps are told ------------------------------

--- a/tools/yaml-to-json/src/main.js
+++ b/tools/yaml-to-json/src/main.js
@@ -1,6 +1,9 @@
 /** UI wiring and application state. */
 
-import { phrase } from './shared/phrases.js';
+import { phrase, fill } from './shared/phrases.js';
+import { sizeText } from './shared/format.js';
+import { downloadLink } from './shared/download.js';
+import { messageBox } from './shared/message-box.js';
 import { wireFilePicker } from './shared/file-picker.js';
 import { CONVERSIONS, conversionById } from './convert.js';
 import { SAMPLES } from './samples.js';
@@ -28,9 +31,14 @@ const el = {
   privacyPanel: $('privacy-panel'),
 };
 
+const { show: showError, clear: clearError } = messageBox(el.error, {
+  onShow: () => { el.resultNote.textContent = phrase('out.empty'); },
+});
+const download = downloadLink(el.download);
+const humanBytes = (n) => sizeText(n, phrase, { under: 'size.bytes', kb: 1, mb: 2 });
+
 /** The text of the last successful result, for the copy and download buttons. */
 let result = null;
-let downloadUrl = null;
 
 /* ---------------------------------------------------------------- the menu */
 
@@ -173,22 +181,7 @@ function show(text, note, name) {
   el.resultNote.textContent = note;
   result = { text, name };
   el.copy.disabled = text === '';
-  offerDownload(text, name);
-}
-
-/**
- * The download is a blob: URL made in this page from a string that was already
- * in this page. Nothing is uploaded to produce it and nothing is fetched to
- * serve it.
- */
-function offerDownload(text, name) {
-  if (downloadUrl) URL.revokeObjectURL(downloadUrl);
-  downloadUrl = null;
-  if (text === '') { el.download.hidden = true; return; }
-  downloadUrl = URL.createObjectURL(new Blob([text], { type: 'text/plain;charset=utf-8' }));
-  el.download.href = downloadUrl;
-  el.download.download = name;
-  el.download.hidden = false;
+  download.offer(text, name);
 }
 
 el.copy.addEventListener('click', async () => {
@@ -212,10 +205,8 @@ el.copy.addEventListener('click', async () => {
 function clearResult() {
   el.output.textContent = '';
   el.copy.disabled = true;
-  el.download.hidden = true;
+  download.clear();
   result = null;
-  if (downloadUrl) URL.revokeObjectURL(downloadUrl);
-  downloadUrl = null;
 }
 
 /**
@@ -231,9 +222,6 @@ function clearResult() {
  * cannot find, so it still reads as itself.
  */
 function say(error) {
-  const fill = (values = {}) => Object.fromEntries(Object.entries(values)
-    .map(([name, value]) => [name, value?.key ? phrase(value.key, value.values) : value]));
-
   if (error?.name === 'ParseError') {
     return phrase('parse.at', {
       reason: phrase(error.reason, fill(error.values)),
@@ -244,26 +232,9 @@ function say(error) {
   return error?.message ? phrase(error.message, fill(error.values)) : String(error);
 }
 
-function showError(message) {
-  el.error.textContent = message;
-  el.error.hidden = false;
-  el.resultNote.textContent = phrase('out.empty');
-}
-
-function clearError() {
-  el.error.hidden = true;
-  el.error.textContent = '';
-}
-
 /* ----------------------------------------------------------------- wording */
 
 const indentString = () => (el.indent.value === 'tab' ? '\t' : ' '.repeat(Number(el.indent.value)));
-
-function humanBytes(bytes) {
-  if (bytes < 1024) return phrase('size.bytes', { n: bytes });
-  if (bytes < 1024 * 1024) return phrase('size.kb', { n: (bytes / 1024).toFixed(1) });
-  return phrase('size.mb', { n: (bytes / (1024 * 1024)).toFixed(2) });
-}
 
 /* ------------------------------------------------- privacy panel + offline */
 

--- a/tools/yaml-to-json/tool.toml
+++ b/tools/yaml-to-json/tool.toml
@@ -56,7 +56,7 @@ roadmap_group = "beyond"
 # Shared modules this tool asks for. file-picker brings in the drop zone, which
 # is here for the config file that is easier to drop than to open, select all
 # and copy.
-js_parts = ["file-picker", "parse-errors", "parse-json", "parse-yaml"]
+js_parts = ["file-picker", "parse-errors", "parse-json", "parse-yaml", "message-box", "download", "format"]
 lastmod = "2026-09-02"
 
 # --- what search engines and chat apps are told ------------------------------


### PR DESCRIPTION
Phase 3 of the shared-parts plan: the small helpers every tool wrote for itself. A byte formatter, a duration formatter, the two lines that show and clear an error, the download, the "will the browser open this" probe - between four and forty lines each, written into thirty-nine tools, and drifting. This moves them to four new shared parts and one new export of `phrases.js`, and touches nothing a visitor sees.

## What this does

- **`shared/js/format.js`** - `sizeText`, `durationText`, `clockText`. Twenty-three tools carried a byte formatter and between them they were *eleven* formatters: some with a tier below a kilobyte and some starting at "0 KB", kilobytes with a decimal or without, a gigabyte tier or not, and two different keys for the bytes tier. None of that is a decision anybody recorded, but all of it is a number on screen, so the shared function does not pick a winner: each tool names its old choices in a one-line `style` and gets its old output. The seven duration formatters are the same story with an hours key and a count of decimals. The differences are now one line per tool where a later pass can read them side by side and decide.
- **`shared/js/message-box.js`** - `messageBox(element)` returns `{ show, clear }`, and each tool destructures it under the names its call sites already use: `const { show: showError, clear: clearError } = messageBox(el.error);`. Sixty-seven copies of the same four lines across thirty-five tools, differing only in which element they named; the formatter pages pass `onShow` for the "Nothing came out" note they set beside it.
- **`shared/js/download.js`** - `saveBlob` for a download that starts now (five copies, plus the `download` in compare-heights and qr-barcode, which appended the link to the document and revoked after a second; the shared one does the former and keeps the sixty-second revoke, since revoking early is what cancels a download that has not started) and `downloadLink(link)` for the link on the formatter pages that follows the latest result, which also retires their module-level `downloadUrl` and the three lines of `clearResult` that managed it.
- **`shared/js/media.js`** - `openInPlayer` (six video tools) and `measureImage` (three image tools), identical copies.
- **`phrases.js` gains `fill`**, the five-line resolver of nested `{key, values}` that five tools carried and three more had inlined inside `say()`. It belongs beside `phrase()`: it is the other half of the "a leaf returns a key" rule.
- **trim-video's `dur.minutes`/`dur.seconds` become `time.minutes`/`time.seconds`** with the placeholders every other video tool uses, in all fifteen languages, so its duration formatter is the plain one. Same words on the page.
- **One behaviour change, deliberate:** video-to-gif's range bar floored the seconds and rounded the fraction separately, so 3.9996 s was written `0:03.1000` - four digits in a three-digit field, which parses back as 3.1. The trimmers' clock rounds to a millisecond once and had a paragraph saying why; that clock is now `clockText` and all three bars share it.
- **`js_parts`** in thirty-nine `tool.toml` files ask for the parts each tool uses; compare-heights gets its first line. `docs/adding-a-tool.md` lists the four parts.

## Before and after

Nothing on any page changes. The sizes and durations are proved identical below, the trim-video phrases render the same text under new keys, and the error lines and download links do what they did.

## Verified

- **Old against new, mechanically.** A script (not committed) pulled every replaced formatter out of `git show HEAD:…`, ran it beside the shared one with that tool's `style`, and compared the strings over 3,500 sizes and 3,500 durations each, the tier boundaries included: every size formatter agrees on every integer input (a file size is always one; the only divergence is a fractional byte count, which the old code printed raw and the new one rounds), every duration formatter agrees on everything, and the two trimmers' clocks agree on everything. video-to-gif's clock differs on four inputs out of 3,528, all of them the `.1000` case above.
- **Tests:** four new files for the shared parts (`format`, `message-box`, `download`, `media` - the last two with a counting `URL` and the runner's mock clock) and a `fill` case in `phrases.test.js`. With them, every JavaScript test that touches a migrated tool - eighty-seven files under the resolve hook - passes: 1,876 tests. `test_english_in_js`, `test_duplicates`, `test_imports` and `test_phrases` pass with no baseline moved: what left the tools was code, not sentences.
- **Builds:** scoped English builds of eight tools ship the right parts in `src/shared/` (compare-heights gets `download.js` alone), and a CI-style full build passes.
- **In the built pages, served locally:** json-formatter shows "52 B" and "77 B" through the shared size text, offers `formatted.json` as a blob link, shows a parse error with "Nothing came out." beside it through the box's `onShow`, and hides both again on empty input. crop-video refuses a junk file through its own phrase, and the shared `openInPlayer` answers `ok: false` for it. compare-heights' "Download SVG" clicks a link that is in the document, named `height-chart.svg` with `rel=noopener`, removes it, and says "Saved."

## What this leaves

The helpers that are still per tool are the ones whose difference is a decision: compress-image and compress-pdf's `bytes` return a `{key, values}` pair with an `{amount}` placeholder rather than words, exif-editor, redact-pdf and text-diff's formatters are still English (counted by the ratchet), and the WebCodecs helpers (`throwIfAborted`, `decoderConfig`, `averageFps`, `micros`, `settle`) travel with an `AbortedError` whose message is each tool's own - that is the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
