### PR TITLE
Start the video cutter's page again, and refuse an import of a name the file no longer has

### DIFF
--- a/buildlib/imports.py
+++ b/buildlib/imports.py
@@ -69,6 +69,92 @@ def specifiers(source, where='<js>'):
     return found
 
 
+def bindings(source, where='<js>'):
+    """Every named import, as (line, specifier, [names]).
+
+    `import { a, b as c } from './x.js'` names `a` and `b` - what x.js has to
+    export, not what this module calls them. A default or a side-effect import
+    names nothing and is not listed; those are the specifier check's business.
+
+    This exists because a specifier can land on a file that exists and still
+    name something that is no longer in it. Moving a function into a shared
+    part leaves every `import { it } from './old.js'` pointing at a real file,
+    the build ships it, and the page's module fails to link on the visitor's
+    machine - which is how the video cutter spent an afternoon showing "this
+    page's code did not start" after its frame-rate helper moved.
+    """
+    found = []
+    tokens = minify.tokenize_js(source, where)
+    index = 0
+    while index < len(tokens):
+        line, text = tokens[index]
+        if text != 'import' or index + 1 >= len(tokens):
+            index += 1
+            continue
+        # skip a default binding before the braces: `import x, { a } from`
+        cursor = index + 1
+        if tokens[cursor][1] not in ('{', '(') and tokens[cursor][1][0] not in '\'"':
+            cursor += 1
+            if cursor < len(tokens) and tokens[cursor][1] == ',':
+                cursor += 1
+        if cursor >= len(tokens) or tokens[cursor][1] != '{':
+            index += 1
+            continue
+        names = []
+        cursor += 1
+        while cursor < len(tokens) and tokens[cursor][1] != '}':
+            item = tokens[cursor][1]
+            if item != ',':
+                names.append(item)
+                if cursor + 2 < len(tokens) and tokens[cursor + 1][1] == 'as':
+                    cursor += 2
+            cursor += 1
+        # `} from '…'`
+        if (cursor + 2 < len(tokens) and tokens[cursor + 1][1] == 'from'
+                and tokens[cursor + 2][1][0] in '\'"'):
+            found.append((line, tokens[cursor + 2][1][1:-1], names))
+        index = cursor + 1
+    return found
+
+
+def exports(source, where='<js>'):
+    """The names `source` exports, as a set.
+
+    Declarations (`export function f`, `export const c`, `export class C`,
+    `async` and `*` included), lists (`export { a, b as c }`), and re-exports
+    (`export { a } from './x.js'`, where the name this module offers is the
+    one after `as`, or `a`). `export default` names nothing here, and
+    `export * from` is not followed: nothing in this repository writes it.
+    """
+    names = set()
+    tokens = minify.tokenize_js(source, where)
+    index = 0
+    while index < len(tokens):
+        if tokens[index][1] != 'export' or index + 1 >= len(tokens):
+            index += 1
+            continue
+        cursor = index + 1
+        text = tokens[cursor][1]
+        if text == '{':
+            cursor += 1
+            while cursor < len(tokens) and tokens[cursor][1] != '}':
+                item = tokens[cursor][1]
+                if item != ',':
+                    if cursor + 2 < len(tokens) and tokens[cursor + 1][1] == 'as':
+                        item = tokens[cursor + 2][1]
+                        cursor += 2
+                    names.add(item)
+                cursor += 1
+        elif text in ('function', 'class', 'const', 'let', 'var', 'async'):
+            while cursor < len(tokens) and tokens[cursor][1] in (
+                    'function', 'class', 'const', 'let', 'var', 'async', '*'):
+                cursor += 1
+            if cursor < len(tokens):
+                names.add(tokens[cursor][1])
+        index = cursor + 1
+    return names
+
+
 def resolve(importer, specifier):
     """Where `specifier`, written inside `importer`, points.
 
@@ -97,11 +183,13 @@ def check(shipped, read, where):
     and fixing them one build at a time is a poor way to spend an afternoon.
     """
     problems = []
+    offered = {}
 
     for name in sorted(shipped):
         if not name.endswith('.js'):
             continue
-        for line, specifier in specifiers(read(name), f'{where}/{name}'):
+        source = read(name)
+        for line, specifier in specifiers(source, f'{where}/{name}'):
             target = resolve(name, specifier)
             if target is None:
                 problems.append(
@@ -113,9 +201,24 @@ def check(shipped, read, where):
                     f'{name}:{line}: "{specifier}" -> {target}, which this '
                     f'tool does not ship')
 
+        # A file that exists can still lack the name asked of it; the browser
+        # refuses to link the whole module and the page's code never starts.
+        for line, specifier, names in bindings(source, f'{where}/{name}'):
+            target = resolve(name, specifier)
+            if target is None or target not in shipped:
+                continue
+            if target not in offered:
+                offered[target] = exports(read(target), f'{where}/{target}')
+            for wanted in names:
+                if wanted not in offered[target]:
+                    problems.append(
+                        f'{name}:{line}: "{specifier}" has no export named '
+                        f'{wanted}')
+
     if problems:
         raise ConfigError(
             f'{where}: {len(problems)} import(s) lead nowhere:\n    '
             + '\n    '.join(problems)
             + '\n  A shared module is only shipped if tool.toml asks for it by '
-              'name in js_parts.')
+              'name in js_parts, and a name has to be exported by the file '
+              'it is imported from.')

--- a/tests/python/test_imports.py
+++ b/tests/python/test_imports.py
@@ -94,7 +94,7 @@ class Resolve(unittest.TestCase):
 class Check(unittest.TestCase):
     def test_a_tool_whose_imports_all_land(self):
         files = {'src/main.js': "import { z } from './zip.js';",
-                 'src/zip.js': ''}
+                 'src/zip.js': 'export function z() {}'}
         imports.check(set(files), files.get, 'demo')       # does not raise
 
     def test_a_typo_is_refused(self):
@@ -133,3 +133,54 @@ class Check(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+
+
+class Named(unittest.TestCase):
+    """A name has to be exported by the file it is imported from.
+
+    The specifier check above proves the file is there; this proves the file
+    still has the thing in it. The case it was written for: a helper moved to
+    a shared part, and a main.js that went on importing it from the old file -
+    which the build shipped, and which the browser then refused to link.
+    """
+
+    def test_named_bindings_are_read_with_their_module(self):
+        found = imports.bindings(
+            "import { a, b as c } from './x.js';\n"
+            "import d, { e } from './y.js';\n"
+            "import f from './z.js';\n"
+            "import './w.js';")
+        self.assertEqual(found, [(1, './x.js', ['a', 'b']), (2, './y.js', ['e'])])
+
+    def test_every_export_shape_is_read(self):
+        names = imports.exports(
+            "export function f() {}\n"
+            "export async function g() {}\n"
+            "export const c = 1;\n"
+            "export let l = 2;\n"
+            "export class K {}\n"
+            "export { m, n as o };\n"
+            "export { p as q } from './x.js';\n"
+            "export default r;\n"
+            "const notExported = 3;")
+        self.assertEqual(names, {'f', 'g', 'c', 'l', 'K', 'm', 'o', 'q'})
+
+    def test_a_name_the_module_does_not_export_is_refused(self):
+        # trim-video's main.js after averageFps moved to shared/js/webcodecs.js.
+        files = {'src/main.js': "import { join, averageFps } from './transcode.js';",
+                 'src/transcode.js': 'export function join() {}'}
+        with self.assertRaises(ConfigError) as caught:
+            imports.check(set(files), files.get, 'demo')
+        self.assertIn('no export named averageFps', str(caught.exception))
+        self.assertNotIn('no export named join', str(caught.exception))
+
+    def test_a_renamed_re_export_satisfies_the_import(self):
+        files = {'src/main.js': "import { formatTime } from './timeline.js';",
+                 'src/timeline.js': "export { clockText as formatTime } from './shared/format.js';",
+                 'src/shared/format.js': 'export function clockText() {}'}
+        imports.check(set(files), files.get, 'demo')       # does not raise
+
+    def test_a_default_import_is_not_checked_for_a_name(self):
+        files = {'src/main.js': "import thing from './x.js';",
+                 'src/x.js': 'export default 1;'}
+        imports.check(set(files), files.get, 'demo')       # does not raise

--- a/tools/trim-video/src/main.js
+++ b/tools/trim-video/src/main.js
@@ -7,9 +7,8 @@ import { messageBox } from './shared/message-box.js';
 import { wireFilePicker, readingLabel } from './shared/file-picker.js';
 import { demux, UnsupportedFile } from './shared/mp4-reader.js';
 import { joinByCopy, estimateJoinCopy } from './copy.js';
-import {
-  joinExact, grabFrame, decoderConfig, averageFps, chooseJoinBitrate,
-} from './transcode.js';
+import { decoderConfig, averageFps } from './shared/webcodecs.js';
+import { joinExact, grabFrame, chooseJoinBitrate } from './transcode.js';
 import { trimByRecording, estimateRecording } from './record.js';
 import { joinability, outputFrame } from './clips.js';
 import { fittedBox } from './draw.js';


### PR DESCRIPTION
**Hotfix.** `/trim-video/` on the live site has shown "This page's code did not start" five seconds after loading since #331 merged, and nothing happens when a video is chosen. One import line fixes it; the rest of this PR makes the build refuse the shape of mistake that caused it.

## What went wrong

#331 moved `decoderConfig` and `averageFps` into `shared/js/webcodecs.js` and repointed the four tools whose `main.js` imported them from a leaf. The cutter's import spanned two lines:

```js
import {
  joinExact, grabFrame, decoderConfig, averageFps, chooseJoinBitrate,
} from './transcode.js';
```

so the one-line search missed it. `./transcode.js` still existed, so `buildlib/imports.py` - which proves every specifier lands on a shipped file - was satisfied; no test loads a tool's `main.js` (it is DOM code); the in-page check on that PR exercised crop-video, not the cutter. The browser then refused to link the module with `The requested module './transcode.js' does not provide an export named 'averageFps'`, and the page's last line, the one that removes the banner, never ran.

## What this does

- **`tools/trim-video/src/main.js`** imports the two names from `./shared/webcodecs.js`, as the other four tools do.
- **`buildlib/imports.py`** gains `bindings()` (the named imports of a module, with their specifiers) and `exports()` (the names a module offers: declarations, lists, renames, re-exports), both read with the tokeniser as the specifier check is; `check()` now also refuses an import of a name the file it lands on does not export, listed beside the other problems. Every tool in the tree passes it; the tree-wide sweep that found this bug found nothing else.
- **`tests/python/test_imports.py`**: five cases for the new check, including the exact shape of the cutter's line, a renamed re-export (`export { clockText as formatTime } from …`, which the trimmers use), and a default import, which is not a name. The one existing fixture that imported `{ z }` from an empty file now exports it.

## Verified

- Live `/trim-video/`: `import('./src/main.js')` from the page rejects with the message above and `#boot-warning` is still in the document; the other six video pages import cleanly and have no banner.
- Locally built with the fix: the same import resolves, the banner is gone from the document, and the drop zone is there.
- `test_imports`: 27 pass. A full English build of every tool passes the new check.
- The check catches the bug: with the fix reverted in a fixture, `check()` refuses `"./transcode.js" has no export named averageFps`.

## Before and after

The before is the picture that reported this: the red "did not start" banner on the cutter after five seconds. After, the page is the cutter again. No other page changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
