### PR TITLE
Let a tool's name wrap on a phone before it pushes the page sideways

### DIFF
--- a/shared/css/tool-frame.css
+++ b/shared/css/tool-frame.css
@@ -246,6 +246,16 @@ main, .topbar, .crumbs, .privacy, .pledge, .faq, .tool-next, footer {
 
 @media (max-width: 620px) {
   .brand h1 .h1-kw { display: block; }
+  /* A tool's name is written with non-breaking spaces so it reads as one
+     thing, and on a phone one of them can be wider than the room beside the
+     mark: "Base64 Encoder & Decoder" at 1.4rem, in the font a Linux machine
+     falls back to, came out five pixels past the edge and made the whole page
+     scroll sideways. `anywhere` adds a break only where a run would otherwise
+     overflow, so every name that fits is left exactly as written and the one
+     that does not breaks rather than pushing the page. The break it picks is
+     not a good one, which is why base64's own heading now allows a better
+     one before the ampersand; this is the net under the rest. */
+  .brand h1 { overflow-wrap: anywhere; }
 }
 
 .tagline { margin: 0.15rem 0 0; color: var(--text-dim); font-size: 0.9rem; }

--- a/tools/base64/tool.toml
+++ b/tools/base64/tool.toml
@@ -24,7 +24,7 @@ slug = "base64"
 name = "Base64 Encoder & Decoder"
 # The trailing span is the rest of what the page does. The product name stays
 # the loud half; see .brand h1 .h1-kw in shared/css/tool-frame.css.
-heading = "Base64&nbsp;Encoder&nbsp;&amp;&nbsp;Decoder <span class=\"h1-kw\">&mdash; and URLs, HTML entities, hex and escapes</span>"
+heading = "Base64&nbsp;Encoder &amp;&nbsp;Decoder <span class=\"h1-kw\">&mdash; and URLs, HTML entities, hex and escapes</span>"
 tagline = "Base64, percent-encoding, HTML entities, hex and backslash escapes, both ways. Nothing is pasted into anyone else's server."
 icon = "&#128291;"          # the mark beside the page heading
 favicon = "&#128291;"       # the tab icon, drawn into an inline SVG
@@ -45,7 +45,7 @@ css_parts = ["form", "panes", "modes"]
 # Shared modules this tool asks for. file-picker brings in the drop zone, which
 # is here for the file that is easier to drop than to open, select all and copy.
 js_parts = ["file-picker", "message-box", "download", "format"]
-lastmod = "2026-08-30"
+lastmod = "2026-09-02"
 
 # --- what search engines and chat apps are told ------------------------------
 


### PR DESCRIPTION
`/base64/` was **five pixels wider than a 393-pixel phone**, and the QA suite's overflow check has failed on it for three runs (A-Box-of-Tools/qa#56).

It never reproduced on a developer's machine, and the reason is the font. *"Base64 Encoder & Decoder"* at 1.4rem fits beside the mark in Segoe UI with a pixel to spare; in the face a Linux machine falls back to, it does not. The name is written with non-breaking spaces so it reads as one thing, so the row could not shrink and the page scrolled sideways instead. (The diagnostic named the mark, because hiding the first child was enough to make the row fit. The row was the culprit.)

## Two changes, one for the instance and one for the class

**base64's heading** now allows a break before the ampersand: *Base64 Encoder* stays together, and *& Decoder* may go to a second line on a phone. It is the longest name on the site and the only one that reached the wall.

**The phone media query** gives `.brand h1` `overflow-wrap: anywhere`, which adds a break only where a run would otherwise overflow. Every name that fits is left exactly as written; one that does not breaks rather than pushing the page. The break it picks is not a good one — mid-word, at the last character that fits — which is why base64 has its own better one above. This is the net under the rest, for the next name that is long enough and the next font that is wide enough.

## Before / After

| Before | After |
|---|---|
| `base64-heading-before.png` | `base64-heading-after.png` |

**On a Windows machine the two are pixel-identical — 390×312 both — because the name already fitted there.** The five pixels only exist with Linux's fallback font, which is what CI runs, and that is where the check now passes. The Japanese page, where every character is already a break opportunity, is also unchanged: `base64-heading-ja-after.png`.

The three filenames are placeholders. GitHub's image uploader lives in the web editor's own session, so the pictures have to be dropped in by hand; all three were handed over in the session that opened this PR.

**How to put them in:**

1. On this page, open the **⋯** menu at the top right of the description and choose **Edit**.
2. Click into the `Before` cell of the table above and drag `base64-heading-before.png` onto it. (The paperclip in the toolbar, or a plain <kbd>Ctrl</kbd>+<kbd>V</kbd> of the image, does the same thing.)
3. GitHub uploads it and leaves `![base64-heading-before.png](https://github.com/user-attachments/assets/…)` in the cell. That markdown **is** the image — delete the `` `base64-heading-before.png` `` placeholder sitting next to it.
4. Repeat in the `After` cell with `base64-heading-after.png`, then press **Save**.
5. Delete this instruction block once both images are showing.

## Verified

| | |
|---|---|
| `responsive.spec.ts -g base64`, Mobile Chrome + Mobile Safari, against a build of this branch | 2 passed |
| `python build.py --out _plain --clean --no-minify` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
