### PR TITLE
Share the results rules nineteen tools wrote alike, and prove the cascade did not move

### DIFF
--- a/docs/adding-a-tool.md
+++ b/docs/adding-a-tool.md
@@ -87,6 +87,7 @@ A component more than one tool needs, and that no tool should own, lives under
 | Part | Named in | Becomes |
 |---|---|---|
 | `shared/css/file-list.css` | `css_parts = ["file-list"]` | appended to the tool's stylesheet |
+| `shared/css/results.css` | `css_parts = ["results"]` | the source panel, the summary rows, the result and its meta line, the results list; put before the tool's own rules, so a tool that wants one of them different keeps its own |
 | `shared/js/file-picker.js` | `js_parts = ["file-picker"]` | copied to `<tool>/src/shared/` |
 | `templates/partials/file-picker.html` | `{% include %}` in `body.html` | the drop-zone markup |
 | `shared/js/url-import.js` + its CSS | `[picker.urls]` | the "add from a web address" panel |

--- a/shared/css/results.css
+++ b/shared/css/results.css
@@ -1,0 +1,136 @@
+/* ---------------------------------------------------------------- results
+   What a tool shows about the file it was given and what it made of it: the
+   source panel, the summary rows, the result and its meta line, the results
+   list and its rows.
+
+   Asked for with `css_parts = ["results"]`. Nineteen tools carried these
+   rules token for token before this file; the build puts it before a tool's
+   own stylesheet, so a tool that wants one of them different writes its own
+   rule and wins - provided it sets every property the rule here sets, or the
+   value here shows through the gap. A tool whose page has none of these
+   classes can ask for it too; a rule nothing matches costs nothing. */
+
+.source {
+  display: grid;
+  font-size: 0.88rem;
+  gap: 0 1.2rem;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  margin: 1rem 0 0;
+}
+
+.source > div {
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  gap: 0.6rem;
+  justify-content: space-between;
+  padding: 0.35rem 0;
+}
+
+.source dt {
+  color: var(--text-dim);
+  flex: none;
+}
+
+.source dd {
+  font-weight: 600;
+  margin: 0;
+  overflow-wrap: anywhere;
+  text-align: end;
+}
+
+.summary > div {
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  gap: 0.5rem;
+  justify-content: space-between;
+  padding: 0.35rem 0;
+}
+
+.result { margin-top: 1.25rem; }
+
+.result-meta {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: space-between;
+  margin-top: 0.8rem;
+}
+
+.result-meta p {
+  color: var(--text-dim);
+  font-size: 0.88rem;
+  margin: 0;
+}
+
+.results { margin-top: 1.4rem; }
+
+.results-head {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: space-between;
+  margin-bottom: 0.4rem;
+}
+
+.results-head h3 {
+  font-size: 0.95rem;
+  margin: 0;
+}
+
+.result-list {
+  display: grid;
+  gap: 0.6rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.result-name {
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin: 0;
+  word-break: break-all;
+}
+
+.result-actions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.file-name {
+  font-size: 0.92rem;
+  font-weight: 600;
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.file-sub {
+  color: var(--text-dim);
+  font-size: 0.8rem;
+  margin: 0;
+}
+
+.file-main-wrap {
+  align-items: center;
+  display: flex;
+  flex: 1;
+  gap: 0.75rem;
+  min-width: 0;
+  padding: 0.6rem 0.7rem;
+}
+
+.row-remove:hover {
+  background: color-mix(in srgb, var(--danger) 12%, transparent);
+  color: var(--danger);
+}
+
+.row-remove:disabled {
+  cursor: default;
+  opacity: 0.4;
+}

--- a/tools/compress-image/styles.css
+++ b/tools/compress-image/styles.css
@@ -27,32 +27,9 @@
   max-width: 68ch;
 }
 
-.file-main-wrap {
-  flex: 1;
-  min-width: 0;
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 0.6rem 0.7rem;
-}
-
-.file-name {
-  margin: 0;
-  font-weight: 600;
-  font-size: 0.92rem;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.file-sub { margin: 0; font-size: 0.8rem; color: var(--text-dim); }
-
 /* Said on the row itself rather than only in the results, so that "nothing
    happened to this one" is expected rather than a surprise afterwards. */
 .file-note { margin: 0.1rem 0 0; font-size: 0.78rem; color: var(--ok); font-weight: 600; }
-
-.row-remove:hover { background: color-mix(in srgb, var(--danger) 12%, transparent); color: var(--danger); }
-.row-remove:disabled { opacity: 0.4; cursor: default; }
 
 /* ------------------------------------------------------------- the target */
 
@@ -152,27 +129,12 @@
 
 /* ----------------------------------------------------------------- results */
 
-.results { margin-top: 1.4rem; }
-
-.results-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-  flex-wrap: wrap;
-  margin-bottom: 0.4rem;
-}
-
-.results-head h3 { margin: 0; font-size: 0.95rem; }
-
 .results-summary {
   margin: 0 0 0.8rem;
   font-size: 0.88rem;
   color: var(--text-dim);
   max-width: 72ch;
 }
-
-.result-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 0.6rem; }
 
 .result-row {
   display: flex;
@@ -202,8 +164,6 @@
 
 .result-text { min-width: 0; flex: 1 1 24rem; }
 
-.result-name { margin: 0; font-weight: 600; font-size: 0.9rem; word-break: break-all; }
-
 .result-headline {
   margin: 0.25rem 0 0;
   font-size: 0.95rem;
@@ -230,8 +190,6 @@
   color: var(--danger);
   max-width: 68ch;
 }
-
-.result-actions { display: flex; gap: 0.4rem; align-items: center; flex-wrap: wrap; }
 
 /* ---------------------------------------------------------------- compare */
 

--- a/tools/compress-image/tool.toml
+++ b/tools/compress-image/tool.toml
@@ -28,7 +28,7 @@ roadmap_group = "images"
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. file-list is the drop-a-file-then-see-a-row widget that
 # more than one tool needs and that no tool should own.
-css_parts = ["file-list", "progress"]
+css_parts = ["file-list", "progress", "results"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.

--- a/tools/crop-video/styles.css
+++ b/tools/crop-video/styles.css
@@ -3,30 +3,6 @@
 
 /* -------------------------------------------------------------- the source */
 
-.source {
-  margin: 1rem 0 0;
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
-  gap: 0 1.2rem;
-  font-size: 0.88rem;
-}
-
-.source > div {
-  display: flex;
-  justify-content: space-between;
-  gap: 0.6rem;
-  padding: 0.35rem 0;
-  border-bottom: 1px solid var(--border);
-}
-
-.source dt { color: var(--text-dim); flex: none; }
-.source dd {
-  margin: 0;
-  font-weight: 600;
-  text-align: end;
-  overflow-wrap: anywhere;
-}
-
 .path-note,
 .stage-note {
   margin: 0.9rem 0 0;
@@ -334,14 +310,6 @@
   gap: 0 1.2rem;
 }
 
-.summary > div {
-  display: flex;
-  justify-content: space-between;
-  gap: 0.5rem;
-  padding: 0.35rem 0;
-  border-bottom: 1px solid var(--border);
-}
-
 .summary dt { color: var(--text-dim); flex: none; }
 .summary dd {
   margin: 0;
@@ -365,8 +333,6 @@
   white-space: pre-line;
 }
 
-.result { margin-top: 1.25rem; }
-
 .result video {
   width: 100%;
   max-height: 60vh;
@@ -374,17 +340,6 @@
   background: #000;
   display: block;
 }
-
-.result-meta {
-  margin-top: 0.8rem;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  flex-wrap: wrap;
-}
-
-.result-meta p { margin: 0; font-size: 0.88rem; color: var(--text-dim); }
 
 /* The element the recording path plays into. It has to be in the page and it
    has to be painted - a browser that never composites it never presents a

--- a/tools/crop-video/tool.toml
+++ b/tools/crop-video/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "video"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress"]
+css_parts = ["progress", "results"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no

--- a/tools/edit-audio/styles.css
+++ b/tools/edit-audio/styles.css
@@ -3,30 +3,6 @@
 
 /* -------------------------------------------------------------- the source */
 
-.source {
-  margin: 1rem 0 0;
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
-  gap: 0 1.2rem;
-  font-size: 0.88rem;
-}
-
-.source > div {
-  display: flex;
-  justify-content: space-between;
-  gap: 0.6rem;
-  padding: 0.35rem 0;
-  border-bottom: 1px solid var(--border);
-}
-
-.source dt { color: var(--text-dim); flex: none; }
-.source dd {
-  margin: 0;
-  font-weight: 600;
-  text-align: end;
-  overflow-wrap: anywhere;
-}
-
 .path-note {
   margin: 0.9rem 0 0;
   padding: 0.6rem 0.8rem;
@@ -171,14 +147,6 @@ input[type="range"] {
   gap: 0 1.2rem;
 }
 
-.summary > div {
-  display: flex;
-  justify-content: space-between;
-  gap: 0.5rem;
-  padding: 0.35rem 0;
-  border-bottom: 1px solid var(--border);
-}
-
 .summary dt { color: var(--text-dim); flex: none; }
 .summary dd {
   margin: 0;
@@ -208,19 +176,6 @@ input[type="range"] {
   font-size: 0.9rem;
   white-space: pre-line;
 }
-
-.result { margin-top: 1.25rem; }
-
-.result-meta {
-  margin-top: 0.8rem;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  flex-wrap: wrap;
-}
-
-.result-meta p { margin: 0; font-size: 0.88rem; color: var(--text-dim); }
 
 @media (max-width: 620px) {
   .value-box { width: 5.5rem; }

--- a/tools/edit-audio/tool.toml
+++ b/tools/edit-audio/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "audio"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress"]
+css_parts = ["progress", "results"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts, and for
 # the same reason: a component more than one tool needs and no tool should own.

--- a/tools/extract-audio-from-video/styles.css
+++ b/tools/extract-audio-from-video/styles.css
@@ -3,30 +3,6 @@
 
 /* -------------------------------------------------------------- the source */
 
-.source {
-  margin: 1rem 0 0;
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
-  gap: 0 1.2rem;
-  font-size: 0.88rem;
-}
-
-.source > div {
-  display: flex;
-  justify-content: space-between;
-  gap: 0.6rem;
-  padding: 0.35rem 0;
-  border-bottom: 1px solid var(--border);
-}
-
-.source dt { color: var(--text-dim); flex: none; }
-.source dd {
-  margin: 0;
-  font-weight: 600;
-  text-align: end;
-  overflow-wrap: anywhere;
-}
-
 .path-note {
   margin: 0.9rem 0 0;
   padding: 0.6rem 0.8rem;
@@ -171,14 +147,6 @@ input[type="range"] {
   gap: 0 1.2rem;
 }
 
-.summary > div {
-  display: flex;
-  justify-content: space-between;
-  gap: 0.5rem;
-  padding: 0.35rem 0;
-  border-bottom: 1px solid var(--border);
-}
-
 .summary dt { color: var(--text-dim); flex: none; }
 .summary dd {
   margin: 0;
@@ -208,19 +176,6 @@ input[type="range"] {
   font-size: 0.9rem;
   white-space: pre-line;
 }
-
-.result { margin-top: 1.25rem; }
-
-.result-meta {
-  margin-top: 0.8rem;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  flex-wrap: wrap;
-}
-
-.result-meta p { margin: 0; font-size: 0.88rem; color: var(--text-dim); }
 
 @media (max-width: 620px) {
   .value-box { width: 5.5rem; }

--- a/tools/extract-audio-from-video/tool.toml
+++ b/tools/extract-audio-from-video/tool.toml
@@ -69,7 +69,7 @@ roadmap_group = "audio"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar the shared picker draws while it reads.
-css_parts = ["progress"]
+css_parts = ["progress", "results"]
 
 # Shared modules this tool asks for. file-picker brings in the drop zone.
 js_parts = ["file-picker", "audio-decode", "samplerate", "wav", "message-box", "format"]

--- a/tools/gif-maker/styles.css
+++ b/tools/gif-maker/styles.css
@@ -311,13 +311,6 @@
 }
 
 .summary { margin: 0; font-size: 0.88rem; }
-.summary > div {
-  display: flex;
-  justify-content: space-between;
-  gap: 0.5rem;
-  padding: 0.35rem 0;
-  border-bottom: 1px solid var(--border);
-}
 .summary > div:last-child { border-bottom: none; }
 .summary dt { color: var(--text-dim); }
 .summary dd { margin: 0; font-variant-numeric: tabular-nums; font-weight: 600; }
@@ -338,8 +331,6 @@
   max-height: 12rem;
   overflow-y: auto;
 }
-
-.result { margin-top: 1.25rem; }
 
 /* The finished animation is drawn on the same chequerboard the preview uses,
    because a GIF with transparency on a white card looks like a GIF with a white
@@ -364,12 +355,3 @@
   height: auto;
 }
 
-.result-meta {
-  margin-top: 0.8rem;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  flex-wrap: wrap;
-}
-.result-meta p { margin: 0; font-size: 0.88rem; color: var(--text-dim); }

--- a/tools/gif-maker/tool.toml
+++ b/tools/gif-maker/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "gif"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress"]
+css_parts = ["progress", "results"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts, and for
 # the same reason: a component more than one tool needs and no tool should own.

--- a/tools/grab-frame/styles.css
+++ b/tools/grab-frame/styles.css
@@ -3,30 +3,6 @@
 
 /* -------------------------------------------------------------- the source */
 
-.source {
-  margin: 1rem 0 0;
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
-  gap: 0 1.2rem;
-  font-size: 0.88rem;
-}
-
-.source > div {
-  display: flex;
-  justify-content: space-between;
-  gap: 0.6rem;
-  padding: 0.35rem 0;
-  border-bottom: 1px solid var(--border);
-}
-
-.source dt { color: var(--text-dim); flex: none; }
-.source dd {
-  margin: 0;
-  font-weight: 600;
-  text-align: end;
-  overflow-wrap: anywhere;
-}
-
 .path-note,
 .stage-note {
   margin: 0.9rem 0 0;

--- a/tools/grab-frame/tool.toml
+++ b/tools/grab-frame/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "video"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress"]
+css_parts = ["progress", "results"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no

--- a/tools/heic-to-jpg/styles.css
+++ b/tools/heic-to-jpg/styles.css
@@ -29,26 +29,6 @@
   max-width: 68ch;
 }
 
-.file-main-wrap {
-  flex: 1;
-  min-width: 0;
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 0.6rem 0.7rem;
-}
-
-.file-name {
-  margin: 0;
-  font-weight: 600;
-  font-size: 0.92rem;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.file-sub { margin: 0; font-size: 0.8rem; color: var(--text-dim); }
-
 /* What the metadata in this particular photo says. Dim by default, because for
    most files it is a date and a phone model and nothing to think about. */
 .file-note { margin: 0.1rem 0 0; font-size: 0.78rem; color: var(--text-dim); }
@@ -57,9 +37,6 @@
    that might change somebody's mind about the checkbox below, so it is allowed
    to be the one line that is not grey. */
 .file-note-gps { color: var(--ok); font-weight: 600; }
-
-.row-remove:hover { background: color-mix(in srgb, var(--danger) 12%, transparent); color: var(--danger); }
-.row-remove:disabled { opacity: 0.4; cursor: default; }
 
 /* ------------------------------------------------------------- the options */
 
@@ -159,27 +136,12 @@
 
 /* ----------------------------------------------------------------- results */
 
-.results { margin-top: 1.4rem; }
-
-.results-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-  flex-wrap: wrap;
-  margin-bottom: 0.4rem;
-}
-
-.results-head h3 { margin: 0; font-size: 0.95rem; }
-
 .results-summary {
   margin: 0 0 0.8rem;
   font-size: 0.88rem;
   color: var(--text-dim);
   max-width: 72ch;
 }
-
-.result-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 0.6rem; }
 
 .result-row {
   display: flex;
@@ -206,8 +168,6 @@
 
 .result-text { min-width: 0; flex: 1 1 22rem; }
 
-.result-name { margin: 0; font-weight: 600; font-size: 0.9rem; word-break: break-all; }
-
 .result-headline {
   margin: 0.25rem 0 0;
   font-size: 0.95rem;
@@ -223,4 +183,3 @@
   max-width: 68ch;
 }
 
-.result-actions { display: flex; gap: 0.4rem; align-items: center; flex-wrap: wrap; }

--- a/tools/heic-to-jpg/tool.toml
+++ b/tools/heic-to-jpg/tool.toml
@@ -31,7 +31,7 @@ roadmap_group = "images"
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. file-list is the drop-a-file-then-see-a-row widget that
 # more than one tool needs and that no tool should own.
-css_parts = ["file-list", "progress"]
+css_parts = ["file-list", "progress", "results"]
 # Shared modules this tool asks for. file-picker brings in the drop zone.
 js_parts = ["file-picker", "zip", "crc32", "message-box", "download", "format", "errors"]
 lastmod = "2026-08-27"

--- a/tools/image-to-ico/styles.css
+++ b/tools/image-to-ico/styles.css
@@ -32,31 +32,8 @@
 
 /* --------------------------------------------------------------- file list */
 
-.file-main-wrap {
-  flex: 1;
-  min-width: 0;
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 0.6rem 0.7rem;
-}
-
-.file-name {
-  margin: 0;
-  font-weight: 600;
-  font-size: 0.92rem;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.file-sub { margin: 0; font-size: 0.8rem; color: var(--text-dim); }
-
 /* The row whose picture the preview is showing. */
 .file-row.active { border-color: var(--accent); }
-
-.row-remove:hover { background: color-mix(in srgb, var(--danger) 12%, transparent); color: var(--danger); }
-.row-remove:disabled { opacity: 0.4; cursor: default; }
 
 /* Thumbnails here are logos as often as photographs, and a logo cropped to a
    square tile loses the half of it that says what the company is called. */
@@ -296,27 +273,12 @@
 
 /* ----------------------------------------------------------------- results */
 
-.results { margin-top: 1.4rem; }
-
-.results-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-  flex-wrap: wrap;
-  margin-bottom: 0.4rem;
-}
-
-.results-head h3 { margin: 0; font-size: 0.95rem; }
-
 .results-summary {
   margin: 0 0 0.8rem;
   font-size: 0.88rem;
   color: var(--text-dim);
   max-width: 72ch;
 }
-
-.result-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 0.6rem; }
 
 .result-row {
   display: flex;
@@ -331,7 +293,6 @@
 }
 
 .result-text { min-width: 0; flex: 1 1 22rem; }
-.result-name { margin: 0; font-weight: 600; font-size: 0.9rem; word-break: break-all; }
 
 .result-headline {
   margin: 0.25rem 0 0;
@@ -367,8 +328,6 @@
   background: var(--surface-2);
   color: var(--text-dim);
 }
-
-.result-actions { display: flex; gap: 0.4rem; align-items: center; flex-wrap: wrap; }
 
 /* ---------------------------------------------------------------- snippet */
 

--- a/tools/image-to-ico/tool.toml
+++ b/tools/image-to-ico/tool.toml
@@ -28,7 +28,7 @@ roadmap_group = "images"
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. file-list is the drop-a-file-then-see-a-row widget that
 # more than one tool needs and that no tool should own.
-css_parts = ["file-list", "progress"]
+css_parts = ["file-list", "progress", "results"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.

--- a/tools/images-to-video/styles.css
+++ b/tools/images-to-video/styles.css
@@ -402,13 +402,6 @@
 }
 
 .summary { margin: 0; font-size: 0.88rem; }
-.summary > div {
-  display: flex;
-  justify-content: space-between;
-  gap: 0.5rem;
-  padding: 0.35rem 0;
-  border-bottom: 1px solid var(--border);
-}
 .summary > div:last-child { border-bottom: none; }
 .summary dt { color: var(--text-dim); }
 .summary dd { margin: 0; font-variant-numeric: tabular-nums; font-weight: 600; }
@@ -431,7 +424,6 @@
   overflow-y: auto;
 }
 
-.result { margin-top: 1.25rem; }
 .result video {
   width: 100%;
   border-radius: var(--radius);
@@ -439,12 +431,3 @@
   display: block;
 }
 
-.result-meta {
-  margin-top: 0.8rem;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  flex-wrap: wrap;
-}
-.result-meta p { margin: 0; font-size: 0.88rem; color: var(--text-dim); }

--- a/tools/images-to-video/tool.toml
+++ b/tools/images-to-video/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "video"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress"]
+css_parts = ["progress", "results"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no

--- a/tools/redact-image/styles.css
+++ b/tools/redact-image/styles.css
@@ -367,8 +367,6 @@ kbd {
 
 .progress-label { margin: 0.7rem 0 0; font-size: 0.85rem; color: var(--text-dim); }
 
-.results { margin-top: 1.4rem; }
-
 .results-head {
   display: flex;
   align-items: center;
@@ -378,7 +376,6 @@ kbd {
   margin-bottom: 0.7rem;
 }
 
-.results-head h3 { margin: 0; font-size: 0.95rem; }
 .results-head .as-button { text-decoration: none; }
 
 .result-image {

--- a/tools/redact-image/tool.toml
+++ b/tools/redact-image/tool.toml
@@ -28,6 +28,9 @@ roadmap_group = "images"
 # Shared modules this tool asks for. file-picker brings in the drop zone; the
 # list of boxes underneath the picture is this tool's own, because it is a list
 # of rectangles rather than a list of files.
+# Shared stylesheet parts this tool asks for, put before its own rules by
+# the build so that its own can override them.
+css_parts = ["results"]
 js_parts = ["file-picker", "message-box"]
 lastmod = "2026-08-27"
 

--- a/tools/resize-image/styles.css
+++ b/tools/resize-image/styles.css
@@ -54,17 +54,6 @@ button.file-main-wrap:focus-visible {
   outline-offset: -2px;
 }
 
-.file-name {
-  margin: 0;
-  font-weight: 600;
-  font-size: 0.92rem;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.file-sub { margin: 0; font-size: 0.8rem; color: var(--text-dim); }
-
 /* What this row is about to become, said on the row itself rather than only
    after the run. A batch where one picture is already smaller than the size
    asked for behaves differently from the rest, and that is worth seeing
@@ -114,9 +103,6 @@ button.file-main-wrap:focus-visible {
   text-transform: uppercase;
   white-space: nowrap;
 }
-
-.row-remove:hover { background: color-mix(in srgb, var(--danger) 12%, transparent); color: var(--danger); }
-.row-remove:disabled { opacity: 0.4; cursor: default; }
 
 /* --------------------------------------------------------------- the stage */
 
@@ -456,27 +442,12 @@ button.file-main-wrap:focus-visible {
 
 /* ----------------------------------------------------------------- results */
 
-.results { margin-top: 1.4rem; }
-
-.results-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-  flex-wrap: wrap;
-  margin-bottom: 0.4rem;
-}
-
-.results-head h3 { margin: 0; font-size: 0.95rem; }
-
 .results-summary {
   margin: 0 0 0.8rem;
   font-size: 0.88rem;
   color: var(--text-dim);
   max-width: 72ch;
 }
-
-.result-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 0.6rem; }
 
 .result-row {
   display: flex;
@@ -527,8 +498,6 @@ button.file-main-wrap:focus-visible {
 
 .result-text { min-width: 0; flex: 1 1 22rem; }
 
-.result-name { margin: 0; font-weight: 600; font-size: 0.9rem; word-break: break-all; }
-
 .result-headline {
   margin: 0.25rem 0 0;
   font-size: 0.92rem;
@@ -544,8 +513,6 @@ button.file-main-wrap:focus-visible {
   color: var(--text-dim);
   max-width: 68ch;
 }
-
-.result-actions { display: flex; gap: 0.4rem; align-items: center; flex-wrap: wrap; }
 
 /* ------------------------------------------------------------------ viewer */
 

--- a/tools/resize-image/tool.toml
+++ b/tools/resize-image/tool.toml
@@ -28,7 +28,7 @@ roadmap_group = "images"
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. file-list is the drop-a-file-then-see-a-row widget that
 # more than one tool needs and that no tool should own.
-css_parts = ["file-list", "progress"]
+css_parts = ["file-list", "progress", "results"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.

--- a/tools/reverse-video/styles.css
+++ b/tools/reverse-video/styles.css
@@ -3,30 +3,6 @@
 
 /* -------------------------------------------------------------- the source */
 
-.source {
-  margin: 1rem 0 0;
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
-  gap: 0 1.2rem;
-  font-size: 0.88rem;
-}
-
-.source > div {
-  display: flex;
-  justify-content: space-between;
-  gap: 0.6rem;
-  padding: 0.35rem 0;
-  border-bottom: 1px solid var(--border);
-}
-
-.source dt { color: var(--text-dim); flex: none; }
-.source dd {
-  margin: 0;
-  font-weight: 600;
-  text-align: end;
-  overflow-wrap: anywhere;
-}
-
 .path-note,
 .stage-note {
   margin: 0.9rem 0 0;
@@ -89,14 +65,6 @@
   gap: 0 1.2rem;
 }
 
-.summary > div {
-  display: flex;
-  justify-content: space-between;
-  gap: 0.5rem;
-  padding: 0.35rem 0;
-  border-bottom: 1px solid var(--border);
-}
-
 .summary dt { color: var(--text-dim); flex: none; }
 .summary dd {
   margin: 0;
@@ -120,8 +88,6 @@
   white-space: pre-line;
 }
 
-.result { margin-top: 1.25rem; }
-
 .result video {
   width: 100%;
   max-height: 60vh;
@@ -130,13 +96,3 @@
   display: block;
 }
 
-.result-meta {
-  margin-top: 0.8rem;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  flex-wrap: wrap;
-}
-
-.result-meta p { margin: 0; font-size: 0.88rem; color: var(--text-dim); }

--- a/tools/reverse-video/tool.toml
+++ b/tools/reverse-video/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "video"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress"]
+css_parts = ["progress", "results"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no

--- a/tools/split-gif/styles.css
+++ b/tools/split-gif/styles.css
@@ -3,30 +3,6 @@
 
 /* -------------------------------------------------------------- the source */
 
-.source {
-  margin: 1rem 0 0;
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
-  gap: 0 1.2rem;
-  font-size: 0.88rem;
-}
-
-.source > div {
-  display: flex;
-  justify-content: space-between;
-  gap: 0.6rem;
-  padding: 0.35rem 0;
-  border-bottom: 1px solid var(--border);
-}
-
-.source dt { color: var(--text-dim); flex: none; }
-.source dd {
-  margin: 0;
-  font-weight: 600;
-  text-align: end;
-  overflow-wrap: anywhere;
-}
-
 .path-note {
   margin: 0.9rem 0 0;
   padding: 0.6rem 0.8rem;

--- a/tools/split-gif/tool.toml
+++ b/tools/split-gif/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "gif"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress"]
+css_parts = ["progress", "results"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts, and for
 # the same reason: a component more than one tool needs and no tool should own.

--- a/tools/stack-images/styles.css
+++ b/tools/stack-images/styles.css
@@ -188,8 +188,6 @@
 
 /* ------------------------------------------------------------- the result */
 
-.result { margin-top: 1.25rem; }
-
 /* A checkerboard behind the picture, because a stack in Lighten mode over a
    night sky is very nearly black and would otherwise be indistinguishable from
    an empty box. */
@@ -208,16 +206,5 @@
   max-height: 60vh;
   object-fit: contain;
 }
-
-.result-meta {
-  margin-top: 0.8rem;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  flex-wrap: wrap;
-}
-
-.result-meta p { margin: 0; font-size: 0.88rem; color: var(--text-dim); }
 
 .result-meta .field-note { flex-basis: 100%; }

--- a/tools/stack-images/tool.toml
+++ b/tools/stack-images/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "images"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress"]
+css_parts = ["progress", "results"]
 
 # Shared modules this tool asks for. Only the drop zone: the list underneath it
 # is this tool's own, because a row in it carries what was found inside a RAW

--- a/tools/svg-to-image/styles.css
+++ b/tools/svg-to-image/styles.css
@@ -33,26 +33,6 @@
 
 /* --------------------------------------------------------------- file list */
 
-.file-main-wrap {
-  flex: 1;
-  min-width: 0;
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 0.6rem 0.7rem;
-}
-
-.file-name {
-  margin: 0;
-  font-weight: 600;
-  font-size: 0.92rem;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.file-sub { margin: 0; font-size: 0.8rem; color: var(--text-dim); }
-
 /* The size this row is about to come out at, which is the number the page
    exists to settle. Kept beside the size it came from, so the two can be read
    against each other without moving your eyes off the row. */
@@ -68,9 +48,6 @@
 
 /* The row whose drawing the preview is showing. */
 .file-row.active { border-color: var(--accent); }
-
-.row-remove:hover { background: color-mix(in srgb, var(--danger) 12%, transparent); color: var(--danger); }
-.row-remove:disabled { opacity: 0.4; cursor: default; }
 
 /* A thumbnail here is a logo far more often than a photograph, and a logo
    cropped to a square tile loses the half of it that says what the company is
@@ -238,27 +215,12 @@
 
 /* ----------------------------------------------------------------- results */
 
-.results { margin-top: 1.4rem; }
-
-.results-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-  flex-wrap: wrap;
-  margin-bottom: 0.4rem;
-}
-
-.results-head h3 { margin: 0; font-size: 0.95rem; }
-
 .results-summary {
   margin: 0 0 0.8rem;
   font-size: 0.88rem;
   color: var(--text-dim);
   max-width: 72ch;
 }
-
-.result-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 0.6rem; }
 
 .result-row {
   display: flex;
@@ -273,7 +235,6 @@
 }
 
 .result-text { min-width: 0; flex: 1 1 22rem; }
-.result-name { margin: 0; font-weight: 600; font-size: 0.9rem; word-break: break-all; }
 
 .result-headline {
   margin: 0.25rem 0 0;
@@ -290,8 +251,6 @@
   color: var(--text-dim);
   max-width: 68ch;
 }
-
-.result-actions { display: flex; gap: 0.4rem; align-items: center; flex-wrap: wrap; }
 
 @media (max-width: 620px) {
   .preview-stage { padding: 0.6rem; }

--- a/tools/svg-to-image/tool.toml
+++ b/tools/svg-to-image/tool.toml
@@ -28,7 +28,7 @@ roadmap_group = "images"
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. file-list is the drop-a-file-then-see-a-row widget that
 # more than one tool needs and that no tool should own.
-css_parts = ["file-list", "progress"]
+css_parts = ["file-list", "progress", "results"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.

--- a/tools/timelapse-video/styles.css
+++ b/tools/timelapse-video/styles.css
@@ -22,30 +22,6 @@
   background: #000;
 }
 
-.source {
-  margin: 1rem 0 0;
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
-  gap: 0 1.2rem;
-  font-size: 0.88rem;
-}
-
-.source > div {
-  display: flex;
-  justify-content: space-between;
-  gap: 0.6rem;
-  padding: 0.35rem 0;
-  border-bottom: 1px solid var(--border);
-}
-
-.source dt { color: var(--text-dim); flex: none; }
-.source dd {
-  margin: 0;
-  font-weight: 600;
-  text-align: end;
-  overflow-wrap: anywhere;
-}
-
 .path-note {
   margin: 0.9rem 0 0;
   padding: 0.6rem 0.8rem;
@@ -145,14 +121,6 @@
   gap: 0 1.2rem;
 }
 
-.summary > div {
-  display: flex;
-  justify-content: space-between;
-  gap: 0.5rem;
-  padding: 0.35rem 0;
-  border-bottom: 1px solid var(--border);
-}
-
 .summary dt { color: var(--text-dim); flex: none; }
 .summary dd {
   margin: 0;
@@ -182,8 +150,6 @@
   white-space: pre-line;
 }
 
-.result { margin-top: 1.25rem; }
-
 .result video {
   width: 100%;
   max-height: 60vh;
@@ -192,13 +158,3 @@
   display: block;
 }
 
-.result-meta {
-  margin-top: 0.8rem;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  flex-wrap: wrap;
-}
-
-.result-meta p { margin: 0; font-size: 0.88rem; color: var(--text-dim); }

--- a/tools/timelapse-video/tool.toml
+++ b/tools/timelapse-video/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "video"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress"]
+css_parts = ["progress", "results"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no

--- a/tools/trim-audio/styles.css
+++ b/tools/trim-audio/styles.css
@@ -3,30 +3,6 @@
 
 /* ---------------------------------------------------------- what was opened */
 
-.source {
-  margin: 1rem 0 0;
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
-  gap: 0 1.2rem;
-  font-size: 0.88rem;
-}
-
-.source > div {
-  display: flex;
-  justify-content: space-between;
-  gap: 0.6rem;
-  padding: 0.35rem 0;
-  border-bottom: 1px solid var(--border);
-}
-
-.source dt { color: var(--text-dim); flex: none; }
-.source dd {
-  margin: 0;
-  font-weight: 600;
-  text-align: end;
-  overflow-wrap: anywhere;
-}
-
 .path-note {
   margin: 0.9rem 0 0;
   padding: 0.6rem 0.8rem;
@@ -426,14 +402,6 @@ audio.player {
   gap: 0 1.2rem;
 }
 
-.summary > div {
-  display: flex;
-  justify-content: space-between;
-  gap: 0.5rem;
-  padding: 0.35rem 0;
-  border-bottom: 1px solid var(--border);
-}
-
 .summary dt { color: var(--text-dim); flex: none; }
 .summary dd { margin: 0; font-weight: 600; text-align: end; overflow-wrap: anywhere; }
 
@@ -457,19 +425,6 @@ audio.player {
   font-size: 0.9rem;
   white-space: pre-line;
 }
-
-.result { margin-top: 1.25rem; }
-
-.result-meta {
-  margin-top: 0.8rem;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  flex-wrap: wrap;
-}
-
-.result-meta p { margin: 0; font-size: 0.88rem; color: var(--text-dim); }
 
 @media (max-width: 620px) {
   .tl-track { height: 84px; }

--- a/tools/trim-audio/tool.toml
+++ b/tools/trim-audio/tool.toml
@@ -35,7 +35,7 @@ roadmap_group = "audio"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress"]
+css_parts = ["progress", "results"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts, and for
 # the same reason: a component more than one tool needs and no tool should own.

--- a/tools/trim-video/styles.css
+++ b/tools/trim-video/styles.css
@@ -492,14 +492,6 @@ kbd {
   gap: 0 1.2rem;
 }
 
-.summary > div {
-  display: flex;
-  justify-content: space-between;
-  gap: 0.5rem;
-  padding: 0.35rem 0;
-  border-bottom: 1px solid var(--border);
-}
-
 .summary dt { color: var(--text-dim); flex: none; }
 .summary dd { margin: 0; font-weight: 600; text-align: end; overflow-wrap: anywhere; }
 
@@ -524,8 +516,6 @@ kbd {
   white-space: pre-line;
 }
 
-.result { margin-top: 1.25rem; }
-
 .result video {
   width: 100%;
   max-height: 60vh;
@@ -533,17 +523,6 @@ kbd {
   background: #000;
   display: block;
 }
-
-.result-meta {
-  margin-top: 0.8rem;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  flex-wrap: wrap;
-}
-
-.result-meta p { margin: 0; font-size: 0.88rem; color: var(--text-dim); }
 
 /* The element the recording path plays into. It has to be in the page and it
    has to be painted - a browser that never composites it never presents a

--- a/tools/trim-video/tool.toml
+++ b/tools/trim-video/tool.toml
@@ -28,7 +28,7 @@ roadmap_group = "video"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress"]
+css_parts = ["progress", "results"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts, and for
 # the same reason: a component more than one tool needs and no tool should own.

--- a/tools/video-to-gif/styles.css
+++ b/tools/video-to-gif/styles.css
@@ -3,30 +3,6 @@
 
 /* -------------------------------------------------------------- the source */
 
-.source {
-  margin: 1rem 0 0;
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
-  gap: 0 1.2rem;
-  font-size: 0.88rem;
-}
-
-.source > div {
-  display: flex;
-  justify-content: space-between;
-  gap: 0.6rem;
-  padding: 0.35rem 0;
-  border-bottom: 1px solid var(--border);
-}
-
-.source dt { color: var(--text-dim); flex: none; }
-.source dd {
-  margin: 0;
-  font-weight: 600;
-  text-align: end;
-  overflow-wrap: anywhere;
-}
-
 .path-note,
 .stage-note {
   margin: 0.9rem 0 0;
@@ -225,14 +201,6 @@
   gap: 0 1.2rem;
 }
 
-.summary > div {
-  display: flex;
-  justify-content: space-between;
-  gap: 0.5rem;
-  padding: 0.35rem 0;
-  border-bottom: 1px solid var(--border);
-}
-
 .summary dt { color: var(--text-dim); flex: none; }
 .summary dd {
   margin: 0;
@@ -256,8 +224,6 @@
   white-space: pre-line;
 }
 
-.result { margin-top: 1.25rem; }
-
 /* The result is an <img>, so the browser animates it: what is on the page is
    the file, playing, rather than a preview of it. The ground behind it shows
    only while it is still arriving - every frame a GIF from here writes is
@@ -272,13 +238,3 @@
   background: var(--surface-2);
 }
 
-.result-meta {
-  margin-top: 0.8rem;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  flex-wrap: wrap;
-}
-
-.result-meta p { margin: 0; font-size: 0.88rem; color: var(--text-dim); }

--- a/tools/video-to-gif/tool.toml
+++ b/tools/video-to-gif/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "gif"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress"]
+css_parts = ["progress", "results"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no


### PR DESCRIPTION
Phase 5 of the shared-parts plan, first part: the stylesheet rules for a tool's results that nineteen tools carried token for token. Nothing a visitor sees changes, and this time that is proved rather than photographed.

## What this does

- **`shared/css/results.css`** - nineteen rules: the source panel (`.source`, its rows, `dt`/`dd`), the summary rows (`.summary > div`), the result and its meta line (`.result`, `.result-meta`, `.result-meta p`), and the results list (`.results`, `.results-head`, `.results-head h3`, `.result-list`, `.result-name`, `.result-actions`, `.file-name`, `.file-sub`, `.file-main-wrap`, `.row-remove:hover`, `.row-remove:disabled`). Each is the body every tool that had it agreed on.
- **Nineteen tools ask for it** (`css_parts = ["results"]`) and lose the copies: 135 rules, 648 lines. A tool that wants one of these rules different keeps its own - `resize-image`'s `.file-main-wrap`, `redact-image`'s `.results-head` - and its own wins, because the build puts parts before a tool's stylesheet.
- **Four tools are left out, with their own rules intact,** because the part would have changed them: `exif-editor` (its `.file-name` and `.file-sub` carry no `margin`, which the part's do), `id-photo` and `image-to-data-uri` (their results head and result name are their own shapes), `images-to-pdf` (its `.result-meta` sits differently). Those are the four the extraction refused, not a hand-picked list.
- One row in `docs/adding-a-tool.md`.

## How it was kept invisible

Two tests decided who may ask for the part, applied by the extraction script rather than by eye:

1. A tool's own rule for a part selector must set every property the part sets. Otherwise the part's value would show through the gap - a `margin: 0` a tool never wrote would appear on its file names - and the tool is left out.
2. A selector the part brings that a tool never styled is harmless only if nothing on that page carries the class: not in `body.html`, and not in anything its scripts create (`className`, `classList`, `class="…"` in a template, `querySelector('.…')`). Otherwise the tool is left out.

Then the proof: all thirty-two candidate tools were built before and after, unminified, and the **cascade** of each built stylesheet - the declaration that finally wins for every selector, inside and outside media queries - was compared. **Zero differ.** The 224 selectors the part adds where a tool had none are all for classes that page never uses, by the second test above.

## Before and after

Nothing on any page changes: the same declarations win for every selector on all nineteen pages, and the four pages the part would have touched do not take it.

## Verified

- The cascade comparison above, over 32 built tools (19 asking, 13 not).
- **A CI-style full build** passes, the new part minified with the rest.
- `test_english_in_js`, `test_duplicates`, `test_imports` and `test_phrases` pass.

## What this leaves

The rest of phase 5, the same way: the form vocabulary (`.field`, `.card-lede`, `.check`, `.option-row`, `.options`, `.run-row` - the biggest family, and the one where the tools disagree most), the notes (`.error` in three margins, `.path-note`), the text tools' panes, and the modes. Each will carry the same before-and-after cascade proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
