### PR TITLE
Share the cancel, the WebCodecs arithmetic and the MP4 box builders the video tools each carried

### DIFF
--- a/docs/adding-a-tool.md
+++ b/docs/adding-a-tool.md
@@ -97,8 +97,11 @@ A component more than one tool needs, and that no tool should own, lives under
 | `shared/js/pdf-filters.js` | `js_parts = ["pdf-filters"]` | the stream filters, deflate included |
 | `shared/js/pdf-writer.js` | `js_parts = ["pdf-writer"]` | writing a PDF back out |
 | `shared/js/mp4-reader.js` | `js_parts = ["mp4-reader"]` | the MP4/MOV reader: every sample, where it is and when it shows |
-| `shared/js/mp4-writer.js` | `js_parts = ["mp4-writer"]` | the MP4 writer for tracks being copied: two tracks, interleaved, sample entries as bytes |
-| `shared/js/mp4-muxer.js` | `js_parts = ["mp4-muxer"]` | the MP4 writer for one H.264 track an encoder just produced |
+| `shared/js/mp4-boxes.js` | `js_parts = ["mp4-boxes"]` | the bytes an MP4 is built out of: big-endian integers, four-character types, a box round a payload; both writers import it |
+| `shared/js/mp4-writer.js` | `js_parts = ["mp4-writer"]` | the MP4 writer for tracks being copied: two tracks, interleaved, sample entries as bytes; imports `mp4-boxes` |
+| `shared/js/mp4-muxer.js` | `js_parts = ["mp4-muxer"]` | the MP4 writer for one H.264 track an encoder just produced; imports `mp4-boxes` |
+| `shared/js/webcodecs.js` | `js_parts = ["webcodecs"]` | a decoder's configuration, a track's frame rate, microseconds, and the wait that keeps a feed loop behind the codecs |
+| `shared/js/errors.js` | `js_parts = ["errors"]` | the cancellation every page ignores by name, and `said`, the error whose message is a phrase key |
 | `shared/js/audio-decode.js` | `js_parts = ["audio-decode"]` | the browser's own decoder, asked for the audio track and nothing else |
 | `shared/js/samplerate.js` | `js_parts = ["samplerate"]` | the sample rate sniffed out of a file's header before it is decoded; `audio-decode` imports it |
 | `shared/js/wav.js` | `js_parts = ["wav"]` | the WAV writer: a header in front of the samples |

--- a/shared/js/errors.js
+++ b/shared/js/errors.js
@@ -1,0 +1,50 @@
+/**
+ * The two errors every long job here throws: a cancellation the page ignores,
+ * and a message the page looks up.
+ *
+ * GENERATED INTO EACH TOOL. This file lives at shared/js/errors.js and the
+ * build copies it to <tool>/src/shared/errors.js for the tools that ask for
+ * it with `js_parts = ["errors", ...]`. It imports nothing.
+ *
+ * CANCELLATION
+ *
+ * A job that can be cancelled takes an AbortSignal and asks it, between
+ * frames, whether to go on. The answer is thrown, because the job is usually
+ * several calls deep when it arrives and unwinding is the point. What is
+ * thrown carries the name `AbortError`, which is what the platform's own
+ * cancellations are called - a fetch that was aborted, a stream that was
+ * cancelled - so a page has one test for "the visitor pressed Cancel", however
+ * the job was cancelled, and it is `error.name === 'AbortError'`.
+ *
+ * The message is never shown. Eleven tools carried this class with a message
+ * of their own ("Crop cancelled.", "Export cancelled.") and no page ever put
+ * one on screen: every catch checks the name and stops. So the one copy says
+ * nothing a visitor would read.
+ *
+ * A KEY, NOT A SENTENCE
+ *
+ * Nothing under src/ is translated (see shared/js/phrases.js), so a module
+ * that has to say why it stopped hands back a phrase key and lets main.js
+ * turn it into the visitor's own sentence. `said` is that error: its message
+ * is the key, and `values` are what fill the blanks.
+ */
+
+export class AbortedError extends Error {
+  constructor() {
+    super('aborted');
+    this.name = 'AbortError';
+  }
+}
+
+/** Stop here if the visitor has pressed Cancel. */
+export function throwIfAborted(signal) {
+  if (signal?.aborted) throw new AbortedError();
+}
+
+/**
+ * An error whose message is a phrase key; the caller resolves it.
+ *
+ * @param {string} key  a `data-phrase` in the tool's body
+ * @param {Record<string, string|number>} [values]  what fills its blanks
+ */
+export const said = (key, values = {}) => Object.assign(new Error(key), { values });

--- a/shared/js/mp4-boxes.js
+++ b/shared/js/mp4-boxes.js
@@ -1,0 +1,77 @@
+/**
+ * The bytes an MP4 is built out of: big-endian integers, four-character
+ * types, and the box that wraps a payload in a length and a type.
+ *
+ * GENERATED INTO EACH TOOL. This file lives at shared/js/mp4-boxes.js and the
+ * build copies it to <tool>/src/shared/mp4-boxes.js for the tools that ask
+ * for it with `js_parts = ["mp4-boxes", ...]`. It imports nothing; the two
+ * shared MP4 writers import it, so a tool that asks for `mp4-writer` or
+ * `mp4-muxer` asks for this as well.
+ *
+ * Five files wrote these - the two writers, the cropper's own writer, and the
+ * AAC description the trimmer and the reverser build for a re-encoded audio
+ * track - and every one of them was the same forty lines. The functions are
+ * small because the format is: an MP4 is boxes inside boxes, and a box is a
+ * 32-bit length, four ASCII characters, and whatever is inside.
+ */
+
+/** The four (or however many) ASCII characters of a box type or a brand. */
+export function ascii(text) {
+  const out = new Uint8Array(text.length);
+  for (let i = 0; i < text.length; i++) out[i] = text.charCodeAt(i);
+  return out;
+}
+
+/** A handful of byte values as an array, for the odd fixed field. */
+export function bytes(...values) {
+  return new Uint8Array(values);
+}
+
+export function u16(n) {
+  return new Uint8Array([(n >> 8) & 0xff, n & 0xff]);
+}
+
+export function u32(n) {
+  return new Uint8Array([(n >>> 24) & 0xff, (n >>> 16) & 0xff, (n >>> 8) & 0xff, n & 0xff]);
+}
+
+/** Two's complement, which is what u32 already produces for a negative number. */
+export function i32(n) {
+  return u32(n | 0);
+}
+
+export function zeros(n) {
+  return new Uint8Array(n);
+}
+
+export function concat(parts) {
+  let length = 0;
+  for (const part of parts) length += part.byteLength;
+  const out = new Uint8Array(length);
+  let at = 0;
+  for (const part of parts) {
+    out.set(part, at);
+    at += part.byteLength;
+  }
+  return out;
+}
+
+/** A plain box: size + type + payload. */
+export function box(type, ...payload) {
+  const body = concat(payload);
+  return concat([u32(body.byteLength + 8), ascii(type), body]);
+}
+
+/** A full box: adds the version + 24-bit flags header. */
+export function fullBox(type, version, flags, ...payload) {
+  const header = new Uint8Array([
+    version, (flags >> 16) & 0xff, (flags >> 8) & 0xff, flags & 0xff,
+  ]);
+  return box(type, header, ...payload);
+}
+
+/** The four characters at `at`, read back out of a file. */
+export function fourcc(view, at) {
+  return String.fromCharCode(
+    view.getUint8(at), view.getUint8(at + 1), view.getUint8(at + 2), view.getUint8(at + 3));
+}

--- a/shared/js/mp4-muxer.js
+++ b/shared/js/mp4-muxer.js
@@ -24,51 +24,11 @@
  *     without seeking to the end.
  */
 
+import { ascii, u16, u32, zeros, concat, box, fullBox } from './mp4-boxes.js';
+
 const TIMESCALE = 90000; // divides evenly by 24, 25, 30, 50 and 60 fps
 
 /* ---------------------------------------------------------------- helpers */
-
-function ascii(s) {
-  const out = new Uint8Array(s.length);
-  for (let i = 0; i < s.length; i++) out[i] = s.charCodeAt(i);
-  return out;
-}
-
-function u16(n) {
-  return new Uint8Array([(n >> 8) & 0xff, n & 0xff]);
-}
-
-function u32(n) {
-  return new Uint8Array([(n >>> 24) & 0xff, (n >>> 16) & 0xff, (n >>> 8) & 0xff, n & 0xff]);
-}
-
-function zeros(n) {
-  return new Uint8Array(n);
-}
-
-function concat(parts) {
-  let length = 0;
-  for (const p of parts) length += p.byteLength;
-  const out = new Uint8Array(length);
-  let at = 0;
-  for (const p of parts) {
-    out.set(p, at);
-    at += p.byteLength;
-  }
-  return out;
-}
-
-/** A plain box: size + type + payload. */
-function box(type, ...payload) {
-  const body = concat(payload);
-  return concat([u32(body.byteLength + 8), ascii(type), body]);
-}
-
-/** A full box: adds the version + 24-bit flags header. */
-function fullBox(type, version, flags, ...payload) {
-  const header = new Uint8Array([version, (flags >> 16) & 0xff, (flags >> 8) & 0xff, flags & 0xff]);
-  return box(type, header, ...payload);
-}
 
 /** The identity transformation matrix every player expects. */
 const UNITY_MATRIX = concat([

--- a/shared/js/mp4-writer.js
+++ b/shared/js/mp4-writer.js
@@ -44,6 +44,8 @@
  *     raises a clear error rather than producing a file that opens wrong.
  */
 
+import { ascii, u16, u32, i32, zeros, concat, box, fullBox } from './mp4-boxes.js';
+
 /** The timescale the movie header and every edit list is counted in. */
 export const MOVIE_TIMESCALE = 1000;
 
@@ -51,55 +53,6 @@ export const MOVIE_TIMESCALE = 1000;
 const CHUNK_SECONDS = 1;
 
 /* ---------------------------------------------------------------- helpers */
-
-function ascii(text) {
-  const out = new Uint8Array(text.length);
-  for (let i = 0; i < text.length; i++) out[i] = text.charCodeAt(i);
-  return out;
-}
-
-function u16(n) {
-  return new Uint8Array([(n >> 8) & 0xff, n & 0xff]);
-}
-
-function u32(n) {
-  return new Uint8Array([(n >>> 24) & 0xff, (n >>> 16) & 0xff, (n >>> 8) & 0xff, n & 0xff]);
-}
-
-/** Two's complement, which is what u32 already produces for a negative number. */
-function i32(n) {
-  return u32(n | 0);
-}
-
-function zeros(n) {
-  return new Uint8Array(n);
-}
-
-function concat(parts) {
-  let length = 0;
-  for (const part of parts) length += part.byteLength;
-  const out = new Uint8Array(length);
-  let at = 0;
-  for (const part of parts) {
-    out.set(part, at);
-    at += part.byteLength;
-  }
-  return out;
-}
-
-/** A plain box: size + type + payload. */
-function box(type, ...payload) {
-  const body = concat(payload);
-  return concat([u32(body.byteLength + 8), ascii(type), body]);
-}
-
-/** A full box: adds the version + 24-bit flags header. */
-function fullBox(type, version, flags, ...payload) {
-  const header = new Uint8Array([
-    version, (flags >> 16) & 0xff, (flags >> 8) & 0xff, flags & 0xff,
-  ]);
-  return box(type, header, ...payload);
-}
 
 const UNITY_MATRIX = concat([
   u32(0x00010000), u32(0), u32(0),

--- a/shared/js/webcodecs.js
+++ b/shared/js/webcodecs.js
@@ -1,0 +1,108 @@
+/**
+ * The arithmetic around a VideoDecoder and a VideoEncoder that every tool
+ * driving one had written for itself.
+ *
+ * GENERATED INTO EACH TOOL. This file lives at shared/js/webcodecs.js and the
+ * build copies it to <tool>/src/shared/webcodecs.js for the tools that ask
+ * for it with `js_parts = ["webcodecs", ...]`. It imports nothing.
+ *
+ * Four of these are pure functions over a track that mp4-reader's demux()
+ * found - the decoder's configuration, the average frame rate, a time on the
+ * file's clock in WebCodecs' microseconds - and were byte-identical wherever
+ * they appeared. The fifth, `settle`, is the wait that keeps a feed loop from
+ * running ahead of the codecs, and it existed in four shapes: a decoder and an
+ * encoder watched together, an encoder alone, a decoder alone, and the
+ * reverser's version that gives up after thirty seconds without progress.
+ * One function takes the codecs as a list and the stall ceiling as an option.
+ */
+
+/**
+ * Frames in flight before a feed loop waits for the pipeline to catch up.
+ *
+ * A decoder or encoder holds the frames it has been given until it has dealt
+ * with them, and each is a full picture. Eight is enough to keep either busy
+ * and small enough that the frames waiting are not what fills the memory.
+ */
+export const QUEUE_LIMIT = 8;
+
+/** The configuration VideoDecoder needs to open a track demux() found. */
+export function decoderConfig(video) {
+  const config = {
+    codec: video.codec,
+    codedWidth: video.codedWidth,
+    codedHeight: video.codedHeight,
+  };
+  // VP9 carries everything it needs in the bitstream; the others hand over the
+  // configuration record the file was written with, untouched.
+  if (video.description) config.description = video.description;
+  return config;
+}
+
+/**
+ * Frames per second, averaged over the whole track.
+ *
+ * Clamped to what a real clip can be: a track whose duration is missing or
+ * nonsense would otherwise ask an encoder for thousands of frames a second.
+ */
+export function averageFps(video) {
+  const seconds = video.duration / video.timescale;
+  if (!seconds) return 30;
+  return Math.min(240, Math.max(1, video.samples.length / seconds));
+}
+
+/** Presentation time in microseconds, which is what WebCodecs counts in. */
+export function micros(ticks, timescale) {
+  return Math.round(ticks / timescale * 1_000_000);
+}
+
+/** How much a codec is holding, whichever kind it is. */
+const queued = (codec) => codec.decodeQueueSize ?? codec.encodeQueueSize ?? 0;
+
+/**
+ * Wait until every codec given has drained below the queue limit.
+ *
+ * A stalled codec does not reliably report anything: it stops draining and the
+ * `dequeue` event this waits on simply never comes again. A caller that names
+ * `stallAfter` gets an error whose message is `stallKey` once the queues have
+ * gone that long without ever getting shorter, which is far longer than a
+ * queue of eight frames takes anywhere that is really working, software 4K
+ * included; the page can then say so instead of sitting at "Preparing..."
+ * forever, which is the one failure a visitor cannot tell from slow progress.
+ *
+ * @param {(VideoDecoder|VideoEncoder)[]} codecs
+ * @param {object} [options]
+ * @param {number} [options.limit]  frames in flight allowed before waiting
+ * @param {number} [options.stallAfter]  milliseconds without progress before
+ *   giving up; leave it out to wait indefinitely
+ * @param {string} [options.stallKey]  the phrase key the error then carries
+ */
+export async function settle(codecs, { limit = QUEUE_LIMIT, stallAfter = 0, stallKey = 'stall.both' } = {}) {
+  let bestSeen = Infinity;
+  let progressAt = Date.now();
+
+  while (codecs.some((codec) => queued(codec) > limit)) {
+    if (stallAfter) {
+      const size = codecs.reduce((total, codec) => total + queued(codec), 0);
+      if (size < bestSeen) {
+        bestSeen = size;
+        progressAt = Date.now();
+      } else if (Date.now() - progressAt > stallAfter) {
+        throw new Error(stallKey);
+      }
+    }
+
+    await new Promise((resolve) => {
+      let settled = false;
+      const done = () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        for (const codec of codecs) codec.removeEventListener('dequeue', done);
+        resolve();
+      };
+      // `dequeue` is not in every implementation yet, so cap the wait.
+      const timer = setTimeout(done, 20);
+      for (const codec of codecs) codec.addEventListener('dequeue', done);
+    });
+  }
+}

--- a/tests/js/errors.test.js
+++ b/tests/js/errors.test.js
@@ -1,0 +1,36 @@
+/**
+ * shared/js/errors.js - a cancellation the page ignores, a key the page looks up.
+ *
+ * The contract every page relies on is the name: `error.name === 'AbortError'`
+ * is the one test for "the visitor pressed Cancel", so the name is what is
+ * pinned here, and so is the promise that a signal nobody aborted throws
+ * nothing at all.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { AbortedError, throwIfAborted, said } from '../../shared/js/errors.js';
+
+test('a cancellation is an AbortError, like the platform\'s own', () => {
+  const error = new AbortedError();
+  assert.equal(error.name, 'AbortError');
+  assert.ok(error instanceof Error);
+  assert.equal(new DOMException('', 'AbortError').name, error.name);
+});
+
+test('throwIfAborted throws only once the signal has fired', () => {
+  const controller = new AbortController();
+  assert.doesNotThrow(() => throwIfAborted(controller.signal));
+  assert.doesNotThrow(() => throwIfAborted(undefined), 'a job run with no signal');
+  controller.abort();
+  assert.throws(() => throwIfAborted(controller.signal), { name: 'AbortError' });
+});
+
+test('said carries the key as the message and the values beside it', () => {
+  const error = said('stall.decoder', { seconds: 30 });
+  assert.ok(error instanceof Error);
+  assert.equal(error.message, 'stall.decoder');
+  assert.deepEqual(error.values, { seconds: 30 });
+  assert.deepEqual(said('read.short').values, {});
+});

--- a/tests/js/grab-frame.test.js
+++ b/tests/js/grab-frame.test.js
@@ -19,8 +19,9 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
-  displayOrder, frameNear, keyframeBefore, lookaheadFor, micros, seriesFrames,
+  displayOrder, frameNear, keyframeBefore, lookaheadFor, seriesFrames,
 } from '../../tools/grab-frame/src/frames.js';
+import { micros } from '../../shared/js/webcodecs.js';
 import {
   clockTime, stillName, timecode,
 } from '../../tools/grab-frame/src/still.js';

--- a/tests/js/mp4-boxes.test.js
+++ b/tests/js/mp4-boxes.test.js
@@ -1,0 +1,51 @@
+/**
+ * shared/js/mp4-boxes.js - the bytes an MP4 is built out of.
+ *
+ * The writers that use these are tested end to end elsewhere (a file they
+ * wrote is read back by the reader), so what is pinned here is the byte-level
+ * contract each of them assumes: big-endian, a length that counts its own
+ * eight bytes, and a full box's four-byte header in front of the payload.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  ascii, bytes, u16, u32, i32, zeros, concat, box, fullBox, fourcc,
+} from '../../shared/js/mp4-boxes.js';
+
+test('integers are big-endian, and a negative one is two\'s complement', () => {
+  assert.deepEqual([...u16(0x1234)], [0x12, 0x34]);
+  assert.deepEqual([...u32(0x01020304)], [1, 2, 3, 4]);
+  assert.deepEqual([...u32(0xffffffff)], [255, 255, 255, 255]);
+  assert.deepEqual([...i32(-1)], [255, 255, 255, 255]);
+  assert.deepEqual([...i32(-2)], [255, 255, 255, 254]);
+});
+
+test('ascii, bytes and zeros are what they say', () => {
+  assert.deepEqual([...ascii('moov')], [0x6d, 0x6f, 0x6f, 0x76]);
+  assert.deepEqual([...bytes(1, 2, 250)], [1, 2, 250]);
+  assert.deepEqual([...zeros(3)], [0, 0, 0]);
+});
+
+test('concat joins runs in order and copes with an empty list', () => {
+  assert.deepEqual([...concat([bytes(1), bytes(), bytes(2, 3)])], [1, 2, 3]);
+  assert.equal(concat([]).byteLength, 0);
+});
+
+test('a box is its total length, its type, then the payload', () => {
+  const made = box('free', bytes(9, 9));
+  assert.deepEqual([...made], [0, 0, 0, 10, 0x66, 0x72, 0x65, 0x65, 9, 9]);
+  assert.equal(box('free').byteLength, 8, 'an empty box is eight bytes');
+});
+
+test('a full box carries version and 24-bit flags before the payload', () => {
+  const made = fullBox('tkhd', 1, 0x000007, bytes(0xaa));
+  assert.deepEqual([...made.subarray(0, 8)], [0, 0, 0, 13, 0x74, 0x6b, 0x68, 0x64]);
+  assert.deepEqual([...made.subarray(8)], [1, 0, 0, 7, 0xaa]);
+});
+
+test('fourcc reads a type back out of a view', () => {
+  const view = new DataView(box('mdat', bytes(1)).buffer);
+  assert.equal(fourcc(view, 4), 'mdat');
+});

--- a/tests/js/reverse-video.test.js
+++ b/tests/js/reverse-video.test.js
@@ -21,9 +21,9 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
-  averageFps, closeDurations, displayTimes, frameWindows, gopRanges, outputSize,
-  reversedTimes, windowLimit,
+  closeDurations, displayTimes, frameWindows, gopRanges, outputSize, reversedTimes, windowLimit,
 } from '../../tools/reverse-video/src/timeline.js';
+import { averageFps } from '../../shared/js/webcodecs.js';
 import { reverseChannels } from '../../tools/reverse-video/src/audio.js';
 
 /* ------------------------------------------------------------- fixtures */

--- a/tests/js/webcodecs.test.js
+++ b/tests/js/webcodecs.test.js
@@ -1,0 +1,108 @@
+/**
+ * shared/js/webcodecs.js - the arithmetic around a decoder and an encoder.
+ *
+ * A codec here is an EventTarget with a queue size, which is all `settle`
+ * reads, and the clock is the runner's, so the thirty-second stall can be
+ * reached in a test that takes none.
+ */
+
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { decoderConfig, averageFps, micros, settle, QUEUE_LIMIT } from '../../shared/js/webcodecs.js';
+
+/** A decoder or encoder holding `queued` frames. */
+function codec(kind, queued) {
+  const target = new EventTarget();
+  target[kind === 'decoder' ? 'decodeQueueSize' : 'encodeQueueSize'] = queued;
+  target.drain = (n) => {
+    target[kind === 'decoder' ? 'decodeQueueSize' : 'encodeQueueSize'] -= n;
+    target.dispatchEvent(new Event('dequeue'));
+  };
+  return target;
+}
+
+test('decoderConfig hands over the description only when the track has one', () => {
+  const h264 = { codec: 'avc1.64001f', codedWidth: 1920, codedHeight: 1088, description: new Uint8Array(3) };
+  assert.deepEqual(decoderConfig(h264), {
+    codec: 'avc1.64001f', codedWidth: 1920, codedHeight: 1088, description: h264.description,
+  });
+  const vp9 = { codec: 'vp09.00.10.08', codedWidth: 640, codedHeight: 360 };
+  assert.deepEqual(decoderConfig(vp9), { codec: 'vp09.00.10.08', codedWidth: 640, codedHeight: 360 });
+});
+
+test('averageFps is the sample count over the duration, within what a clip can be', () => {
+  assert.equal(averageFps({ duration: 6000, timescale: 600, samples: new Array(300) }), 30);
+  assert.equal(averageFps({ duration: 0, timescale: 600, samples: [] }), 30, 'no duration: assume 30');
+  assert.equal(averageFps({ duration: 600, timescale: 600, samples: new Array(5000) }), 240);
+  assert.equal(averageFps({ duration: 6000, timescale: 600, samples: new Array(2) }), 1);
+});
+
+test('micros converts a time on the file own clock into what WebCodecs counts in', () => {
+  assert.equal(micros(0, 600), 0);
+  assert.equal(micros(600, 600), 1_000_000);
+  assert.equal(micros(20, 600), 33333);
+  assert.equal(micros(3003, 90000), 33367);
+});
+
+test('settle returns at once when nothing is over the limit', async () => {
+  await settle([codec('decoder', QUEUE_LIMIT), codec('encoder', 0)]);
+});
+
+test('settle waits for every codec over the limit to drain', async () => {
+  const decoder = codec('decoder', QUEUE_LIMIT + 3);
+  const encoder = codec('encoder', QUEUE_LIMIT + 1);
+  let done = false;
+  const waiting = settle([decoder, encoder]).then(() => { done = true; });
+
+  await Promise.resolve();
+  assert.equal(done, false);
+  decoder.drain(3);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(done, false, 'the encoder is still over');
+  encoder.drain(1);
+  await waiting;
+  assert.equal(done, true);
+});
+
+test('settle polls when no dequeue event ever comes', async () => {
+  // `dequeue` is not in every implementation, so the wait is capped and the
+  // queue size is read again.
+  const encoder = codec('encoder', QUEUE_LIMIT + 1);
+  setTimeout(() => { encoder.encodeQueueSize = 0; }, 5);
+  await settle([encoder]);
+});
+
+test('settle gives up after stallAfter without progress, under the key given', async () => {
+  mock.timers.enable({ apis: ['setTimeout', 'Date'] });
+  const decoder = codec('decoder', QUEUE_LIMIT + 2);
+  const failed = settle([decoder], { stallAfter: 30_000, stallKey: 'stall.both' })
+    .then(() => 'resolved', (error) => error.message);
+  // Each 20 ms poll finds the same queue; thirty seconds of that is a stall.
+  for (let i = 0; i < 1600; i += 1) {
+    mock.timers.tick(20);
+    await Promise.resolve();
+    await Promise.resolve();
+  }
+  assert.equal(await failed, 'stall.both');
+  mock.timers.reset();
+});
+
+test('progress resets the stall clock', async () => {
+  mock.timers.enable({ apis: ['setTimeout', 'Date'] });
+  const decoder = codec('decoder', QUEUE_LIMIT + 4);
+  const waiting = settle([decoder], { stallAfter: 100 });
+  for (let step = 0; step < 4; step += 1) {
+    // 80 ms without progress each time, then one frame drains: never a stall.
+    for (let i = 0; i < 4; i += 1) {
+      mock.timers.tick(20);
+      await Promise.resolve();
+      await Promise.resolve();
+    }
+    decoder.drain(1);
+    await Promise.resolve();
+    await Promise.resolve();
+  }
+  await waiting;
+  mock.timers.reset();
+});

--- a/tools/crop-video/src/main.js
+++ b/tools/crop-video/src/main.js
@@ -1,12 +1,13 @@
 /** UI wiring and application state. */
 
 import { phrase, fill } from './shared/phrases.js';
+import { decoderConfig, averageFps } from './shared/webcodecs.js';
 import { sizeText, durationText } from './shared/format.js';
 import { openInPlayer } from './shared/media.js';
 import { messageBox } from './shared/message-box.js';
 import { wireFilePicker } from './shared/file-picker.js';
 import { demux, UnsupportedFile } from './shared/mp4-reader.js';
-import { cropExact, grabFrame, decoderConfig, averageFps } from './transcode.js';
+import { cropExact, grabFrame } from './transcode.js';
 import { cropByRecording } from './record.js';
 import { Cropper } from './cropper.js';
 import { hasWebCodecs, hasMediaRecorder, canDecode } from './shared/video-support.js';
@@ -130,7 +131,6 @@ const picker = wireFilePicker({
     if (file) loadFile(file);
   },
 });
-
 
 /* ------------------------------------------------------------------ loading */
 

--- a/tools/crop-video/src/mp4.js
+++ b/tools/crop-video/src/mp4.js
@@ -22,6 +22,8 @@
  *     raises a clear error rather than producing a file that opens wrong.
  */
 
+import { ascii, u16, u32, zeros, concat, box, fullBox } from './shared/mp4-boxes.js';
+
 /** Divides evenly by 24, 25, 30, 50 and 60 fps. */
 export const VIDEO_TIMESCALE = 90000;
 
@@ -29,50 +31,6 @@ export const VIDEO_TIMESCALE = 90000;
 const CHUNK_SECONDS = 1;
 
 /* ---------------------------------------------------------------- helpers */
-
-function ascii(text) {
-  const out = new Uint8Array(text.length);
-  for (let i = 0; i < text.length; i++) out[i] = text.charCodeAt(i);
-  return out;
-}
-
-function u16(n) {
-  return new Uint8Array([(n >> 8) & 0xff, n & 0xff]);
-}
-
-function u32(n) {
-  return new Uint8Array([(n >>> 24) & 0xff, (n >>> 16) & 0xff, (n >>> 8) & 0xff, n & 0xff]);
-}
-
-function zeros(n) {
-  return new Uint8Array(n);
-}
-
-function concat(parts) {
-  let length = 0;
-  for (const part of parts) length += part.byteLength;
-  const out = new Uint8Array(length);
-  let at = 0;
-  for (const part of parts) {
-    out.set(part, at);
-    at += part.byteLength;
-  }
-  return out;
-}
-
-/** A plain box: size + type + payload. */
-function box(type, ...payload) {
-  const body = concat(payload);
-  return concat([u32(body.byteLength + 8), ascii(type), body]);
-}
-
-/** A full box: adds the version + 24-bit flags header. */
-function fullBox(type, version, flags, ...payload) {
-  const header = new Uint8Array([
-    version, (flags >> 16) & 0xff, (flags >> 8) & 0xff, flags & 0xff,
-  ]);
-  return box(type, header, ...payload);
-}
 
 /** The identity transformation matrix every player expects. */
 const UNITY_MATRIX = concat([

--- a/tools/crop-video/src/transcode.js
+++ b/tools/crop-video/src/transcode.js
@@ -16,6 +16,8 @@ import { FileWindow } from './shared/mp4-reader.js';
 import { Mp4Writer, VIDEO_TIMESCALE } from './mp4.js';
 import { drawCropped } from './draw.js';
 import { pickH264Codec } from './shared/video-support.js';
+import { decoderConfig, averageFps, micros, settle } from './shared/webcodecs.js';
+import { throwIfAborted, said } from './shared/errors.js';
 
 /** Bits per pixel per frame. Real footage moves, so these sit above the
  *  slideshow figures the images-to-video tool uses. */
@@ -27,42 +29,8 @@ const QUALITY_HEADROOM = { low: 0.8, medium: 1.25, high: 2 };
 const MIN_BITRATE = 200_000;
 const MAX_BITRATE = 60_000_000;
 
-/** Frames in flight before the feed loop waits for the pipeline to catch up. */
-const QUEUE_LIMIT = 8;
-
 /** Seconds between keyframes in the output, so seeking stays usable. */
 const KEYFRAME_SECONDS = 2;
-
-class AbortedError extends Error {
-  constructor() {
-    super('Crop cancelled.');
-    this.name = 'AbortError';
-  }
-}
-
-function throwIfAborted(signal) {
-  if (signal?.aborted) throw new AbortedError();
-}
-
-/** The configuration VideoDecoder needs to open this track. */
-export function decoderConfig(video) {
-  const config = {
-    codec: video.codec,
-    codedWidth: video.codedWidth,
-    codedHeight: video.codedHeight,
-  };
-  // VP9 carries everything it needs in the bitstream; the others hand over the
-  // configuration record the file was written with, untouched.
-  if (video.description) config.description = video.description;
-  return config;
-}
-
-/** Frames per second, averaged over the whole track. */
-export function averageFps(video) {
-  const seconds = video.duration / video.timescale;
-  if (!seconds) return 30;
-  return Math.min(240, Math.max(1, video.samples.length / seconds));
-}
 
 /**
  * What to spend on the cropped picture.
@@ -87,32 +55,6 @@ export function chooseBitrate({ video, crop, fps, quality }) {
   }
 
   return Math.round(Math.min(MAX_BITRATE, Math.max(MIN_BITRATE, ceiling)));
-}
-
-/** Wait until both queues have drained below the limit. */
-async function settle(decoder, encoder) {
-  while (decoder.decodeQueueSize > QUEUE_LIMIT || encoder.encodeQueueSize > QUEUE_LIMIT) {
-    await new Promise((resolve) => {
-      let settled = false;
-      const done = () => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(timer);
-        decoder.removeEventListener('dequeue', done);
-        encoder.removeEventListener('dequeue', done);
-        resolve();
-      };
-      // `dequeue` is not in every implementation yet, so cap the wait.
-      const timer = setTimeout(done, 20);
-      decoder.addEventListener('dequeue', done);
-      encoder.addEventListener('dequeue', done);
-    });
-  }
-}
-
-/** Presentation time in microseconds, which is what WebCodecs counts in. */
-function micros(ticks, timescale) {
-  return Math.round(ticks / timescale * 1_000_000);
 }
 
 /**
@@ -150,12 +92,6 @@ async function readAudio(file, audio, signal) {
  *   in display coordinates, with even width and height
  * @returns {Promise<{blob: Blob, extension: string, codec: string, frames: number}>}
  */
-/**
- * A refusal named rather than written out. This module is copied byte for
- * byte into fifteen languages, so what it can hand back is a phrase key;
- * main.js turns it into the reader's own sentence.
- */
-const said = (key, values = {}) => Object.assign(new Error(key), { values });
 
 export async function cropExact({
   file, media, crop, quality = 'medium', keepAudio = true, onProgress, signal,
@@ -267,7 +203,7 @@ export async function cropExact({
       throwIfAborted(signal);
       if (failure) throw failure;
 
-      await settle(decoder, encoder);
+      await settle([decoder, encoder]);
 
       const sample = video.samples[i];
       const bytes = await window.read(sample.offset, sample.size);

--- a/tools/crop-video/tool.toml
+++ b/tools/crop-video/tool.toml
@@ -32,7 +32,7 @@ css_parts = ["progress"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.
-js_parts = ["file-picker", "codec-support", "mp4-reader", "video-support", "message-box", "media", "format"]
+js_parts = ["file-picker", "codec-support", "mp4-reader", "video-support", "message-box", "media", "format", "webcodecs", "errors", "mp4-boxes"]
 # Where a finished result can be carried without being saved first: the row of
 # links shared/handoff.js shows beside the download once there is one. Slugs of
 # tools whose picker takes what this page produces; checked against the tools

--- a/tools/gif-maker/src/encode.js
+++ b/tools/gif-maker/src/encode.js
@@ -25,17 +25,7 @@ import { GifWriter } from './gif.js';
 import { createHistogram, addToHistogram, buildPalette, mapFrame } from './quantize.js';
 import { drawFrame } from './compose.js';
 import { decodeFull } from './images.js';
-
-class AbortedError extends Error {
-  constructor() {
-    super('Export cancelled.');
-    this.name = 'AbortError';
-  }
-}
-
-function throwIfAborted(signal) {
-  if (signal?.aborted) throw new AbortedError();
-}
+import { throwIfAborted } from './shared/errors.js';
 
 /** Hand the main thread back so a click on Cancel is heard and the bar moves. */
 const yieldToPage = () => new Promise((resolve) => setTimeout(resolve, 0));

--- a/tools/gif-maker/tool.toml
+++ b/tools/gif-maker/tool.toml
@@ -32,7 +32,7 @@ css_parts = ["progress"]
 # Shared modules this tool asks for. The same arrangement as css_parts, and for
 # the same reason: a component more than one tool needs and no tool should own.
 # file-picker brings in the drop zone.
-js_parts = ["file-picker", "message-box", "format"]
+js_parts = ["file-picker", "message-box", "format", "errors"]
 # Where a finished result can be carried without being saved first: the row of
 # links shared/handoff.js shows beside the download once there is one. Slugs of
 # tools whose picker takes what this page produces; checked against the tools

--- a/tools/grab-frame/src/frames.js
+++ b/tools/grab-frame/src/frames.js
@@ -29,11 +29,8 @@
 
 import { FileWindow } from './shared/mp4-reader.js';
 import { drawUpright } from './draw.js';
-
-/** Presentation time in microseconds, which is what WebCodecs counts in. */
-export function micros(ticks, timescale) {
-  return Math.round(ticks / timescale * 1_000_000);
-}
+import { micros } from './shared/webcodecs.js';
+import { throwIfAborted } from './shared/errors.js';
 
 /**
  * The frames of a track in the order they are watched in.
@@ -148,17 +145,6 @@ export function seriesFrames(order, { every, from = 0, to = Infinity, limit = 50
 export function lookaheadFor(width, height, budgetBytes = 96 << 20) {
   const perFrame = Math.max(1, width * height * 4);
   return Math.max(2, Math.min(16, Math.floor(budgetBytes / perFrame)));
-}
-
-class AbortedError extends Error {
-  constructor(message = 'Cancelled.') {
-    super(message);
-    this.name = 'AbortError';
-  }
-}
-
-function throwIfAborted(signal) {
-  if (signal?.aborted) throw new AbortedError();
 }
 
 /**

--- a/tools/grab-frame/tool.toml
+++ b/tools/grab-frame/tool.toml
@@ -32,7 +32,7 @@ css_parts = ["progress"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.
-js_parts = ["file-picker", "zip", "crc32", "mp4-reader", "message-box", "download", "media", "format"]
+js_parts = ["file-picker", "zip", "crc32", "mp4-reader", "message-box", "download", "media", "format", "webcodecs", "errors"]
 lastmod = "2026-09-02"
 
 # --- what search engines and chat apps are told ------------------------------

--- a/tools/heic-to-jpg/src/codecs.js
+++ b/tools/heic-to-jpg/src/codecs.js
@@ -12,6 +12,8 @@
  * surest way to pass that test is to have the browser write it.
  */
 
+import { said } from './shared/errors.js';
+
 export const JPEG = 'image/jpeg';
 export const PNG = 'image/png';
 export const WEBP = 'image/webp';
@@ -84,9 +86,6 @@ export async function encodePixels(picture, { mime, quality }) {
   if (!blob) throw said('codec.nowrite', { format: FORMATS[mime]?.label ?? mime });
   return blob;
 }
-
-/** An error whose message is a phrase key; the caller resolves it. */
-const said = (key, values = {}) => Object.assign(new Error(key), { values });
 
 function canvas(width, height, alpha) {
   const el = document.createElement('canvas');

--- a/tools/heic-to-jpg/src/heif.js
+++ b/tools/heic-to-jpg/src/heif.js
@@ -39,15 +39,14 @@
  * policy is the proof here, not the promise.
  */
 
+import { said } from './shared/errors.js';
+
 /**
  * Where the engine sits, worked out from this module's own address rather than
  * from the page's. A relative URL in a `<script>` tag resolves against the
  * document, which would break the moment this file moved.
  */
 const ENGINE = new URL('../vendor/libheif.js', import.meta.url);
-
-/** An error whose message is a phrase key; the caller resolves it. */
-const said = (key, values = {}) => Object.assign(new Error(key), { values });
 
 /** The load, started once and shared by every caller. @type {Promise|null} */
 let loading = null;

--- a/tools/heic-to-jpg/tool.toml
+++ b/tools/heic-to-jpg/tool.toml
@@ -33,7 +33,7 @@ roadmap_group = "images"
 # more than one tool needs and that no tool should own.
 css_parts = ["file-list", "progress"]
 # Shared modules this tool asks for. file-picker brings in the drop zone.
-js_parts = ["file-picker", "zip", "crc32", "message-box", "download", "format"]
+js_parts = ["file-picker", "zip", "crc32", "message-box", "download", "format", "errors"]
 lastmod = "2026-08-27"
 
 # --- what search engines and chat apps are told ------------------------------

--- a/tools/images-to-video/src/encoder.js
+++ b/tools/images-to-video/src/encoder.js
@@ -9,43 +9,14 @@ import { Mp4Muxer } from './shared/mp4-muxer.js';
 import { drawFrame } from './compose.js';
 import { decodeFull } from './images.js';
 import { pickH264Codec } from './support.js';
+import { settle } from './shared/webcodecs.js';
+import { throwIfAborted } from './shared/errors.js';
 
 /** Bits per pixel per frame. Slideshows are mostly static, so rate control
  *  lands well under these ceilings in practice. */
 const QUALITY_BPP = { low: 0.03, medium: 0.07, high: 0.15 };
 
 const MAX_BITRATE = 50_000_000;
-const QUEUE_LIMIT = 8; // frames in flight before we wait for the encoder
-
-class AbortedError extends Error {
-  constructor() {
-    super('Export cancelled.');
-    this.name = 'AbortError';
-  }
-}
-
-function throwIfAborted(signal) {
-  if (signal?.aborted) throw new AbortedError();
-}
-
-/** Wait until the encoder has drained below the queue limit. */
-async function applyBackpressure(encoder) {
-  while (encoder.encodeQueueSize > QUEUE_LIMIT) {
-    await new Promise((resolve) => {
-      let settled = false;
-      const done = () => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(timer);
-        encoder.removeEventListener('dequeue', done);
-        resolve();
-      };
-      // `dequeue` is not in every implementation yet, so cap the wait.
-      const timer = setTimeout(done, 50);
-      encoder.addEventListener('dequeue', done);
-    });
-  }
-}
 
 /** Total frames the timeline will produce. */
 export function countFrames(items, fps) {
@@ -128,7 +99,7 @@ export async function encodeToMp4({ items, settings, onProgress, signal }) {
         throwIfAborted(signal);
         if (encoderError) throw encoderError;
 
-        await applyBackpressure(encoder);
+        await settle([encoder]);
 
         const frame = new VideoFrame(canvas, {
           timestamp: Math.round(frameIndex * frameDurationUs),

--- a/tools/images-to-video/tool.toml
+++ b/tools/images-to-video/tool.toml
@@ -32,7 +32,7 @@ css_parts = ["progress"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.
-js_parts = ["file-picker", "codec-support", "mp4-muxer", "message-box", "format"]
+js_parts = ["file-picker", "codec-support", "mp4-muxer", "message-box", "format", "webcodecs", "errors", "mp4-boxes"]
 lastmod = "2026-08-27"
 
 # --- what search engines and chat apps are told ------------------------------

--- a/tools/reverse-video/src/audio.js
+++ b/tools/reverse-video/src/audio.js
@@ -29,6 +29,8 @@
  * and the encoding are the browser's own, running on this machine.
  */
 
+import { fourcc, bytes, concat, u16, u32, box } from './shared/mp4-boxes.js';
+
 /** What a reversed track is encoded at. */
 const TARGET_BITRATE = 160_000;
 
@@ -54,11 +56,6 @@ function descriptorLength(view, at) {
     if (!(byte & 0x80)) break;
   }
   return { value, next };
-}
-
-function fourcc(view, at) {
-  return String.fromCharCode(
-    view.getUint8(at), view.getUint8(at + 1), view.getUint8(at + 2), view.getUint8(at + 3));
 }
 
 /** The AAC object type, which is the last number in the codec string. */
@@ -140,37 +137,6 @@ export function audioDecoderConfig(track) {
 }
 
 /* ------------------------------------------------------- writing a description */
-
-function bytes(...values) {
-  return new Uint8Array(values);
-}
-
-function concat(parts) {
-  let length = 0;
-  for (const part of parts) length += part.byteLength;
-  const out = new Uint8Array(length);
-  let at = 0;
-  for (const part of parts) {
-    out.set(part, at);
-    at += part.byteLength;
-  }
-  return out;
-}
-
-function u16(n) {
-  return bytes((n >> 8) & 0xff, n & 0xff);
-}
-
-function u32(n) {
-  return bytes((n >>> 24) & 0xff, (n >>> 16) & 0xff, (n >>> 8) & 0xff, n & 0xff);
-}
-
-function box(type, ...payload) {
-  const body = concat(payload);
-  const header = concat([u32(body.byteLength + 8), bytes(
-    type.charCodeAt(0), type.charCodeAt(1), type.charCodeAt(2), type.charCodeAt(3))]);
-  return concat([header, body]);
-}
 
 /**
  * One descriptor. The length is written as a single byte, which is legal and is

--- a/tools/reverse-video/src/main.js
+++ b/tools/reverse-video/src/main.js
@@ -1,14 +1,15 @@
 /** UI wiring and application state. */
 
 import { phrase } from './shared/phrases.js';
+import { decoderConfig, averageFps } from './shared/webcodecs.js';
 import { sizeText, durationText } from './shared/format.js';
 import { openInPlayer } from './shared/media.js';
 import { messageBox } from './shared/message-box.js';
 import { wireFilePicker } from './shared/file-picker.js';
 import { demux, UnsupportedFile } from './shared/mp4-reader.js';
-import { reverseExact, decoderConfig } from './reverse.js';
+import { reverseExact } from './reverse.js';
 import { measureFps, reverseByPlayback } from './playback.js';
-import { averageFps, gopRanges } from './timeline.js';
+import { gopRanges } from './timeline.js';
 import { hasWebCodecs, hasEncoder, canDecode } from './shared/video-support.js';
 
 /**

--- a/tools/reverse-video/src/playback.js
+++ b/tools/reverse-video/src/playback.js
@@ -31,6 +31,8 @@ import { drawFitted } from './draw.js';
 import { pickH264Codec } from './shared/video-support.js';
 import { reversedAudioTrack } from './audio.js';
 import { writeFile } from './reverse.js';
+import { settle } from './shared/webcodecs.js';
+import { throwIfAborted, said } from './shared/errors.js';
 
 /** Bits per pixel per frame, as in reverse.js. */
 const QUALITY_BPP = { low: 0.05, medium: 0.1, high: 0.2 };
@@ -42,28 +44,11 @@ const MAX_BITRATE = 60_000_000;
 /** Seconds between keyframes in the output, so seeking stays usable. */
 const KEYFRAME_SECONDS = 2;
 
-/** Frames in flight before the loop waits for the encoder to catch up. */
-const QUEUE_LIMIT = 8;
-
 /** How long one seek may take before the clip is called unreadable. */
-/** An error whose message is a phrase key; the caller resolves it. */
-const said = (key, values = {}) => Object.assign(new Error(key), { values });
-
 const SEEK_TIMEOUT = 10_000;
 
 /** What the frame rate is assumed to be when the browser will not say. */
 const ASSUMED_FPS = 30;
-
-class AbortedError extends Error {
-  constructor() {
-    super('Reverse cancelled.');
-    this.name = 'AbortError';
-  }
-}
-
-function throwIfAborted(signal) {
-  if (signal?.aborted) throw new AbortedError();
-}
 
 /**
  * What to spend on the picture, when all that is known about the source is how
@@ -170,24 +155,6 @@ export async function measureFps(video, seconds = 1) {
   }
 }
 
-/** Wait until the encoder has caught up. */
-async function settle(encoder) {
-  while (encoder.encodeQueueSize > QUEUE_LIMIT) {
-    await new Promise((resolve) => {
-      let settled = false;
-      const done = () => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(timer);
-        encoder.removeEventListener('dequeue', done);
-        resolve();
-      };
-      const timer = setTimeout(done, 20);
-      encoder.addEventListener('dequeue', done);
-    });
-  }
-}
-
 /**
  * @param {object} args
  * @param {File} args.file  for the sound; the picture comes from `video`
@@ -277,7 +244,7 @@ export async function reverseByPlayback({
         (total - 1 - k) / fps + 0.5 / fps);
 
       await seekTo(video, at);
-      await settle(encoder);
+      await settle([encoder]);
 
       // The player has already turned the picture whichever way the file asked
       // for, so there is nothing left here to rotate.

--- a/tools/reverse-video/src/reverse.js
+++ b/tools/reverse-video/src/reverse.js
@@ -36,8 +36,10 @@ import { drawFitted } from './draw.js';
 import { pickH264Codec } from './shared/video-support.js';
 import { reversedAudioTrack } from './audio.js';
 import {
-  averageFps, closeDurations, frameWindows, gopRanges, outputSize, reversedTimes, windowLimit,
+  closeDurations, frameWindows, gopRanges, outputSize, reversedTimes, windowLimit,
 } from './timeline.js';
+import { decoderConfig, averageFps, micros, settle } from './shared/webcodecs.js';
+import { throwIfAborted, said } from './shared/errors.js';
 
 /** Divides evenly by 24, 25, 30, 50 and 60 fps. */
 const VIDEO_TIMESCALE = 90000;
@@ -51,9 +53,6 @@ const QUALITY_HEADROOM = { low: 0.8, medium: 1.25, high: 2 };
 
 const MIN_BITRATE = 200_000;
 const MAX_BITRATE = 60_000_000;
-
-/** Frames in flight before the feed loop waits for the pipeline to catch up. */
-const QUEUE_LIMIT = 8;
 
 /**
  * How long the queues may sit without draining before a reversal gives up.
@@ -69,9 +68,6 @@ const QUEUE_LIMIT = 8;
  * outcome to be worth a backstop, and thirty seconds is far longer than a queue
  * of eight frames takes anywhere that is really working, software 4K included.
  */
-/** An error whose message is a phrase key; the caller resolves it. */
-const said = (key, values = {}) => Object.assign(new Error(key), { values });
-
 const STALL_TIMEOUT_MS = 30_000;
 
 /** Seconds between keyframes in the output, so seeking stays usable. */
@@ -79,30 +75,6 @@ const KEYFRAME_SECONDS = 2;
 
 /** How much of one group may be held as compressed bytes to save re-reading it. */
 const GROUP_CACHE_BYTES = 64 << 20;
-
-class AbortedError extends Error {
-  constructor() {
-    super('Reverse cancelled.');
-    this.name = 'AbortError';
-  }
-}
-
-function throwIfAborted(signal) {
-  if (signal?.aborted) throw new AbortedError();
-}
-
-/** The configuration VideoDecoder needs to open this track. */
-export function decoderConfig(video) {
-  const config = {
-    codec: video.codec,
-    codedWidth: video.codedWidth,
-    codedHeight: video.codedHeight,
-  };
-  // VP9 carries everything it needs in the bitstream; the others hand over the
-  // configuration record the file was written with, untouched.
-  if (video.description) config.description = video.description;
-  return config;
-}
 
 /**
  * What to spend on the picture.
@@ -211,43 +183,6 @@ function withStallTimeout(promise, which) {
       () => reject(new Error(`stall.${which}`)), STALL_TIMEOUT_MS);
   });
   return Promise.race([promise, stalled]).finally(() => clearTimeout(timer));
-}
-
-/** Wait until both queues have drained below the limit. */
-async function settle(decoder, encoder) {
-  let bestSeen = decoder.decodeQueueSize + encoder.encodeQueueSize;
-  let progressAt = Date.now();
-
-  while (decoder.decodeQueueSize > QUEUE_LIMIT || encoder.encodeQueueSize > QUEUE_LIMIT) {
-    const size = decoder.decodeQueueSize + encoder.encodeQueueSize;
-    if (size < bestSeen) {
-      bestSeen = size;
-      progressAt = Date.now();
-    } else if (Date.now() - progressAt > STALL_TIMEOUT_MS) {
-      throw new Error('stall.both');
-    }
-
-    await new Promise((resolve) => {
-      let settled = false;
-      const done = () => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(timer);
-        decoder.removeEventListener('dequeue', done);
-        encoder.removeEventListener('dequeue', done);
-        resolve();
-      };
-      // `dequeue` is not in every implementation yet, so cap the wait.
-      const timer = setTimeout(done, 20);
-      decoder.addEventListener('dequeue', done);
-      encoder.addEventListener('dequeue', done);
-    });
-  }
-}
-
-/** Presentation time in microseconds, which is what WebCodecs counts in. */
-function micros(ticks, timescale) {
-  return Math.round(ticks / timescale * 1_000_000);
 }
 
 /**
@@ -575,7 +510,7 @@ export async function reverseExact({
           throwIfAborted(signal);
           if (failure) throw failure;
 
-          await settle(decoder, encoder);
+          await settle([decoder, encoder], { stallAfter: STALL_TIMEOUT_MS });
           const sample = video.samples[i];
           decoder.decode(new EncodedVideoChunk({
             type: sample.isKey ? 'key' : 'delta',
@@ -601,7 +536,7 @@ export async function reverseExact({
           if (!slot.data && !slot.bitmap) continue;
           emit(drawable(slot), wanted.get(slot.timestamp));
           discard(slot);
-          await settle(decoder, encoder);
+          await settle([decoder, encoder], { stallAfter: STALL_TIMEOUT_MS });
         }
         kept = [];
 

--- a/tools/reverse-video/src/timeline.js
+++ b/tools/reverse-video/src/timeline.js
@@ -180,19 +180,6 @@ export function closeDurations(samples) {
   return samples;
 }
 
-/**
- * Frames per second, averaged over the whole track.
- *
- * Only ever used to choose an encoder configuration and to describe the file on
- * the page. The frame times themselves are never averaged: they are carried
- * across one by one by `reversedTimes`.
- */
-export function averageFps(video) {
-  const seconds = video.duration / video.timescale;
-  if (!seconds) return 30;
-  return Math.min(240, Math.max(1, video.samples.length / seconds));
-}
-
 /** The output frame size: the picture as watched, rounded to what H.264 can store. */
 export function outputSize(video) {
   return {

--- a/tools/reverse-video/tool.toml
+++ b/tools/reverse-video/tool.toml
@@ -32,7 +32,7 @@ css_parts = ["progress"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.
-js_parts = ["file-picker", "codec-support", "mp4-reader", "mp4-writer", "video-support", "message-box", "media", "format"]
+js_parts = ["file-picker", "codec-support", "mp4-reader", "mp4-writer", "video-support", "message-box", "media", "format", "webcodecs", "errors", "mp4-boxes"]
 # Where a finished result can be carried without being saved first: the row of
 # links shared/handoff.js shows beside the download once there is one. Slugs of
 # tools whose picker takes what this page produces; checked against the tools

--- a/tools/timelapse-video/src/decode.js
+++ b/tools/timelapse-video/src/decode.js
@@ -19,40 +19,8 @@
 import { FileWindow } from './shared/mp4-reader.js';
 import { decodeRuns } from './plan.js';
 import { drawScaled, frameCanvas } from './draw.js';
-
-/** Frames in flight before the feed loop waits for the pipeline to catch up. */
-const QUEUE_LIMIT = 8;
-
-class AbortedError extends Error {
-  constructor() {
-    super('Cancelled.');
-    this.name = 'AbortError';
-  }
-}
-
-function throwIfAborted(signal) {
-  if (signal?.aborted) throw new AbortedError();
-}
-
-/** The configuration VideoDecoder needs to open a track demux() found. */
-export function decoderConfig(video) {
-  const config = {
-    codec: video.codec,
-    codedWidth: video.codedWidth,
-    codedHeight: video.codedHeight,
-  };
-  // VP9 carries everything it needs in the bitstream; the others hand over the
-  // configuration record the file was written with, untouched.
-  if (video.description) config.description = video.description;
-  return config;
-}
-
-/** Frames per second, averaged over the whole track. */
-export function averageFps(video) {
-  const seconds = video.duration / video.timescale;
-  if (!seconds) return 30;
-  return Math.min(240, Math.max(1, video.samples.length / seconds));
-}
+import { decoderConfig, settle } from './shared/webcodecs.js';
+import { throwIfAborted } from './shared/errors.js';
 
 /**
  * Serves each wanted instant from the last frame at or before it.
@@ -186,7 +154,7 @@ export async function timelapseByDecoding({
           data: bytes,   // EncodedVideoChunk copies, so the window may move on
         }));
 
-        while (decoder.decodeQueueSize > QUEUE_LIMIT) await tick(decoder);
+        await settle([decoder]);
         while (writer.busy) await writer.settle();
 
         fed += 1;
@@ -206,23 +174,6 @@ export async function timelapseByDecoding({
     if (decoder.state !== 'closed') decoder.close();
     canvas.width = 0;   // let the browser drop the backing store now
   }
-}
-
-/** Wait for the decoder to hand something back, with a cap in case it does not. */
-function tick(decoder) {
-  return new Promise((resolve) => {
-    let settled = false;
-    const done = () => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      decoder.removeEventListener('dequeue', done);
-      resolve();
-    };
-    // `dequeue` is not in every implementation yet, so cap the wait.
-    const timer = setTimeout(done, 20);
-    decoder.addEventListener('dequeue', done);
-  });
 }
 
 /**

--- a/tools/timelapse-video/src/encode.js
+++ b/tools/timelapse-video/src/encode.js
@@ -15,9 +15,7 @@
  */
 
 import { Mp4Muxer } from './shared/mp4-muxer.js';
-
-/** Frames in flight before the caller is asked to wait. */
-const QUEUE_LIMIT = 8;
+import { QUEUE_LIMIT } from './shared/webcodecs.js';
 
 /**
  * Seconds of *output* between keyframes, so the finished clip scrubs.

--- a/tools/timelapse-video/src/main.js
+++ b/tools/timelapse-video/src/main.js
@@ -1,12 +1,13 @@
 /** UI wiring and application state. */
 
 import { phrase, fill } from './shared/phrases.js';
+import { decoderConfig, averageFps } from './shared/webcodecs.js';
 import { sizeText, durationText } from './shared/format.js';
 import { openInPlayer } from './shared/media.js';
 import { messageBox } from './shared/message-box.js';
 import { wireFilePicker } from './shared/file-picker.js';
 import { demux, UnsupportedFile } from './shared/mp4-reader.js';
-import { timelapseByDecoding, previewFrame, decoderConfig, averageFps } from './decode.js';
+import { timelapseByDecoding, previewFrame } from './decode.js';
 import { timelapseByPlaying } from './playback.js';
 import { TimelapseWriter } from './encode.js';
 import { hasEncoder, hasWebCodecs, canDecode, pickH264Codec } from './shared/video-support.js';
@@ -15,6 +16,7 @@ import {
   clampSpeed, speedForLength, lengthForSpeed, sampleInterval, frameTimes, repeatsFrames,
   outputSize, chooseBitrate, estimateBytes, decodeRuns, decodeCost,
 } from './plan.js';
+import { said } from './shared/errors.js';
 
 /**
  * A reader refusal, in the reader's language. The demuxer is copied byte for
@@ -503,9 +505,6 @@ function updateSummary() {
 }
 
 /* ------------------------------------------------------------------ export */
-
-/** An error whose message is a phrase key; showError resolves it. */
-const said = (key, values = {}) => Object.assign(new Error(key), { values });
 
 function setProgress({ phase, done, total }) {
   const fraction = total > 0 ? Math.min(1, done / total) : 0;

--- a/tools/timelapse-video/src/playback.js
+++ b/tools/timelapse-video/src/playback.js
@@ -16,19 +16,10 @@
  */
 
 import { drawScaled, frameCanvas } from './draw.js';
+import { throwIfAborted, said } from './shared/errors.js';
 
 /** Give up on a seek that never lands rather than hanging the page. */
 const SEEK_TIMEOUT = 10_000;
-
-class AbortedError extends Error {
-  constructor() {
-    super('Cancelled.');
-    this.name = 'AbortError';
-  }
-}
-
-/** An error whose message is a phrase key; the caller resolves it. */
-const said = (key, values = {}) => Object.assign(new Error(key), { values });
 
 /**
  * What the four MediaError codes mean, in words somebody can act on.
@@ -76,7 +67,7 @@ export async function timelapseByPlaying({
 
   try {
     for (let i = 0; i < times.length; i += 1) {
-      if (signal?.aborted) throw new AbortedError();
+      throwIfAborted(signal);
 
       // A media element's error is sticky, and it can be set between two seeks
       // rather than during one - where no listener of ours is attached to hear

--- a/tools/timelapse-video/tool.toml
+++ b/tools/timelapse-video/tool.toml
@@ -32,7 +32,7 @@ css_parts = ["progress"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.
-js_parts = ["file-picker", "codec-support", "mp4-reader", "mp4-muxer", "video-support", "message-box", "media", "format"]
+js_parts = ["file-picker", "codec-support", "mp4-reader", "mp4-muxer", "video-support", "message-box", "media", "format", "webcodecs", "errors", "mp4-boxes"]
 # Where a finished result can be carried without being saved first: the row of
 # links shared/handoff.js shows beside the download once there is one. Slugs of
 # tools whose picker takes what this page produces; checked against the tools

--- a/tools/trim-video/src/audio.js
+++ b/tools/trim-video/src/audio.js
@@ -26,6 +26,8 @@
  * browser's own, running on this machine.
  */
 
+import { fourcc, bytes, concat, u16, u32, box } from './shared/mp4-boxes.js';
+
 /** What a joined track is encoded at when the clips cannot agree. */
 const TARGET_BITRATE = 160_000;
 
@@ -48,11 +50,6 @@ function descriptorLength(view, at) {
     if (!(byte & 0x80)) break;
   }
   return { value, next };
-}
-
-function fourcc(view, at) {
-  return String.fromCharCode(
-    view.getUint8(at), view.getUint8(at + 1), view.getUint8(at + 2), view.getUint8(at + 3));
 }
 
 /** The AAC object type, which is the last number in the codec string. */
@@ -133,37 +130,6 @@ export function audioDecoderConfig(track) {
 }
 
 /* ------------------------------------------------------- writing a description */
-
-function bytes(...values) {
-  return new Uint8Array(values);
-}
-
-function concat(parts) {
-  let length = 0;
-  for (const part of parts) length += part.byteLength;
-  const out = new Uint8Array(length);
-  let at = 0;
-  for (const part of parts) {
-    out.set(part, at);
-    at += part.byteLength;
-  }
-  return out;
-}
-
-function u16(n) {
-  return bytes((n >> 8) & 0xff, n & 0xff);
-}
-
-function u32(n) {
-  return bytes((n >>> 24) & 0xff, (n >>> 16) & 0xff, (n >>> 8) & 0xff, n & 0xff);
-}
-
-function box(type, ...payload) {
-  const body = concat(payload);
-  const header = concat([u32(body.byteLength + 8), bytes(
-    type.charCodeAt(0), type.charCodeAt(1), type.charCodeAt(2), type.charCodeAt(3))]);
-  return concat([header, body]);
-}
 
 /**
  * One descriptor. The length is written as a single byte, which is legal and is

--- a/tools/trim-video/src/copy.js
+++ b/tools/trim-video/src/copy.js
@@ -43,17 +43,7 @@
 
 import { Mp4Writer, MOVIE_TIMESCALE } from './shared/mp4-writer.js';
 import { planRanges } from './ranges.js';
-
-class AbortedError extends Error {
-  constructor() {
-    super('Trim cancelled.');
-    this.name = 'AbortError';
-  }
-}
-
-function throwIfAborted(signal) {
-  if (signal?.aborted) throw new AbortedError();
-}
+import { throwIfAborted } from './shared/errors.js';
 
 /** Ticks on one clock, in ticks on another. */
 function rescale(ticks, from, to) {

--- a/tools/trim-video/src/transcode.js
+++ b/tools/trim-video/src/transcode.js
@@ -28,6 +28,8 @@ import { closeDurations, audioSamplesFor } from './copy.js';
 import { encodeJoinedAudio, targetAudioFormat } from './audio.js';
 import { drawFitted } from './draw.js';
 import { pickH264Codec } from './shared/video-support.js';
+import { decoderConfig, averageFps, micros, settle } from './shared/webcodecs.js';
+import { throwIfAborted } from './shared/errors.js';
 
 /** Divides evenly by 24, 25, 30, 50 and 60 fps. */
 const VIDEO_TIMESCALE = 90000;
@@ -42,42 +44,8 @@ const QUALITY_HEADROOM = { low: 0.8, medium: 1.25, high: 2 };
 const MIN_BITRATE = 200_000;
 const MAX_BITRATE = 60_000_000;
 
-/** Frames in flight before the feed loop waits for the pipeline to catch up. */
-const QUEUE_LIMIT = 8;
-
 /** Seconds between keyframes in the output, so seeking stays usable. */
 const KEYFRAME_SECONDS = 2;
-
-class AbortedError extends Error {
-  constructor() {
-    super('Trim cancelled.');
-    this.name = 'AbortError';
-  }
-}
-
-function throwIfAborted(signal) {
-  if (signal?.aborted) throw new AbortedError();
-}
-
-/** The configuration VideoDecoder needs to open this track. */
-export function decoderConfig(video) {
-  const config = {
-    codec: video.codec,
-    codedWidth: video.codedWidth,
-    codedHeight: video.codedHeight,
-  };
-  // VP9 carries everything it needs in the bitstream; the others hand over the
-  // configuration record the file was written with, untouched.
-  if (video.description) config.description = video.description;
-  return config;
-}
-
-/** Frames per second, averaged over the whole track. */
-export function averageFps(video) {
-  const seconds = video.duration / video.timescale;
-  if (!seconds) return 30;
-  return Math.min(240, Math.max(1, video.samples.length / seconds));
-}
 
 /** The output frame size for one clip: the picture as watched, rounded to the
  *  even numbers H.264 can describe. */
@@ -128,32 +96,6 @@ export function chooseJoinBitrate({ clips, frame, fps, quality }) {
     }));
   }
   return best;
-}
-
-/** Wait until both queues have drained below the limit. */
-async function settle(decoder, encoder) {
-  while (decoder.decodeQueueSize > QUEUE_LIMIT || encoder.encodeQueueSize > QUEUE_LIMIT) {
-    await new Promise((resolve) => {
-      let settled = false;
-      const done = () => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(timer);
-        decoder.removeEventListener('dequeue', done);
-        encoder.removeEventListener('dequeue', done);
-        resolve();
-      };
-      // `dequeue` is not in every implementation yet, so cap the wait.
-      const timer = setTimeout(done, 20);
-      decoder.addEventListener('dequeue', done);
-      encoder.addEventListener('dequeue', done);
-    });
-  }
-}
-
-/** Presentation time in microseconds, which is what WebCodecs counts in. */
-function micros(ticks, timescale) {
-  return Math.round(ticks / timescale * 1_000_000);
 }
 
 /**
@@ -346,7 +288,7 @@ export async function joinExact({
             throwIfAborted(signal);
             if (failure) throw failure;
 
-            await settle(decoder, encoder);
+            await settle([decoder, encoder]);
 
             const sample = video.samples[i];
             const data = await window.read(sample.offset, sample.size);

--- a/tools/trim-video/tool.toml
+++ b/tools/trim-video/tool.toml
@@ -33,7 +33,7 @@ css_parts = ["progress"]
 # Shared modules this tool asks for. The same arrangement as css_parts, and for
 # the same reason: a component more than one tool needs and no tool should own.
 # file-picker brings in the drop zone.
-js_parts = ["file-picker", "codec-support", "mp4-reader", "mp4-writer", "video-support", "message-box", "media", "format"]
+js_parts = ["file-picker", "codec-support", "mp4-reader", "mp4-writer", "video-support", "message-box", "media", "format", "errors", "webcodecs", "mp4-boxes"]
 # Where a finished result can be carried without being saved first: the row of
 # links shared/handoff.js shows beside the download once there is one. Slugs of
 # tools whose picker takes what this page produces; checked against the tools

--- a/tools/video-to-gif/src/frames.js
+++ b/tools/video-to-gif/src/frames.js
@@ -26,9 +26,8 @@
 
 import { FileWindow } from './shared/mp4-reader.js';
 import { drawScaled, frameCanvas } from './draw.js';
-
-/** Frames in flight before the feed loop waits for the decoder to catch up. */
-const QUEUE_LIMIT = 8;
+import { decoderConfig, settle } from './shared/webcodecs.js';
+import { throwIfAborted } from './shared/errors.js';
 
 /**
  * How far past the last wanted instant to keep feeding the decoder.
@@ -43,30 +42,6 @@ const REORDER_SLACK = 0.5;
 
 /** Give up on a seek that never lands rather than hanging the page. */
 const SEEK_TIMEOUT = 10_000;
-
-class AbortedError extends Error {
-  constructor() {
-    super('Cancelled.');
-    this.name = 'AbortError';
-  }
-}
-
-function throwIfAborted(signal) {
-  if (signal?.aborted) throw new AbortedError();
-}
-
-/** The configuration VideoDecoder needs to open a track demux() found. */
-export function decoderConfig(video) {
-  const config = {
-    codec: video.codec,
-    codedWidth: video.codedWidth,
-    codedHeight: video.codedHeight,
-  };
-  // VP9 carries everything it needs in the bitstream; the others hand over the
-  // configuration record the file was written with, untouched.
-  if (video.description) config.description = video.description;
-  return config;
-}
 
 /**
  * Collects one RGBA buffer per wanted instant.
@@ -200,7 +175,7 @@ export async function framesByDecoding({
 
       if (sample.pts > endTicks + REORDER_SLACK * video.timescale) break;
 
-      while (decoder.decodeQueueSize > QUEUE_LIMIT) await tick(decoder);
+      await settle([decoder]);
     }
 
     await decoder.flush();
@@ -213,23 +188,6 @@ export async function framesByDecoding({
     if (decoder.state !== 'closed') decoder.close();
     canvas.width = 0;   // let the browser drop the backing store now
   }
-}
-
-/** Wait for the decoder to hand something back, with a cap in case it does not. */
-function tick(decoder) {
-  return new Promise((resolve) => {
-    let settled = false;
-    const done = () => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      decoder.removeEventListener('dequeue', done);
-      resolve();
-    };
-    // `dequeue` is not in every implementation yet, so cap the wait.
-    const timer = setTimeout(done, 20);
-    decoder.addEventListener('dequeue', done);
-  });
 }
 
 /**

--- a/tools/video-to-gif/src/main.js
+++ b/tools/video-to-gif/src/main.js
@@ -1,12 +1,13 @@
 /** UI wiring and application state. */
 
 import { phrase } from './shared/phrases.js';
+import { decoderConfig } from './shared/webcodecs.js';
 import { sizeText } from './shared/format.js';
 import { openInPlayer } from './shared/media.js';
 import { messageBox } from './shared/message-box.js';
 import { wireFilePicker } from './shared/file-picker.js';
 import { demux, UnsupportedFile } from './shared/mp4-reader.js';
-import { framesByDecoding, framesByPlaying, decoderConfig } from './frames.js';
+import { framesByDecoding, framesByPlaying } from './frames.js';
 import { encodeGif, ColorHistogram, MAX_COLORS } from './encode.js';
 import { RangeBar, formatTime, parseTime } from './range.js';
 import { frameTimes, frameDelays, outputSize, workingBytes, estimateBytes, MAX_FPS } from './plan.js';

--- a/tools/video-to-gif/tool.toml
+++ b/tools/video-to-gif/tool.toml
@@ -32,7 +32,7 @@ css_parts = ["progress"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.
-js_parts = ["file-picker", "mp4-reader", "message-box", "media", "format"]
+js_parts = ["file-picker", "mp4-reader", "message-box", "media", "format", "webcodecs", "errors"]
 # Where a finished result can be carried without being saved first: the row of
 # links shared/handoff.js shows beside the download once there is one. Slugs of
 # tools whose picker takes what this page produces; checked against the tools


### PR DESCRIPTION
Phase 3b of the shared-parts plan, and the last of the small helpers: the cancellation, the WebCodecs arithmetic and the MP4 box builders that every video tool had written for itself. Three new shared parts, nine tools, nothing a visitor sees.

## What this does

- **`shared/js/errors.js`** - `AbortedError`, `throwIfAborted(signal)` and `said(key, values)`. Eleven leaves declared an `AbortedError` of their own, each with a message ("Crop cancelled.", "Export cancelled.", "Trim cancelled.") that no page ever showed: every catch in the repository tests `error.name === 'AbortError'` and stops, which is also how the platform's own cancellations are recognised. So the one copy says nothing a visitor would read. `said` - the error whose message is a phrase key, for a module too deep to reach the page - was written seven times, in the video tools and in heic-to-jpg, and is the other half of the "a leaf returns a key" rule.
- **`shared/js/webcodecs.js`** - `decoderConfig`, `averageFps`, `micros`, `QUEUE_LIMIT` and `settle`. The first three were byte-identical wherever they appeared (five, four and four copies). `settle`, the wait that keeps a feed loop behind the codecs, existed in four shapes: a decoder and an encoder watched together (cropper, trimmer), an encoder alone (the reverser's playback path, the slideshow encoder's `applyBackpressure`), a decoder alone (the `tick` loops in timelapse-video and video-to-gif), and the reverser's exact path, which gives up after thirty seconds without progress. One function takes the codecs as a list and the stall ceiling as an option; the reverser passes `{ stallAfter: STALL_TIMEOUT_MS }` and throws the same `stall.both` key it did.
- **`shared/js/mp4-boxes.js`** - `ascii`, `bytes`, `u16`, `u32`, `i32`, `zeros`, `concat`, `box`, `fullBox`, `fourcc`: the bytes an MP4 is built out of, which `mp4-writer`, `mp4-muxer`, the cropper's own writer and the AAC description in the trimmer's and the reverser's `audio.js` had each written out. The two shared writers import it, so a tool that asks for either asks for this; the docs table says so.
- **The one behaviour change** is the slideshow encoder's poll cap, fifty milliseconds where everything else used twenty. It only matters in a browser that never fires `dequeue`, and twenty is what the other six loops have always used.
- **`js_parts`** in nine `tool.toml` files; two tests (`grab-frame`, `reverse-video`) import `micros` and `averageFps` from the shared file now; three rows in `docs/adding-a-tool.md`.

## Before and after

Nothing on any page changes: the removed sentences were never shown, the arithmetic is byte-identical, and the box builders produce the same bytes (pinned in `mp4-boxes.test.js`).

## Verified

- **Tests:** three new files. `webcodecs.test.js` drives `settle` with fake codecs and the runner's mock clock: it returns at once under the limit, waits for every codec over it, polls when no `dequeue` ever comes, gives up after `stallAfter` under the key given, and lets progress reset the stall clock. With them, every JavaScript test that touches a migrated tool or a shared writer passes under the resolve hook. `test_english_in_js`, `test_duplicates`, `test_imports` and `test_phrases` pass with no baseline moved.
- **A CI-style full build** passes and ships the new parts where they are asked for.
- **In the built cropper, served locally, the whole chain at once:** a 24-frame 320×240 MP4 made in the page by `VideoEncoder` through the shared muxer (so through `mp4-boxes`), read back by the shared reader (24 samples, `averageFps` 24), then cropped by the exact path - `decoderConfig`, `micros`, `settle([decoder, encoder])`, `throwIfAborted` and the cropper's own writer on `mp4-boxes` - to a 160×120 MP4 the reader opens again with 24 samples. The same call with an already-aborted signal throws an error named `AbortError`, which is what the page's catch looks for.

## What this closes

Phase 3. Left per tool on purpose: compress-image and compress-pdf's `bytes` (they return a key with an `{amount}` placeholder), the formatters that are still English, timelapse-video's `TimelapseWriter.busy` (a getter on its own encoder, now reading the shared `QUEUE_LIMIT`), and `withStallTimeout` in the reverser, which watches a flush rather than a queue. Next is phase 4, the near-duplicate leaves that differ by a parameter (the cropper, the two timelines, the AAC half of `audio.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
