### PR TITLE
Let a cache write fail quietly in the service worker

### DIFF
--- a/templates/sw.js
+++ b/templates/sw.js
@@ -83,7 +83,18 @@ self.addEventListener('fetch', (event) => {
         // available offline afterwards.
         if (response.ok && response.type === 'basic') {
           const copy = response.clone();
-          caches.open(CACHE_NAME).then((cache) => cache.put(request, copy));
+          // Kept, not awaited: the response goes back to the page whether or
+          // not the copy lands. But a write that fails - the quota is full,
+          // the store is ephemeral, the engine will not keep this response -
+          // rejects a promise nobody is holding, and an unhandled rejection
+          // in a worker is reported through the page it serves. The hub's QA
+          // check saw exactly that on Mobile Safari, as eleven words and no
+          // stack: "Unhandled Promise Rejection: undefined". A cache write
+          // that fails is a missed cache and nothing more, so it may fail
+          // quietly.
+          caches.open(CACHE_NAME)
+            .then((cache) => cache.put(request, copy))
+            .catch(() => {});
         }
         return response;
       }).catch(() => (


### PR DESCRIPTION
The hub's QA check has been failing on Mobile Safari, on and off since it existed, with eleven words and nothing else:

```
Unhandled Promise Rejection: undefined
```

No reason, no stack, no script. Blocking the three third-party scripts did not stop it, and a listener installed before any script on the page recorded nothing — so it is not raised in the page's own realm (A-Box-of-Tools/qa#69). The one other realm the hub has is its service worker.

## The one promise nobody was holding

The fetch handler caches every successful same-origin response so a first-visit miss is there offline afterwards, and it does that on the side — the response goes back to the page at once and the copy is written when it is written. Right, and worth keeping. But the write was:

```js
caches.open(CACHE_NAME).then((cache) => cache.put(request, copy));
```

and a `put` that fails — the quota is full, the store is ephemeral, the engine will not keep this response — rejects a promise nobody is holding. An unhandled rejection inside a worker is reported through the page it serves, which is exactly the shape of what the suite saw, and "Mobile Safari only" fits a storage-quota difference.

A cache write that fails is a missed cache and nothing more, so it may fail quietly. One `.catch`, on the one chain that needed it: `install` and `activate` hand their promises to `waitUntil`, which is a handler.

I cannot reproduce the rejection from here — it needs that engine's storage — so this is the fix the evidence points at rather than one watched working. The hub test is the confirmation, and it is already instrumented to say more if this is not it.

## Verified

| | |
|---|---|
| `python build.py --only base64 --locale en` | the rendered `sw.js` carries the catch |
| `python build.py --out _plain --clean --no-minify` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
