### PR TITLE
Dress the download as the result it is, on the five text tools

### DIFF
--- a/locales/ar/tools/base64.html
+++ b/locales/ar/tools/base64.html
@@ -68,7 +68,7 @@
       <p class="count" id="result-note">لا شيء بعد.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>انسخ</button>
-        <a id="download" class="ghost as-button" hidden download>نزِّل</a>
+        <a id="download" class="primary as-button" hidden download>نزِّل</a>
       </div>
     </div>
 

--- a/locales/ar/tools/json-formatter.html
+++ b/locales/ar/tools/json-formatter.html
@@ -122,7 +122,7 @@
       <p class="count" id="result-note">لا شيء بعد.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>انسخ</button>
-        <a id="download" class="ghost as-button" hidden download>نزِّل</a>
+        <a id="download" class="primary as-button" hidden download>نزِّل</a>
       </div>
     </div>
 

--- a/locales/ar/tools/text-diff.html
+++ b/locales/ar/tools/text-diff.html
@@ -87,7 +87,7 @@
       <p class="count" id="result-note">لا شيء بعد.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>انسخ</button>
-        <a id="download" class="ghost as-button" hidden download>نزِّل</a>
+        <a id="download" class="primary as-button" hidden download>نزِّل</a>
       </div>
     </div>
 

--- a/locales/ar/tools/xml-formatter.html
+++ b/locales/ar/tools/xml-formatter.html
@@ -97,7 +97,7 @@
       <p class="count" id="result-note">لا شيء بعد.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>انسخ</button>
-        <a id="download" class="ghost as-button" hidden download>نزِّل</a>
+        <a id="download" class="primary as-button" hidden download>نزِّل</a>
       </div>
     </div>
 

--- a/locales/ar/tools/yaml-to-json.html
+++ b/locales/ar/tools/yaml-to-json.html
@@ -85,7 +85,7 @@
       <p class="count" id="result-note">لا شيء بعد.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>انسخ</button>
-        <a id="download" class="ghost as-button" hidden download>نزِّل</a>
+        <a id="download" class="primary as-button" hidden download>نزِّل</a>
       </div>
     </div>
 

--- a/locales/de/tools/base64.html
+++ b/locales/de/tools/base64.html
@@ -68,7 +68,7 @@
       <p class="count" id="result-note">Noch nichts.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Kopieren</button>
-        <a id="download" class="ghost as-button" hidden download>Herunterladen</a>
+        <a id="download" class="primary as-button" hidden download>Herunterladen</a>
       </div>
     </div>
 

--- a/locales/de/tools/json-formatter.html
+++ b/locales/de/tools/json-formatter.html
@@ -123,7 +123,7 @@
       <p class="count" id="result-note">Noch nichts.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Kopieren</button>
-        <a id="download" class="ghost as-button" hidden download>Herunterladen</a>
+        <a id="download" class="primary as-button" hidden download>Herunterladen</a>
       </div>
     </div>
 

--- a/locales/de/tools/text-diff.html
+++ b/locales/de/tools/text-diff.html
@@ -87,7 +87,7 @@
       <p class="count" id="result-note">Noch nichts.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Kopieren</button>
-        <a id="download" class="ghost as-button" hidden download>Herunterladen</a>
+        <a id="download" class="primary as-button" hidden download>Herunterladen</a>
       </div>
     </div>
 

--- a/locales/de/tools/xml-formatter.html
+++ b/locales/de/tools/xml-formatter.html
@@ -98,7 +98,7 @@
       <p class="count" id="result-note">Noch nichts.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Kopieren</button>
-        <a id="download" class="ghost as-button" hidden download>Herunterladen</a>
+        <a id="download" class="primary as-button" hidden download>Herunterladen</a>
       </div>
     </div>
 

--- a/locales/de/tools/yaml-to-json.html
+++ b/locales/de/tools/yaml-to-json.html
@@ -85,7 +85,7 @@
       <p class="count" id="result-note">Noch nichts.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Kopieren</button>
-        <a id="download" class="ghost as-button" hidden download>Herunterladen</a>
+        <a id="download" class="primary as-button" hidden download>Herunterladen</a>
       </div>
     </div>
 

--- a/locales/es/tools/base64.html
+++ b/locales/es/tools/base64.html
@@ -68,7 +68,7 @@
       <p class="count" id="result-note">Todavía nada.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Copiar</button>
-        <a id="download" class="ghost as-button" hidden download>Descargar</a>
+        <a id="download" class="primary as-button" hidden download>Descargar</a>
       </div>
     </div>
 

--- a/locales/es/tools/json-formatter.html
+++ b/locales/es/tools/json-formatter.html
@@ -123,7 +123,7 @@
       <p class="count" id="result-note">Todavía nada.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Copiar</button>
-        <a id="download" class="ghost as-button" hidden download>Descargar</a>
+        <a id="download" class="primary as-button" hidden download>Descargar</a>
       </div>
     </div>
 

--- a/locales/es/tools/text-diff.html
+++ b/locales/es/tools/text-diff.html
@@ -87,7 +87,7 @@
       <p class="count" id="result-note">Todavía nada.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Copiar</button>
-        <a id="download" class="ghost as-button" hidden download>Descargar</a>
+        <a id="download" class="primary as-button" hidden download>Descargar</a>
       </div>
     </div>
 

--- a/locales/es/tools/xml-formatter.html
+++ b/locales/es/tools/xml-formatter.html
@@ -98,7 +98,7 @@
       <p class="count" id="result-note">Todavía nada.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Copiar</button>
-        <a id="download" class="ghost as-button" hidden download>Descargar</a>
+        <a id="download" class="primary as-button" hidden download>Descargar</a>
       </div>
     </div>
 

--- a/locales/es/tools/yaml-to-json.html
+++ b/locales/es/tools/yaml-to-json.html
@@ -85,7 +85,7 @@
       <p class="count" id="result-note">Todavía nada.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Copiar</button>
-        <a id="download" class="ghost as-button" hidden download>Descargar</a>
+        <a id="download" class="primary as-button" hidden download>Descargar</a>
       </div>
     </div>
 

--- a/locales/fr/tools/base64.html
+++ b/locales/fr/tools/base64.html
@@ -68,7 +68,7 @@
       <p class="count" id="result-note">Rien pour l'instant.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Copier</button>
-        <a id="download" class="ghost as-button" hidden download>Télécharger</a>
+        <a id="download" class="primary as-button" hidden download>Télécharger</a>
       </div>
     </div>
 

--- a/locales/fr/tools/json-formatter.html
+++ b/locales/fr/tools/json-formatter.html
@@ -123,7 +123,7 @@
       <p class="count" id="result-note">Rien pour l'instant.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Copier</button>
-        <a id="download" class="ghost as-button" hidden download>Télécharger</a>
+        <a id="download" class="primary as-button" hidden download>Télécharger</a>
       </div>
     </div>
 

--- a/locales/fr/tools/text-diff.html
+++ b/locales/fr/tools/text-diff.html
@@ -87,7 +87,7 @@
       <p class="count" id="result-note">Rien pour l'instant.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Copier</button>
-        <a id="download" class="ghost as-button" hidden download>Télécharger</a>
+        <a id="download" class="primary as-button" hidden download>Télécharger</a>
       </div>
     </div>
 

--- a/locales/fr/tools/xml-formatter.html
+++ b/locales/fr/tools/xml-formatter.html
@@ -98,7 +98,7 @@
       <p class="count" id="result-note">Rien pour l'instant.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Copier</button>
-        <a id="download" class="ghost as-button" hidden download>Télécharger</a>
+        <a id="download" class="primary as-button" hidden download>Télécharger</a>
       </div>
     </div>
 

--- a/locales/fr/tools/yaml-to-json.html
+++ b/locales/fr/tools/yaml-to-json.html
@@ -85,7 +85,7 @@
       <p class="count" id="result-note">Rien pour l'instant.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Copier</button>
-        <a id="download" class="ghost as-button" hidden download>Télécharger</a>
+        <a id="download" class="primary as-button" hidden download>Télécharger</a>
       </div>
     </div>
 

--- a/locales/hi/tools/base64.html
+++ b/locales/hi/tools/base64.html
@@ -68,7 +68,7 @@
       <p class="count" id="result-note">अभी कुछ नहीं।</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>कॉपी</button>
-        <a id="download" class="ghost as-button" hidden download>डाउनलोड</a>
+        <a id="download" class="primary as-button" hidden download>डाउनलोड</a>
       </div>
     </div>
 

--- a/locales/hi/tools/json-formatter.html
+++ b/locales/hi/tools/json-formatter.html
@@ -124,7 +124,7 @@
       <p class="count" id="result-note">अभी कुछ नहीं।</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>कॉपी</button>
-        <a id="download" class="ghost as-button" hidden download>डाउनलोड</a>
+        <a id="download" class="primary as-button" hidden download>डाउनलोड</a>
       </div>
     </div>
 

--- a/locales/hi/tools/text-diff.html
+++ b/locales/hi/tools/text-diff.html
@@ -87,7 +87,7 @@
       <p class="count" id="result-note">अभी कुछ नहीं।</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>कॉपी</button>
-        <a id="download" class="ghost as-button" hidden download>डाउनलोड</a>
+        <a id="download" class="primary as-button" hidden download>डाउनलोड</a>
       </div>
     </div>
 

--- a/locales/hi/tools/xml-formatter.html
+++ b/locales/hi/tools/xml-formatter.html
@@ -98,7 +98,7 @@
       <p class="count" id="result-note">अभी कुछ नहीं।</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>कॉपी</button>
-        <a id="download" class="ghost as-button" hidden download>डाउनलोड</a>
+        <a id="download" class="primary as-button" hidden download>डाउनलोड</a>
       </div>
     </div>
 

--- a/locales/hi/tools/yaml-to-json.html
+++ b/locales/hi/tools/yaml-to-json.html
@@ -85,7 +85,7 @@
       <p class="count" id="result-note">अभी कुछ नहीं।</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>कॉपी</button>
-        <a id="download" class="ghost as-button" hidden download>डाउनलोड</a>
+        <a id="download" class="primary as-button" hidden download>डाउनलोड</a>
       </div>
     </div>
 

--- a/locales/id/tools/base64.html
+++ b/locales/id/tools/base64.html
@@ -68,7 +68,7 @@
       <p class="count" id="result-note">Belum ada apa-apa.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Salin</button>
-        <a id="download" class="ghost as-button" hidden download>Unduh</a>
+        <a id="download" class="primary as-button" hidden download>Unduh</a>
       </div>
     </div>
 

--- a/locales/id/tools/json-formatter.html
+++ b/locales/id/tools/json-formatter.html
@@ -123,7 +123,7 @@
       <p class="count" id="result-note">Belum ada apa-apa.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Salin</button>
-        <a id="download" class="ghost as-button" hidden download>Unduh</a>
+        <a id="download" class="primary as-button" hidden download>Unduh</a>
       </div>
     </div>
 

--- a/locales/id/tools/text-diff.html
+++ b/locales/id/tools/text-diff.html
@@ -87,7 +87,7 @@
       <p class="count" id="result-note">Belum ada apa-apa.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Salin</button>
-        <a id="download" class="ghost as-button" hidden download>Unduh</a>
+        <a id="download" class="primary as-button" hidden download>Unduh</a>
       </div>
     </div>
 

--- a/locales/id/tools/xml-formatter.html
+++ b/locales/id/tools/xml-formatter.html
@@ -98,7 +98,7 @@
       <p class="count" id="result-note">Belum ada apa-apa.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Salin</button>
-        <a id="download" class="ghost as-button" hidden download>Unduh</a>
+        <a id="download" class="primary as-button" hidden download>Unduh</a>
       </div>
     </div>
 

--- a/locales/id/tools/yaml-to-json.html
+++ b/locales/id/tools/yaml-to-json.html
@@ -85,7 +85,7 @@
       <p class="count" id="result-note">Belum ada apa-apa.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Salin</button>
-        <a id="download" class="ghost as-button" hidden download>Unduh</a>
+        <a id="download" class="primary as-button" hidden download>Unduh</a>
       </div>
     </div>
 

--- a/locales/it/tools/base64.html
+++ b/locales/it/tools/base64.html
@@ -68,7 +68,7 @@
       <p class="count" id="result-note">Ancora niente.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Copia</button>
-        <a id="download" class="ghost as-button" hidden download>Scarica</a>
+        <a id="download" class="primary as-button" hidden download>Scarica</a>
       </div>
     </div>
 

--- a/locales/it/tools/json-formatter.html
+++ b/locales/it/tools/json-formatter.html
@@ -122,7 +122,7 @@
       <p class="count" id="result-note">Ancora niente.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Copia</button>
-        <a id="download" class="ghost as-button" hidden download>Scarica</a>
+        <a id="download" class="primary as-button" hidden download>Scarica</a>
       </div>
     </div>
 

--- a/locales/it/tools/text-diff.html
+++ b/locales/it/tools/text-diff.html
@@ -87,7 +87,7 @@
       <p class="count" id="result-note">Ancora niente.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Copia</button>
-        <a id="download" class="ghost as-button" hidden download>Scarica</a>
+        <a id="download" class="primary as-button" hidden download>Scarica</a>
       </div>
     </div>
 

--- a/locales/it/tools/xml-formatter.html
+++ b/locales/it/tools/xml-formatter.html
@@ -97,7 +97,7 @@
       <p class="count" id="result-note">Ancora niente.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Copia</button>
-        <a id="download" class="ghost as-button" hidden download>Scarica</a>
+        <a id="download" class="primary as-button" hidden download>Scarica</a>
       </div>
     </div>
 

--- a/locales/it/tools/yaml-to-json.html
+++ b/locales/it/tools/yaml-to-json.html
@@ -85,7 +85,7 @@
       <p class="count" id="result-note">Ancora niente.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Copia</button>
-        <a id="download" class="ghost as-button" hidden download>Scarica</a>
+        <a id="download" class="primary as-button" hidden download>Scarica</a>
       </div>
     </div>
 

--- a/locales/ja/tools/base64.html
+++ b/locales/ja/tools/base64.html
@@ -68,7 +68,7 @@
       <p class="count" id="result-note">まだ何もありません。</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>コピー</button>
-        <a id="download" class="ghost as-button" hidden download>ダウンロード</a>
+        <a id="download" class="primary as-button" hidden download>ダウンロード</a>
       </div>
     </div>
 

--- a/locales/ja/tools/json-formatter.html
+++ b/locales/ja/tools/json-formatter.html
@@ -121,7 +121,7 @@
       <p class="count" id="result-note">まだ何もありません。</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>コピー</button>
-        <a id="download" class="ghost as-button" hidden download>ダウンロード</a>
+        <a id="download" class="primary as-button" hidden download>ダウンロード</a>
       </div>
     </div>
 

--- a/locales/ja/tools/text-diff.html
+++ b/locales/ja/tools/text-diff.html
@@ -87,7 +87,7 @@
       <p class="count" id="result-note">まだ何もありません。</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>コピー</button>
-        <a id="download" class="ghost as-button" hidden download>ダウンロード</a>
+        <a id="download" class="primary as-button" hidden download>ダウンロード</a>
       </div>
     </div>
 

--- a/locales/ja/tools/xml-formatter.html
+++ b/locales/ja/tools/xml-formatter.html
@@ -97,7 +97,7 @@
       <p class="count" id="result-note">まだ何もありません。</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>コピー</button>
-        <a id="download" class="ghost as-button" hidden download>ダウンロード</a>
+        <a id="download" class="primary as-button" hidden download>ダウンロード</a>
       </div>
     </div>
 

--- a/locales/ja/tools/yaml-to-json.html
+++ b/locales/ja/tools/yaml-to-json.html
@@ -85,7 +85,7 @@
       <p class="count" id="result-note">まだ何もありません。</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>コピー</button>
-        <a id="download" class="ghost as-button" hidden download>ダウンロード</a>
+        <a id="download" class="primary as-button" hidden download>ダウンロード</a>
       </div>
     </div>
 

--- a/locales/ko/tools/base64.html
+++ b/locales/ko/tools/base64.html
@@ -68,7 +68,7 @@
       <p class="count" id="result-note">아직 없습니다.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>복사</button>
-        <a id="download" class="ghost as-button" hidden download>내려받기</a>
+        <a id="download" class="primary as-button" hidden download>내려받기</a>
       </div>
     </div>
 

--- a/locales/ko/tools/json-formatter.html
+++ b/locales/ko/tools/json-formatter.html
@@ -123,7 +123,7 @@
       <p class="count" id="result-note">아직 없습니다.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>복사</button>
-        <a id="download" class="ghost as-button" hidden download>내려받기</a>
+        <a id="download" class="primary as-button" hidden download>내려받기</a>
       </div>
     </div>
 

--- a/locales/ko/tools/text-diff.html
+++ b/locales/ko/tools/text-diff.html
@@ -87,7 +87,7 @@
       <p class="count" id="result-note">아직 없습니다.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>복사</button>
-        <a id="download" class="ghost as-button" hidden download>내려받기</a>
+        <a id="download" class="primary as-button" hidden download>내려받기</a>
       </div>
     </div>
 

--- a/locales/ko/tools/xml-formatter.html
+++ b/locales/ko/tools/xml-formatter.html
@@ -98,7 +98,7 @@
       <p class="count" id="result-note">아직 없습니다.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>복사</button>
-        <a id="download" class="ghost as-button" hidden download>내려받기</a>
+        <a id="download" class="primary as-button" hidden download>내려받기</a>
       </div>
     </div>
 

--- a/locales/ko/tools/yaml-to-json.html
+++ b/locales/ko/tools/yaml-to-json.html
@@ -85,7 +85,7 @@
       <p class="count" id="result-note">아직 없습니다.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>복사</button>
-        <a id="download" class="ghost as-button" hidden download>내려받기</a>
+        <a id="download" class="primary as-button" hidden download>내려받기</a>
       </div>
     </div>
 

--- a/locales/nl/tools/base64.html
+++ b/locales/nl/tools/base64.html
@@ -68,7 +68,7 @@
       <p class="count" id="result-note">Nog niets.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Kopiëren</button>
-        <a id="download" class="ghost as-button" hidden download>Downloaden</a>
+        <a id="download" class="primary as-button" hidden download>Downloaden</a>
       </div>
     </div>
 

--- a/locales/nl/tools/json-formatter.html
+++ b/locales/nl/tools/json-formatter.html
@@ -123,7 +123,7 @@
       <p class="count" id="result-note">Nog niets.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Kopiëren</button>
-        <a id="download" class="ghost as-button" hidden download>Downloaden</a>
+        <a id="download" class="primary as-button" hidden download>Downloaden</a>
       </div>
     </div>
 

--- a/locales/nl/tools/text-diff.html
+++ b/locales/nl/tools/text-diff.html
@@ -87,7 +87,7 @@
       <p class="count" id="result-note">Nog niets.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Kopiëren</button>
-        <a id="download" class="ghost as-button" hidden download>Downloaden</a>
+        <a id="download" class="primary as-button" hidden download>Downloaden</a>
       </div>
     </div>
 

--- a/locales/nl/tools/xml-formatter.html
+++ b/locales/nl/tools/xml-formatter.html
@@ -98,7 +98,7 @@
       <p class="count" id="result-note">Nog niets.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Kopiëren</button>
-        <a id="download" class="ghost as-button" hidden download>Downloaden</a>
+        <a id="download" class="primary as-button" hidden download>Downloaden</a>
       </div>
     </div>
 

--- a/locales/nl/tools/yaml-to-json.html
+++ b/locales/nl/tools/yaml-to-json.html
@@ -85,7 +85,7 @@
       <p class="count" id="result-note">Nog niets.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Kopiëren</button>
-        <a id="download" class="ghost as-button" hidden download>Downloaden</a>
+        <a id="download" class="primary as-button" hidden download>Downloaden</a>
       </div>
     </div>
 

--- a/locales/pt/tools/base64.html
+++ b/locales/pt/tools/base64.html
@@ -68,7 +68,7 @@
       <p class="count" id="result-note">Nada ainda.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Copiar</button>
-        <a id="download" class="ghost as-button" hidden download>Baixar</a>
+        <a id="download" class="primary as-button" hidden download>Baixar</a>
       </div>
     </div>
 

--- a/locales/pt/tools/json-formatter.html
+++ b/locales/pt/tools/json-formatter.html
@@ -122,7 +122,7 @@
       <p class="count" id="result-note">Nada ainda.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Copiar</button>
-        <a id="download" class="ghost as-button" hidden download>Baixar</a>
+        <a id="download" class="primary as-button" hidden download>Baixar</a>
       </div>
     </div>
 

--- a/locales/pt/tools/text-diff.html
+++ b/locales/pt/tools/text-diff.html
@@ -87,7 +87,7 @@
       <p class="count" id="result-note">Nada ainda.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Copiar</button>
-        <a id="download" class="ghost as-button" hidden download>Baixar</a>
+        <a id="download" class="primary as-button" hidden download>Baixar</a>
       </div>
     </div>
 

--- a/locales/pt/tools/xml-formatter.html
+++ b/locales/pt/tools/xml-formatter.html
@@ -97,7 +97,7 @@
       <p class="count" id="result-note">Nada ainda.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Copiar</button>
-        <a id="download" class="ghost as-button" hidden download>Baixar</a>
+        <a id="download" class="primary as-button" hidden download>Baixar</a>
       </div>
     </div>
 

--- a/locales/pt/tools/yaml-to-json.html
+++ b/locales/pt/tools/yaml-to-json.html
@@ -85,7 +85,7 @@
       <p class="count" id="result-note">Nada ainda.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Copiar</button>
-        <a id="download" class="ghost as-button" hidden download>Baixar</a>
+        <a id="download" class="primary as-button" hidden download>Baixar</a>
       </div>
     </div>
 

--- a/locales/tr/tools/base64.html
+++ b/locales/tr/tools/base64.html
@@ -68,7 +68,7 @@
       <p class="count" id="result-note">Henüz bir şey yok.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Kopyala</button>
-        <a id="download" class="ghost as-button" hidden download>İndir</a>
+        <a id="download" class="primary as-button" hidden download>İndir</a>
       </div>
     </div>
 

--- a/locales/tr/tools/json-formatter.html
+++ b/locales/tr/tools/json-formatter.html
@@ -123,7 +123,7 @@
       <p class="count" id="result-note">Henüz bir şey yok.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Kopyala</button>
-        <a id="download" class="ghost as-button" hidden download>İndir</a>
+        <a id="download" class="primary as-button" hidden download>İndir</a>
       </div>
     </div>
 

--- a/locales/tr/tools/text-diff.html
+++ b/locales/tr/tools/text-diff.html
@@ -87,7 +87,7 @@
       <p class="count" id="result-note">Henüz bir şey yok.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Kopyala</button>
-        <a id="download" class="ghost as-button" hidden download>İndir</a>
+        <a id="download" class="primary as-button" hidden download>İndir</a>
       </div>
     </div>
 

--- a/locales/tr/tools/xml-formatter.html
+++ b/locales/tr/tools/xml-formatter.html
@@ -98,7 +98,7 @@
       <p class="count" id="result-note">Henüz bir şey yok.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Kopyala</button>
-        <a id="download" class="ghost as-button" hidden download>İndir</a>
+        <a id="download" class="primary as-button" hidden download>İndir</a>
       </div>
     </div>
 

--- a/locales/tr/tools/yaml-to-json.html
+++ b/locales/tr/tools/yaml-to-json.html
@@ -85,7 +85,7 @@
       <p class="count" id="result-note">Henüz bir şey yok.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Kopyala</button>
-        <a id="download" class="ghost as-button" hidden download>İndir</a>
+        <a id="download" class="primary as-button" hidden download>İndir</a>
       </div>
     </div>
 

--- a/locales/zh-TW/tools/base64.html
+++ b/locales/zh-TW/tools/base64.html
@@ -68,7 +68,7 @@
       <p class="count" id="result-note">還沒有結果。</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>複製</button>
-        <a id="download" class="ghost as-button" hidden download>下載</a>
+        <a id="download" class="primary as-button" hidden download>下載</a>
       </div>
     </div>
 

--- a/locales/zh-TW/tools/json-formatter.html
+++ b/locales/zh-TW/tools/json-formatter.html
@@ -121,7 +121,7 @@
       <p class="count" id="result-note">還沒有結果。</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>複製</button>
-        <a id="download" class="ghost as-button" hidden download>下載</a>
+        <a id="download" class="primary as-button" hidden download>下載</a>
       </div>
     </div>
 

--- a/locales/zh-TW/tools/text-diff.html
+++ b/locales/zh-TW/tools/text-diff.html
@@ -87,7 +87,7 @@
       <p class="count" id="result-note">還沒有結果。</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>複製</button>
-        <a id="download" class="ghost as-button" hidden download>下載</a>
+        <a id="download" class="primary as-button" hidden download>下載</a>
       </div>
     </div>
 

--- a/locales/zh-TW/tools/xml-formatter.html
+++ b/locales/zh-TW/tools/xml-formatter.html
@@ -97,7 +97,7 @@
       <p class="count" id="result-note">還沒有結果。</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>複製</button>
-        <a id="download" class="ghost as-button" hidden download>下載</a>
+        <a id="download" class="primary as-button" hidden download>下載</a>
       </div>
     </div>
 

--- a/locales/zh-TW/tools/yaml-to-json.html
+++ b/locales/zh-TW/tools/yaml-to-json.html
@@ -85,7 +85,7 @@
       <p class="count" id="result-note">還沒有結果。</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>複製</button>
-        <a id="download" class="ghost as-button" hidden download>下載</a>
+        <a id="download" class="primary as-button" hidden download>下載</a>
       </div>
     </div>
 

--- a/locales/zh/tools/base64.html
+++ b/locales/zh/tools/base64.html
@@ -68,7 +68,7 @@
       <p class="count" id="result-note">还没有结果。</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>复制</button>
-        <a id="download" class="ghost as-button" hidden download>下载</a>
+        <a id="download" class="primary as-button" hidden download>下载</a>
       </div>
     </div>
 

--- a/locales/zh/tools/json-formatter.html
+++ b/locales/zh/tools/json-formatter.html
@@ -121,7 +121,7 @@
       <p class="count" id="result-note">还没有结果。</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>复制</button>
-        <a id="download" class="ghost as-button" hidden download>下载</a>
+        <a id="download" class="primary as-button" hidden download>下载</a>
       </div>
     </div>
 

--- a/locales/zh/tools/text-diff.html
+++ b/locales/zh/tools/text-diff.html
@@ -87,7 +87,7 @@
       <p class="count" id="result-note">还没有结果。</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>复制</button>
-        <a id="download" class="ghost as-button" hidden download>下载</a>
+        <a id="download" class="primary as-button" hidden download>下载</a>
       </div>
     </div>
 

--- a/locales/zh/tools/xml-formatter.html
+++ b/locales/zh/tools/xml-formatter.html
@@ -97,7 +97,7 @@
       <p class="count" id="result-note">还没有结果。</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>复制</button>
-        <a id="download" class="ghost as-button" hidden download>下载</a>
+        <a id="download" class="primary as-button" hidden download>下载</a>
       </div>
     </div>
 

--- a/locales/zh/tools/yaml-to-json.html
+++ b/locales/zh/tools/yaml-to-json.html
@@ -85,7 +85,7 @@
       <p class="count" id="result-note">还没有结果。</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>复制</button>
-        <a id="download" class="ghost as-button" hidden download>下载</a>
+        <a id="download" class="primary as-button" hidden download>下载</a>
       </div>
     </div>
 

--- a/tools/base64/body.html
+++ b/tools/base64/body.html
@@ -68,7 +68,7 @@
       <p class="count" id="result-note">Nothing yet.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Copy</button>
-        <a id="download" class="ghost as-button" hidden download>Download</a>
+        <a id="download" class="primary as-button" hidden download>Download</a>
       </div>
     </div>
 

--- a/tools/json-formatter/body.html
+++ b/tools/json-formatter/body.html
@@ -123,7 +123,7 @@
       <p class="count" id="result-note">Nothing yet.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Copy</button>
-        <a id="download" class="ghost as-button" hidden download>Download</a>
+        <a id="download" class="primary as-button" hidden download>Download</a>
       </div>
     </div>
 

--- a/tools/text-diff/body.html
+++ b/tools/text-diff/body.html
@@ -87,7 +87,7 @@
       <p class="count" id="result-note">Nothing yet.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Copy</button>
-        <a id="download" class="ghost as-button" hidden download>Download</a>
+        <a id="download" class="primary as-button" hidden download>Download</a>
       </div>
     </div>
 

--- a/tools/xml-formatter/body.html
+++ b/tools/xml-formatter/body.html
@@ -99,7 +99,7 @@
       <p class="count" id="result-note">Nothing yet.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Copy</button>
-        <a id="download" class="ghost as-button" hidden download>Download</a>
+        <a id="download" class="primary as-button" hidden download>Download</a>
       </div>
     </div>
 

--- a/tools/yaml-to-json/body.html
+++ b/tools/yaml-to-json/body.html
@@ -87,7 +87,7 @@
       <p class="count" id="result-note">Nothing yet.</p>
       <div class="toolbar-actions">
         <button type="button" id="copy" class="ghost" disabled>Copy</button>
-        <a id="download" class="ghost as-button" hidden download>Download</a>
+        <a id="download" class="primary as-button" hidden download>Download</a>
       </div>
     </div>
 


### PR DESCRIPTION
The download link is the page's outcome, and on five tools — base64, json-formatter, text-diff, xml-formatter, yaml-to-json — it was the one control on the page drawn as an afterthought: `ghost`, beside a Copy button that is also ghost, in link blue on white. **Thirty-four other tools draw theirs primary.** A visitor who has just formatted a file looks for the blue button and finds two grey ones.

So the five say `primary` like the rest. Copy stays ghost, which is the hierarchy the row was always meant to have: one action that *is* the result, one that is a convenience beside it.

Seventy-five files, because the markup ships in every language and the class is the same string in all fifteen copies of each page. `scripts/check_locales.py` reports no structural difference on any of the five afterwards.

The other "Download …" buttons on the site that are ghost — *Download all as a ZIP* beside per-file downloads, *Download it* for a DICOM header beside the picture — are secondary by design and are left alone.

## Measured

`#download` on json-formatter once there is output, Mobile Chrome at 390px:

| | before | after |
|---|---|---|
| classes | `ghost as-button` | `primary as-button` |
| background / text | white / link blue | accent / white |
| height | 34px | 41px |

## Before / After

| Before | After |
|---|---|
| <img width="320" alt="download-before-json-formatter" src="https://github.com/user-attachments/assets/aa0eabeb-aaef-4c88-903a-22c33101cb92" /> | <img width="320" alt="download-after-json-formatter" src="https://github.com/user-attachments/assets/bcddfe58-6103-4b66-88f9-d239f265216c" /> |

## Verified

`python build.py --out _plain --clean --no-minify` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
