### PR TITLE
Give every button a thumb's worth of height on a touch screen

### DIFF
--- a/shared/css/tool-frame.css
+++ b/shared/css/tool-frame.css
@@ -809,6 +809,26 @@ button, .as-button {
   font-size: 0.92rem;
 }
 
+/* A thumb needs forty-four pixels of something to land on, and nothing above
+   gives it that: a ghost button is 34 pixels tall, a primary 41, and the
+   tools that set a scale of their own landed between 31 and 36 - so on a
+   phone twenty-nine of the forty-one tools had controls a visitor cannot
+   reliably hit. This is the floor, applied where a thumb is the pointer and
+   nowhere else: a narrow desktop window driven by a mouse does not need it,
+   and the mobile emulations the QA suite runs report a coarse pointer, which
+   is how it is measured. A minimum height rather than padding, so a "1:1"
+   chip or a "-5s" button keeps its width and a row that wrapped before wraps
+   the same way. Links dressed as buttons are inline by default and would
+   ignore a minimum height, so they are laid out as a box here too. */
+@media (pointer: coarse) {
+  button, .as-button { min-height: 44px; }
+  .as-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+}
+
 /*
   The button that starts the work, and the only control on a tool page that
   needs to feel like one.


### PR DESCRIPTION
**Twenty-nine of the forty-one tools have buttons a phone user cannot reliably hit.** Measured on every tool page under a touch pointer: a ghost button is 34px tall, a primary 41, and the trim tools, the cropper, the time-lapse maker and share-text each chose a scale of their own and landed between 31 and 36. The frame said no floor, so nothing had one.

Forty-four pixels is the floor everyone else agrees on — Apple's guidance, the WCAG target-size criterion — and it is applied where it applies: at `pointer: coarse`, which is a thumb, and not on a narrow desktop window driven by a mouse. Every button and every link dressed as one gets it, chips included. On a mouse nothing changes.

A **minimum height rather than padding**, so a `1:1` chip or a `−5s` button keeps its width and a row that wrapped before wraps the same way. Links dressed as buttons are inline by default and would ignore a minimum height, so under a coarse pointer they are laid out as a box too.

## Measured

Every visible button on three pages that between them show every shape — the trim tools' private scale, the plain ghost, compare-heights' icon buttons — on the QA suite's mobile projects, which report a coarse pointer:

| page | before | after |
|---|---|---|
| trim-video | 18 buttons, heights {30, 32, 36, 41} | 18 buttons, all 44 |
| base64 | 3 buttons, all 34 | all 44 |
| compare-heights | 13 buttons, {34, 37, 41} | all 44 |
| any of them, Desktop Chrome (fine pointer) | unchanged | unchanged |

## Before / After

| Before | After |
|---|---|
| <img width="320" alt="tap-before-trim-video" src="https://github.com/user-attachments/assets/4d98ff73-012f-4b14-93aa-20e1b124d8f5" /> | <img width="320" alt="tap-after-trim-video" src="https://github.com/user-attachments/assets/57d20689-747b-4653-a17d-d12aed9606aa" /> |
| <img width="320" alt="tap-before-base64" src="https://github.com/user-attachments/assets/85b80606-5bef-46b5-9dd1-563f8db10eb6" /> | <img width="320" alt="tap-after-base64" src="https://github.com/user-attachments/assets/69df29cb-23a8-476d-8d71-cc00fc7661e2" /> |
| <img width="320" alt="tap-before-compare-heights" src="https://github.com/user-attachments/assets/c0173198-7832-4c91-a713-72fa2fb28b57" /> | <img width="320" alt="tap-after-compare-heights" src="https://github.com/user-attachments/assets/789d08a1-3d92-4d33-8b84-584fbf567b91" /> |

Shot on Mobile Chrome at 390px, since the change is gated on a touch pointer and a desktop screenshot would show nothing.

## Verified

`python build.py --out _plain --clean --no-minify` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
