### PR TITLE
One check row, in its two shapes, for every tool that has one

### DIFF
--- a/docs/adding-a-tool.md
+++ b/docs/adding-a-tool.md
@@ -89,7 +89,7 @@ A component more than one tool needs, and that no tool should own, lives under
 | `shared/css/file-list.css` | `css_parts = ["file-list"]` | appended to the tool's stylesheet |
 | `shared/css/results.css` | `css_parts = ["results"]` | the source panel, the summary rows, the result and its meta line, the results list; put before the tool's own rules, so a tool that wants one of them different keeps its own |
 | `shared/css/form.css` | `css_parts = ["form"]` | the controls' vocabulary: fields and their notes, the card lede, the big button, option rows, the options box, the run and export rows, number fields |
-| `shared/css/checks.css` | `css_parts = ["checks"]` | a checkbox row with a bold title and a dim note, as the image and PDF tools draw it |
+| `shared/css/checks.css` | `css_parts = ["checks"]` | a checkbox row, in both its shapes: a bold title with a dim note beneath, or a few words on one line |
 | `shared/css/notes.css` | `css_parts = ["notes"]` | the error line, and the note that says which path a file took |
 | `shared/css/panes.css` | `css_parts = ["panes"]` | the two text panes of a formatter page and the head above each |
 | `shared/css/modes.css` | `css_parts = ["modes"]` | a choice between two ways of working, as radio rows with a title and an explanation |

--- a/shared/css/checks.css
+++ b/shared/css/checks.css
@@ -1,14 +1,20 @@
 /* ---------------------------------------------------------------- checks
-   A checkbox with a title and a note under it, laid out as a row the whole
-   of which can be clicked: the input at the top of the row, the title in
-   bold, the note dim beneath.
+   A checkbox and its words, laid out as a row the whole of which can be
+   clicked. It comes in two shapes, told apart by what is in it:
 
-   Asked for with `css_parts = ["checks"]`. Thirteen tools - the image and
-   PDF ones - carried these rules token for token; the build puts this file
-   before a tool's own stylesheet, so a tool that wants one of them different
-   writes its own rule and wins, provided it sets every property the rule
-   here sets. The video and text tools style their checkboxes another way
-   and do not ask for this. */
+     - a title in bold with a note dim beneath it, the input at the top of
+       the row - "Keep the date, the camera and the place / Where and when
+       it was taken stay in the file";
+     - a few words on one line, no title and no note - "Keep the sound",
+       "Sort the keys of every object" - the input centred on them and the
+       words in bold at the size of a label.
+
+   Asked for with `css_parts = ["checks"]`. The build puts this file before a
+   tool's own stylesheet, so a tool that wants one of them different writes
+   its own rule and wins, provided it sets every property the rule here sets;
+   the second shape is written with :where so that it has no more weight than
+   `.check` itself. Before this file every tool drew these for itself - twelve
+   ways between twenty-one tools, the same row at three sizes and two gaps. */
 
 .check {
   align-items: flex-start;
@@ -20,6 +26,19 @@
 .check input {
   flex: none;
   margin-top: 0.25rem;
+}
+
+/* The one-line shape. A check with a bold title is the other kind; one
+   without is this. */
+.check:where(:not(:has(strong))) {
+  align-items: center;
+  font-size: 0.88rem;
+  font-weight: 600;
+  gap: 0.45rem;
+}
+
+.check:where(:not(:has(strong))) input {
+  margin: 0;
 }
 
 .check strong {

--- a/tools/compress-pdf/styles.css
+++ b/tools/compress-pdf/styles.css
@@ -245,11 +245,7 @@
 .unit { font-size: 0.82rem; color: var(--text-dim); }
 
 .check {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.6rem;
   margin-top: 1.1rem;
-  cursor: pointer;
 }
 
 /* ----------------------------------------------------------------- running */

--- a/tools/crop-video/styles.css
+++ b/tools/crop-video/styles.css
@@ -211,16 +211,6 @@
 }
 
 .field > label { font-size: 0.85rem; font-weight: 600; }
-
-.check {
-  display: flex;
-  align-items: center;
-  gap: 0.45rem;
-  font-weight: 600;
-  font-size: 0.85rem;
-}
-.check input { margin: 0; }
-
 .summary {
   margin: 1.2rem 0;
   font-size: 0.88rem;

--- a/tools/crop-video/tool.toml
+++ b/tools/crop-video/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "video"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "results", "form", "notes", "cropper"]
+css_parts = ["progress", "results", "form", "notes", "cropper", "checks"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no

--- a/tools/document-scanner/styles.css
+++ b/tools/document-scanner/styles.css
@@ -329,10 +329,6 @@ kbd {
 }
 
 .check {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.6rem;
-  cursor: pointer;
   margin-bottom: 0.8rem;
 }
 

--- a/tools/edit-audio/styles.css
+++ b/tools/edit-audio/styles.css
@@ -89,16 +89,6 @@ input[type="range"] {
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
   gap: 0.7rem;
 }
-
-.check {
-  display: flex;
-  align-items: center;
-  gap: 0.45rem;
-  font-weight: 600;
-  font-size: 0.9rem;
-}
-.check input { margin: 0; }
-
 .field > label { font-size: 0.85rem; font-weight: 600; }
 .field-note { margin: 0.5rem 0 0; font-size: 0.78rem; color: var(--text-dim); }
 

--- a/tools/edit-audio/tool.toml
+++ b/tools/edit-audio/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "audio"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "results", "form", "notes", "modes"]
+css_parts = ["progress", "results", "form", "notes", "modes", "checks"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts, and for
 # the same reason: a component more than one tool needs and no tool should own.

--- a/tools/exif-editor/styles.css
+++ b/tools/exif-editor/styles.css
@@ -120,11 +120,7 @@
 }
 
 .check {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.6rem;
   margin-bottom: 0.7rem;
-  cursor: pointer;
 }
 
 /* The exact bargain the button above is offering, restated as one sentence

--- a/tools/extract-audio-from-video/styles.css
+++ b/tools/extract-audio-from-video/styles.css
@@ -89,16 +89,6 @@ input[type="range"] {
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
   gap: 0.7rem;
 }
-
-.check {
-  display: flex;
-  align-items: center;
-  gap: 0.45rem;
-  font-weight: 600;
-  font-size: 0.9rem;
-}
-.check input { margin: 0; }
-
 .field > label { font-size: 0.85rem; font-weight: 600; }
 .field-note { margin: 0.5rem 0 0; font-size: 0.78rem; color: var(--text-dim); }
 

--- a/tools/extract-audio-from-video/tool.toml
+++ b/tools/extract-audio-from-video/tool.toml
@@ -69,7 +69,7 @@ roadmap_group = "audio"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar the shared picker draws while it reads.
-css_parts = ["progress", "results", "form", "notes", "modes"]
+css_parts = ["progress", "results", "form", "notes", "modes", "checks"]
 
 # Shared modules this tool asks for. file-picker brings in the drop zone.
 js_parts = ["file-picker", "audio-decode", "samplerate", "wav", "message-box", "format"]

--- a/tools/image-to-data-uri/styles.css
+++ b/tools/image-to-data-uri/styles.css
@@ -116,12 +116,6 @@
   color: var(--text-dim);
 }
 
-.check { display: flex; gap: 0.6rem; align-items: flex-start; cursor: pointer; }
-.check input { flex: none; margin-top: 0.2rem; }
-.check > span { display: flex; flex-direction: column; gap: 0.25rem; }
-.check strong { font-size: 0.92rem; }
-.check-note { font-size: 0.82rem; line-height: 1.55; color: var(--text-dim); max-width: 62ch; }
-
 /* ------------------------------------------------------------- the results */
 
 .results-head {

--- a/tools/image-to-data-uri/tool.toml
+++ b/tools/image-to-data-uri/tool.toml
@@ -28,7 +28,7 @@ roadmap_group = "images"
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. file-list is the drop-a-file-then-see-a-row widget that
 # more than one tool needs and that no tool should own.
-css_parts = ["file-list", "form"]
+css_parts = ["file-list", "form", "checks"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no

--- a/tools/image-to-ico/styles.css
+++ b/tools/image-to-ico/styles.css
@@ -136,10 +136,6 @@
 .option-row { min-width: 0; }
 
 .check {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.6rem;
-  cursor: pointer;
   margin-top: 1.2rem;
 }
 

--- a/tools/image-to-svg/styles.css
+++ b/tools/image-to-svg/styles.css
@@ -26,14 +26,6 @@
   padding-inline-start: 0.9rem;
   margin: 0 0 0.9rem;
 }
-
-.check {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  color: var(--text);
-}
-
 .field-note {
   margin: 0 0 0.8rem;
   color: var(--text-dim);

--- a/tools/image-to-svg/tool.toml
+++ b/tools/image-to-svg/tool.toml
@@ -39,7 +39,7 @@ roadmap_group = "images"
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. file-list is not among them: this tool takes one picture,
 # so there is no list to draw.
-css_parts = []
+css_parts = ["checks"]
 # Shared modules this tool asks for. file-picker brings in the drop zone;
 # phrases arrives on its own, for every tool.
 js_parts = ["file-picker", "download"]

--- a/tools/json-formatter/styles.css
+++ b/tools/json-formatter/styles.css
@@ -46,15 +46,6 @@
   gap: 0.9rem 1.2rem;
   align-items: start;
 }
-
-.check {
-  display: flex;
-  align-items: center;
-  gap: 0.45rem;
-  font-weight: 600;
-  font-size: 0.88rem;
-}
-.check input { margin: 0; }
 /* -------------------------------------------------------------- the boxes */
 
 textarea {

--- a/tools/json-formatter/tool.toml
+++ b/tools/json-formatter/tool.toml
@@ -35,7 +35,7 @@ roadmap_group = "beyond"
 
 # Shared stylesheet parts this tool asks for, put before its own rules by
 # the build so that its own can override them.
-css_parts = ["form", "panes"]
+css_parts = ["form", "panes", "checks"]
 
 # Shared modules this tool asks for. file-picker brings in the drop zone, which
 # is here for the file that is easier to drop than to open, select all and copy.

--- a/tools/merge-pdf/styles.css
+++ b/tools/merge-pdf/styles.css
@@ -292,11 +292,7 @@
 .preset-note input[type="text"] { width: 7rem; }
 
 .check {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.6rem;
   margin-top: 1.1rem;
-  cursor: pointer;
 }
 
 /* ----------------------------------------------------------------- running */

--- a/tools/password-generator/styles.css
+++ b/tools/password-generator/styles.css
@@ -73,13 +73,6 @@
 .field-note { margin: 0.15rem 0 0; font-size: 0.78rem; color: var(--text-dim); }
 
 .checks-label { font-size: 0.85rem; font-weight: 600; }
-
-.check {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: 0.88rem;
-}
 .check input { width: 1rem; height: 1rem; }
 
 .field code {

--- a/tools/password-generator/tool.toml
+++ b/tools/password-generator/tool.toml
@@ -97,7 +97,7 @@ card = """
 
 # Shared stylesheet parts this tool asks for, put before its own rules by
 # the build so that its own can override them.
-css_parts = ["panes"]
+css_parts = ["panes", "checks"]
 
 # The nouns this tool uses for the things it works on. They appear in the boot
 # warning, the pledge line and the analytics comment, which is why they are a

--- a/tools/redact-image/styles.css
+++ b/tools/redact-image/styles.css
@@ -180,10 +180,6 @@ kbd {
 /* ------------------------------------------------------------- the settings */
 
 .check {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.6rem;
-  cursor: pointer;
   margin-bottom: 0.8rem;
 }
 

--- a/tools/redact-pdf/styles.css
+++ b/tools/redact-pdf/styles.css
@@ -285,11 +285,7 @@
 /* --------------------------------------------------------------- the run */
 
 .check {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.6rem;
   margin-top: 1rem;
-  cursor: pointer;
 }
 
 /* ---------------------------------------------------------------- results */

--- a/tools/reverse-video/styles.css
+++ b/tools/reverse-video/styles.css
@@ -34,16 +34,6 @@
 }
 
 .field > label { font-size: 0.85rem; font-weight: 600; }
-
-.check {
-  display: flex;
-  align-items: center;
-  gap: 0.45rem;
-  font-weight: 600;
-  font-size: 0.85rem;
-}
-.check input { margin: 0; }
-
 .summary {
   margin: 1.2rem 0;
   font-size: 0.88rem;
@@ -69,4 +59,3 @@
   background: #000;
   display: block;
 }
-

--- a/tools/reverse-video/tool.toml
+++ b/tools/reverse-video/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "video"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "results", "form", "notes"]
+css_parts = ["progress", "results", "form", "notes", "checks"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no

--- a/tools/share-text/tool.toml
+++ b/tools/share-text/tool.toml
@@ -32,6 +32,10 @@ favicon = "&#128279;"        # the tab icon, drawn into an inline SVG
 glyph = "send"
 category = "text-codes-and-passwords"
 roadmap_group = "beyond"
+
+# Optional stylesheets from shared/css, dropped in between the frame and this
+# tool's own rules: the checkbox rows of the sharing options.
+css_parts = ["checks"]
 lastmod = "2026-08-27"
 
 # --- what search engines and chat apps are told ------------------------------

--- a/tools/text-diff/styles.css
+++ b/tools/text-diff/styles.css
@@ -13,16 +13,6 @@
   gap: 0.9rem 1.2rem;
   align-items: start;
 }
-
-.check {
-  display: flex;
-  align-items: center;
-  gap: 0.45rem;
-  font-weight: 600;
-  font-size: 0.88rem;
-}
-.check input { margin: 0; }
-
 /* -------------------------------------------------------------- the boxes */
 
 /* Two boxes side by side once there is room for both, and stacked before

--- a/tools/text-diff/tool.toml
+++ b/tools/text-diff/tool.toml
@@ -37,7 +37,7 @@ roadmap_group = "beyond"
 
 # Shared stylesheet parts this tool asks for, put before its own rules by
 # the build so that its own can override them.
-css_parts = ["form", "panes"]
+css_parts = ["form", "panes", "checks"]
 
 # Shared modules this tool asks for. file-picker brings in the drop zone, which
 # is here for the two files that are easier to drop than to open, select all

--- a/tools/trim-video/styles.css
+++ b/tools/trim-video/styles.css
@@ -447,16 +447,6 @@ kbd {
 }
 
 .field > label { font-size: 0.85rem; font-weight: 600; }
-
-.check {
-  display: flex;
-  align-items: center;
-  gap: 0.45rem;
-  font-weight: 600;
-  font-size: 0.85rem;
-}
-.check input { margin: 0; }
-
 .summary {
   margin: 1.2rem 0 0;
   font-size: 0.88rem;

--- a/tools/trim-video/tool.toml
+++ b/tools/trim-video/tool.toml
@@ -28,7 +28,7 @@ roadmap_group = "video"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "results", "form", "notes", "modes"]
+css_parts = ["progress", "results", "form", "notes", "modes", "checks"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts, and for
 # the same reason: a component more than one tool needs and no tool should own.

--- a/tools/video-to-gif/styles.css
+++ b/tools/video-to-gif/styles.css
@@ -170,16 +170,6 @@
 }
 
 .field > label { font-size: 0.85rem; font-weight: 600; }
-
-.check {
-  display: flex;
-  align-items: center;
-  gap: 0.45rem;
-  font-weight: 600;
-  font-size: 0.85rem;
-}
-.check input { margin: 0; }
-
 .summary {
   margin: 1.2rem 0;
   font-size: 0.88rem;
@@ -211,4 +201,3 @@
   border-radius: var(--radius);
   background: var(--surface-2);
 }
-

--- a/tools/video-to-gif/tool.toml
+++ b/tools/video-to-gif/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "gif"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "results", "form", "notes"]
+css_parts = ["progress", "results", "form", "notes", "checks"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no

--- a/tools/xml-formatter/styles.css
+++ b/tools/xml-formatter/styles.css
@@ -46,15 +46,6 @@
   gap: 0.9rem 1.2rem;
   align-items: start;
 }
-
-.check {
-  display: flex;
-  align-items: center;
-  gap: 0.45rem;
-  font-weight: 600;
-  font-size: 0.88rem;
-}
-.check input { margin: 0; }
 /* -------------------------------------------------------------- the boxes */
 
 textarea {

--- a/tools/xml-formatter/tool.toml
+++ b/tools/xml-formatter/tool.toml
@@ -56,7 +56,7 @@ roadmap_group = "beyond"
 
 # Shared stylesheet parts this tool asks for, put before its own rules by
 # the build so that its own can override them.
-css_parts = ["form", "panes"]
+css_parts = ["form", "panes", "checks"]
 
 # Shared modules this tool asks for. file-picker brings in the drop zone, which
 # is here for the file that is easier to drop than to open, select all and copy.

--- a/tools/yaml-to-json/styles.css
+++ b/tools/yaml-to-json/styles.css
@@ -46,15 +46,6 @@
   gap: 0.9rem 1.2rem;
   align-items: start;
 }
-
-.check {
-  display: flex;
-  align-items: center;
-  gap: 0.45rem;
-  font-weight: 600;
-  font-size: 0.88rem;
-}
-.check input { margin: 0; }
 /* -------------------------------------------------------------- the boxes */
 
 textarea {

--- a/tools/yaml-to-json/tool.toml
+++ b/tools/yaml-to-json/tool.toml
@@ -55,7 +55,7 @@ roadmap_group = "beyond"
 
 # Shared stylesheet parts this tool asks for, put before its own rules by
 # the build so that its own can override them.
-css_parts = ["form", "panes"]
+css_parts = ["form", "panes", "checks"]
 
 # Shared modules this tool asks for. file-picker brings in the drop zone, which
 # is here for the config file that is easier to drop than to open, select all


### PR DESCRIPTION
Twenty-one tools draw a checkbox row, and between them they drew it **twelve ways**. `checks.css` knew one shape — a bold title with a dim note beneath, the input at the top — and thirteen tools asked for it; nine of those then wrote the same four declarations again in their own stylesheet to add a margin. The other shape — a checkbox and a few words on one line, *Keep the sound*, *Sort the keys* — was not in the family at all, so ten tools wrote it for themselves at three sizes and two gaps, one wrote it without the bold, one wrote it inline, and one never wrote it and got the browser's default label.

So the family learns the second shape, told apart by structure: a check with a `<strong>` inside is the stacked kind, one without is the one-line kind — centred on its input, 0.88rem and bold, the size the text tools chose. The selector is wrapped in `:where()` so it weighs no more than `.check` and a tool's own rule still wins on order.

Every private copy comes out:

- the nine that restated the family keep only their margin;
- the twelve that drew the one-line shape (the six video/audio tools, the five text tools, password-generator) ask for the family and keep nothing, bar password-generator's 1rem checkbox;
- image-to-data-uri, which had copied the stacked shape with three values off by a hair, joins the family;
- image-to-svg and share-text ask for it for the first time.

`docs/adding-a-tool.md` describes the part's two shapes.

## Measured

Every `.check` on the 22 pages, computed style on Mobile Chrome, production against this branch. Unchanged unless listed:

| page | before | after |
|---|---|---|
| edit-audio, extract-audio-from-video | 0.9rem | 0.88rem |
| image-to-svg | 1rem, regular, gap 0.4rem, input 3px down | 0.88rem, bold, gap 0.45rem, input centred |
| share-text | browser default (inline, regular) | the family's one-line row |
| password-generator | gap 0.5rem | gap 0.45rem |
| image-to-data-uri | input 3.2px down | 4px, like the other stacked ones |
| every one-line check | `cursor: default` | `cursor: pointer`, like the stacked ones |

The video and text tools that wrote 0.85rem keep it: a `.field > label` rule of their own says so and still wins. The nine stacked adopters measure identically before and after.

## Before / After

| Before | After |
|---|---|
| <img width="320" alt="checks-before-image-to-svg" src="https://github.com/user-attachments/assets/60f924af-28cd-4f8e-887f-b84e8bc16891" /> | <img width="320" alt="checks-after-image-to-svg" src="https://github.com/user-attachments/assets/33f3000b-a808-410f-9c38-b5c37f0ce5d6" /> |
| <img width="320" alt="checks-before-share-text" src="https://github.com/user-attachments/assets/bb548d25-5a4f-4c28-b07f-53dcb5a2c7d5" /> | <img width="320" alt="checks-after-share-text" src="https://github.com/user-attachments/assets/e63a678a-d084-42bd-bf06-3a5b42624aaf" /> |

## Verified

- the table above, from a throwaway spec in the QA suite that reads every `.check` on the 22 pages
- `python build.py --out _plain --clean --no-minify` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
