### PR TITLE
Dress text fields the way the frame already dresses selects and numbers

### DIFF
--- a/shared/css/tool-frame.css
+++ b/shared/css/tool-frame.css
@@ -785,12 +785,21 @@ main, .topbar, .crumbs, .privacy, .pledge, .faq, .tool-next, footer {
 
 /* ------------------------------------------------------------ form controls */
 
-input, select, button {
+input, select, textarea, button {
   font: inherit;
   color: var(--text);
 }
 
-select, input[type="number"], input[type="color"] {
+/* Text fields too. This rule named selects, numbers and colours and stopped
+   there, so a page range, a start time or a name got the browser's own box
+   and each tool then drew its own: 31 pixels with square corners in one,
+   26 in another, the frame's look copied by hand in five more. A field is a
+   field. What a tool chooses on purpose - a width, tabular figures, a
+   textarea's height - it still says in a rule of its own, which wins on
+   order; what it no longer has to say is what a field looks like. */
+select, textarea,
+input[type="number"], input[type="color"],
+input[type="text"], input[type="search"], input[type="url"], input[type="email"] {
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 6px;

--- a/tools/base64/styles.css
+++ b/tools/base64/styles.css
@@ -30,10 +30,6 @@ textarea {
   min-height: 220px;
   resize: vertical;
   padding: 0.7rem 0.8rem;
-  background: var(--surface);
-  color: var(--text);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
   font: 0.86rem/1.5 ui-monospace, "SF Mono", "Cascadia Mono", Menlo, Consolas, monospace;
   tab-size: 2;
 }

--- a/tools/json-formatter/styles.css
+++ b/tools/json-formatter/styles.css
@@ -55,14 +55,6 @@
   font-size: 0.88rem;
 }
 .check input { margin: 0; }
-
-input[type="text"] {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 0.4rem 0.5rem;
-}
-
 /* -------------------------------------------------------------- the boxes */
 
 textarea {
@@ -70,10 +62,6 @@ textarea {
   min-height: 220px;
   resize: vertical;
   padding: 0.7rem 0.8rem;
-  background: var(--surface);
-  color: var(--text);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
   font: 0.86rem/1.5 ui-monospace, "SF Mono", "Cascadia Mono", Menlo, Consolas, monospace;
   tab-size: 2;
 }

--- a/tools/text-diff/styles.css
+++ b/tools/text-diff/styles.css
@@ -37,10 +37,6 @@ textarea {
   min-height: 220px;
   resize: vertical;
   padding: 0.7rem 0.8rem;
-  background: var(--surface);
-  color: var(--text);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
   font: 0.86rem/1.5 ui-monospace, "SF Mono", "Cascadia Mono", Menlo, Consolas, monospace;
   tab-size: 2;
 }

--- a/tools/xml-formatter/styles.css
+++ b/tools/xml-formatter/styles.css
@@ -55,14 +55,6 @@
   font-size: 0.88rem;
 }
 .check input { margin: 0; }
-
-input[type="text"] {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 0.4rem 0.5rem;
-}
-
 /* -------------------------------------------------------------- the boxes */
 
 textarea {
@@ -70,10 +62,6 @@ textarea {
   min-height: 220px;
   resize: vertical;
   padding: 0.7rem 0.8rem;
-  background: var(--surface);
-  color: var(--text);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
   font: 0.86rem/1.5 ui-monospace, "SF Mono", "Cascadia Mono", Menlo, Consolas, monospace;
   tab-size: 2;
 }

--- a/tools/yaml-to-json/styles.css
+++ b/tools/yaml-to-json/styles.css
@@ -55,14 +55,6 @@
   font-size: 0.88rem;
 }
 .check input { margin: 0; }
-
-input[type="text"] {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 0.4rem 0.5rem;
-}
-
 /* -------------------------------------------------------------- the boxes */
 
 textarea {
@@ -70,10 +62,6 @@ textarea {
   min-height: 220px;
   resize: vertical;
   padding: 0.7rem 0.8rem;
-  background: var(--surface);
-  color: var(--text);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
   font: 0.86rem/1.5 ui-monospace, "SF Mono", "Cascadia Mono", Menlo, Consolas, monospace;
   tab-size: 2;
 }


### PR DESCRIPTION
The frame's control rule covers `select`, `input[type=number]` and `input[type=color]`, and stops there. A text field — a page range, a start time, a name — gets the browser's own box, and each tool then draws its own or doesn't:

| field | before | after |
|---|---|---|
| edit-audio `#speed-value`, `#volume-value` | 31px, square, 2px browser border | 40px, 6px, 1px |
| video-to-gif `#start-time`, `#end-time` | 31px, square | 40px, 6px |
| merge-pdf `#range` / `#split-at` | 31px / 27px, square | 40px / 36px, 6px |
| json-formatter (and the four other text tools) `textarea` | 10px corners, by its own rule | 6px, like every other control |
| every `select` on those pages | 38px, 6px | unchanged |

So the rule names text fields and textareas too, and `textarea` joins the `font: inherit` rule beside `input` and `select`. The copies come out: the `input[type=text]` rule three text tools had written by hand, and the four declarations of their `textarea` rule that only restated the frame.

**Nothing a tool chose on purpose is lost.** The audio editor's value boxes keep their width, alignment and tabular figures; the text tools keep their textarea height, resize handle, monospace face and padding; video-to-gif keeps its 16px-on-touch rule that stops iOS zooming into the field. A rule of the tool's own still wins on order. What it no longer has to say is what a field looks like.

## Before / After

| Before | After |
|---|---|
| <img width="320" alt="fields-before-edit-audio" src="https://github.com/user-attachments/assets/b59c4640-6c30-4a96-b910-3b9404c96b8b" /> | <img width="320" alt="fields-after-edit-audio" src="https://github.com/user-attachments/assets/d673c99c-fe50-4376-82c8-04e4c604a960" /> |
| <img width="320" alt="fields-before-json-formatter" src="https://github.com/user-attachments/assets/ee184b29-54b8-4c50-b14e-4c07afdba405" /> | <img width="320" alt="fields-after-json-formatter" src="https://github.com/user-attachments/assets/4db4a853-5bae-40cf-8003-bcb03a09ee82" /> |

## Verified

- the table above, measured on the QA suite's Mobile Chrome project against production and against a build of this branch
- `python build.py --out _plain --clean --no-minify` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
