### PR TITLE
Wire the privacy toggle image-to-svg left out

### DIFF
--- a/tools/image-to-svg/src/main.js
+++ b/tools/image-to-svg/src/main.js
@@ -19,6 +19,9 @@ const el = {
   clearImage: $('clear-image'),
   loadError: $('load-error'),
 
+  privacyToggle: $('privacy-toggle'),
+  privacyPanel: $('privacy-panel'),
+
   findCard: $('find-card'),
   find: $('find'),
   thresholdGroup: $('threshold-group'),
@@ -626,6 +629,20 @@ addEventListener('resize', () => {
   if (!picture) return;
   clearTimeout(resizing);
   resizing = setTimeout(redraw, 120);
+});
+
+/* ------------------------------------------------- privacy panel + offline */
+
+// The header's toggle, which the other thirty-nine tools wire and this one did
+// not - the same omission compare-heights shipped with. The panel it opens is
+// the live network check, the page's own evidence for the claim it makes about
+// a picture somebody uploaded, so a toggle that does nothing is the one control
+// here it is worst to leave dead. Nothing throws, so nothing said so: the QA
+// suite's generic page check is what noticed, on all four of its browsers.
+el.privacyToggle.addEventListener('click', () => {
+  const open = el.privacyPanel.hidden;
+  el.privacyPanel.hidden = !open;
+  el.privacyToggle.setAttribute('aria-expanded', String(open));
 });
 
 // The frame puts a "this page's code did not start" panel in every tool page

--- a/tools/image-to-svg/tool.toml
+++ b/tools/image-to-svg/tool.toml
@@ -43,7 +43,7 @@ css_parts = []
 # Shared modules this tool asks for. file-picker brings in the drop zone;
 # phrases arrives on its own, for every tool.
 js_parts = ["file-picker", "download"]
-lastmod = "2026-09-01"
+lastmod = "2026-09-02"
 
 # --- what search engines and chat apps are told ------------------------------
 


### PR DESCRIPTION
The header's privacy toggle does nothing on `/image-to-svg/`.

Every other tool adds the listener; this one looks up neither element and adds nothing, so a click lands and is ignored. Nothing throws, so nothing said so — the same omission compare-heights shipped with in #310, noticed the same way: the QA suite's generic `tool-pages` check, on all four of its browsers (A-Box-of-Tools/qa#65).

The panel it opens is the **live network check** — the page's own evidence for the claim it makes about a picture somebody uploaded to be traced. That makes it the one control on the page it is worst to leave dead.

Three lines, the same three every other tool has. Forty copies of them is its own argument for the frame wiring its own toggle, which the sharing series could take on; this only restores the page.

## Verified

`tool-pages.spec.ts -g image-to-svg` against a `--only` build of this branch on Desktop Chrome: 5 passed, where the privacy-panel test had been failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
