### PR TITLE
Share the last five stylesheet families: the checkbox rows, the notes, the panes, the modes and the crop box

### DIFF
--- a/docs/adding-a-tool.md
+++ b/docs/adding-a-tool.md
@@ -93,6 +93,7 @@ A component more than one tool needs, and that no tool should own, lives under
 | `shared/css/notes.css` | `css_parts = ["notes"]` | the error line, and the note that says which path a file took |
 | `shared/css/panes.css` | `css_parts = ["panes"]` | the two text panes of a formatter page and the head above each |
 | `shared/css/modes.css` | `css_parts = ["modes"]` | a choice between two ways of working, as radio rows with a title and an explanation |
+| `shared/css/cropper.css` | `css_parts = ["cropper"]` | the crop box `cropper.js` draws: the box, the dimmed surround, the handles, the size label |
 | `shared/js/file-picker.js` | `js_parts = ["file-picker"]` | copied to `<tool>/src/shared/` |
 | `shared/js/image-list.js` | `js_parts = ["image-list"]` | a list of pictures to work through in order: decoded once for a thumbnail and their size, sorted, reordered, re-decoded one at a time |
 | `templates/partials/file-picker.html` | `{% include %}` in `body.html` | the drop-zone markup |

--- a/docs/adding-a-tool.md
+++ b/docs/adding-a-tool.md
@@ -89,6 +89,7 @@ A component more than one tool needs, and that no tool should own, lives under
 | `shared/css/file-list.css` | `css_parts = ["file-list"]` | appended to the tool's stylesheet |
 | `shared/css/results.css` | `css_parts = ["results"]` | the source panel, the summary rows, the result and its meta line, the results list; put before the tool's own rules, so a tool that wants one of them different keeps its own |
 | `shared/css/form.css` | `css_parts = ["form"]` | the controls' vocabulary: fields and their notes, the card lede, the big button, option rows, the options box, the run and export rows, number fields |
+| `shared/css/checks.css` | `css_parts = ["checks"]` | a checkbox row with a bold title and a dim note, as the image and PDF tools draw it |
 | `shared/js/file-picker.js` | `js_parts = ["file-picker"]` | copied to `<tool>/src/shared/` |
 | `shared/js/image-list.js` | `js_parts = ["image-list"]` | a list of pictures to work through in order: decoded once for a thumbnail and their size, sorted, reordered, re-decoded one at a time |
 | `templates/partials/file-picker.html` | `{% include %}` in `body.html` | the drop-zone markup |

--- a/docs/adding-a-tool.md
+++ b/docs/adding-a-tool.md
@@ -92,6 +92,7 @@ A component more than one tool needs, and that no tool should own, lives under
 | `shared/css/checks.css` | `css_parts = ["checks"]` | a checkbox row with a bold title and a dim note, as the image and PDF tools draw it |
 | `shared/css/notes.css` | `css_parts = ["notes"]` | the error line, and the note that says which path a file took |
 | `shared/css/panes.css` | `css_parts = ["panes"]` | the two text panes of a formatter page and the head above each |
+| `shared/css/modes.css` | `css_parts = ["modes"]` | a choice between two ways of working, as radio rows with a title and an explanation |
 | `shared/js/file-picker.js` | `js_parts = ["file-picker"]` | copied to `<tool>/src/shared/` |
 | `shared/js/image-list.js` | `js_parts = ["image-list"]` | a list of pictures to work through in order: decoded once for a thumbnail and their size, sorted, reordered, re-decoded one at a time |
 | `templates/partials/file-picker.html` | `{% include %}` in `body.html` | the drop-zone markup |

--- a/docs/adding-a-tool.md
+++ b/docs/adding-a-tool.md
@@ -90,6 +90,7 @@ A component more than one tool needs, and that no tool should own, lives under
 | `shared/css/results.css` | `css_parts = ["results"]` | the source panel, the summary rows, the result and its meta line, the results list; put before the tool's own rules, so a tool that wants one of them different keeps its own |
 | `shared/css/form.css` | `css_parts = ["form"]` | the controls' vocabulary: fields and their notes, the card lede, the big button, option rows, the options box, the run and export rows, number fields |
 | `shared/css/checks.css` | `css_parts = ["checks"]` | a checkbox row with a bold title and a dim note, as the image and PDF tools draw it |
+| `shared/css/notes.css` | `css_parts = ["notes"]` | the error line, and the note that says which path a file took |
 | `shared/js/file-picker.js` | `js_parts = ["file-picker"]` | copied to `<tool>/src/shared/` |
 | `shared/js/image-list.js` | `js_parts = ["image-list"]` | a list of pictures to work through in order: decoded once for a thumbnail and their size, sorted, reordered, re-decoded one at a time |
 | `templates/partials/file-picker.html` | `{% include %}` in `body.html` | the drop-zone markup |

--- a/docs/adding-a-tool.md
+++ b/docs/adding-a-tool.md
@@ -91,6 +91,7 @@ A component more than one tool needs, and that no tool should own, lives under
 | `shared/css/form.css` | `css_parts = ["form"]` | the controls' vocabulary: fields and their notes, the card lede, the big button, option rows, the options box, the run and export rows, number fields |
 | `shared/css/checks.css` | `css_parts = ["checks"]` | a checkbox row with a bold title and a dim note, as the image and PDF tools draw it |
 | `shared/css/notes.css` | `css_parts = ["notes"]` | the error line, and the note that says which path a file took |
+| `shared/css/panes.css` | `css_parts = ["panes"]` | the two text panes of a formatter page and the head above each |
 | `shared/js/file-picker.js` | `js_parts = ["file-picker"]` | copied to `<tool>/src/shared/` |
 | `shared/js/image-list.js` | `js_parts = ["image-list"]` | a list of pictures to work through in order: decoded once for a thumbnail and their size, sorted, reordered, re-decoded one at a time |
 | `templates/partials/file-picker.html` | `{% include %}` in `body.html` | the drop-zone markup |

--- a/shared/css/checks.css
+++ b/shared/css/checks.css
@@ -1,0 +1,37 @@
+/* ---------------------------------------------------------------- checks
+   A checkbox with a title and a note under it, laid out as a row the whole
+   of which can be clicked: the input at the top of the row, the title in
+   bold, the note dim beneath.
+
+   Asked for with `css_parts = ["checks"]`. Thirteen tools - the image and
+   PDF ones - carried these rules token for token; the build puts this file
+   before a tool's own stylesheet, so a tool that wants one of them different
+   writes its own rule and wins, provided it sets every property the rule
+   here sets. The video and text tools style their checkboxes another way
+   and do not ask for this. */
+
+.check {
+  align-items: flex-start;
+  cursor: pointer;
+  display: flex;
+  gap: 0.6rem;
+}
+
+.check input {
+  flex: none;
+  margin-top: 0.25rem;
+}
+
+.check strong {
+  display: block;
+  font-size: 0.9rem;
+}
+
+.check-note {
+  color: var(--text-dim);
+  display: block;
+  font-size: 0.82rem;
+  line-height: 1.55;
+  margin-top: 0.15rem;
+  max-width: 70ch;
+}

--- a/shared/css/cropper.css
+++ b/shared/css/cropper.css
@@ -1,0 +1,72 @@
+/* --------------------------------------------------------------- cropper
+   The crop box shared/js/cropper.js draws: the box itself with the dimmed
+   picture round it, its eight handles, the size label, and the ring it
+   wears when a keyboard has it.
+
+   Asked for with `css_parts = ["cropper"]`. The video cropper and the image
+   resizer, which share the class that draws the box, carried these rules
+   token for token, and the ID photo tool most of them; the build puts this
+   file before a tool's own stylesheet, so a tool that wants one of them
+   different writes its own rule and wins, provided it sets every property
+   the rule here sets. */
+
+.crop-box {
+  border: 1px solid rgb(255 255 255 / 90%);
+  box-shadow: 0 0 0 100vmax rgb(0 0 0 / 45%);
+  box-sizing: border-box;
+  cursor: move;
+  position: absolute;
+  touch-action: none;
+}
+
+.crop-box::before {
+  background: linear-gradient(to right, transparent calc(33.333% - 0.5px), rgb(255 255 255 / 55%) calc(33.333% - 0.5px) calc(33.333% + 0.5px), transparent calc(33.333% + 0.5px), transparent calc(66.667% - 0.5px), rgb(255 255 255 / 55%) calc(66.667% - 0.5px) calc(66.667% + 0.5px), transparent calc(66.667% + 0.5px)), linear-gradient(to bottom, transparent calc(33.333% - 0.5px), rgb(255 255 255 / 55%) calc(33.333% - 0.5px) calc(33.333% + 0.5px), transparent calc(33.333% + 0.5px), transparent calc(66.667% - 0.5px), rgb(255 255 255 / 55%) calc(66.667% - 0.5px) calc(66.667% + 0.5px), transparent calc(66.667% + 0.5px));
+  content: "";
+  inset: 0;
+  opacity: 0.55;
+  pointer-events: none;
+  position: absolute;
+}
+
+.crop-box.dragging::before { opacity: 0.9; }
+
+.crop-box:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.crop-handle {
+  background: #fff;
+  border: 1px solid rgb(0 0 0 / 45%);
+  border-radius: 3px;
+  height: 14px;
+  position: absolute;
+  width: 14px;
+}
+
+.crop-handle::after {
+  content: "";
+  inset: -10px;
+  position: absolute;
+}
+
+.crop-size {
+  background: rgb(0 0 0 / 65%);
+  border-radius: 99px;
+  bottom: 0.4rem;
+  color: #fff;
+  font-size: 0.75rem;
+  font-variant-numeric: tabular-nums;
+  left: 50%;
+  padding: 0.1rem 0.45rem;
+  pointer-events: none;
+  position: absolute;
+  transform: translateX(-50%);
+  white-space: nowrap;
+}
+
+.crop-controls {
+  display: grid;
+  gap: 0.9rem;
+  margin-top: 1rem;
+}

--- a/shared/css/modes.css
+++ b/shared/css/modes.css
@@ -1,0 +1,40 @@
+/* ----------------------------------------------------------------- modes
+   A choice between two ways of working, drawn as a pair of radio rows with
+   a bold title and a dim explanation each: keep the marked parts or cut
+   them out, encode or decode.
+
+   Asked for with `css_parts = ["modes"]`. Five tools carried these rules
+   token for token; the build puts this file before a tool's own stylesheet,
+   so a tool that wants one of them different writes its own rule and wins,
+   provided it sets every property the rule here sets. */
+
+.mode {
+  align-items: start;
+  cursor: pointer;
+  display: flex;
+  font-size: 0.85rem;
+  gap: 0.55rem;
+}
+
+.mode input {
+  flex: none;
+  margin: 0.15rem 0 0;
+}
+
+.mode span {
+  color: var(--text-dim);
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.mode strong {
+  color: var(--text);
+  font-size: 0.9rem;
+}
+
+.modes legend {
+  color: var(--text-dim);
+  font-size: 0.8rem;
+  padding: 0 0.35rem;
+}

--- a/shared/css/notes.css
+++ b/shared/css/notes.css
@@ -1,0 +1,41 @@
+/* ----------------------------------------------------------------- notes
+   The error line under a drop zone or a control, and the note that says
+   which path a file took or what the stage is showing.
+
+   Asked for with `css_parts = ["notes"]`. Sixteen tools carried these rules
+   token for token; the build puts this file before a tool's own stylesheet,
+   so a tool that wants one of them different writes its own rule and wins,
+   provided it sets every property the rule here sets. The image tools give
+   `.error` a ceiling and a scrollbar and the text tools set its margin the
+   other way; each keeps that as a rule of its own on top of this one. */
+
+.error {
+  background: color-mix(in srgb, var(--danger) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
+  border-radius: 7px;
+  color: var(--danger);
+  font-size: 0.9rem;
+  margin: 1rem 0 0;
+  padding: 0.7rem 0.9rem;
+  white-space: pre-line;
+}
+
+.path-note {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  color: var(--text-dim);
+  font-size: 0.84rem;
+  margin: 0.9rem 0 0;
+  padding: 0.6rem 0.8rem;
+}
+
+.stage-note {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  color: var(--text-dim);
+  font-size: 0.84rem;
+  margin: 0.9rem 0 0;
+  padding: 0.6rem 0.8rem;
+}

--- a/shared/css/panes.css
+++ b/shared/css/panes.css
@@ -1,0 +1,37 @@
+/* ----------------------------------------------------------------- panes
+   The two text panes of a formatter page - the input and the output, side
+   by side where there is room - and the head above each with its label.
+
+   Asked for with `css_parts = ["panes"]`. The six text tools carried these
+   rules token for token; the build puts this file before a tool's own
+   stylesheet, so a tool that wants one of them different writes its own
+   rule and wins, provided it sets every property the rule here sets. */
+
+.pane {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.pane-head {
+  align-items: baseline;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+  justify-content: space-between;
+}
+
+.pane-head label {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.panes {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: 1fr;
+  margin-top: 1rem;
+}
+
+.field.checks { gap: 0.5rem; }

--- a/tools/base64/styles.css
+++ b/tools/base64/styles.css
@@ -23,24 +23,6 @@
   gap: 0.7rem;
 }
 
-.modes legend {
-  padding: 0 0.35rem;
-  font-size: 0.8rem;
-  color: var(--text-dim);
-}
-
-.mode {
-  display: flex;
-  gap: 0.55rem;
-  align-items: start;
-  font-size: 0.85rem;
-  cursor: pointer;
-}
-
-.mode input { margin: 0.15rem 0 0; flex: none; }
-.mode span { display: flex; flex-direction: column; gap: 0.1rem; color: var(--text-dim); }
-.mode strong { color: var(--text); font-size: 0.9rem; }
-
 /* -------------------------------------------------------------- the boxes */
 
 textarea {

--- a/tools/base64/styles.css
+++ b/tools/base64/styles.css
@@ -43,25 +43,6 @@
 
 /* -------------------------------------------------------------- the boxes */
 
-.panes {
-  margin-top: 1rem;
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 1rem;
-}
-
-.pane { display: flex; flex-direction: column; gap: 0.35rem; min-width: 0; }
-
-.pane-head {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 0.8rem;
-  flex-wrap: wrap;
-}
-
-.pane-head label { font-size: 0.85rem; font-weight: 600; }
-
 textarea {
   width: 100%;
   min-height: 220px;

--- a/tools/base64/tool.toml
+++ b/tools/base64/tool.toml
@@ -40,7 +40,7 @@ roadmap_group = "beyond"
 
 # Shared stylesheet parts this tool asks for, put before its own rules by
 # the build so that its own can override them.
-css_parts = ["form"]
+css_parts = ["form", "panes"]
 
 # Shared modules this tool asks for. file-picker brings in the drop zone, which
 # is here for the file that is easier to drop than to open, select all and copy.

--- a/tools/base64/tool.toml
+++ b/tools/base64/tool.toml
@@ -40,7 +40,7 @@ roadmap_group = "beyond"
 
 # Shared stylesheet parts this tool asks for, put before its own rules by
 # the build so that its own can override them.
-css_parts = ["form", "panes"]
+css_parts = ["form", "panes", "modes"]
 
 # Shared modules this tool asks for. file-picker brings in the drop zone, which
 # is here for the file that is easier to drop than to open, select all and copy.

--- a/tools/compare-heights/styles.css
+++ b/tools/compare-heights/styles.css
@@ -7,17 +7,6 @@
   reader moving between the two files is reading the same rules.
 */
 
-.error {
-  margin: 1rem 0 0;
-  padding: 0.7rem 0.9rem;
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
-  color: var(--danger);
-  font-size: 0.9rem;
-  white-space: pre-line;
-}
-
 .field-summary.warn { color: var(--warn); }
 
 /* ------------------------------------------------------------ the row table */

--- a/tools/compare-heights/styles.css
+++ b/tools/compare-heights/styles.css
@@ -199,29 +199,11 @@ body.is-reordering { user-select: none; }
 
 .option-row input[type="number"] { width: 7rem; }
 
-.check {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.6rem;
-  cursor: pointer;
-}
-
 /* A checkbox has no bottom margin of its own, so the option row that follows
    one sits straight underneath it. */
 .check + .option-row { margin-top: 0.9rem; }
 
-.check input { margin-top: 0.25rem; flex: none; }
-.check strong { display: block; font-size: 0.9rem; }
 .check + .check { margin-top: 0.8rem; }
-
-.check-note {
-  display: block;
-  margin-top: 0.15rem;
-  font-size: 0.82rem;
-  line-height: 1.55;
-  color: var(--text-dim);
-  max-width: 70ch;
-}
 
 .options .field-summary {
   padding-top: 0.7rem;

--- a/tools/compare-heights/tool.toml
+++ b/tools/compare-heights/tool.toml
@@ -108,7 +108,7 @@ card = """
 
 # Shared stylesheet parts this tool asks for, put before its own rules by
 # the build so that its own can override them.
-css_parts = ["form"]
+css_parts = ["form", "checks"]
 
 # Shared modules this tool asks for, copied into it at src/shared/ by the
 # build: download hands the chart to the browser as a file.

--- a/tools/compare-heights/tool.toml
+++ b/tools/compare-heights/tool.toml
@@ -108,7 +108,7 @@ card = """
 
 # Shared stylesheet parts this tool asks for, put before its own rules by
 # the build so that its own can override them.
-css_parts = ["form", "checks"]
+css_parts = ["form", "checks", "notes"]
 
 # Shared modules this tool asks for, copied into it at src/shared/ by the
 # build: download hands the chart to the browser as a file.

--- a/tools/compress-image/styles.css
+++ b/tools/compress-image/styles.css
@@ -65,25 +65,6 @@
    `min-width`, the row stayed as wide as that sentence on a narrow screen. */
 .option-row { min-width: 0; }
 
-.check {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.6rem;
-  cursor: pointer;
-}
-
-.check input { margin-top: 0.25rem; flex: none; }
-.check strong { display: block; font-size: 0.9rem; }
-
-.check-note {
-  display: block;
-  margin-top: 0.15rem;
-  font-size: 0.82rem;
-  line-height: 1.55;
-  color: var(--text-dim);
-  max-width: 70ch;
-}
-
 .options .field-summary {
   padding-top: 0.7rem;
   border-top: 1px dashed var(--border);

--- a/tools/compress-image/tool.toml
+++ b/tools/compress-image/tool.toml
@@ -28,7 +28,7 @@ roadmap_group = "images"
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. file-list is the drop-a-file-then-see-a-row widget that
 # more than one tool needs and that no tool should own.
-css_parts = ["file-list", "progress", "results", "form"]
+css_parts = ["file-list", "progress", "results", "form", "checks"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.

--- a/tools/compress-pdf/styles.css
+++ b/tools/compress-pdf/styles.css
@@ -252,18 +252,6 @@
   cursor: pointer;
 }
 
-.check input { margin-top: 0.25rem; flex: none; }
-.check strong { display: block; font-size: 0.9rem; }
-
-.check-note {
-  display: block;
-  margin-top: 0.15rem;
-  font-size: 0.82rem;
-  line-height: 1.55;
-  color: var(--text-dim);
-  max-width: 70ch;
-}
-
 /* ----------------------------------------------------------------- running */
 
 .run-row { display: flex; align-items: center; gap: 0.9rem; flex-wrap: wrap; }

--- a/tools/compress-pdf/tool.toml
+++ b/tools/compress-pdf/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "documents"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress"]
+css_parts = ["progress", "checks"]
 
 # file-picker brings in the drop zone. The four pdf-* parts are the PDF itself
 # - the object grammar, the stream filters, the reader and the writer - and

--- a/tools/crop-video/styles.css
+++ b/tools/crop-video/styles.css
@@ -119,67 +119,13 @@
 /* Everything outside the box is dimmed by one enormous shadow rather than four
    overlay elements, which keeps the markup to a single div and the dimming
    exactly in step with the box as it moves. */
-.crop-box {
-  position: absolute;
-  box-sizing: border-box;
-  border: 1px solid rgb(255 255 255 / 90%);
-  box-shadow: 0 0 0 100vmax rgb(0 0 0 / 45%);
-  cursor: move;
-  touch-action: none;
-}
-
-.crop-box:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
 
 .crop-box.disabled { pointer-events: none; opacity: 0.7; }
 
 /* Thirds, the way a viewfinder draws them. Two gradients, no extra elements. */
-.crop-box::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  opacity: 0.55;
-  background:
-    linear-gradient(to right, transparent calc(33.333% - 0.5px), rgb(255 255 255 / 55%) calc(33.333% - 0.5px) calc(33.333% + 0.5px), transparent calc(33.333% + 0.5px), transparent calc(66.667% - 0.5px), rgb(255 255 255 / 55%) calc(66.667% - 0.5px) calc(66.667% + 0.5px), transparent calc(66.667% + 0.5px)),
-    linear-gradient(to bottom, transparent calc(33.333% - 0.5px), rgb(255 255 255 / 55%) calc(33.333% - 0.5px) calc(33.333% + 0.5px), transparent calc(33.333% + 0.5px), transparent calc(66.667% - 0.5px), rgb(255 255 255 / 55%) calc(66.667% - 0.5px) calc(66.667% + 0.5px), transparent calc(66.667% + 0.5px));
-}
-
-.crop-box.dragging::before { opacity: 0.9; }
-
-.crop-size {
-  position: absolute;
-  left: 50%;
-  bottom: 0.4rem;
-  transform: translateX(-50%);
-  padding: 0.1rem 0.45rem;
-  border-radius: 99px;
-  background: rgb(0 0 0 / 65%);
-  color: #fff;
-  font-size: 0.75rem;
-  font-variant-numeric: tabular-nums;
-  white-space: nowrap;
-  pointer-events: none;
-}
-
-.crop-handle {
-  position: absolute;
-  width: 14px;
-  height: 14px;
-  background: #fff;
-  border: 1px solid rgb(0 0 0 / 45%);
-  border-radius: 3px;
-}
 
 /* A touch target larger than the dot it draws, so a handle can be grabbed with
    a finger without making the dot itself cover the picture. */
-.crop-handle::after {
-  content: "";
-  position: absolute;
-  inset: -10px;
-}
 
 .handle-n  { top: -7px; left: 50%; margin-left: -7px; cursor: ns-resize; }
 .handle-s  { bottom: -7px; left: 50%; margin-left: -7px; cursor: ns-resize; }
@@ -197,12 +143,6 @@
 }
 
 /* --------------------------------------------------------- crop controls */
-
-.crop-controls {
-  margin-top: 1rem;
-  display: grid;
-  gap: 0.9rem;
-}
 
 .aspect-row {
   display: flex;

--- a/tools/crop-video/styles.css
+++ b/tools/crop-video/styles.css
@@ -3,17 +3,6 @@
 
 /* -------------------------------------------------------------- the source */
 
-.path-note,
-.stage-note {
-  margin: 0.9rem 0 0;
-  padding: 0.6rem 0.8rem;
-  border-radius: 7px;
-  background: var(--surface-2);
-  border: 1px solid var(--border);
-  color: var(--text-dim);
-  font-size: 0.84rem;
-}
-
 /* --------------------------------------------------------------- the stage */
 
 .stage-hint {
@@ -309,17 +298,6 @@
 }
 
 /* ------------------------------------------------------------------ export */
-
-.error {
-  margin: 1rem 0 0;
-  padding: 0.7rem 0.9rem;
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
-  color: var(--danger);
-  font-size: 0.9rem;
-  white-space: pre-line;
-}
 
 .result video {
   width: 100%;

--- a/tools/crop-video/tool.toml
+++ b/tools/crop-video/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "video"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "results", "form", "notes"]
+css_parts = ["progress", "results", "form", "notes", "cropper"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no

--- a/tools/crop-video/tool.toml
+++ b/tools/crop-video/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "video"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "results", "form"]
+css_parts = ["progress", "results", "form", "notes"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no

--- a/tools/document-scanner/styles.css
+++ b/tools/document-scanner/styles.css
@@ -8,17 +8,6 @@
 /* The one button on the page big enough to be found without reading. */
 .big { font-size: 1.02rem; padding: 0.7rem 1.3rem; }
 
-.error {
-  margin: 1rem 0 0;
-  padding: 0.7rem 0.9rem;
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
-  color: var(--danger);
-  font-size: 0.9rem;
-  white-space: pre-line;
-}
-
 .card-lede {
   margin: -0.4rem 0 1.1rem;
   font-size: 0.92rem;

--- a/tools/document-scanner/styles.css
+++ b/tools/document-scanner/styles.css
@@ -347,18 +347,6 @@ kbd {
   margin-bottom: 0.8rem;
 }
 
-.check input { margin-top: 0.25rem; flex: none; }
-.check strong { display: block; font-size: 0.9rem; }
-
-.check-note {
-  display: block;
-  margin-top: 0.15rem;
-  font-size: 0.82rem;
-  line-height: 1.55;
-  color: var(--text-dim);
-  max-width: 70ch;
-}
-
 .option-row {
   display: flex;
   align-items: center;

--- a/tools/document-scanner/tool.toml
+++ b/tools/document-scanner/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "documents"
 
 # Shared stylesheet parts this tool asks for, put before its own rules by
 # the build so that its own can override them.
-css_parts = ["checks"]
+css_parts = ["checks", "notes"]
 
 # Shared modules this tool asks for. file-picker brings in the drop zone; zip is
 # for saving several pages as pictures rather than as a document, and needs crc32

--- a/tools/document-scanner/tool.toml
+++ b/tools/document-scanner/tool.toml
@@ -25,6 +25,10 @@ category = "documents-and-audio"
 # It sits at the top of that group as a link, above the names still to be built.
 roadmap_group = "documents"
 
+# Shared stylesheet parts this tool asks for, put before its own rules by
+# the build so that its own can override them.
+css_parts = ["checks"]
+
 # Shared modules this tool asks for. file-picker brings in the drop zone; zip is
 # for saving several pages as pictures rather than as a document, and needs crc32
 # beside it because the archive stores a checksum per entry.

--- a/tools/edit-audio/styles.css
+++ b/tools/edit-audio/styles.css
@@ -3,16 +3,6 @@
 
 /* -------------------------------------------------------------- the source */
 
-.path-note {
-  margin: 0.9rem 0 0;
-  padding: 0.6rem 0.8rem;
-  border-radius: 7px;
-  background: var(--surface-2);
-  border: 1px solid var(--border);
-  color: var(--text-dim);
-  font-size: 0.84rem;
-}
-
 /* ------------------------------------------------------------ the waveform */
 
 .wave-wrap { margin-top: 1rem; }
@@ -163,17 +153,6 @@ input[type="range"] {
   gap: 0.6rem;
   align-items: center;
   flex-wrap: wrap;
-}
-
-.error {
-  margin: 1rem 0 0;
-  padding: 0.7rem 0.9rem;
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
-  color: var(--danger);
-  font-size: 0.9rem;
-  white-space: pre-line;
 }
 
 @media (max-width: 620px) {

--- a/tools/edit-audio/styles.css
+++ b/tools/edit-audio/styles.css
@@ -90,24 +90,6 @@ input[type="range"] {
   gap: 0.7rem;
 }
 
-.modes legend {
-  padding: 0 0.35rem;
-  font-size: 0.8rem;
-  color: var(--text-dim);
-}
-
-.mode {
-  display: flex;
-  gap: 0.55rem;
-  align-items: start;
-  font-size: 0.85rem;
-  cursor: pointer;
-}
-
-.mode input { margin: 0.15rem 0 0; flex: none; }
-.mode span { display: flex; flex-direction: column; gap: 0.1rem; color: var(--text-dim); }
-.mode strong { color: var(--text); font-size: 0.9rem; }
-
 .check {
   display: flex;
   align-items: center;

--- a/tools/edit-audio/tool.toml
+++ b/tools/edit-audio/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "audio"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "results", "form"]
+css_parts = ["progress", "results", "form", "notes"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts, and for
 # the same reason: a component more than one tool needs and no tool should own.

--- a/tools/edit-audio/tool.toml
+++ b/tools/edit-audio/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "audio"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "results", "form", "notes"]
+css_parts = ["progress", "results", "form", "notes", "modes"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts, and for
 # the same reason: a component more than one tool needs and no tool should own.

--- a/tools/exif-editor/styles.css
+++ b/tools/exif-editor/styles.css
@@ -127,18 +127,6 @@
   cursor: pointer;
 }
 
-.check input { margin-top: 0.25rem; flex: none; }
-.check strong { display: block; font-size: 0.9rem; }
-
-.check-note {
-  display: block;
-  margin-top: 0.15rem;
-  font-size: 0.82rem;
-  line-height: 1.55;
-  color: var(--text-dim);
-  max-width: 70ch;
-}
-
 /* The exact bargain the button above is offering, restated as one sentence
    that changes with the boxes. "Remove all" that keeps things without saying so
    would be the one dishonest line on the page. */

--- a/tools/exif-editor/tool.toml
+++ b/tools/exif-editor/tool.toml
@@ -28,7 +28,7 @@ roadmap_group = "images"
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. file-list is the drop-a-file-then-see-a-row widget that
 # more than one tool needs and that no tool should own.
-css_parts = ["file-list", "form"]
+css_parts = ["file-list", "form", "checks"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no

--- a/tools/extract-audio-from-video/styles.css
+++ b/tools/extract-audio-from-video/styles.css
@@ -3,16 +3,6 @@
 
 /* -------------------------------------------------------------- the source */
 
-.path-note {
-  margin: 0.9rem 0 0;
-  padding: 0.6rem 0.8rem;
-  border-radius: 7px;
-  background: var(--surface-2);
-  border: 1px solid var(--border);
-  color: var(--text-dim);
-  font-size: 0.84rem;
-}
-
 /* ------------------------------------------------------------ the waveform */
 
 .wave-wrap { margin-top: 1rem; }
@@ -163,17 +153,6 @@ input[type="range"] {
   gap: 0.6rem;
   align-items: center;
   flex-wrap: wrap;
-}
-
-.error {
-  margin: 1rem 0 0;
-  padding: 0.7rem 0.9rem;
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
-  color: var(--danger);
-  font-size: 0.9rem;
-  white-space: pre-line;
 }
 
 @media (max-width: 620px) {

--- a/tools/extract-audio-from-video/styles.css
+++ b/tools/extract-audio-from-video/styles.css
@@ -90,24 +90,6 @@ input[type="range"] {
   gap: 0.7rem;
 }
 
-.modes legend {
-  padding: 0 0.35rem;
-  font-size: 0.8rem;
-  color: var(--text-dim);
-}
-
-.mode {
-  display: flex;
-  gap: 0.55rem;
-  align-items: start;
-  font-size: 0.85rem;
-  cursor: pointer;
-}
-
-.mode input { margin: 0.15rem 0 0; flex: none; }
-.mode span { display: flex; flex-direction: column; gap: 0.1rem; color: var(--text-dim); }
-.mode strong { color: var(--text); font-size: 0.9rem; }
-
 .check {
   display: flex;
   align-items: center;

--- a/tools/extract-audio-from-video/tool.toml
+++ b/tools/extract-audio-from-video/tool.toml
@@ -69,7 +69,7 @@ roadmap_group = "audio"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar the shared picker draws while it reads.
-css_parts = ["progress", "results", "form"]
+css_parts = ["progress", "results", "form", "notes"]
 
 # Shared modules this tool asks for. file-picker brings in the drop zone.
 js_parts = ["file-picker", "audio-decode", "samplerate", "wav", "message-box", "format"]

--- a/tools/extract-audio-from-video/tool.toml
+++ b/tools/extract-audio-from-video/tool.toml
@@ -69,7 +69,7 @@ roadmap_group = "audio"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar the shared picker draws while it reads.
-css_parts = ["progress", "results", "form", "notes"]
+css_parts = ["progress", "results", "form", "notes", "modes"]
 
 # Shared modules this tool asks for. file-picker brings in the drop zone.
 js_parts = ["file-picker", "audio-decode", "samplerate", "wav", "message-box", "format"]

--- a/tools/grab-frame/styles.css
+++ b/tools/grab-frame/styles.css
@@ -3,17 +3,6 @@
 
 /* -------------------------------------------------------------- the source */
 
-.path-note,
-.stage-note {
-  margin: 0.9rem 0 0;
-  padding: 0.6rem 0.8rem;
-  border-radius: 7px;
-  background: var(--surface-2);
-  border: 1px solid var(--border);
-  color: var(--text-dim);
-  font-size: 0.84rem;
-}
-
 /* --------------------------------------------------------------- the stage */
 
 .stage-hint {
@@ -144,17 +133,6 @@
 }
 
 /* ------------------------------------------------------------ grabbing */
-
-.error {
-  margin: 1rem 0 0;
-  padding: 0.7rem 0.9rem;
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
-  color: var(--danger);
-  font-size: 0.9rem;
-  white-space: pre-line;
-}
 
 /* ------------------------------------------------------------- the stills */
 

--- a/tools/grab-frame/tool.toml
+++ b/tools/grab-frame/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "video"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "results", "form"]
+css_parts = ["progress", "results", "form", "notes"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no

--- a/tools/heic-to-jpg/styles.css
+++ b/tools/heic-to-jpg/styles.css
@@ -58,25 +58,6 @@
 
 /* The sentence under a control, restating what it is about to do. */
 
-.check {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.6rem;
-  cursor: pointer;
-}
-
-.check input { margin-top: 0.25rem; flex: none; }
-.check strong { display: block; font-size: 0.9rem; }
-
-.check-note {
-  display: block;
-  margin-top: 0.15rem;
-  font-size: 0.82rem;
-  line-height: 1.55;
-  color: var(--text-dim);
-  max-width: 70ch;
-}
-
 .options .field-summary {
   padding-top: 0.7rem;
   border-top: 1px dashed var(--border);

--- a/tools/heic-to-jpg/tool.toml
+++ b/tools/heic-to-jpg/tool.toml
@@ -31,7 +31,7 @@ roadmap_group = "images"
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. file-list is the drop-a-file-then-see-a-row widget that
 # more than one tool needs and that no tool should own.
-css_parts = ["file-list", "progress", "results", "form"]
+css_parts = ["file-list", "progress", "results", "form", "checks"]
 # Shared modules this tool asks for. file-picker brings in the drop zone.
 js_parts = ["file-picker", "zip", "crc32", "message-box", "download", "format", "errors"]
 lastmod = "2026-08-27"

--- a/tools/id-photo/styles.css
+++ b/tools/id-photo/styles.css
@@ -7,17 +7,6 @@
 
 /* The one button on the page big enough to be found without reading. */
 
-.error {
-  margin: 1rem 0 0;
-  padding: 0.7rem 0.9rem;
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
-  color: var(--danger);
-  font-size: 0.9rem;
-  white-space: pre-line;
-}
-
 .hint-line {
   margin: 0.5rem 0 0;
   font-size: 0.84rem;

--- a/tools/id-photo/tool.toml
+++ b/tools/id-photo/tool.toml
@@ -26,7 +26,7 @@ roadmap_group = "images"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "form"]
+css_parts = ["progress", "form", "notes"]
 
 # Shared modules this tool asks for. file-picker brings in the drop zone.
 js_parts = ["file-picker", "message-box"]

--- a/tools/image-to-ico/styles.css
+++ b/tools/image-to-ico/styles.css
@@ -143,18 +143,6 @@
   margin-top: 1.2rem;
 }
 
-.check input { margin-top: 0.25rem; flex: none; }
-.check strong { display: block; font-size: 0.9rem; }
-
-.check-note {
-  display: block;
-  margin-top: 0.15rem;
-  font-size: 0.82rem;
-  line-height: 1.55;
-  color: var(--text-dim);
-  max-width: 70ch;
-}
-
 .check code {
   font-size: 0.95em;
   padding: 0.05rem 0.25rem;

--- a/tools/image-to-ico/tool.toml
+++ b/tools/image-to-ico/tool.toml
@@ -28,7 +28,7 @@ roadmap_group = "images"
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. file-list is the drop-a-file-then-see-a-row widget that
 # more than one tool needs and that no tool should own.
-css_parts = ["file-list", "progress", "results", "form"]
+css_parts = ["file-list", "progress", "results", "form", "checks"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.

--- a/tools/json-formatter/styles.css
+++ b/tools/json-formatter/styles.css
@@ -40,8 +40,6 @@
 .field-note { margin: 0.15rem 0 0; font-size: 0.78rem; color: var(--text-dim); }
 .field-note:empty { display: none; }
 
-.field.checks { gap: 0.5rem; }
-
 .settings {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
@@ -66,25 +64,6 @@ input[type="text"] {
 }
 
 /* -------------------------------------------------------------- the boxes */
-
-.panes {
-  margin-top: 1rem;
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 1rem;
-}
-
-.pane { display: flex; flex-direction: column; gap: 0.35rem; min-width: 0; }
-
-.pane-head {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 0.8rem;
-  flex-wrap: wrap;
-}
-
-.pane-head label { font-size: 0.85rem; font-weight: 600; }
 
 textarea {
   width: 100%;

--- a/tools/json-formatter/tool.toml
+++ b/tools/json-formatter/tool.toml
@@ -35,7 +35,7 @@ roadmap_group = "beyond"
 
 # Shared stylesheet parts this tool asks for, put before its own rules by
 # the build so that its own can override them.
-css_parts = ["form"]
+css_parts = ["form", "panes"]
 
 # Shared modules this tool asks for. file-picker brings in the drop zone, which
 # is here for the file that is easier to drop than to open, select all and copy.

--- a/tools/merge-pdf/styles.css
+++ b/tools/merge-pdf/styles.css
@@ -299,18 +299,6 @@
   cursor: pointer;
 }
 
-.check input { margin-top: 0.25rem; flex: none; }
-.check strong { display: block; font-size: 0.9rem; }
-
-.check-note {
-  display: block;
-  margin-top: 0.15rem;
-  font-size: 0.82rem;
-  line-height: 1.55;
-  color: var(--text-dim);
-  max-width: 70ch;
-}
-
 /* ----------------------------------------------------------------- running */
 
 /* ----------------------------------------------------------------- results */

--- a/tools/merge-pdf/tool.toml
+++ b/tools/merge-pdf/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "documents"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "form"]
+css_parts = ["progress", "form", "checks"]
 
 # file-picker brings in the drop zone; zip is the archive a split comes back
 # in when it is more than one file, and crc32 is the checksum it needs. The

--- a/tools/password-generator/styles.css
+++ b/tools/password-generator/styles.css
@@ -72,7 +72,6 @@
 .field > label { font-size: 0.85rem; font-weight: 600; }
 .field-note { margin: 0.15rem 0 0; font-size: 0.78rem; color: var(--text-dim); }
 
-.field.checks { gap: 0.5rem; }
 .checks-label { font-size: 0.85rem; font-weight: 600; }
 
 .check {

--- a/tools/password-generator/tool.toml
+++ b/tools/password-generator/tool.toml
@@ -95,6 +95,10 @@ card = """
             A strong random password, or a passphrase built from a bundled
             wordlist. Drawn by your own browser and never sent anywhere."""
 
+# Shared stylesheet parts this tool asks for, put before its own rules by
+# the build so that its own can override them.
+css_parts = ["panes"]
+
 # The nouns this tool uses for the things it works on. They appear in the boot
 # warning, the pledge line and the analytics comment, which is why they are a
 # setting rather than three copies of the same word in three files.

--- a/tools/qr-barcode-reader/styles.css
+++ b/tools/qr-barcode-reader/styles.css
@@ -100,25 +100,6 @@ kbd {
   min-width: 0;
 }
 
-.check {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.6rem;
-  cursor: pointer;
-}
-
-.check input { margin-top: 0.25rem; flex: none; }
-.check strong { display: block; font-size: 0.9rem; }
-
-.check-note {
-  display: block;
-  margin-top: 0.15rem;
-  font-size: 0.82rem;
-  line-height: 1.55;
-  color: var(--text-dim);
-  max-width: 70ch;
-}
-
 /* ------------------------------------------------------------ the results */
 
 .result {

--- a/tools/qr-barcode-reader/tool.toml
+++ b/tools/qr-barcode-reader/tool.toml
@@ -37,7 +37,7 @@ lastmod = "2026-09-01"
 
 # Shared stylesheet parts this tool asks for, put before its own rules by
 # the build so that its own can override them.
-css_parts = ["form"]
+css_parts = ["form", "checks"]
 
 # The drop zone brings in shared/js/file-picker.js. Several files at once is
 # deliberate: a folder of screenshots, or a photograph of a page of codes, is a

--- a/tools/qr-barcode/styles.css
+++ b/tools/qr-barcode/styles.css
@@ -7,17 +7,6 @@
   now that was every control on the site.
 */
 
-.error {
-  margin: 1rem 0 0;
-  padding: 0.7rem 0.9rem;
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
-  color: var(--danger);
-  font-size: 0.9rem;
-  white-space: pre-line;
-}
-
 /* ------------------------------------------------------------- the options */
 
 .option-row {

--- a/tools/qr-barcode/styles.css
+++ b/tools/qr-barcode/styles.css
@@ -31,25 +31,7 @@
 
 .option-row input[type="number"] { width: 7rem; }
 
-.check {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.6rem;
-  cursor: pointer;
-}
-
-.check input { margin-top: 0.25rem; flex: none; }
-.check strong { display: block; font-size: 0.9rem; }
 .check + .check { margin-top: 0.8rem; }
-
-.check-note {
-  display: block;
-  margin-top: 0.15rem;
-  font-size: 0.82rem;
-  line-height: 1.55;
-  color: var(--text-dim);
-  max-width: 70ch;
-}
 
 .options .field-summary {
   padding-top: 0.7rem;

--- a/tools/qr-barcode/tool.toml
+++ b/tools/qr-barcode/tool.toml
@@ -29,7 +29,7 @@ category = "text-codes-and-passwords"
 roadmap_group = "beyond"
 # Shared stylesheet parts this tool asks for, put before its own rules by
 # the build so that its own can override them.
-css_parts = ["form", "checks"]
+css_parts = ["form", "checks", "notes"]
 js_parts = ["qr-tables", "download"]
 lastmod = "2026-08-27"
 

--- a/tools/qr-barcode/tool.toml
+++ b/tools/qr-barcode/tool.toml
@@ -29,7 +29,7 @@ category = "text-codes-and-passwords"
 roadmap_group = "beyond"
 # Shared stylesheet parts this tool asks for, put before its own rules by
 # the build so that its own can override them.
-css_parts = ["form"]
+css_parts = ["form", "checks"]
 js_parts = ["qr-tables", "download"]
 lastmod = "2026-08-27"
 

--- a/tools/redact-image/styles.css
+++ b/tools/redact-image/styles.css
@@ -7,17 +7,6 @@
 
 /* The one button on the page big enough to be found without reading. */
 
-.error {
-  margin: 1rem 0 0;
-  padding: 0.7rem 0.9rem;
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
-  color: var(--danger);
-  font-size: 0.9rem;
-  white-space: pre-line;
-}
-
 .hint-line {
   margin: 0.5rem 0 0;
   font-size: 0.84rem;

--- a/tools/redact-image/styles.css
+++ b/tools/redact-image/styles.css
@@ -198,18 +198,6 @@ kbd {
   margin-bottom: 0.8rem;
 }
 
-.check input { margin-top: 0.25rem; flex: none; }
-.check strong { display: block; font-size: 0.9rem; }
-
-.check-note {
-  display: block;
-  margin-top: 0.15rem;
-  font-size: 0.82rem;
-  line-height: 1.55;
-  color: var(--text-dim);
-  max-width: 70ch;
-}
-
 .option-row {
   display: flex;
   align-items: center;

--- a/tools/redact-image/tool.toml
+++ b/tools/redact-image/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "images"
 
 # Shared stylesheet parts this tool asks for, put before its own rules by
 # the build so that its own can override them.
-css_parts = ["results", "form", "checks"]
+css_parts = ["results", "form", "checks", "notes"]
 
 # Shared modules this tool asks for. file-picker brings in the drop zone; the
 # list of boxes underneath the picture is this tool's own, because it is a list

--- a/tools/redact-image/tool.toml
+++ b/tools/redact-image/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "images"
 
 # Shared stylesheet parts this tool asks for, put before its own rules by
 # the build so that its own can override them.
-css_parts = ["results", "form"]
+css_parts = ["results", "form", "checks"]
 
 # Shared modules this tool asks for. file-picker brings in the drop zone; the
 # list of boxes underneath the picture is this tool's own, because it is a list

--- a/tools/redact-pdf/styles.css
+++ b/tools/redact-pdf/styles.css
@@ -292,18 +292,6 @@
   cursor: pointer;
 }
 
-.check input { margin-top: 0.25rem; flex: none; }
-.check strong { display: block; font-size: 0.9rem; }
-
-.check-note {
-  display: block;
-  margin-top: 0.15rem;
-  font-size: 0.82rem;
-  line-height: 1.55;
-  color: var(--text-dim);
-  max-width: 70ch;
-}
-
 /* ---------------------------------------------------------------- results */
 
 .result { margin-top: 1.2rem; }

--- a/tools/redact-pdf/tool.toml
+++ b/tools/redact-pdf/tool.toml
@@ -33,7 +33,7 @@ roadmap_group = "documents"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "form"]
+css_parts = ["progress", "form", "checks"]
 
 # file-picker brings in the drop zone. The four pdf-* parts are the PDF itself
 # - the object grammar, the stream filters, the reader and the writer - and

--- a/tools/resize-image/styles.css
+++ b/tools/resize-image/styles.css
@@ -176,69 +176,15 @@ button.file-main-wrap:focus-visible {
 /* Everything outside the box is dimmed by one enormous shadow rather than four
    overlay elements, which keeps the markup to a single div and the dimming
    exactly in step with the box as it moves. */
-.crop-box {
-  position: absolute;
-  box-sizing: border-box;
-  border: 1px solid rgb(255 255 255 / 90%);
-  box-shadow: 0 0 0 100vmax rgb(0 0 0 / 45%);
-  cursor: move;
-  touch-action: none;
-}
-
-.crop-box:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
 
 /* Cropping is off, so the box is showing what will be kept - which is all of
    it - rather than offering to be dragged. */
 .crop-box.disabled { pointer-events: none; opacity: 0; }
 
 /* Thirds, the way a viewfinder draws them. Two gradients, no extra elements. */
-.crop-box::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  opacity: 0.55;
-  background:
-    linear-gradient(to right, transparent calc(33.333% - 0.5px), rgb(255 255 255 / 55%) calc(33.333% - 0.5px) calc(33.333% + 0.5px), transparent calc(33.333% + 0.5px), transparent calc(66.667% - 0.5px), rgb(255 255 255 / 55%) calc(66.667% - 0.5px) calc(66.667% + 0.5px), transparent calc(66.667% + 0.5px)),
-    linear-gradient(to bottom, transparent calc(33.333% - 0.5px), rgb(255 255 255 / 55%) calc(33.333% - 0.5px) calc(33.333% + 0.5px), transparent calc(33.333% + 0.5px), transparent calc(66.667% - 0.5px), rgb(255 255 255 / 55%) calc(66.667% - 0.5px) calc(66.667% + 0.5px), transparent calc(66.667% + 0.5px));
-}
-
-.crop-box.dragging::before { opacity: 0.9; }
-
-.crop-size {
-  position: absolute;
-  left: 50%;
-  bottom: 0.4rem;
-  transform: translateX(-50%);
-  padding: 0.1rem 0.45rem;
-  border-radius: 99px;
-  background: rgb(0 0 0 / 65%);
-  color: #fff;
-  font-size: 0.75rem;
-  font-variant-numeric: tabular-nums;
-  white-space: nowrap;
-  pointer-events: none;
-}
-
-.crop-handle {
-  position: absolute;
-  width: 14px;
-  height: 14px;
-  background: #fff;
-  border: 1px solid rgb(0 0 0 / 45%);
-  border-radius: 3px;
-}
 
 /* A touch target larger than the dot it draws, so a handle can be grabbed with
    a finger without making the dot itself cover the picture. */
-.crop-handle::after {
-  content: "";
-  position: absolute;
-  inset: -10px;
-}
 
 .handle-n  { top: -7px; left: 50%; margin-left: -7px; cursor: ns-resize; }
 .handle-s  { bottom: -7px; left: 50%; margin-left: -7px; cursor: ns-resize; }
@@ -256,12 +202,6 @@ button.file-main-wrap:focus-visible {
 }
 
 /* --------------------------------------------------------------- controls */
-
-.crop-controls {
-  margin-top: 1rem;
-  display: grid;
-  gap: 0.9rem;
-}
 
 .aspect-row {
   display: flex;

--- a/tools/resize-image/styles.css
+++ b/tools/resize-image/styles.css
@@ -349,25 +349,6 @@ button.file-main-wrap:focus-visible {
 
 .presets { display: flex; gap: 0.4rem; flex-wrap: wrap; }
 
-.check {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.6rem;
-  cursor: pointer;
-}
-
-.check input { margin-top: 0.25rem; flex: none; }
-.check strong { display: block; font-size: 0.9rem; }
-
-.check-note {
-  display: block;
-  margin-top: 0.15rem;
-  font-size: 0.82rem;
-  line-height: 1.55;
-  color: var(--text-dim);
-  max-width: 70ch;
-}
-
 /* The sentence under a group of controls, restating what they are about to do.
    Every step on this page has one, because "contain, 1920, no enlarge" means
    nothing to somebody who came here to make a photograph fit an upload form.

--- a/tools/resize-image/tool.toml
+++ b/tools/resize-image/tool.toml
@@ -28,7 +28,7 @@ roadmap_group = "images"
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. file-list is the drop-a-file-then-see-a-row widget that
 # more than one tool needs and that no tool should own.
-css_parts = ["file-list", "progress", "results", "form"]
+css_parts = ["file-list", "progress", "results", "form", "checks"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.

--- a/tools/resize-image/tool.toml
+++ b/tools/resize-image/tool.toml
@@ -28,7 +28,7 @@ roadmap_group = "images"
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. file-list is the drop-a-file-then-see-a-row widget that
 # more than one tool needs and that no tool should own.
-css_parts = ["file-list", "progress", "results", "form", "checks"]
+css_parts = ["file-list", "progress", "results", "form", "checks", "cropper"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.

--- a/tools/reverse-video/styles.css
+++ b/tools/reverse-video/styles.css
@@ -3,17 +3,6 @@
 
 /* -------------------------------------------------------------- the source */
 
-.path-note,
-.stage-note {
-  margin: 0.9rem 0 0;
-  padding: 0.6rem 0.8rem;
-  border-radius: 7px;
-  background: var(--surface-2);
-  border: 1px solid var(--border);
-  color: var(--text-dim);
-  font-size: 0.84rem;
-}
-
 /* -------------------------------------------------------------- the preview */
 
 /* Nothing is dragged over this one - a reversal has no rectangle to place - so
@@ -72,17 +61,6 @@
 }
 
 /* ------------------------------------------------------------------ export */
-
-.error {
-  margin: 1rem 0 0;
-  padding: 0.7rem 0.9rem;
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
-  color: var(--danger);
-  font-size: 0.9rem;
-  white-space: pre-line;
-}
 
 .result video {
   width: 100%;

--- a/tools/reverse-video/tool.toml
+++ b/tools/reverse-video/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "video"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "results", "form"]
+css_parts = ["progress", "results", "form", "notes"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no

--- a/tools/split-gif/styles.css
+++ b/tools/split-gif/styles.css
@@ -3,27 +3,6 @@
 
 /* -------------------------------------------------------------- the source */
 
-.path-note {
-  margin: 0.9rem 0 0;
-  padding: 0.6rem 0.8rem;
-  border-radius: 7px;
-  background: var(--surface-2);
-  border: 1px solid var(--border);
-  color: var(--text-dim);
-  font-size: 0.84rem;
-}
-
-.error {
-  margin: 1rem 0 0;
-  padding: 0.7rem 0.9rem;
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
-  color: var(--danger);
-  font-size: 0.9rem;
-  white-space: pre-line;
-}
-
 /* ---------------------------------------------------------------- settings */
 
 .settings {

--- a/tools/split-gif/tool.toml
+++ b/tools/split-gif/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "gif"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "results", "form"]
+css_parts = ["progress", "results", "form", "notes"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts, and for
 # the same reason: a component more than one tool needs and no tool should own.

--- a/tools/stack-images/styles.css
+++ b/tools/stack-images/styles.css
@@ -171,17 +171,6 @@
 
 /* ----------------------------------------------------------- running it */
 
-.error {
-  margin: 1rem 0 0;
-  padding: 0.7rem 0.9rem;
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
-  color: var(--danger);
-  font-size: 0.9rem;
-  white-space: pre-line;
-}
-
 /* ------------------------------------------------------------- the result */
 
 /* A checkerboard behind the picture, because a stack in Lighten mode over a

--- a/tools/stack-images/tool.toml
+++ b/tools/stack-images/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "images"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "results", "form"]
+css_parts = ["progress", "results", "form", "notes"]
 
 # Shared modules this tool asks for. Only the drop zone: the list underneath it
 # is this tool's own, because a row in it carries what was found inside a RAW

--- a/tools/text-diff/styles.css
+++ b/tools/text-diff/styles.css
@@ -7,8 +7,6 @@
 .field-note { margin: 0.15rem 0 0; font-size: 0.78rem; color: var(--text-dim); }
 .field-note:empty { display: none; }
 
-.field.checks { gap: 0.5rem; }
-
 .settings {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
@@ -27,31 +25,12 @@
 
 /* -------------------------------------------------------------- the boxes */
 
-.panes {
-  margin-top: 1rem;
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 1rem;
-}
-
 /* Two boxes side by side once there is room for both, and stacked before
    that - a comparison on a phone is two full-width boxes, not two narrow
    ones. */
 @media (min-width: 780px) {
   .panes { grid-template-columns: 1fr 1fr; }
 }
-
-.pane { display: flex; flex-direction: column; gap: 0.35rem; min-width: 0; }
-
-.pane-head {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 0.8rem;
-  flex-wrap: wrap;
-}
-
-.pane-head label { font-size: 0.85rem; font-weight: 600; }
 
 textarea {
   width: 100%;

--- a/tools/text-diff/tool.toml
+++ b/tools/text-diff/tool.toml
@@ -37,7 +37,7 @@ roadmap_group = "beyond"
 
 # Shared stylesheet parts this tool asks for, put before its own rules by
 # the build so that its own can override them.
-css_parts = ["form"]
+css_parts = ["form", "panes"]
 
 # Shared modules this tool asks for. file-picker brings in the drop zone, which
 # is here for the two files that are easier to drop than to open, select all

--- a/tools/timelapse-video/styles.css
+++ b/tools/timelapse-video/styles.css
@@ -22,16 +22,6 @@
   background: #000;
 }
 
-.path-note {
-  margin: 0.9rem 0 0;
-  padding: 0.6rem 0.8rem;
-  border-radius: 7px;
-  background: var(--surface-2);
-  border: 1px solid var(--border);
-  color: var(--text-dim);
-  font-size: 0.84rem;
-}
-
 /* --------------------------------------------------------------- the speed */
 
 .speed-row {
@@ -121,17 +111,6 @@
 }
 
 /* ------------------------------------------------------------------ export */
-
-.error {
-  margin: 1rem 0 0;
-  padding: 0.7rem 0.9rem;
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
-  color: var(--danger);
-  font-size: 0.9rem;
-  white-space: pre-line;
-}
 
 .result video {
   width: 100%;

--- a/tools/timelapse-video/tool.toml
+++ b/tools/timelapse-video/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "video"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "results", "form"]
+css_parts = ["progress", "results", "form", "notes"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no

--- a/tools/trim-audio/styles.css
+++ b/tools/trim-audio/styles.css
@@ -3,16 +3,6 @@
 
 /* ---------------------------------------------------------- what was opened */
 
-.path-note {
-  margin: 0.9rem 0 0;
-  padding: 0.6rem 0.8rem;
-  border-radius: 7px;
-  background: var(--surface-2);
-  border: 1px solid var(--border);
-  color: var(--text-dim);
-  font-size: 0.84rem;
-}
-
 .stage-hint { margin: 0 0 0.9rem; font-size: 0.85rem; color: var(--text-dim); }
 
 kbd {
@@ -411,17 +401,6 @@ audio.player {
   gap: 0.6rem;
   align-items: center;
   flex-wrap: wrap;
-}
-
-.error {
-  margin: 1rem 0 0;
-  padding: 0.7rem 0.9rem;
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
-  color: var(--danger);
-  font-size: 0.9rem;
-  white-space: pre-line;
 }
 
 @media (max-width: 620px) {

--- a/tools/trim-audio/styles.css
+++ b/tools/trim-audio/styles.css
@@ -358,20 +358,6 @@ audio.player {
   gap: 0.7rem;
 }
 
-.modes legend { padding: 0 0.35rem; font-size: 0.8rem; color: var(--text-dim); }
-
-.mode {
-  display: flex;
-  gap: 0.55rem;
-  align-items: start;
-  font-size: 0.85rem;
-  cursor: pointer;
-}
-
-.mode input { margin: 0.15rem 0 0; flex: none; }
-.mode span { display: flex; flex-direction: column; gap: 0.1rem; color: var(--text-dim); }
-.mode strong { color: var(--text); font-size: 0.9rem; }
-
 /* ---------------------------------------------------------------- settings */
 
 .settings {

--- a/tools/trim-audio/tool.toml
+++ b/tools/trim-audio/tool.toml
@@ -35,7 +35,7 @@ roadmap_group = "audio"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "results", "form"]
+css_parts = ["progress", "results", "form", "notes"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts, and for
 # the same reason: a component more than one tool needs and no tool should own.

--- a/tools/trim-audio/tool.toml
+++ b/tools/trim-audio/tool.toml
@@ -35,7 +35,7 @@ roadmap_group = "audio"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "results", "form", "notes"]
+css_parts = ["progress", "results", "form", "notes", "modes"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts, and for
 # the same reason: a component more than one tool needs and no tool should own.

--- a/tools/trim-video/styles.css
+++ b/tools/trim-video/styles.css
@@ -1,17 +1,6 @@
 /* Rules only the video cutter needs. The frame around it - the header, the
    pledge, the cards, the buttons - is shared/css/tool-frame.css. */
 
-.path-note,
-.stage-note {
-  margin: 0.9rem 0 0;
-  padding: 0.6rem 0.8rem;
-  border-radius: 7px;
-  background: var(--surface-2);
-  border: 1px solid var(--border);
-  color: var(--text-dim);
-  font-size: 0.84rem;
-}
-
 /* ---------------------------------------------------------------- the list */
 
 /* One row a video, in the order they will be joined. Only drawn when there is
@@ -501,17 +490,6 @@ kbd {
   gap: 0.6rem;
   align-items: center;
   flex-wrap: wrap;
-}
-
-.error {
-  margin: 1rem 0 0;
-  padding: 0.7rem 0.9rem;
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
-  color: var(--danger);
-  font-size: 0.9rem;
-  white-space: pre-line;
 }
 
 .result video {

--- a/tools/trim-video/styles.css
+++ b/tools/trim-video/styles.css
@@ -438,20 +438,6 @@ kbd {
   gap: 0.7rem;
 }
 
-.modes legend { padding: 0 0.35rem; font-size: 0.8rem; color: var(--text-dim); }
-
-.mode {
-  display: flex;
-  gap: 0.55rem;
-  align-items: start;
-  font-size: 0.85rem;
-  cursor: pointer;
-}
-
-.mode input { margin: 0.15rem 0 0; flex: none; }
-.mode span { display: flex; flex-direction: column; gap: 0.1rem; color: var(--text-dim); }
-.mode strong { color: var(--text); font-size: 0.9rem; }
-
 /* ---------------------------------------------------------------- settings */
 
 .settings {

--- a/tools/trim-video/tool.toml
+++ b/tools/trim-video/tool.toml
@@ -28,7 +28,7 @@ roadmap_group = "video"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "results", "form"]
+css_parts = ["progress", "results", "form", "notes"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts, and for
 # the same reason: a component more than one tool needs and no tool should own.

--- a/tools/trim-video/tool.toml
+++ b/tools/trim-video/tool.toml
@@ -28,7 +28,7 @@ roadmap_group = "video"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "results", "form", "notes"]
+css_parts = ["progress", "results", "form", "notes", "modes"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts, and for
 # the same reason: a component more than one tool needs and no tool should own.

--- a/tools/video-to-gif/styles.css
+++ b/tools/video-to-gif/styles.css
@@ -3,17 +3,6 @@
 
 /* -------------------------------------------------------------- the source */
 
-.path-note,
-.stage-note {
-  margin: 0.9rem 0 0;
-  padding: 0.6rem 0.8rem;
-  border-radius: 7px;
-  background: var(--surface-2);
-  border: 1px solid var(--border);
-  color: var(--text-dim);
-  font-size: 0.84rem;
-}
-
 /* --------------------------------------------------------------- the stage */
 
 .hint {
@@ -208,17 +197,6 @@
 }
 
 /* ------------------------------------------------------------------ export */
-
-.error {
-  margin: 1rem 0 0;
-  padding: 0.7rem 0.9rem;
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
-  color: var(--danger);
-  font-size: 0.9rem;
-  white-space: pre-line;
-}
 
 /* The result is an <img>, so the browser animates it: what is on the page is
    the file, playing, rather than a preview of it. The ground behind it shows

--- a/tools/video-to-gif/tool.toml
+++ b/tools/video-to-gif/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "gif"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "results", "form"]
+css_parts = ["progress", "results", "form", "notes"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no

--- a/tools/xml-formatter/styles.css
+++ b/tools/xml-formatter/styles.css
@@ -40,8 +40,6 @@
 .field-note { margin: 0.15rem 0 0; font-size: 0.78rem; color: var(--text-dim); }
 .field-note:empty { display: none; }
 
-.field.checks { gap: 0.5rem; }
-
 .settings {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
@@ -66,25 +64,6 @@ input[type="text"] {
 }
 
 /* -------------------------------------------------------------- the boxes */
-
-.panes {
-  margin-top: 1rem;
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 1rem;
-}
-
-.pane { display: flex; flex-direction: column; gap: 0.35rem; min-width: 0; }
-
-.pane-head {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 0.8rem;
-  flex-wrap: wrap;
-}
-
-.pane-head label { font-size: 0.85rem; font-weight: 600; }
 
 textarea {
   width: 100%;

--- a/tools/xml-formatter/tool.toml
+++ b/tools/xml-formatter/tool.toml
@@ -56,7 +56,7 @@ roadmap_group = "beyond"
 
 # Shared stylesheet parts this tool asks for, put before its own rules by
 # the build so that its own can override them.
-css_parts = ["form"]
+css_parts = ["form", "panes"]
 
 # Shared modules this tool asks for. file-picker brings in the drop zone, which
 # is here for the file that is easier to drop than to open, select all and copy.

--- a/tools/yaml-to-json/styles.css
+++ b/tools/yaml-to-json/styles.css
@@ -40,8 +40,6 @@
 .field-note { margin: 0.15rem 0 0; font-size: 0.78rem; color: var(--text-dim); }
 .field-note:empty { display: none; }
 
-.field.checks { gap: 0.5rem; }
-
 .settings {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
@@ -66,25 +64,6 @@ input[type="text"] {
 }
 
 /* -------------------------------------------------------------- the boxes */
-
-.panes {
-  margin-top: 1rem;
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 1rem;
-}
-
-.pane { display: flex; flex-direction: column; gap: 0.35rem; min-width: 0; }
-
-.pane-head {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 0.8rem;
-  flex-wrap: wrap;
-}
-
-.pane-head label { font-size: 0.85rem; font-weight: 600; }
 
 textarea {
   width: 100%;

--- a/tools/yaml-to-json/tool.toml
+++ b/tools/yaml-to-json/tool.toml
@@ -55,7 +55,7 @@ roadmap_group = "beyond"
 
 # Shared stylesheet parts this tool asks for, put before its own rules by
 # the build so that its own can override them.
-css_parts = ["form"]
+css_parts = ["form", "panes"]
 
 # Shared modules this tool asks for. file-picker brings in the drop zone, which
 # is here for the config file that is easier to drop than to open, select all


### PR DESCRIPTION
Phase 5 of the shared-parts plan, the last five stylesheet families, stacked on #338: the checkbox rows, the notes, the text panes, the mode rows and the crop box. One commit per part, each with its own before-and-after cascade proof; one PR because each is small and a five-deep stack of squash merges would cost a rebase apiece. Nothing a visitor sees changes.

## What this does

| Part | Rules | Tools | What it is |
|---|---|---|---|
| `shared/css/checks.css` | 4 | 13 | a checkbox row with a bold title and a dim note, as the image and PDF tools draw it |
| `shared/css/notes.css` | 3 | 16 | the error line, and the note that says which path a file took |
| `shared/css/panes.css` | 5 | 6 | the two text panes of a formatter page and the head above each |
| `shared/css/modes.css` | 5 | 5 | a choice between two ways of working, as radio rows with a title and an explanation |
| `shared/css/cropper.css` | 8 | 2 | the crop box `shared/js/cropper.js` draws (#333): the box, the dimmed surround, the handles, the size label |

Across the five: 142 rules and 812 lines leave the tools' stylesheets, against 269 in the five parts and the docs; a row for each in `docs/adding-a-tool.md`; `password-generator`, which had neither a `js_parts` nor a `css_parts` line, gets its `css_parts` above its first table.

**Left out, with reasons the extraction printed:** `image-to-data-uri` from `checks` (its title and note rules set fewer properties than the part's, which would have shown through); `id-photo` from `cropper` (it draws no dimmed surround, so the part's `::before` rules would have started one). The video and text tools' checkboxes are a different style and were never candidates for `checks`; the image tools' `.error` ceiling and the text tools' `.error` margin stay as each tool's own rule on top of `notes`, since each sets everything the part sets.

## Before and after

Nothing on any page changes. For every part, all forty-one tools were built before and after (English, unminified) and the cascade of each built stylesheet - the declaration that finally wins for every selector, inside and outside media queries - compared. **Zero differ**, five times over. The selectors a part adds to a page that never styled them (16 for `notes`, 5 for `panes`, none for the others) are all for classes that page never carries, in its markup or in anything its scripts create.

## Verified

- The five cascade comparisons above.
- **A CI-style full build** passes.
- `test_english_in_js`, `test_duplicates`, `test_imports` and `test_phrases` pass.

## What this closes

Phase 5, and with it the shared-parts plan: five phases, eighteen pull requests since the resolve hook in #319. Every declared copy is a part under `shared/js/`, the helpers every tool wrote for itself are shared with each tool's own numbers kept, the near-duplicate leaves are one file with a parameter, and the stylesheet vocabulary the tools repeated is seven parts a tool asks for by name. What stays per tool now is per tool on purpose, and the duplicate test's on-disk scanner is the alarm for the next copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
