### PR TITLE
Stop numbering a report's first card as if a second were coming

### DIFF
--- a/locales/ar/tools/dicom-viewer.html
+++ b/locales/ar/tools/dicom-viewer.html
@@ -8,7 +8,7 @@
     promise a sequence of decisions that does not exist.
   -->
   <section class="card">
-    <h2><span class="step">1</span> اختر صورة أشعة</h2>
+    <h2>اختر صورة أشعة</h2>
 
     {% include "partials/file-picker.html" %}
 

--- a/locales/ar/tools/gif-analyzer.html
+++ b/locales/ar/tools/gif-analyzer.html
@@ -9,7 +9,7 @@
     somebody looking for step 4's button.
   -->
   <section class="card">
-    <h2><span class="step">1</span> اختر ملف GIF</h2>
+    <h2>اختر ملف GIF</h2>
 
     <!--
       A real <label> drives the file picker natively. Calling .click() on a

--- a/locales/de/tools/dicom-viewer.html
+++ b/locales/de/tools/dicom-viewer.html
@@ -19,7 +19,7 @@
     promise a sequence of decisions that does not exist.
   -->
   <section class="card">
-    <h2><span class="step">1</span> Aufnahme wählen</h2>
+    <h2>Aufnahme wählen</h2>
 
     {% include "partials/file-picker.html" %}
 

--- a/locales/de/tools/gif-analyzer.html
+++ b/locales/de/tools/gif-analyzer.html
@@ -9,7 +9,7 @@
     somebody looking for step 4's button.
   -->
   <section class="card">
-    <h2><span class="step">1</span> Ein GIF auswählen</h2>
+    <h2>Ein GIF auswählen</h2>
 
     <!--
       A real <label> drives the file picker natively. Calling .click() on a

--- a/locales/es/tools/dicom-viewer.html
+++ b/locales/es/tools/dicom-viewer.html
@@ -19,7 +19,7 @@
     promise a sequence of decisions that does not exist.
   -->
   <section class="card">
-    <h2><span class="step">1</span> Elige un estudio</h2>
+    <h2>Elige un estudio</h2>
 
     {% include "partials/file-picker.html" %}
 

--- a/locales/es/tools/gif-analyzer.html
+++ b/locales/es/tools/gif-analyzer.html
@@ -9,7 +9,7 @@
     somebody looking for step 4's button.
   -->
   <section class="card">
-    <h2><span class="step">1</span> Elige un GIF</h2>
+    <h2>Elige un GIF</h2>
 
     <!--
       A real <label> drives the file picker natively. Calling .click() on a

--- a/locales/fr/tools/dicom-viewer.html
+++ b/locales/fr/tools/dicom-viewer.html
@@ -19,7 +19,7 @@
     promise a sequence of decisions that does not exist.
   -->
   <section class="card">
-    <h2><span class="step">1</span> Choisissez un examen</h2>
+    <h2>Choisissez un examen</h2>
 
     {% include "partials/file-picker.html" %}
 

--- a/locales/fr/tools/gif-analyzer.html
+++ b/locales/fr/tools/gif-analyzer.html
@@ -9,7 +9,7 @@
     somebody looking for step 4's button.
   -->
   <section class="card">
-    <h2><span class="step">1</span> Choisissez un GIF</h2>
+    <h2>Choisissez un GIF</h2>
 
     <!--
       A real <label> drives the file picker natively. Calling .click() on a

--- a/locales/hi/tools/dicom-viewer.html
+++ b/locales/hi/tools/dicom-viewer.html
@@ -18,7 +18,7 @@
     promise a sequence of decisions that does not exist.
   -->
   <section class="card">
-    <h2><span class="step">1</span> स्कैन चुनिए</h2>
+    <h2>स्कैन चुनिए</h2>
 
     {% include "partials/file-picker.html" %}
 

--- a/locales/hi/tools/gif-analyzer.html
+++ b/locales/hi/tools/gif-analyzer.html
@@ -9,7 +9,7 @@
     somebody looking for step 4's button.
   -->
   <section class="card">
-    <h2><span class="step">1</span> एक GIF चुनिए</h2>
+    <h2>एक GIF चुनिए</h2>
 
     <!--
       A real <label> drives the file picker natively. Calling .click() on a

--- a/locales/id/tools/dicom-viewer.html
+++ b/locales/id/tools/dicom-viewer.html
@@ -19,7 +19,7 @@
     promise a sequence of decisions that does not exist.
   -->
   <section class="card">
-    <h2><span class="step">1</span> Pilih sebuah pindaian</h2>
+    <h2>Pilih sebuah pindaian</h2>
 
     {% include "partials/file-picker.html" %}
 

--- a/locales/id/tools/gif-analyzer.html
+++ b/locales/id/tools/gif-analyzer.html
@@ -15,7 +15,7 @@
     somebody looking for step 4's button.
   -->
   <section class="card">
-    <h2><span class="step">1</span> Pilih sebuah GIF</h2>
+    <h2>Pilih sebuah GIF</h2>
 
     <!--
       A real <label> drives the file picker natively. Calling .click() on a

--- a/locales/it/tools/dicom-viewer.html
+++ b/locales/it/tools/dicom-viewer.html
@@ -19,7 +19,7 @@
     promise a sequence of decisions that does not exist.
   -->
   <section class="card">
-    <h2><span class="step">1</span> Scegli la scansione</h2>
+    <h2>Scegli la scansione</h2>
 
     {% include "partials/file-picker.html" %}
 

--- a/locales/it/tools/gif-analyzer.html
+++ b/locales/it/tools/gif-analyzer.html
@@ -9,7 +9,7 @@
     somebody looking for step 4's button.
   -->
   <section class="card">
-    <h2><span class="step">1</span> Scegli una GIF</h2>
+    <h2>Scegli una GIF</h2>
 
     <!--
       A real <label> drives the file picker natively. Calling .click() on a

--- a/locales/ja/tools/dicom-viewer.html
+++ b/locales/ja/tools/dicom-viewer.html
@@ -18,7 +18,7 @@
     promise a sequence of decisions that does not exist.
   -->
   <section class="card">
-    <h2><span class="step">1</span> 検査画像を選ぶ</h2>
+    <h2>検査画像を選ぶ</h2>
 
     {% include "partials/file-picker.html" %}
 

--- a/locales/ja/tools/gif-analyzer.html
+++ b/locales/ja/tools/gif-analyzer.html
@@ -9,7 +9,7 @@
     somebody looking for step 4's button.
   -->
   <section class="card">
-    <h2><span class="step">1</span> GIFを選ぶ</h2>
+    <h2>GIFを選ぶ</h2>
 
     <!--
       A real <label> drives the file picker natively. Calling .click() on a

--- a/locales/ko/tools/dicom-viewer.html
+++ b/locales/ko/tools/dicom-viewer.html
@@ -18,7 +18,7 @@
     promise a sequence of decisions that does not exist.
   -->
   <section class="card">
-    <h2><span class="step">1</span> 영상 고르기</h2>
+    <h2>영상 고르기</h2>
 
     {% include "partials/file-picker.html" %}
 

--- a/locales/ko/tools/gif-analyzer.html
+++ b/locales/ko/tools/gif-analyzer.html
@@ -9,7 +9,7 @@
     somebody looking for step 4's button.
   -->
   <section class="card">
-    <h2><span class="step">1</span> GIF 고르기</h2>
+    <h2>GIF 고르기</h2>
 
     <!--
       A real <label> drives the file picker natively. Calling .click() on a

--- a/locales/nl/tools/dicom-viewer.html
+++ b/locales/nl/tools/dicom-viewer.html
@@ -19,7 +19,7 @@
     promise a sequence of decisions that does not exist.
   -->
   <section class="card">
-    <h2><span class="step">1</span> Kies een scan</h2>
+    <h2>Kies een scan</h2>
 
     {% include "partials/file-picker.html" %}
 

--- a/locales/nl/tools/gif-analyzer.html
+++ b/locales/nl/tools/gif-analyzer.html
@@ -9,7 +9,7 @@
     somebody looking for step 4's button.
   -->
   <section class="card">
-    <h2><span class="step">1</span> Kies een GIF</h2>
+    <h2>Kies een GIF</h2>
 
     <!--
       A real <label> drives the file picker natively. Calling .click() on a

--- a/locales/pt/tools/dicom-viewer.html
+++ b/locales/pt/tools/dicom-viewer.html
@@ -19,7 +19,7 @@
     promise a sequence of decisions that does not exist.
   -->
   <section class="card">
-    <h2><span class="step">1</span> Escolha o exame</h2>
+    <h2>Escolha o exame</h2>
 
     {% include "partials/file-picker.html" %}
 

--- a/locales/pt/tools/gif-analyzer.html
+++ b/locales/pt/tools/gif-analyzer.html
@@ -9,7 +9,7 @@
     somebody looking for step 4's button.
   -->
   <section class="card">
-    <h2><span class="step">1</span> Escolha um GIF</h2>
+    <h2>Escolha um GIF</h2>
 
     <!--
       A real <label> drives the file picker natively. Calling .click() on a

--- a/locales/tr/tools/dicom-viewer.html
+++ b/locales/tr/tools/dicom-viewer.html
@@ -18,7 +18,7 @@
     promise a sequence of decisions that does not exist.
   -->
   <section class="card">
-    <h2><span class="step">1</span> Bir tarama seçin</h2>
+    <h2>Bir tarama seçin</h2>
 
     {% include "partials/file-picker.html" %}
 

--- a/locales/tr/tools/gif-analyzer.html
+++ b/locales/tr/tools/gif-analyzer.html
@@ -15,7 +15,7 @@
     somebody looking for step 4's button.
   -->
   <section class="card">
-    <h2><span class="step">1</span> Bir GIF seçin</h2>
+    <h2>Bir GIF seçin</h2>
 
     <!--
       A real <label> drives the file picker natively. Calling .click() on a

--- a/locales/zh-TW/tools/dicom-viewer.html
+++ b/locales/zh-TW/tools/dicom-viewer.html
@@ -20,7 +20,7 @@
     promise a sequence of decisions that does not exist.
   -->
   <section class="card">
-    <h2><span class="step">1</span> 選影像</h2>
+    <h2>選影像</h2>
 
     {% include "partials/file-picker.html" %}
 

--- a/locales/zh-TW/tools/gif-analyzer.html
+++ b/locales/zh-TW/tools/gif-analyzer.html
@@ -9,7 +9,7 @@
     somebody looking for step 4's button.
   -->
   <section class="card">
-    <h2><span class="step">1</span> 選一個 GIF</h2>
+    <h2>選一個 GIF</h2>
 
     <!--
       A real <label> drives the file picker natively. Calling .click() on a

--- a/locales/zh/tools/dicom-viewer.html
+++ b/locales/zh/tools/dicom-viewer.html
@@ -20,7 +20,7 @@
     promise a sequence of decisions that does not exist.
   -->
   <section class="card">
-    <h2><span class="step">1</span> 选影像</h2>
+    <h2>选影像</h2>
 
     {% include "partials/file-picker.html" %}
 

--- a/locales/zh/tools/gif-analyzer.html
+++ b/locales/zh/tools/gif-analyzer.html
@@ -9,7 +9,7 @@
     somebody looking for step 4's button.
   -->
   <section class="card">
-    <h2><span class="step">1</span> 选一个 GIF</h2>
+    <h2>选一个 GIF</h2>
 
     <!--
       A real <label> drives the file picker natively. Calling .click() on a

--- a/tools/dicom-viewer/body.html
+++ b/tools/dicom-viewer/body.html
@@ -8,7 +8,7 @@
     promise a sequence of decisions that does not exist.
   -->
   <section class="card">
-    <h2><span class="step">1</span> Choose a scan</h2>
+    <h2>Choose a scan</h2>
 
     {% include "partials/file-picker.html" %}
 

--- a/tools/gif-analyzer/body.html
+++ b/tools/gif-analyzer/body.html
@@ -9,7 +9,7 @@
     somebody looking for step 4's button.
   -->
   <section class="card">
-    <h2><span class="step">1</span> Choose a GIF</h2>
+    <h2>Choose a GIF</h2>
 
     <!--
       A real <label> drives the file picker natively. Calling .click() on a


### PR DESCRIPTION
The DICOM viewer and the GIF analyser open with **1 Choose a scan** / **1 Choose a GIF** — and then nothing is 2. What follows is a report: *what this file is, what identifies the patient, every tag*; *what stands out, where the bytes went, frame by frame*. Those cards are sections, not steps, and are rightly unnumbered. A lone 1 reads as a sequence that was cut off, and it is the only place on the site a visitor sees a numbered step with no next one.

The badge comes off those two pages, in every language — thirty files, the same string in each. Nothing else moves: the heading, its fold and its help are as they were.

**Left alone on purpose:** the tools whose unnumbered cards are asides *between* numbered steps — password-generator's "Nothing here is remembered", qr-barcode-reader's "The camera", share-text's "Someone is sharing with you". There the sequence is real and the aside is an aside.

## Before / After

| Before | After |
|---|---|
| <img width="320" alt="steps-before-gif-analyzer" src="https://github.com/user-attachments/assets/04f4172d-702d-472d-ae95-0bdaee375e84" /> | <img width="320" alt="steps-after-gif-analyzer" src="https://github.com/user-attachments/assets/9d212eff-ec02-4a19-b7b9-db899f53dcfa" /> |
| <img width="320" alt="steps-before-dicom-viewer" src="https://github.com/user-attachments/assets/901f85ef-d288-458c-b5ef-a5ae94e4ace0" /> | <img width="320" alt="steps-after-dicom-viewer" src="https://github.com/user-attachments/assets/af4ea6f3-8929-4f9d-a92b-116ce2a1899c" /> |

## Verified

- the built pages carry no `class="step"` at all
- `python build.py --out _plain --clean --no-minify` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
