### PR TITLE
Share the image list of the GIF maker and the slideshow maker, and let each say what a picture is held for

### DIFF
--- a/docs/adding-a-tool.md
+++ b/docs/adding-a-tool.md
@@ -88,6 +88,7 @@ A component more than one tool needs, and that no tool should own, lives under
 |---|---|---|
 | `shared/css/file-list.css` | `css_parts = ["file-list"]` | appended to the tool's stylesheet |
 | `shared/js/file-picker.js` | `js_parts = ["file-picker"]` | copied to `<tool>/src/shared/` |
+| `shared/js/image-list.js` | `js_parts = ["image-list"]` | a list of pictures to work through in order: decoded once for a thumbnail and their size, sorted, reordered, re-decoded one at a time |
 | `templates/partials/file-picker.html` | `{% include %}` in `body.html` | the drop-zone markup |
 | `shared/js/url-import.js` + its CSS | `[picker.urls]` | the "add from a web address" panel |
 | `shared/js/zip.js` | `js_parts = ["zip"]` | the stored-only archive writer |

--- a/shared/js/image-list.js
+++ b/shared/js/image-list.js
@@ -1,0 +1,110 @@
+/**
+ * A list of pictures to work through in order.
+ *
+ * GENERATED INTO EACH TOOL. This file lives at shared/js/image-list.js and
+ * the build copies it to <tool>/src/shared/image-list.js for the tools that
+ * ask for it with `js_parts = ["image-list", ...]`: the GIF maker and the
+ * slideshow maker, which carried the same file apart from the size of the
+ * thumbnail and what each picture is held for. It imports nothing.
+ *
+ * Full-size bitmaps are deliberately not kept in memory: a hundred
+ * 12-megapixel photos would be several gigabytes of decoded RGBA. Each file is
+ * decoded once on import to read its dimensions and build a small thumbnail,
+ * then closed. Export re-decodes from the File, one image at a time.
+ *
+ * What a tool adds to each item is its own business - the GIF maker holds a
+ * frame for a number of seconds, the slideshow maker for a number of frames or
+ * seconds, whichever unit was typed - so `loadImages` takes a `fields`
+ * function and spreads what it returns into the item.
+ */
+
+let nextId = 1;
+
+const isImage = (file) => file.type.startsWith('image/');
+
+async function makeThumbnail(bitmap, thumbMax) {
+  const scale = Math.min(1, thumbMax / Math.max(bitmap.width, bitmap.height));
+  const canvas = document.createElement('canvas');
+  canvas.width = Math.max(1, Math.round(bitmap.width * scale));
+  canvas.height = Math.max(1, Math.round(bitmap.height * scale));
+  canvas.getContext('2d').drawImage(bitmap, 0, 0, canvas.width, canvas.height);
+
+  const blob = await new Promise((resolve) => canvas.toBlob(resolve, 'image/jpeg', 0.8));
+  return URL.createObjectURL(blob);
+}
+
+/**
+ * @param {FileList|File[]} files
+ * @param {object} [options]
+ * @param {number} [options.thumbMax=240]  the thumbnail's longer side, in pixels
+ * @param {(file: File) => object} [options.fields]  what the tool adds to
+ *   each item - how long it is held, in the tool's own unit
+ * @returns {Promise<{items: object[], skipped: string[]}>}  `skipped` names
+ *   the files that were not images or would not decode
+ */
+export async function loadImages(files, { thumbMax = 240, fields = () => ({}) } = {}) {
+  const items = [];
+  const skipped = [];
+
+  for (const file of Array.from(files)) {
+    if (!isImage(file)) {
+      skipped.push(file.name);
+      continue;
+    }
+
+    let bitmap;
+    try {
+      // imageOrientation honours EXIF rotation, so portrait photos are not
+      // sideways in the result.
+      bitmap = await createImageBitmap(file, { imageOrientation: 'from-image' });
+    } catch {
+      skipped.push(file.name);
+      continue;
+    }
+
+    try {
+      items.push({
+        id: nextId++,
+        file,
+        name: file.name,
+        width: bitmap.width,
+        height: bitmap.height,
+        lastModified: file.lastModified,
+        ...fields(file),
+        thumbUrl: await makeThumbnail(bitmap, thumbMax),
+      });
+    } finally {
+      bitmap.close();
+    }
+  }
+
+  return { items, skipped };
+}
+
+/** Decode one item at full size. The caller owns the bitmap and must close it. */
+export function decodeFull(item) {
+  return createImageBitmap(item.file, { imageOrientation: 'from-image' });
+}
+
+/** Release an item's thumbnail object URL. */
+export function releaseItem(item) {
+  URL.revokeObjectURL(item.thumbUrl);
+}
+
+const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
+
+/** Sort in place by the given key. 'name' uses natural order, so img2 precedes img10. */
+export function sortItems(items, key) {
+  if (key === 'name') return items.sort((a, b) => collator.compare(a.name, b.name));
+  if (key === 'date') return items.sort((a, b) => a.lastModified - b.lastModified);
+  if (key === 'reverse') return items.reverse();
+  return items;
+}
+
+/** Move the item at `from` to index `to`, shifting the rest. */
+export function moveItem(items, from, to) {
+  if (to < 0 || to >= items.length || from === to) return items;
+  const [moved] = items.splice(from, 1);
+  items.splice(to, 0, moved);
+  return items;
+}

--- a/tests/js/image-list.test.js
+++ b/tests/js/image-list.test.js
@@ -1,0 +1,97 @@
+/**
+ * shared/js/image-list.js - a list of pictures to work through in order.
+ *
+ * The decode and the thumbnail are the browser's; here they are stubs that
+ * record what they were asked for, so the test can pin what the two tools
+ * that share this file relied on: a file that is not an image or will not
+ * decode is skipped by name rather than failing the batch, the full-size
+ * bitmap is closed once the thumbnail exists, the thumbnail is bounded by the
+ * size the tool names, and the tool's own fields land on the item.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { loadImages, moveItem, sortItems } from '../../shared/js/image-list.js';
+
+/** A browser that decodes any image whose name says its size, and refuses "broken". */
+function browser() {
+  const closed = [];
+  const canvases = [];
+  globalThis.createImageBitmap = async (file) => {
+    if (file.name.startsWith('broken')) throw new Error('undecodable');
+    const [width, height] = file.name.match(/(\d+)x(\d+)/).slice(1).map(Number);
+    return { width, height, close: () => closed.push(file.name) };
+  };
+  globalThis.document = {
+    createElement: () => {
+      const canvas = {
+        getContext: () => ({ drawImage() {} }),
+        toBlob: (resolve) => resolve({ size: canvas.width * canvas.height }),
+      };
+      canvases.push(canvas);
+      return canvas;
+    },
+  };
+  globalThis.URL.createObjectURL = (blob) => `blob:${blob.size}`;
+  return { closed, canvases };
+}
+
+const file = (name, type = 'image/jpeg', lastModified = 0) => ({ name, type, lastModified });
+
+test('images are decoded once, measured, thumbnailed within the size given, and closed', async () => {
+  const { closed, canvases } = browser();
+  const { items, skipped } = await loadImages(
+    [file('a-4000x3000.jpg'), file('b-100x50.png', 'image/png')],
+    { thumbMax: 200, fields: () => ({ delay: 0.5 }) });
+
+  assert.deepEqual(skipped, []);
+  assert.equal(items.length, 2);
+  assert.deepEqual(
+    items.map(({ name, width, height, delay }) => ({ name, width, height, delay })),
+    [{ name: 'a-4000x3000.jpg', width: 4000, height: 3000, delay: 0.5 },
+      { name: 'b-100x50.png', width: 100, height: 50, delay: 0.5 }]);
+  assert.deepEqual([canvases[0].width, canvases[0].height], [200, 150], 'scaled to the longer side');
+  assert.deepEqual([canvases[1].width, canvases[1].height], [100, 50], 'never scaled up');
+  assert.ok(items[0].thumbUrl.startsWith('blob:'));
+  assert.deepEqual(closed, ['a-4000x3000.jpg', 'b-100x50.png']);
+  assert.ok(items[1].id > items[0].id);
+});
+
+test('a file that is not an image or will not decode is skipped by name', async () => {
+  browser();
+  const { items, skipped } = await loadImages(
+    [file('notes.txt', 'text/plain'), file('broken-10x10.jpg'), file('ok-10x10.jpg')]);
+  assert.deepEqual(skipped, ['notes.txt', 'broken-10x10.jpg']);
+  assert.deepEqual(items.map((item) => item.name), ['ok-10x10.jpg']);
+});
+
+test('the tool decides what else an item carries', async () => {
+  browser();
+  const { items } = await loadImages([file('ok-10x10.jpg')], {
+    fields: () => ({ frames: 12, seconds: 0.5 }),
+  });
+  assert.equal(items[0].frames, 12);
+  assert.equal(items[0].seconds, 0.5);
+  assert.equal('delay' in items[0], false);
+});
+
+test('sorting is natural by name, by date, or reversed, in place', () => {
+  const items = [
+    { name: 'img10.jpg', lastModified: 3 },
+    { name: 'img2.jpg', lastModified: 1 },
+    { name: 'IMG1.jpg', lastModified: 2 },
+  ];
+  assert.deepEqual(sortItems(items, 'name').map((i) => i.name), ['IMG1.jpg', 'img2.jpg', 'img10.jpg']);
+  assert.deepEqual(sortItems(items, 'date').map((i) => i.lastModified), [1, 2, 3]);
+  assert.deepEqual(sortItems(items, 'reverse').map((i) => i.lastModified), [3, 2, 1]);
+  assert.equal(sortItems(items, 'unknown'), items);
+});
+
+test('moving an item shifts the rest and refuses a place off the end', () => {
+  const items = ['a', 'b', 'c', 'd'];
+  assert.deepEqual(moveItem(items, 0, 2), ['b', 'c', 'a', 'd']);
+  assert.deepEqual(moveItem(items, 3, 0), ['d', 'b', 'c', 'a']);
+  assert.deepEqual(moveItem(items, 1, 4), ['d', 'b', 'c', 'a']);
+  assert.deepEqual(moveItem(items, 2, 2), ['d', 'b', 'c', 'a']);
+});

--- a/tools/gif-maker/src/images.js
+++ b/tools/gif-maker/src/images.js
@@ -1,12 +1,13 @@
 /**
- * Loading and ordering the source images.
- *
- * Full-size bitmaps are deliberately not kept in memory: a hundred 12-megapixel
- * photos would be several gigabytes of decoded RGBA. Each file is decoded once
- * on import to read its dimensions and build a small thumbnail, then closed.
- * Export re-decodes from the File, one image at a time.
+ * The GIF maker's image list: shared/js/image-list.js, with each picture
+ * held for a number of seconds, and the rules about how long that can be.
  */
 
+import { loadImages as loadList } from './shared/image-list.js';
+
+export { decodeFull, moveItem, releaseItem, sortItems } from './shared/image-list.js';
+
+/** The longer side of a thumbnail in the list, in pixels. */
 const THUMB_MAX = 200;
 
 /**
@@ -28,63 +29,13 @@ export const DEFAULT_DELAY = 0.5;
 export const MIN_DELAY = 0.02;
 export const MAX_DELAY = 60;
 
-let nextId = 1;
-
-const isImage = (file) => file.type.startsWith('image/');
-
-async function makeThumbnail(bitmap) {
-  const scale = Math.min(1, THUMB_MAX / Math.max(bitmap.width, bitmap.height));
-  const canvas = document.createElement('canvas');
-  canvas.width = Math.max(1, Math.round(bitmap.width * scale));
-  canvas.height = Math.max(1, Math.round(bitmap.height * scale));
-  canvas.getContext('2d').drawImage(bitmap, 0, 0, canvas.width, canvas.height);
-
-  const blob = await new Promise((resolve) => canvas.toBlob(resolve, 'image/jpeg', 0.8));
-  return URL.createObjectURL(blob);
-}
-
 /**
  * @param {FileList|File[]} files
  * @param {number} delay  seconds each new image is held
  * @returns {Promise<{items: object[], skipped: string[]}>}
  */
-export async function loadImages(files, delay) {
-  const items = [];
-  const skipped = [];
-
-  for (const file of Array.from(files)) {
-    if (!isImage(file)) {
-      skipped.push(file.name);
-      continue;
-    }
-
-    let bitmap;
-    try {
-      // imageOrientation honours EXIF rotation, so portrait photos are not
-      // sideways in the animation.
-      bitmap = await createImageBitmap(file, { imageOrientation: 'from-image' });
-    } catch {
-      skipped.push(file.name);
-      continue;
-    }
-
-    try {
-      items.push({
-        id: nextId++,
-        file,
-        name: file.name,
-        width: bitmap.width,
-        height: bitmap.height,
-        lastModified: file.lastModified,
-        delay: clampDelay(delay),
-        thumbUrl: await makeThumbnail(bitmap),
-      });
-    } finally {
-      bitmap.close();
-    }
-  }
-
-  return { items, skipped };
+export function loadImages(files, delay) {
+  return loadList(files, { thumbMax: THUMB_MAX, fields: () => ({ delay: clampDelay(delay) }) });
 }
 
 /** A delay in seconds, rounded to the hundredths the format actually stores. */
@@ -92,32 +43,4 @@ export function clampDelay(seconds) {
   const value = Number(seconds);
   if (!Number.isFinite(value)) return DEFAULT_DELAY;
   return Math.min(MAX_DELAY, Math.max(MIN_DELAY, Math.round(value * 100) / 100));
-}
-
-/** Decode one item at full size. The caller owns the bitmap and must close it. */
-export function decodeFull(item) {
-  return createImageBitmap(item.file, { imageOrientation: 'from-image' });
-}
-
-/** Release an item's thumbnail object URL. */
-export function releaseItem(item) {
-  URL.revokeObjectURL(item.thumbUrl);
-}
-
-const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
-
-/** Sort in place by the given key. 'name' uses natural order, so img2 precedes img10. */
-export function sortItems(items, key) {
-  if (key === 'name') return items.sort((a, b) => collator.compare(a.name, b.name));
-  if (key === 'date') return items.sort((a, b) => a.lastModified - b.lastModified);
-  if (key === 'reverse') return items.reverse();
-  return items;
-}
-
-/** Move the item at `from` to index `to`, shifting the rest. */
-export function moveItem(items, from, to) {
-  if (to < 0 || to >= items.length || from === to) return items;
-  const [moved] = items.splice(from, 1);
-  items.splice(to, 0, moved);
-  return items;
 }

--- a/tools/gif-maker/tool.toml
+++ b/tools/gif-maker/tool.toml
@@ -32,7 +32,7 @@ css_parts = ["progress"]
 # Shared modules this tool asks for. The same arrangement as css_parts, and for
 # the same reason: a component more than one tool needs and no tool should own.
 # file-picker brings in the drop zone.
-js_parts = ["file-picker", "message-box", "format", "errors"]
+js_parts = ["file-picker", "message-box", "format", "errors", "image-list"]
 # Where a finished result can be carried without being saved first: the row of
 # links shared/handoff.js shows beside the download once there is one. Slugs of
 # tools whose picker takes what this page produces; checked against the tools

--- a/tools/images-to-video/src/images.js
+++ b/tools/images-to-video/src/images.js
@@ -1,31 +1,14 @@
 /**
- * Loading and ordering the source images.
- *
- * Full-size bitmaps are deliberately *not* kept in memory: a hundred 12-megapixel
- * photos would be several gigabytes of decoded RGBA. Instead each file is decoded
- * once on import to read its dimensions and build a small thumbnail, then closed.
- * Export re-decodes from the File one image at a time.
+ * The slideshow maker's image list: shared/js/image-list.js, with each
+ * picture held for a number of frames or of seconds.
  */
 
+import { loadImages as loadList } from './shared/image-list.js';
+
+export { decodeFull, moveItem, releaseItem, sortItems } from './shared/image-list.js';
+
+/** The longer side of a thumbnail in the list, in pixels. */
 const THUMB_MAX = 240;
-
-let nextId = 1;
-
-/** @returns {boolean} */
-function isSupportedImage(file) {
-  return file.type.startsWith('image/');
-}
-
-async function makeThumbnail(bitmap) {
-  const scale = Math.min(1, THUMB_MAX / Math.max(bitmap.width, bitmap.height));
-  const canvas = document.createElement('canvas');
-  canvas.width = Math.max(1, Math.round(bitmap.width * scale));
-  canvas.height = Math.max(1, Math.round(bitmap.height * scale));
-  canvas.getContext('2d').drawImage(bitmap, 0, 0, canvas.width, canvas.height);
-
-  const blob = await new Promise((resolve) => canvas.toBlob(resolve, 'image/jpeg', 0.8));
-  return URL.createObjectURL(blob);
-}
 
 /**
  * Each item carries both a frame count and a seconds value. Which one is used
@@ -33,72 +16,12 @@ async function makeThumbnail(bitmap) {
  * and forth never loses what was typed.
  *
  * @param {FileList|File[]} files
- * @param {{frames: number, seconds: number}} defaults how long each new image is held
+ * @param {{frames: number, seconds: number}} defaults  how long each new image is held
  * @returns {Promise<{items: object[], skipped: string[]}>}
  */
-export async function loadImages(files, defaults) {
-  const items = [];
-  const skipped = [];
-
-  for (const file of Array.from(files)) {
-    if (!isSupportedImage(file)) {
-      skipped.push(file.name);
-      continue;
-    }
-
-    let bitmap;
-    try {
-      // imageOrientation honours EXIF rotation so portrait photos are not sideways.
-      bitmap = await createImageBitmap(file, { imageOrientation: 'from-image' });
-    } catch {
-      skipped.push(file.name);
-      continue;
-    }
-
-    try {
-      items.push({
-        id: nextId++,
-        file,
-        name: file.name,
-        width: bitmap.width,
-        height: bitmap.height,
-        lastModified: file.lastModified,
-        frames: defaults.frames,
-        seconds: defaults.seconds,
-        thumbUrl: await makeThumbnail(bitmap),
-      });
-    } finally {
-      bitmap.close();
-    }
-  }
-
-  return { items, skipped };
-}
-
-/** Decode one item at full size. The caller owns the bitmap and must close it. */
-export function decodeFull(item) {
-  return createImageBitmap(item.file, { imageOrientation: 'from-image' });
-}
-
-/** Release an item's thumbnail object URL. */
-export function releaseItem(item) {
-  URL.revokeObjectURL(item.thumbUrl);
-}
-
-const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
-
-/** Sort in place by the given key. 'name' uses natural order, so img2 precedes img10. */
-export function sortItems(items, key) {
-  if (key === 'name') return items.sort((a, b) => collator.compare(a.name, b.name));
-  if (key === 'date') return items.sort((a, b) => a.lastModified - b.lastModified);
-  if (key === 'reverse') return items.reverse();
-  return items;
-}
-
-/** Move the item at `from` to index `to`, shifting the rest. */
-export function moveItem(items, from, to) {
-  if (to < 0 || to >= items.length || from === to) return items;
-  const [moved] = items.splice(from, 1);
-  items.splice(to, 0, moved);
-  return items;
+export function loadImages(files, defaults) {
+  return loadList(files, {
+    thumbMax: THUMB_MAX,
+    fields: () => ({ frames: defaults.frames, seconds: defaults.seconds }),
+  });
 }

--- a/tools/images-to-video/tool.toml
+++ b/tools/images-to-video/tool.toml
@@ -32,7 +32,7 @@ css_parts = ["progress"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.
-js_parts = ["file-picker", "codec-support", "mp4-muxer", "message-box", "format", "webcodecs", "errors", "mp4-boxes"]
+js_parts = ["file-picker", "codec-support", "mp4-muxer", "message-box", "format", "webcodecs", "errors", "mp4-boxes", "image-list"]
 lastmod = "2026-08-27"
 
 # --- what search engines and chat apps are told ------------------------------


### PR DESCRIPTION
Phase 4 of the shared-parts plan, fourth group: the image list the GIF maker and the slideshow maker each carried. The same list apart from the thumbnail's size and what each picture is held for. Nothing a visitor sees changes.

## What this does

- **`shared/js/image-list.js`** - `loadImages`, `decodeFull`, `releaseItem`, `sortItems`, `moveItem`: decode each file once for its size and a thumbnail, close the bitmap, keep nothing full-size (a hundred 12-megapixel photos would be gigabytes of RGBA), sort by natural name or by date, move an item, re-decode one at a time on export. `loadImages` takes `thumbMax` and a `fields` function whose result is spread into each item.
- **Each tool's `images.js`** is now the twenty lines that say its half: the GIF maker's `loadImages(files, delay)` passes a 200-pixel thumbnail and `{ delay: clampDelay(delay) }`, with `DEFAULT_DELAY`, `MIN_DELAY`, `MAX_DELAY` and `clampDelay` staying beside it (the floor is a rule about what browsers do with a GIF's delay field, and belongs to that tool); the slideshow maker's `loadImages(files, defaults)` passes 240 and `{ frames, seconds }`. `main.js`, `encode.js`, `encoder.js` and `recorder.js` import from the tool's file as before.
- `js_parts` gains `image-list` in both tools; one row in `docs/adding-a-tool.md`.

## Before and after

Nothing on either page changes: the same thumbnails at the same sizes, the same order rules, the same per-picture defaults.

## Verified

- **Tests:** the list gets its first, `image-list.test.js`, with a browser that is two stubs - a decoder that reads a file's size off its name and refuses one called `broken`, and a canvas that remembers how big it was asked to be: a 4000 × 3000 photo gets a 200 × 150 thumbnail and a 100 × 50 one is never scaled up, every bitmap is closed, a text file and an undecodable image are skipped by name rather than failing the batch, the tool's fields land on the item, natural sort puts `img2` before `img10`, and `moveItem` shifts the rest and refuses a place off the end. With it, every test touching either tool passes. `test_english_in_js`, `test_duplicates`, `test_imports` and `test_phrases` pass with a real exit code.
- **A CI-style full build** passes; both tools ship `image-list.js` in `src/shared/`.
- **In the built pages, served locally.** gif-maker: two PNGs drawn in the page (800 × 600 and 120 × 90) plus a text file, through the tool's own `loadImages(files, 0.5)`, come back as two items with their sizes, `delay: 0.5` and rising ids, the text file skipped by name; the thumbnails measure 200 × 150 and 120 × 90 (bounded by the tool's 200, never scaled up); `clampDelay` still floors at 0.02 and falls back to 0.5. Dropped on the real page, the list shows both pictures, "2 frames", "Runs for 1.00s". images-to-video: a 1200 × 300 and a 30 × 30 PNG through `loadImages(files, { frames: 12, seconds: 0.5 })` carry `frames` and `seconds` and no `delay`, thumbnails 240 × 60 and 30 × 30; `moveItem` reorders; dropped on the real page, "2 images" with both thumbnails in the list.

## What this leaves

The AAC description half of the trimmer's and the reverser's `audio.js`, which is identical apart from one phrase key and waits for #332 (both touch the trimmer's `tool.toml`). The recorder pair and the two `codecs.js` differ in what they do rather than in a parameter, and stay per tool. After that, phase 5: the stylesheet parts, which is the visible one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
