### PR TITLE
Share the form vocabulary thirty-three tools wrote alike

### DIFF
--- a/docs/adding-a-tool.md
+++ b/docs/adding-a-tool.md
@@ -88,6 +88,7 @@ A component more than one tool needs, and that no tool should own, lives under
 |---|---|---|
 | `shared/css/file-list.css` | `css_parts = ["file-list"]` | appended to the tool's stylesheet |
 | `shared/css/results.css` | `css_parts = ["results"]` | the source panel, the summary rows, the result and its meta line, the results list; put before the tool's own rules, so a tool that wants one of them different keeps its own |
+| `shared/css/form.css` | `css_parts = ["form"]` | the controls' vocabulary: fields and their notes, the card lede, the big button, option rows, the options box, the run and export rows, number fields |
 | `shared/js/file-picker.js` | `js_parts = ["file-picker"]` | copied to `<tool>/src/shared/` |
 | `shared/js/image-list.js` | `js_parts = ["image-list"]` | a list of pictures to work through in order: decoded once for a thumbnail and their size, sorted, reordered, re-decoded one at a time |
 | `templates/partials/file-picker.html` | `{% include %}` in `body.html` | the drop-zone markup |

--- a/shared/css/form.css
+++ b/shared/css/form.css
@@ -1,0 +1,97 @@
+/* ------------------------------------------------------------------- form
+   The vocabulary of a tool's controls: a labelled field and its note, the
+   summary line under a group of them, the lede of a card, the large button,
+   the option rows and the options box, the row the run or export button
+   sits in, and the number fields.
+
+   Asked for with `css_parts = ["form"]`. Thirty-three tools carried these
+   rules token for token before this file; the build puts it before a tool's
+   own stylesheet, so a tool that wants one of them different writes its own
+   rule and wins - provided it sets every property the rule here sets, or the
+   value here shows through the gap. `.option-row` itself is not here: the
+   tools disagree on its width and its margin, so each keeps its own. */
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.field-note {
+  color: var(--text-dim);
+  font-size: 0.78rem;
+  margin: 0;
+}
+
+.field-summary {
+  color: var(--text-dim);
+  font-size: 0.86rem;
+  line-height: 1.55;
+  margin: 0.9rem 0 0;
+  max-width: 72ch;
+}
+
+.card-lede {
+  color: var(--text-dim);
+  font-size: 0.92rem;
+  line-height: 1.6;
+  margin: -0.4rem 0 1.1rem;
+  max-width: 68ch;
+}
+
+.big {
+  font-size: 1.02rem;
+  padding: 0.7rem 1.3rem;
+}
+
+.option-row label {
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.option-row select {
+  max-width: 100%;
+  min-width: 0;
+}
+
+.options {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  margin: 1.2rem 0 0;
+  padding: 0.9rem 1rem;
+}
+
+.options legend {
+  color: var(--text-dim);
+  font-size: 0.85rem;
+  font-weight: 700;
+  padding: 0 0.4rem;
+}
+
+.run-row {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.9rem;
+}
+
+.export-row {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.numbers input {
+  font-variant-numeric: tabular-nums;
+  width: 6.5rem;
+}
+
+.numbers label {
+  color: var(--text-dim);
+  display: flex;
+  flex-direction: column;
+  font-size: 0.8rem;
+  gap: 0.2rem;
+}

--- a/tools/base64/styles.css
+++ b/tools/base64/styles.css
@@ -3,7 +3,6 @@
 
 /* ------------------------------------------------------------- the options */
 
-.field { display: flex; flex-direction: column; gap: 0.3rem; }
 .field > label { font-size: 0.85rem; font-weight: 600; }
 .field-note { margin: 0.15rem 0 0; font-size: 0.78rem; color: var(--text-dim); }
 .field-note:empty { display: none; }

--- a/tools/base64/tool.toml
+++ b/tools/base64/tool.toml
@@ -38,6 +38,10 @@ category = "text-codes-and-passwords"
 # It sits at the top of that group as a link, above the names still to be built.
 roadmap_group = "beyond"
 
+# Shared stylesheet parts this tool asks for, put before its own rules by
+# the build so that its own can override them.
+css_parts = ["form"]
+
 # Shared modules this tool asks for. file-picker brings in the drop zone, which
 # is here for the file that is easier to drop than to open, select all and copy.
 js_parts = ["file-picker", "message-box", "download", "format"]

--- a/tools/compare-heights/styles.css
+++ b/tools/compare-heights/styles.css
@@ -18,22 +18,6 @@
   white-space: pre-line;
 }
 
-.card-lede {
-  margin: -0.4rem 0 1.1rem;
-  font-size: 0.92rem;
-  line-height: 1.6;
-  color: var(--text-dim);
-  max-width: 68ch;
-}
-
-.field-summary {
-  margin: 0.9rem 0 0;
-  font-size: 0.86rem;
-  line-height: 1.55;
-  color: var(--text-dim);
-  max-width: 72ch;
-}
-
 .field-summary.warn { color: var(--warn); }
 
 /* ------------------------------------------------------------ the row table */
@@ -204,21 +188,6 @@ body.is-reordering { user-select: none; }
 
 /* ------------------------------------------------------------- the options */
 
-.options {
-  margin: 1.2rem 0 0;
-  padding: 0.9rem 1rem;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--surface-2);
-}
-
-.options legend {
-  padding: 0 0.4rem;
-  font-size: 0.85rem;
-  font-weight: 700;
-  color: var(--text-dim);
-}
-
 .option-row {
   display: flex;
   align-items: center;
@@ -228,8 +197,6 @@ body.is-reordering { user-select: none; }
   min-width: 0;
 }
 
-.option-row label { font-size: 0.9rem; font-weight: 600; }
-.option-row select { min-width: 0; max-width: 100%; }
 .option-row input[type="number"] { width: 7rem; }
 
 .check {

--- a/tools/compare-heights/tool.toml
+++ b/tools/compare-heights/tool.toml
@@ -106,6 +106,10 @@ card = """
             centimetres or feet and inches &mdash; and download it as a PNG or
             an SVG."""
 
+# Shared stylesheet parts this tool asks for, put before its own rules by
+# the build so that its own can override them.
+css_parts = ["form"]
+
 # Shared modules this tool asks for, copied into it at src/shared/ by the
 # build: download hands the chart to the browser as a file.
 js_parts = ["download"]

--- a/tools/compress-image/styles.css
+++ b/tools/compress-image/styles.css
@@ -1,7 +1,6 @@
 /* ----------------------------------------------------- buy me a coffee */
 
 /* The one button on the page big enough to be found without reading. */
-.big { font-size: 1.02rem; padding: 0.7rem 1.3rem; }
 
 .error {
   margin: 1rem 0 0;
@@ -18,14 +17,6 @@
 }
 
 /* --------------------------------------------------------------- file list */
-
-.card-lede {
-  margin: -0.4rem 0 1.1rem;
-  font-size: 0.92rem;
-  line-height: 1.6;
-  color: var(--text-dim);
-  max-width: 68ch;
-}
 
 /* Said on the row itself rather than only in the results, so that "nothing
    happened to this one" is expected rather than a surprise afterwards. */
@@ -58,30 +49,8 @@
 /* The sentence under a control, restating what it is about to do. Every
    setting on this page has one, because "quality 0.78, scale 0.61" means
    nothing to somebody who came here to get under 500 KB. */
-.field-summary {
-  margin: 0.9rem 0 0;
-  font-size: 0.86rem;
-  line-height: 1.55;
-  color: var(--text-dim);
-  max-width: 72ch;
-}
 
 .field-summary.warn { color: var(--danger); font-weight: 600; }
-
-.options {
-  margin: 1.2rem 0 0;
-  padding: 0.9rem 1rem;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--surface-2);
-}
-
-.options legend {
-  padding: 0 0.4rem;
-  font-size: 0.85rem;
-  font-weight: 700;
-  color: var(--text-dim);
-}
 
 .option-row {
   display: flex;
@@ -91,13 +60,10 @@
   margin-bottom: 0.9rem;
 }
 
-.option-row label { font-size: 0.9rem; font-weight: 600; }
-
 /* `max-width` alone loses: a flex item's automatic minimum is min-content, and
    for a <select> that is its longest option - a whole sentence here. Without the
    `min-width`, the row stayed as wide as that sentence on a narrow screen. */
 .option-row { min-width: 0; }
-.option-row select { min-width: 0; max-width: 100%; }
 
 .check {
   display: flex;
@@ -124,8 +90,6 @@
 }
 
 /* ----------------------------------------------------------------- running */
-
-.run-row { display: flex; align-items: center; gap: 0.9rem; flex-wrap: wrap; }
 
 /* ----------------------------------------------------------------- results */
 

--- a/tools/compress-image/tool.toml
+++ b/tools/compress-image/tool.toml
@@ -28,7 +28,7 @@ roadmap_group = "images"
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. file-list is the drop-a-file-then-see-a-row widget that
 # more than one tool needs and that no tool should own.
-css_parts = ["file-list", "progress", "results"]
+css_parts = ["file-list", "progress", "results", "form"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.

--- a/tools/crop-video/styles.css
+++ b/tools/crop-video/styles.css
@@ -247,14 +247,6 @@
   gap: 0.6rem;
 }
 
-.numbers label {
-  display: flex;
-  flex-direction: column;
-  gap: 0.2rem;
-  font-size: 0.8rem;
-  color: var(--text-dim);
-}
-
 .numbers input {
   width: 6rem;
   font-variant-numeric: tabular-nums;
@@ -289,9 +281,7 @@
   gap: 0.9rem;
 }
 
-.field { display: flex; flex-direction: column; gap: 0.3rem; }
 .field > label { font-size: 0.85rem; font-weight: 600; }
-.field-note { margin: 0; font-size: 0.78rem; color: var(--text-dim); }
 
 .check {
   display: flex;
@@ -319,8 +309,6 @@
 }
 
 /* ------------------------------------------------------------------ export */
-
-.export-row { display: flex; gap: 0.6rem; align-items: center; flex-wrap: wrap; }
 
 .error {
   margin: 1rem 0 0;

--- a/tools/crop-video/tool.toml
+++ b/tools/crop-video/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "video"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "results"]
+css_parts = ["progress", "results", "form"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no

--- a/tools/edit-audio/styles.css
+++ b/tools/edit-audio/styles.css
@@ -127,7 +127,6 @@ input[type="range"] {
 }
 .check input { margin: 0; }
 
-.field { display: flex; flex-direction: column; gap: 0.3rem; }
 .field > label { font-size: 0.85rem; font-weight: 600; }
 .field-note { margin: 0.5rem 0 0; font-size: 0.78rem; color: var(--text-dim); }
 

--- a/tools/edit-audio/tool.toml
+++ b/tools/edit-audio/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "audio"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "results"]
+css_parts = ["progress", "results", "form"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts, and for
 # the same reason: a component more than one tool needs and no tool should own.

--- a/tools/exif-editor/styles.css
+++ b/tools/exif-editor/styles.css
@@ -1,7 +1,6 @@
 /* ----------------------------------------------------- buy me a coffee */
 
 /* The one button on the page big enough to be found without reading. */
-.big { font-size: 1.02rem; padding: 0.7rem 1.3rem; }
 
 .error {
   margin: 1rem 0 0;
@@ -18,14 +17,6 @@
 }
 
 /* --------------------------------------------------------------- file list */
-
-.card-lede {
-  margin: -0.4rem 0 1.1rem;
-  font-size: 0.92rem;
-  line-height: 1.6;
-  color: var(--text-dim);
-  max-width: 68ch;
-}
 
 .file-row.selected {
   border-color: var(--accent);

--- a/tools/exif-editor/tool.toml
+++ b/tools/exif-editor/tool.toml
@@ -28,7 +28,7 @@ roadmap_group = "images"
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. file-list is the drop-a-file-then-see-a-row widget that
 # more than one tool needs and that no tool should own.
-css_parts = ["file-list"]
+css_parts = ["file-list", "form"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no

--- a/tools/extract-audio-from-video/styles.css
+++ b/tools/extract-audio-from-video/styles.css
@@ -127,7 +127,6 @@ input[type="range"] {
 }
 .check input { margin: 0; }
 
-.field { display: flex; flex-direction: column; gap: 0.3rem; }
 .field > label { font-size: 0.85rem; font-weight: 600; }
 .field-note { margin: 0.5rem 0 0; font-size: 0.78rem; color: var(--text-dim); }
 

--- a/tools/extract-audio-from-video/tool.toml
+++ b/tools/extract-audio-from-video/tool.toml
@@ -69,7 +69,7 @@ roadmap_group = "audio"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar the shared picker draws while it reads.
-css_parts = ["progress", "results"]
+css_parts = ["progress", "results", "form"]
 
 # Shared modules this tool asks for. file-picker brings in the drop zone.
 js_parts = ["file-picker", "audio-decode", "samplerate", "wav", "message-box", "format"]

--- a/tools/gif-maker/styles.css
+++ b/tools/gif-maker/styles.css
@@ -243,7 +243,6 @@
   gap: 0.9rem;
 }
 
-.field { display: flex; flex-direction: column; gap: 0.3rem; }
 .field label { font-size: 0.85rem; font-weight: 600; }
 .field-note { margin: 0; font-size: 0.78rem; color: var(--text-dim); min-height: 1em; }
 
@@ -316,8 +315,6 @@
 .summary dd { margin: 0; font-variant-numeric: tabular-nums; font-weight: 600; }
 
 /* ------------------------------------------------------------------ export */
-
-.export-row { display: flex; gap: 0.6rem; align-items: center; flex-wrap: wrap; }
 
 .error {
   margin: 1rem 0 0;

--- a/tools/gif-maker/tool.toml
+++ b/tools/gif-maker/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "gif"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "results"]
+css_parts = ["progress", "results", "form"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts, and for
 # the same reason: a component more than one tool needs and no tool should own.

--- a/tools/grab-frame/styles.css
+++ b/tools/grab-frame/styles.css
@@ -120,9 +120,7 @@
   margin-bottom: 1.2rem;
 }
 
-.field { display: flex; flex-direction: column; gap: 0.3rem; }
 .field > label { font-size: 0.85rem; font-weight: 600; }
-.field-note { margin: 0; font-size: 0.78rem; color: var(--text-dim); }
 
 .inline-pair {
   display: flex;
@@ -146,8 +144,6 @@
 }
 
 /* ------------------------------------------------------------ grabbing */
-
-.export-row { display: flex; gap: 0.6rem; align-items: center; flex-wrap: wrap; }
 
 .error {
   margin: 1rem 0 0;

--- a/tools/grab-frame/tool.toml
+++ b/tools/grab-frame/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "video"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "results"]
+css_parts = ["progress", "results", "form"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no

--- a/tools/heic-to-jpg/styles.css
+++ b/tools/heic-to-jpg/styles.css
@@ -3,7 +3,6 @@
    file list is shared/css/file-list.css. */
 
 /* The one button on the page big enough to be found without reading. */
-.big { font-size: 1.02rem; padding: 0.7rem 1.3rem; }
 
 .error {
   margin: 1rem 0 0;
@@ -21,14 +20,6 @@
 
 /* --------------------------------------------------------------- file list */
 
-.card-lede {
-  margin: -0.4rem 0 1.1rem;
-  font-size: 0.92rem;
-  line-height: 1.6;
-  color: var(--text-dim);
-  max-width: 68ch;
-}
-
 /* What the metadata in this particular photo says. Dim by default, because for
    most files it is a date and a phone model and nothing to think about. */
 .file-note { margin: 0.1rem 0 0; font-size: 0.78rem; color: var(--text-dim); }
@@ -40,21 +31,6 @@
 
 /* ------------------------------------------------------------- the options */
 
-.options {
-  margin: 1.2rem 0 0;
-  padding: 0.9rem 1rem;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--surface-2);
-}
-
-.options legend {
-  padding: 0 0.4rem;
-  font-size: 0.85rem;
-  font-weight: 700;
-  color: var(--text-dim);
-}
-
 .option-row {
   display: flex;
   align-items: center;
@@ -65,9 +41,6 @@
      and for a <select> that is its longest option - a whole sentence here. */
   min-width: 0;
 }
-
-.option-row label { font-size: 0.9rem; font-weight: 600; }
-.option-row select { min-width: 0; max-width: 100%; }
 
 .inline-pair { display: flex; gap: 0.6rem; align-items: center; }
 
@@ -84,13 +57,6 @@
 }
 
 /* The sentence under a control, restating what it is about to do. */
-.field-summary {
-  margin: 0.9rem 0 0;
-  font-size: 0.86rem;
-  line-height: 1.55;
-  color: var(--text-dim);
-  max-width: 72ch;
-}
 
 .check {
   display: flex;
@@ -117,8 +83,6 @@
 }
 
 /* ----------------------------------------------------------------- running */
-
-.run-row { display: flex; align-items: center; gap: 0.9rem; flex-wrap: wrap; }
 
 /* The decoder's own line. It is the only place on this site where a page
    admits to loading a megabyte of anything, so it sits directly under the

--- a/tools/heic-to-jpg/tool.toml
+++ b/tools/heic-to-jpg/tool.toml
@@ -31,7 +31,7 @@ roadmap_group = "images"
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. file-list is the drop-a-file-then-see-a-row widget that
 # more than one tool needs and that no tool should own.
-css_parts = ["file-list", "progress", "results"]
+css_parts = ["file-list", "progress", "results", "form"]
 # Shared modules this tool asks for. file-picker brings in the drop zone.
 js_parts = ["file-picker", "zip", "crc32", "message-box", "download", "format", "errors"]
 lastmod = "2026-08-27"

--- a/tools/id-photo/styles.css
+++ b/tools/id-photo/styles.css
@@ -6,7 +6,6 @@
 */
 
 /* The one button on the page big enough to be found without reading. */
-.big { font-size: 1.02rem; padding: 0.7rem 1.3rem; }
 
 .error {
   margin: 1rem 0 0;
@@ -19,25 +18,9 @@
   white-space: pre-line;
 }
 
-.card-lede {
-  margin: -0.4rem 0 1.1rem;
-  font-size: 0.92rem;
-  line-height: 1.6;
-  color: var(--text-dim);
-  max-width: 68ch;
-}
-
 .hint-line {
   margin: 0.5rem 0 0;
   font-size: 0.84rem;
-  line-height: 1.55;
-  color: var(--text-dim);
-  max-width: 72ch;
-}
-
-.field-summary {
-  margin: 0.9rem 0 0;
-  font-size: 0.86rem;
   line-height: 1.55;
   color: var(--text-dim);
   max-width: 72ch;
@@ -51,8 +34,6 @@
   margin-bottom: 0.9rem;
   min-width: 0;
 }
-
-.option-row label { font-size: 0.9rem; font-weight: 600; }
 
 /* `max-width` alone loses: a flex item's automatic minimum is min-content, and
    for a <select> that is its longest option - a whole sentence here. */
@@ -147,16 +128,6 @@
   align-items: end;
   gap: 0.6rem;
 }
-
-.numbers label {
-  display: flex;
-  flex-direction: column;
-  gap: 0.2rem;
-  font-size: 0.8rem;
-  color: var(--text-dim);
-}
-
-.numbers input { width: 6.5rem; font-variant-numeric: tabular-nums; }
 
 /* Safari zooms the page into any field it focuses whose text is under 16px,
    and then leaves it zoomed. Sixteen only where there is a finger. */
@@ -528,8 +499,6 @@
 }
 
 /* ----------------------------------------------------------------- running */
-
-.run-row { display: flex; align-items: center; gap: 0.9rem; flex-wrap: wrap; }
 
 /* ----------------------------------------------------------------- results */
 

--- a/tools/id-photo/tool.toml
+++ b/tools/id-photo/tool.toml
@@ -26,7 +26,7 @@ roadmap_group = "images"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress"]
+css_parts = ["progress", "form"]
 
 # Shared modules this tool asks for. file-picker brings in the drop zone.
 js_parts = ["file-picker", "message-box"]

--- a/tools/image-to-data-uri/styles.css
+++ b/tools/image-to-data-uri/styles.css
@@ -16,14 +16,6 @@
   overflow-y: auto;
 }
 
-.card-lede {
-  margin: -0.4rem 0 1.1rem;
-  font-size: 0.92rem;
-  line-height: 1.6;
-  color: var(--text-dim);
-  max-width: 68ch;
-}
-
 .field-summary {
   margin: 0.9rem 0 0;
   font-size: 0.85rem;
@@ -114,14 +106,6 @@
 }
 
 /* ------------------------------------------------------------- the options */
-
-.options {
-  margin: 1.2rem 0 0;
-  padding: 0.9rem 1rem;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--surface-2);
-}
 
 .options legend {
   padding: 0 0.4rem;

--- a/tools/image-to-data-uri/tool.toml
+++ b/tools/image-to-data-uri/tool.toml
@@ -28,7 +28,7 @@ roadmap_group = "images"
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. file-list is the drop-a-file-then-see-a-row widget that
 # more than one tool needs and that no tool should own.
-css_parts = ["file-list"]
+css_parts = ["file-list", "form"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no

--- a/tools/image-to-ico/styles.css
+++ b/tools/image-to-ico/styles.css
@@ -6,7 +6,6 @@
 */
 
 /* The one button on the page big enough to be found without reading. */
-.big { font-size: 1.02rem; padding: 0.7rem 1.3rem; }
 
 .error {
   margin: 1rem 0 0;
@@ -22,14 +21,6 @@
   overflow-y: auto;
 }
 
-.card-lede {
-  margin: -0.4rem 0 1.1rem;
-  font-size: 0.92rem;
-  line-height: 1.6;
-  color: var(--text-dim);
-  max-width: 68ch;
-}
-
 /* --------------------------------------------------------------- file list */
 
 /* The row whose picture the preview is showing. */
@@ -42,13 +33,6 @@
 /* ------------------------------------------------------------- the presets */
 
 /* The sentence under a control, restating what it is about to do. */
-.field-summary {
-  margin: 0.9rem 0 0;
-  font-size: 0.86rem;
-  line-height: 1.55;
-  color: var(--text-dim);
-  max-width: 72ch;
-}
 
 .field-summary.warn { color: var(--danger); font-weight: 600; }
 
@@ -97,21 +81,6 @@
 
 /* --------------------------------------------------------------- the sizes */
 
-.options {
-  margin: 1.2rem 0 0;
-  padding: 0.9rem 1rem;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--surface-2);
-}
-
-.options legend {
-  padding: 0 0.4rem;
-  font-size: 0.85rem;
-  font-weight: 700;
-  color: var(--text-dim);
-}
-
 .options .field-summary {
   padding-top: 0.7rem;
   border-top: 1px dashed var(--border);
@@ -159,15 +128,12 @@
   margin-bottom: 0.9rem;
 }
 
-.option-row label { font-size: 0.9rem; font-weight: 600; }
-
 /* `max-width` alone loses: a flex item's automatic minimum is min-content, and
    for a <select> that is its longest option - a whole sentence in each of these.
    The rows here wrap early enough that nothing overflows without this, but the
    shape is the one that put six other pages off the side of a phone, so it
    carries the same rule they do. */
 .option-row { min-width: 0; }
-.option-row select { min-width: 0; max-width: 100%; }
 
 .check {
   display: flex;
@@ -268,8 +234,6 @@
 }
 
 /* ----------------------------------------------------------------- running */
-
-.run-row { display: flex; align-items: center; gap: 0.9rem; flex-wrap: wrap; }
 
 /* ----------------------------------------------------------------- results */
 

--- a/tools/image-to-ico/tool.toml
+++ b/tools/image-to-ico/tool.toml
@@ -28,7 +28,7 @@ roadmap_group = "images"
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. file-list is the drop-a-file-then-see-a-row widget that
 # more than one tool needs and that no tool should own.
-css_parts = ["file-list", "progress", "results"]
+css_parts = ["file-list", "progress", "results", "form"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.

--- a/tools/images-to-pdf/styles.css
+++ b/tools/images-to-pdf/styles.css
@@ -176,9 +176,7 @@
   gap: 0.9rem;
 }
 
-.field { display: flex; flex-direction: column; gap: 0.3rem; }
 .field label { font-size: 0.85rem; font-weight: 600; }
-.field-note { margin: 0; font-size: 0.78rem; color: var(--text-dim); }
 
 .field input[type="text"] {
   background: var(--surface);
@@ -293,8 +291,6 @@
 .summary dd { margin: 0; font-variant-numeric: tabular-nums; font-weight: 600; text-align: end; }
 
 /* ------------------------------------------------------------------ export */
-
-.export-row { display: flex; gap: 0.6rem; align-items: center; flex-wrap: wrap; }
 
 .progress-label {
   overflow: hidden;

--- a/tools/images-to-pdf/tool.toml
+++ b/tools/images-to-pdf/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "documents"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress"]
+css_parts = ["progress", "form"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no

--- a/tools/images-to-video/styles.css
+++ b/tools/images-to-video/styles.css
@@ -346,7 +346,6 @@
   gap: 0.9rem;
 }
 
-.field { display: flex; flex-direction: column; gap: 0.3rem; }
 .field label { font-size: 0.85rem; font-weight: 600; }
 .field-note { margin: 0; font-size: 0.78rem; color: var(--text-dim); min-height: 1em; }
 
@@ -407,8 +406,6 @@
 .summary dd { margin: 0; font-variant-numeric: tabular-nums; font-weight: 600; }
 
 /* ------------------------------------------------------------------ export */
-
-.export-row { display: flex; gap: 0.6rem; align-items: center; flex-wrap: wrap; }
 
 .error {
   margin: 1rem 0 0;

--- a/tools/images-to-video/tool.toml
+++ b/tools/images-to-video/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "video"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "results"]
+css_parts = ["progress", "results", "form"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no

--- a/tools/json-formatter/styles.css
+++ b/tools/json-formatter/styles.css
@@ -36,7 +36,6 @@
 
 /* ------------------------------------------------------------- the options */
 
-.field { display: flex; flex-direction: column; gap: 0.3rem; }
 .field > label { font-size: 0.85rem; font-weight: 600; }
 .field-note { margin: 0.15rem 0 0; font-size: 0.78rem; color: var(--text-dim); }
 .field-note:empty { display: none; }

--- a/tools/json-formatter/tool.toml
+++ b/tools/json-formatter/tool.toml
@@ -33,6 +33,10 @@ category = "text-codes-and-passwords"
 # It sits at the top of that group as a link, above the names still to be built.
 roadmap_group = "beyond"
 
+# Shared stylesheet parts this tool asks for, put before its own rules by
+# the build so that its own can override them.
+css_parts = ["form"]
+
 # Shared modules this tool asks for. file-picker brings in the drop zone, which
 # is here for the file that is easier to drop than to open, select all and copy.
 js_parts = ["file-picker", "parse-errors", "parse-json", "parse-yaml", "parse-xml", "message-box", "download", "format"]

--- a/tools/merge-pdf/styles.css
+++ b/tools/merge-pdf/styles.css
@@ -5,7 +5,6 @@
 */
 
 /* The one button on the page big enough to be found without reading. */
-.big { font-size: 1.02rem; padding: 0.7rem 1.3rem; }
 
 .error {
   margin: 1rem 0 0;
@@ -20,24 +19,9 @@
   white-space: pre-line;
 }
 
-.card-lede {
-  margin: -0.4rem 0 1.1rem;
-  font-size: 0.92rem;
-  line-height: 1.6;
-  color: var(--text-dim);
-  max-width: 68ch;
-}
-
 .card-lede .grip { letter-spacing: -2px; font-weight: 700; color: var(--accent); }
 
 /* The sentence under a control, restating what it is about to do. */
-.field-summary {
-  margin: 0.9rem 0 0;
-  font-size: 0.86rem;
-  line-height: 1.55;
-  color: var(--text-dim);
-  max-width: 72ch;
-}
 
 .field-note {
   margin: 0.4rem 0 0;
@@ -328,8 +312,6 @@
 }
 
 /* ----------------------------------------------------------------- running */
-
-.run-row { display: flex; align-items: center; gap: 0.9rem; flex-wrap: wrap; }
 
 /* ----------------------------------------------------------------- results */
 

--- a/tools/merge-pdf/tool.toml
+++ b/tools/merge-pdf/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "documents"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress"]
+css_parts = ["progress", "form"]
 
 # file-picker brings in the drop zone; zip is the archive a split comes back
 # in when it is more than one file, and crc32 is the checksum it needs. The

--- a/tools/qr-barcode-reader/styles.css
+++ b/tools/qr-barcode-reader/styles.css
@@ -8,22 +8,6 @@
   to stop somebody and calm enough not to look like the page has broken.
 */
 
-.card-lede {
-  margin: -0.4rem 0 1.1rem;
-  font-size: 0.92rem;
-  line-height: 1.6;
-  color: var(--text-dim);
-  max-width: 68ch;
-}
-
-.field-summary {
-  margin: 0.9rem 0 0;
-  font-size: 0.86rem;
-  line-height: 1.55;
-  color: var(--text-dim);
-  max-width: 72ch;
-}
-
 .error {
   margin: 1rem 0 0;
   padding: 0.7rem 0.9rem;
@@ -115,9 +99,6 @@ kbd {
   flex-wrap: wrap;
   min-width: 0;
 }
-
-.option-row label { font-size: 0.9rem; font-weight: 600; }
-.option-row select { min-width: 0; max-width: 100%; }
 
 .check {
   display: flex;

--- a/tools/qr-barcode-reader/tool.toml
+++ b/tools/qr-barcode-reader/tool.toml
@@ -35,6 +35,10 @@ category = "text-codes-and-passwords"
 roadmap_group = "beyond"
 lastmod = "2026-09-01"
 
+# Shared stylesheet parts this tool asks for, put before its own rules by
+# the build so that its own can override them.
+css_parts = ["form"]
+
 # The drop zone brings in shared/js/file-picker.js. Several files at once is
 # deliberate: a folder of screenshots, or a photograph of a page of codes, is a
 # real thing people have, and reading them one at a time is the annoying way.

--- a/tools/qr-barcode/styles.css
+++ b/tools/qr-barcode/styles.css
@@ -18,38 +18,7 @@
   white-space: pre-line;
 }
 
-.card-lede {
-  margin: -0.4rem 0 1.1rem;
-  font-size: 0.92rem;
-  line-height: 1.6;
-  color: var(--text-dim);
-  max-width: 68ch;
-}
-
-.field-summary {
-  margin: 0.9rem 0 0;
-  font-size: 0.86rem;
-  line-height: 1.55;
-  color: var(--text-dim);
-  max-width: 72ch;
-}
-
 /* ------------------------------------------------------------- the options */
-
-.options {
-  margin: 1.2rem 0 0;
-  padding: 0.9rem 1rem;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--surface-2);
-}
-
-.options legend {
-  padding: 0 0.4rem;
-  font-size: 0.85rem;
-  font-weight: 700;
-  color: var(--text-dim);
-}
 
 .option-row {
   display: flex;
@@ -60,8 +29,6 @@
   min-width: 0;
 }
 
-.option-row label { font-size: 0.9rem; font-weight: 600; }
-.option-row select { min-width: 0; max-width: 100%; }
 .option-row input[type="number"] { width: 7rem; }
 
 .check {

--- a/tools/qr-barcode/tool.toml
+++ b/tools/qr-barcode/tool.toml
@@ -27,6 +27,9 @@ category = "text-codes-and-passwords"
 # Which group on the roadmap this tool joins, by the id in config/planned.toml.
 # It sits at the top of that group as a link, above the names still to be built.
 roadmap_group = "beyond"
+# Shared stylesheet parts this tool asks for, put before its own rules by
+# the build so that its own can override them.
+css_parts = ["form"]
 js_parts = ["qr-tables", "download"]
 lastmod = "2026-08-27"
 

--- a/tools/redact-image/styles.css
+++ b/tools/redact-image/styles.css
@@ -6,7 +6,6 @@
 */
 
 /* The one button on the page big enough to be found without reading. */
-.big { font-size: 1.02rem; padding: 0.7rem 1.3rem; }
 
 .error {
   margin: 1rem 0 0;
@@ -19,25 +18,9 @@
   white-space: pre-line;
 }
 
-.card-lede {
-  margin: -0.4rem 0 1.1rem;
-  font-size: 0.92rem;
-  line-height: 1.6;
-  color: var(--text-dim);
-  max-width: 68ch;
-}
-
 .hint-line {
   margin: 0.5rem 0 0;
   font-size: 0.84rem;
-  line-height: 1.55;
-  color: var(--text-dim);
-  max-width: 72ch;
-}
-
-.field-summary {
-  margin: 0.9rem 0 0;
-  font-size: 0.86rem;
   line-height: 1.55;
   color: var(--text-dim);
   max-width: 72ch;
@@ -207,21 +190,6 @@ kbd {
 
 /* ------------------------------------------------------------- the settings */
 
-.options {
-  margin: 1.2rem 0 0;
-  padding: 0.9rem 1rem;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--surface-2);
-}
-
-.options legend {
-  padding: 0 0.4rem;
-  font-size: 0.85rem;
-  font-weight: 700;
-  color: var(--text-dim);
-}
-
 .check {
   display: flex;
   align-items: flex-start;
@@ -252,11 +220,8 @@ kbd {
   border-top: 1px dashed var(--border);
 }
 
-.option-row label { font-size: 0.9rem; font-weight: 600; }
-
 /* `max-width` alone loses: a flex item's automatic minimum is min-content, and
    for a <select> that is its longest option. */
-.option-row select { min-width: 0; max-width: 100%; }
 
 .settings {
   display: grid;
@@ -362,8 +327,6 @@ kbd {
 }
 
 /* ------------------------------------------------------------- the result */
-
-.run-row { display: flex; align-items: center; gap: 0.9rem; flex-wrap: wrap; }
 
 .progress-label { margin: 0.7rem 0 0; font-size: 0.85rem; color: var(--text-dim); }
 

--- a/tools/redact-image/tool.toml
+++ b/tools/redact-image/tool.toml
@@ -25,12 +25,13 @@ category = "images"
 # It sits at the top of that group as a link, above the names still to be built.
 roadmap_group = "images"
 
+# Shared stylesheet parts this tool asks for, put before its own rules by
+# the build so that its own can override them.
+css_parts = ["results", "form"]
+
 # Shared modules this tool asks for. file-picker brings in the drop zone; the
 # list of boxes underneath the picture is this tool's own, because it is a list
 # of rectangles rather than a list of files.
-# Shared stylesheet parts this tool asks for, put before its own rules by
-# the build so that its own can override them.
-css_parts = ["results"]
 js_parts = ["file-picker", "message-box"]
 lastmod = "2026-08-27"
 

--- a/tools/redact-pdf/styles.css
+++ b/tools/redact-pdf/styles.css
@@ -5,7 +5,6 @@
 */
 
 /* The one button on the page big enough to be found without reading. */
-.big { font-size: 1.02rem; padding: 0.7rem 1.3rem; }
 
 .error {
   margin: 1rem 0 0;
@@ -18,22 +17,6 @@
   line-height: 1.55;
   max-width: 72ch;
   white-space: pre-line;
-}
-
-.card-lede {
-  margin: -0.4rem 0 1.1rem;
-  font-size: 0.92rem;
-  line-height: 1.6;
-  color: var(--text-dim);
-  max-width: 68ch;
-}
-
-.field-summary {
-  margin: 0.9rem 0 0;
-  font-size: 0.86rem;
-  line-height: 1.55;
-  color: var(--text-dim);
-  max-width: 72ch;
 }
 
 .field-note {
@@ -320,8 +303,6 @@
   color: var(--text-dim);
   max-width: 70ch;
 }
-
-.run-row { display: flex; align-items: center; gap: 0.9rem; flex-wrap: wrap; }
 
 /* ---------------------------------------------------------------- results */
 

--- a/tools/redact-pdf/tool.toml
+++ b/tools/redact-pdf/tool.toml
@@ -33,7 +33,7 @@ roadmap_group = "documents"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress"]
+css_parts = ["progress", "form"]
 
 # file-picker brings in the drop zone. The four pdf-* parts are the PDF itself
 # - the object grammar, the stream filters, the reader and the writer - and

--- a/tools/resize-image/styles.css
+++ b/tools/resize-image/styles.css
@@ -1,5 +1,4 @@
 /* The one button on the page big enough to be found without reading. */
-.big { font-size: 1.02rem; padding: 0.7rem 1.3rem; }
 
 .error {
   margin: 1rem 0 0;
@@ -13,14 +12,6 @@
   white-space: pre-line;
   max-height: 12rem;
   overflow-y: auto;
-}
-
-.card-lede {
-  margin: -0.4rem 0 1.1rem;
-  font-size: 0.92rem;
-  line-height: 1.6;
-  color: var(--text-dim);
-  max-width: 68ch;
 }
 
 /* --------------------------------------------------------------- file list */
@@ -305,19 +296,6 @@ button.file-main-wrap:focus-visible {
   gap: 0.6rem;
 }
 
-.numbers label {
-  display: flex;
-  flex-direction: column;
-  gap: 0.2rem;
-  font-size: 0.8rem;
-  color: var(--text-dim);
-}
-
-.numbers input {
-  width: 6.5rem;
-  font-variant-numeric: tabular-nums;
-}
-
 /* The label is 0.8rem and the input inherits it, which is right on a desktop
    and wrong on an iPhone: Safari zooms the page into any field it is asked to
    focus whose text is under 16px, and then leaves it zoomed. Sixteen only where
@@ -352,13 +330,10 @@ button.file-main-wrap:focus-visible {
   margin-bottom: 0.9rem;
 }
 
-.option-row label { font-size: 0.9rem; font-weight: 600; }
-
 /* `max-width` alone loses: a flex item's automatic minimum is min-content, and
    for a <select> that is its longest option - a whole sentence here. Without the
    `min-width`, the row stayed as wide as that sentence on a narrow screen. */
 .option-row { min-width: 0; }
-.option-row select { min-width: 0; max-width: 100%; }
 
 /* ------------------------------------------------------------- the sizing */
 
@@ -437,8 +412,6 @@ button.file-main-wrap:focus-visible {
 }
 
 /* ----------------------------------------------------------------- running */
-
-.run-row { display: flex; align-items: center; gap: 0.9rem; flex-wrap: wrap; }
 
 /* ----------------------------------------------------------------- results */
 

--- a/tools/resize-image/tool.toml
+++ b/tools/resize-image/tool.toml
@@ -28,7 +28,7 @@ roadmap_group = "images"
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. file-list is the drop-a-file-then-see-a-row widget that
 # more than one tool needs and that no tool should own.
-css_parts = ["file-list", "progress", "results"]
+css_parts = ["file-list", "progress", "results", "form"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.

--- a/tools/reverse-video/styles.css
+++ b/tools/reverse-video/styles.css
@@ -44,9 +44,7 @@
   gap: 0.9rem;
 }
 
-.field { display: flex; flex-direction: column; gap: 0.3rem; }
 .field > label { font-size: 0.85rem; font-weight: 600; }
-.field-note { margin: 0; font-size: 0.78rem; color: var(--text-dim); }
 
 .check {
   display: flex;
@@ -74,8 +72,6 @@
 }
 
 /* ------------------------------------------------------------------ export */
-
-.export-row { display: flex; gap: 0.6rem; align-items: center; flex-wrap: wrap; }
 
 .error {
   margin: 1rem 0 0;

--- a/tools/reverse-video/tool.toml
+++ b/tools/reverse-video/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "video"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "results"]
+css_parts = ["progress", "results", "form"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no

--- a/tools/split-gif/styles.css
+++ b/tools/split-gif/styles.css
@@ -33,9 +33,7 @@
   margin-bottom: 1.2rem;
 }
 
-.field { display: flex; flex-direction: column; gap: 0.3rem; }
 .field > label { font-size: 0.85rem; font-weight: 600; }
-.field-note { margin: 0; font-size: 0.78rem; color: var(--text-dim); }
 
 .inline-pair {
   display: flex;
@@ -59,8 +57,6 @@
 @media (pointer: coarse) {
   .inline-pair input[type="number"] { font-size: 16px; }
 }
-
-.export-row { display: flex; gap: 0.6rem; align-items: center; flex-wrap: wrap; }
 
 /* -------------------------------------------------------------- the frames */
 

--- a/tools/split-gif/tool.toml
+++ b/tools/split-gif/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "gif"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "results"]
+css_parts = ["progress", "results", "form"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts, and for
 # the same reason: a component more than one tool needs and no tool should own.

--- a/tools/stack-images/styles.css
+++ b/tools/stack-images/styles.css
@@ -107,8 +107,6 @@
    and its explanation has room to be a sentence rather than a label. */
 .field-wide { grid-column: 1 / -1; }
 
-.field { display: flex; flex-direction: column; gap: 0.3rem; }
-
 .field label { font-size: 0.85rem; font-weight: 600; }
 
 .field-note {
@@ -172,8 +170,6 @@
 }
 
 /* ----------------------------------------------------------- running it */
-
-.export-row { display: flex; gap: 0.6rem; align-items: center; flex-wrap: wrap; }
 
 .error {
   margin: 1rem 0 0;

--- a/tools/stack-images/tool.toml
+++ b/tools/stack-images/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "images"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "results"]
+css_parts = ["progress", "results", "form"]
 
 # Shared modules this tool asks for. Only the drop zone: the list underneath it
 # is this tool's own, because a row in it carries what was found inside a RAW

--- a/tools/svg-to-image/styles.css
+++ b/tools/svg-to-image/styles.css
@@ -7,7 +7,6 @@
 */
 
 /* The one button on the page big enough to be found without reading. */
-.big { font-size: 1.02rem; padding: 0.7rem 1.3rem; }
 
 .error {
   margin: 1rem 0 0;
@@ -21,14 +20,6 @@
   white-space: pre-line;
   max-height: 12rem;
   overflow-y: auto;
-}
-
-.card-lede {
-  margin: -0.4rem 0 1.1rem;
-  font-size: 0.92rem;
-  line-height: 1.6;
-  color: var(--text-dim);
-  max-width: 68ch;
 }
 
 /* --------------------------------------------------------------- file list */
@@ -76,19 +67,6 @@
   gap: 0.6rem;
 }
 
-.numbers label {
-  display: flex;
-  flex-direction: column;
-  gap: 0.2rem;
-  font-size: 0.8rem;
-  color: var(--text-dim);
-}
-
-.numbers input {
-  width: 6.5rem;
-  font-variant-numeric: tabular-nums;
-}
-
 /* The label is 0.8rem and the input inherits it, which is right on a desktop
    and wrong on an iPhone: Safari zooms the page into any field it is asked to
    focus whose text is under 16px, and then leaves it zoomed. Sixteen only where
@@ -116,12 +94,9 @@
   min-width: 0;
 }
 
-.option-row label { font-size: 0.9rem; font-weight: 600; }
-
 /* `max-width` alone loses: a flex item's automatic minimum is min-content, and
    for a <select> that is its longest option - a whole sentence in each of
    these. */
-.option-row select { min-width: 0; max-width: 100%; }
 
 /* The sentence under a control, restating what it is about to do. */
 .field-summary {
@@ -210,8 +185,6 @@
 }
 
 /* ----------------------------------------------------------------- running */
-
-.run-row { display: flex; align-items: center; gap: 0.9rem; flex-wrap: wrap; }
 
 /* ----------------------------------------------------------------- results */
 

--- a/tools/svg-to-image/tool.toml
+++ b/tools/svg-to-image/tool.toml
@@ -28,7 +28,7 @@ roadmap_group = "images"
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. file-list is the drop-a-file-then-see-a-row widget that
 # more than one tool needs and that no tool should own.
-css_parts = ["file-list", "progress", "results"]
+css_parts = ["file-list", "progress", "results", "form"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.

--- a/tools/text-diff/styles.css
+++ b/tools/text-diff/styles.css
@@ -3,7 +3,6 @@
 
 /* ------------------------------------------------------------- the options */
 
-.field { display: flex; flex-direction: column; gap: 0.3rem; }
 .field > label { font-size: 0.85rem; font-weight: 600; }
 .field-note { margin: 0.15rem 0 0; font-size: 0.78rem; color: var(--text-dim); }
 .field-note:empty { display: none; }

--- a/tools/text-diff/tool.toml
+++ b/tools/text-diff/tool.toml
@@ -35,6 +35,10 @@ category = "text-codes-and-passwords"
 # It sits at the top of that group as a link, above the names still to be built.
 roadmap_group = "beyond"
 
+# Shared stylesheet parts this tool asks for, put before its own rules by
+# the build so that its own can override them.
+css_parts = ["form"]
+
 # Shared modules this tool asks for. file-picker brings in the drop zone, which
 # is here for the two files that are easier to drop than to open, select all
 # and copy - twice.

--- a/tools/timelapse-video/styles.css
+++ b/tools/timelapse-video/styles.css
@@ -68,23 +68,10 @@
   gap: 0.9rem;
 }
 
-.numbers label {
-  display: flex;
-  flex-direction: column;
-  gap: 0.2rem;
-  font-size: 0.8rem;
-  color: var(--text-dim);
-}
-
 /* The unit sits beside the box rather than inside its label, so "10" and the
    times sign read as one value however wide the number gets. */
 .with-unit { display: flex; align-items: center; gap: 0.35rem; }
 .with-unit .unit { color: var(--text-dim); font-size: 0.9rem; }
-
-.numbers input {
-  width: 6.5rem;
-  font-variant-numeric: tabular-nums;
-}
 
 /* The label is 0.8rem and the input inherits it, which is right on a desktop
    and wrong on an iPhone: Safari zooms the page into any field it is asked to
@@ -109,9 +96,7 @@
   gap: 0.9rem;
 }
 
-.field { display: flex; flex-direction: column; gap: 0.3rem; }
 .field > label { font-size: 0.85rem; font-weight: 600; }
-.field-note { margin: 0; font-size: 0.78rem; color: var(--text-dim); }
 
 .summary {
   margin: 0 0 1.2rem;
@@ -136,8 +121,6 @@
 }
 
 /* ------------------------------------------------------------------ export */
-
-.export-row { display: flex; gap: 0.6rem; align-items: center; flex-wrap: wrap; }
 
 .error {
   margin: 1rem 0 0;

--- a/tools/timelapse-video/tool.toml
+++ b/tools/timelapse-video/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "video"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "results"]
+css_parts = ["progress", "results", "form"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no

--- a/tools/trim-audio/styles.css
+++ b/tools/trim-audio/styles.css
@@ -390,9 +390,7 @@ audio.player {
   gap: 0.9rem;
 }
 
-.field { display: flex; flex-direction: column; gap: 0.3rem; }
 .field > label { font-size: 0.85rem; font-weight: 600; }
-.field-note { margin: 0; font-size: 0.78rem; color: var(--text-dim); }
 
 .summary {
   margin: 1.2rem 0 0;

--- a/tools/trim-audio/tool.toml
+++ b/tools/trim-audio/tool.toml
@@ -35,7 +35,7 @@ roadmap_group = "audio"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "results"]
+css_parts = ["progress", "results", "form"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts, and for
 # the same reason: a component more than one tool needs and no tool should own.

--- a/tools/trim-video/styles.css
+++ b/tools/trim-video/styles.css
@@ -471,9 +471,7 @@ kbd {
   gap: 0.9rem;
 }
 
-.field { display: flex; flex-direction: column; gap: 0.3rem; }
 .field > label { font-size: 0.85rem; font-weight: 600; }
-.field-note { margin: 0; font-size: 0.78rem; color: var(--text-dim); }
 
 .check {
   display: flex;

--- a/tools/trim-video/tool.toml
+++ b/tools/trim-video/tool.toml
@@ -28,7 +28,7 @@ roadmap_group = "video"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "results"]
+css_parts = ["progress", "results", "form"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts, and for
 # the same reason: a component more than one tool needs and no tool should own.

--- a/tools/video-to-gif/styles.css
+++ b/tools/video-to-gif/styles.css
@@ -180,9 +180,7 @@
   gap: 0.9rem;
 }
 
-.field { display: flex; flex-direction: column; gap: 0.3rem; }
 .field > label { font-size: 0.85rem; font-weight: 600; }
-.field-note { margin: 0; font-size: 0.78rem; color: var(--text-dim); }
 
 .check {
   display: flex;
@@ -210,8 +208,6 @@
 }
 
 /* ------------------------------------------------------------------ export */
-
-.export-row { display: flex; gap: 0.6rem; align-items: center; flex-wrap: wrap; }
 
 .error {
   margin: 1rem 0 0;

--- a/tools/video-to-gif/tool.toml
+++ b/tools/video-to-gif/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "gif"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "results"]
+css_parts = ["progress", "results", "form"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no

--- a/tools/xml-formatter/styles.css
+++ b/tools/xml-formatter/styles.css
@@ -36,7 +36,6 @@
 
 /* ------------------------------------------------------------- the options */
 
-.field { display: flex; flex-direction: column; gap: 0.3rem; }
 .field > label { font-size: 0.85rem; font-weight: 600; }
 .field-note { margin: 0.15rem 0 0; font-size: 0.78rem; color: var(--text-dim); }
 .field-note:empty { display: none; }

--- a/tools/xml-formatter/tool.toml
+++ b/tools/xml-formatter/tool.toml
@@ -54,6 +54,10 @@ category = "text-codes-and-passwords"
 # It sits at the top of that group as a link, above the names still to be built.
 roadmap_group = "beyond"
 
+# Shared stylesheet parts this tool asks for, put before its own rules by
+# the build so that its own can override them.
+css_parts = ["form"]
+
 # Shared modules this tool asks for. file-picker brings in the drop zone, which
 # is here for the file that is easier to drop than to open, select all and copy.
 js_parts = ["file-picker", "parse-errors", "parse-json", "parse-xml", "message-box", "download", "format"]

--- a/tools/yaml-to-json/styles.css
+++ b/tools/yaml-to-json/styles.css
@@ -36,7 +36,6 @@
 
 /* ------------------------------------------------------------- the options */
 
-.field { display: flex; flex-direction: column; gap: 0.3rem; }
 .field > label { font-size: 0.85rem; font-weight: 600; }
 .field-note { margin: 0.15rem 0 0; font-size: 0.78rem; color: var(--text-dim); }
 .field-note:empty { display: none; }

--- a/tools/yaml-to-json/tool.toml
+++ b/tools/yaml-to-json/tool.toml
@@ -53,6 +53,10 @@ category = "text-codes-and-passwords"
 # It sits at the top of that group as a link, above the names still to be built.
 roadmap_group = "beyond"
 
+# Shared stylesheet parts this tool asks for, put before its own rules by
+# the build so that its own can override them.
+css_parts = ["form"]
+
 # Shared modules this tool asks for. file-picker brings in the drop zone, which
 # is here for the config file that is easier to drop than to open, select all
 # and copy.


### PR DESCRIPTION
Phase 5 of the shared-parts plan, second part, stacked on #337: the form vocabulary - the rules for a tool's controls that thirty-three tools carried token for token. Nothing a visitor sees changes, proved the same way as #337.

## What this does

- **`shared/css/form.css`** - thirteen rules: `.field`, `.field-note`, `.field-summary`, `.card-lede`, `.big`, `.option-row label`, `.option-row select`, `.options`, `.options legend`, `.run-row`, `.export-row`, `.numbers input`, `.numbers label`. Each is the body every tool that had it agreed on.
- **Thirty-three tools ask for it** (`css_parts = ["form"]`; nine of them get their first `css_parts` line) and lose the copies: 122 rules, 472 lines. Tools that want one of these different keep their own rule, which wins because the build puts parts before a tool's stylesheet.
- **`.option-row` itself is deliberately not in the part.** The tools disagree on its `min-width` and `margin-bottom`, and eight of them would have had the part's value show through their own rule; leaving it out lets all eight ask for the rest. `.field > label` is not in either: five tools write the same rule as `.field label`, which the extraction cannot tell is the same thing, so both spellings stay per tool.
- **Three tools are left out,** with their own rules intact, by the extraction's two tests: `compress-pdf` and `document-scanner` never style `.option-row select` but use it (the part would have started to), and `password-generator`'s `.card-lede` is its own (no `line-height`, no `max-width`).
- One row in `docs/adding-a-tool.md`; the `css_parts` block for the tools that had none sits above the `js_parts` comment, so the stylesheet line reads before the module line as it does elsewhere (this also tidies `redact-image`'s from #337, where it had landed between that comment and its line).

## Before and after

Nothing on any page changes. Every one of the forty-one tools was built before and after (English, unminified) and the cascade of each built stylesheet - the declaration that finally wins for every selector, inside and outside media queries - compared: **zero differ**. The 273 selectors the part adds where a tool had none are all for classes that page never carries, in its markup or in anything its scripts create.

## Verified

- The cascade comparison above, over all 41 tools.
- **A CI-style full build** passes.
- `test_english_in_js`, `test_duplicates`, `test_imports` and `test_phrases` pass.

## What this leaves

Three smaller families the same way: the checkbox rows the image and PDF tools share (`.check`, 13 tools), the notes (`.error`, `.path-note`, `.stage-note`, 16 tools), and the text tools' panes and the audio tools' modes (6 and 5 tools).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
