### PR TITLE
Fold the form and notes copies back into the families they restate

### DIFF
--- a/docs/adding-a-tool.md
+++ b/docs/adding-a-tool.md
@@ -88,7 +88,7 @@ A component more than one tool needs, and that no tool should own, lives under
 |---|---|---|
 | `shared/css/file-list.css` | `css_parts = ["file-list"]` | appended to the tool's stylesheet |
 | `shared/css/results.css` | `css_parts = ["results"]` | the source panel, the summary rows, the result and its meta line, the results list; put before the tool's own rules, so a tool that wants one of them different keeps its own |
-| `shared/css/form.css` | `css_parts = ["form"]` | the controls' vocabulary: fields and their notes, the card lede, the big button, option rows, the options box, the run and export rows, number fields |
+| `shared/css/form.css` | `css_parts = ["form"]` | the controls' vocabulary: fields and their notes, the settings grid they sit in, the inline pair, the card lede, the big button, option rows, the options box, the run and export rows, number fields |
 | `shared/css/checks.css` | `css_parts = ["checks"]` | a checkbox row, in both its shapes: a bold title with a dim note beneath, or a few words on one line |
 | `shared/css/notes.css` | `css_parts = ["notes"]` | the error line, and the note that says which path a file took |
 | `shared/css/panes.css` | `css_parts = ["panes"]` | the two text panes of a formatter page and the head above each |

--- a/shared/css/form.css
+++ b/shared/css/form.css
@@ -9,7 +9,13 @@
    own stylesheet, so a tool that wants one of them different writes its own
    rule and wins - provided it sets every property the rule here sets, or the
    value here shows through the gap. `.option-row` itself is not here: the
-   tools disagree on its width and its margin, so each keeps its own. */
+   tools disagree on its width and its margin, so each keeps its own.
+
+   `.settings` and `.inline-pair` came later, from the same kind of count:
+   eleven tools had drawn the settings grid with six different column widths
+   and twelve the pair with three gaps, none of them for a reason a visitor
+   could see. A tool with a real reason - password-generator's settings are a
+   single column - still says so in a rule of its own. */
 
 .field {
   display: flex;
@@ -20,7 +26,29 @@
 .field-note {
   color: var(--text-dim);
   font-size: 0.78rem;
+  line-height: 1.5;
   margin: 0;
+}
+
+/* What an empty note does is the tool's to say: the text tools hide it
+   (`.field-note:empty { display: none }`), the tools whose note is written
+   in later give it a line's height so the page does not jump. Neither is
+   here. */
+
+/* The grid a card's settings sit in: as many columns as fit at 220px, one on
+   a phone. */
+.settings {
+  display: grid;
+  gap: 0.9rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+/* Two controls that read as one - a number and its unit, a slider and its
+   readout, width by height. */
+.inline-pair {
+  align-items: center;
+  display: flex;
+  gap: 0.5rem;
 }
 
 .field-summary {

--- a/shared/css/notes.css
+++ b/shared/css/notes.css
@@ -7,7 +7,10 @@
    so a tool that wants one of them different writes its own rule and wins,
    provided it sets every property the rule here sets. The image tools give
    `.error` a ceiling and a scrollbar and the text tools set its margin the
-   other way; each keeps that as a rule of its own on top of this one. */
+   other way; each keeps that as a rule of its own on top of this one. Every
+   tool that has an error line asks for this now - the three that had drawn
+   it as a grey box with a red edge, and the one that had drawn it as bare
+   red text, draw it as the rest do. */
 
 .error {
   background: color-mix(in srgb, var(--danger) 12%, transparent);

--- a/tools/base64/styles.css
+++ b/tools/base64/styles.css
@@ -4,15 +4,9 @@
 /* ------------------------------------------------------------- the options */
 
 .field > label { font-size: 0.85rem; font-weight: 600; }
-.field-note { margin: 0.15rem 0 0; font-size: 0.78rem; color: var(--text-dim); }
+.field-note { margin: 0.15rem 0 0; }
 .field-note:empty { display: none; }
-
-.settings {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 0.9rem 1.2rem;
-  align-items: start;
-}
+.settings { align-items: start; }
 
 .modes {
   margin: 0;
@@ -61,16 +55,7 @@ textarea:focus-visible, .output:focus-visible {
 
 .output:empty { display: none; }
 
-.error {
-  margin: 0 0 1rem;
-  padding: 0.7rem 0.9rem;
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
-  color: var(--danger);
-  font-size: 0.9rem;
-  white-space: pre-line;
-}
+.error { margin: 0 0 1rem; }
 
 @media (max-width: 620px) {
   textarea { min-height: 170px; font-size: 0.8rem; }

--- a/tools/base64/tool.toml
+++ b/tools/base64/tool.toml
@@ -40,7 +40,7 @@ roadmap_group = "beyond"
 
 # Shared stylesheet parts this tool asks for, put before its own rules by
 # the build so that its own can override them.
-css_parts = ["form", "panes", "modes"]
+css_parts = ["form", "panes", "modes", "notes"]
 
 # Shared modules this tool asks for. file-picker brings in the drop zone, which
 # is here for the file that is easier to drop than to open, select all and copy.

--- a/tools/compare-heights/styles.css
+++ b/tools/compare-heights/styles.css
@@ -244,9 +244,6 @@ body.is-reordering { user-select: none; }
 }
 
 .run-row {
-  display: flex;
-  align-items: center;
   gap: 0.6rem;
-  flex-wrap: wrap;
   margin-top: 1.2rem;
 }

--- a/tools/compress-image/styles.css
+++ b/tools/compress-image/styles.css
@@ -3,15 +3,6 @@
 /* The one button on the page big enough to be found without reading. */
 
 .error {
-  margin: 1rem 0 0;
-  padding: 0.7rem 0.9rem;
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
-  color: var(--danger);
-  font-size: 0.9rem;
-  /* Files that could not be read are reported one per line. */
-  white-space: pre-line;
   max-height: 12rem;
   overflow-y: auto;
 }
@@ -37,8 +28,6 @@
   font-weight: 600;
   margin-bottom: 0.35rem;
 }
-
-.inline-pair { display: flex; gap: 0.4rem; }
 
 /* Wide enough for "1024" and no wider: this is the number the whole page turns
    on, and a full-width box makes it look like a search field. */

--- a/tools/compress-image/tool.toml
+++ b/tools/compress-image/tool.toml
@@ -28,7 +28,7 @@ roadmap_group = "images"
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. file-list is the drop-a-file-then-see-a-row widget that
 # more than one tool needs and that no tool should own.
-css_parts = ["file-list", "progress", "results", "form", "checks"]
+css_parts = ["file-list", "progress", "results", "form", "checks", "notes"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.

--- a/tools/compress-pdf/styles.css
+++ b/tools/compress-pdf/styles.css
@@ -4,36 +4,7 @@
   which the build puts in front of this file.
 */
 
-/* The one button on the page big enough to be found without reading. */
-.big { font-size: 1.02rem; padding: 0.7rem 1.3rem; }
-
-.error {
-  margin: 1rem 0 0;
-  padding: 0.7rem 0.9rem;
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
-  color: var(--danger);
-  font-size: 0.9rem;
-  max-width: 72ch;
-}
-
-.card-lede {
-  margin: -0.4rem 0 1.1rem;
-  font-size: 0.92rem;
-  line-height: 1.6;
-  color: var(--text-dim);
-  max-width: 68ch;
-}
-
-/* The sentence under a control, restating what it is about to do. */
-.field-summary {
-  margin: 0.9rem 0 0;
-  font-size: 0.86rem;
-  line-height: 1.55;
-  color: var(--text-dim);
-  max-width: 72ch;
-}
+.error { max-width: 72ch; }
 
 /* ------------------------------------------------------------- the file row */
 
@@ -236,9 +207,6 @@
   margin-bottom: 0.9rem;
 }
 
-.option-row label { font-size: 0.9rem; font-weight: 600; }
-
-.inline-pair { display: flex; align-items: center; gap: 0.5rem; }
 .inline-pair input[type="number"] { width: 6.5rem; font-size: 1.05rem; font-weight: 600; }
 .inline-pair input[type="range"] { width: 12rem; }
 .inline-pair output { font-variant-numeric: tabular-nums; font-weight: 600; }
@@ -249,8 +217,6 @@
 }
 
 /* ----------------------------------------------------------------- running */
-
-.run-row { display: flex; align-items: center; gap: 0.9rem; flex-wrap: wrap; }
 
 /* ----------------------------------------------------------------- results */
 

--- a/tools/compress-pdf/tool.toml
+++ b/tools/compress-pdf/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "documents"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "checks"]
+css_parts = ["progress", "checks", "form", "notes"]
 
 # file-picker brings in the drop zone. The four pdf-* parts are the PDF itself
 # - the object grammar, the stream filters, the reader and the writer - and

--- a/tools/crop-video/styles.css
+++ b/tools/crop-video/styles.css
@@ -204,12 +204,6 @@
 
 /* ---------------------------------------------------------------- settings */
 
-.settings {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
-  gap: 0.9rem;
-}
-
 .field > label { font-size: 0.85rem; font-weight: 600; }
 .summary {
   margin: 1.2rem 0;

--- a/tools/dicom-viewer/styles.css
+++ b/tools/dicom-viewer/styles.css
@@ -359,16 +359,6 @@
 
 /* -------------------------------------------------------------- the messages */
 
-.error {
-  margin: 1rem 0 0;
-  padding: 0.6rem 0.8rem;
-  border-radius: 7px;
-  background: var(--surface-2);
-  border: 1px solid var(--danger);
-  color: var(--danger);
-  font-size: 0.88rem;
-}
-
 @media (max-width: 560px) {
   .identity-row { grid-template-columns: 1fr; }
   .viewport { height: min(60vh, 420px); }

--- a/tools/dicom-viewer/tool.toml
+++ b/tools/dicom-viewer/tool.toml
@@ -38,6 +38,10 @@ category = "images"
 # It sits at the top of that group as a link, above the names still to be built.
 roadmap_group = "images"
 
+# Optional stylesheets from shared/css, dropped in between the frame and this
+# tool's own rules.
+css_parts = ["notes"]
+
 # Shared modules this tool asks for. file-picker brings in the drop zone; it is
 # set to accept many files because a CT is three hundred of them and dropping a
 # folder is the only sane way to open one.

--- a/tools/document-scanner/styles.css
+++ b/tools/document-scanner/styles.css
@@ -5,17 +5,6 @@
   with its four corner handles, and the straightened page underneath.
 */
 
-/* The one button on the page big enough to be found without reading. */
-.big { font-size: 1.02rem; padding: 0.7rem 1.3rem; }
-
-.card-lede {
-  margin: -0.4rem 0 1.1rem;
-  font-size: 0.92rem;
-  line-height: 1.6;
-  color: var(--text-dim);
-  max-width: 68ch;
-}
-
 .hint-line {
   margin: 0.5rem 0 0;
   font-size: 0.84rem;
@@ -25,14 +14,6 @@
 }
 
 .warn-line { color: var(--danger); }
-
-.field-summary {
-  margin: 0.9rem 0 0;
-  font-size: 0.86rem;
-  line-height: 1.55;
-  color: var(--text-dim);
-  max-width: 72ch;
-}
 
 .optional { color: var(--text-dim); font-weight: 400; }
 
@@ -313,21 +294,6 @@ kbd {
 
 /* ------------------------------------------------------- the four choices */
 
-.options {
-  margin: 1.2rem 0 0;
-  padding: 0.9rem 1rem;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--surface-2);
-}
-
-.options legend {
-  padding: 0 0.4rem;
-  font-size: 0.85rem;
-  font-weight: 700;
-  color: var(--text-dim);
-}
-
 .check {
   margin-bottom: 0.8rem;
 }
@@ -342,19 +308,9 @@ kbd {
   border-top: 1px dashed var(--border);
 }
 
-.option-row label { font-size: 0.9rem; font-weight: 600; }
-
 /* ------------------------------------------------------ the page settings */
 
-.settings {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 0.9rem;
-}
-
-.field { display: flex; flex-direction: column; gap: 0.3rem; }
 .field label { font-size: 0.85rem; font-weight: 600; }
-.field-note { margin: 0; font-size: 0.78rem; line-height: 1.5; color: var(--text-dim); }
 
 .field input[type="text"] {
   background: var(--surface);
@@ -364,13 +320,13 @@ kbd {
   min-width: 0;
 }
 
-.inline-pair { display: flex; align-items: center; gap: 0.6rem; min-width: 0; }
+.inline-pair { min-width: 0; }
 .inline-pair input[type="range"] { flex: 1; min-width: 0; max-width: 22rem; }
 .inline-pair input[type="number"] { min-width: 0; }
 .inline-pair output { font-variant-numeric: tabular-nums; font-size: 0.9rem; flex: none; }
 .unit-label { font-size: 0.88rem; color: var(--text-dim); flex: none; }
 
-.run-row { display: flex; gap: 0.6rem; flex-wrap: wrap; margin-top: 1.2rem; }
+.run-row { gap: 0.6rem; margin-top: 1.2rem; }
 
 .results { margin-top: 1.2rem; }
 

--- a/tools/document-scanner/tool.toml
+++ b/tools/document-scanner/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "documents"
 
 # Shared stylesheet parts this tool asks for, put before its own rules by
 # the build so that its own can override them.
-css_parts = ["checks", "notes"]
+css_parts = ["checks", "notes", "form"]
 
 # Shared modules this tool asks for. file-picker brings in the drop zone; zip is
 # for saving several pages as pictures rather than as a document, and needs crc32

--- a/tools/edit-audio/styles.css
+++ b/tools/edit-audio/styles.css
@@ -90,13 +90,7 @@ input[type="range"] {
   gap: 0.7rem;
 }
 .field > label { font-size: 0.85rem; font-weight: 600; }
-.field-note { margin: 0.5rem 0 0; font-size: 0.78rem; color: var(--text-dim); }
-
-.settings {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 0.9rem;
-}
+.field-note { margin: 0.5rem 0 0; }
 
 .settings .field-note { margin-top: 0.15rem; }
 
@@ -121,10 +115,6 @@ input[type="range"] {
 
 .export-row {
   margin-top: 1.2rem;
-  display: flex;
-  gap: 0.6rem;
-  align-items: center;
-  flex-wrap: wrap;
 }
 
 @media (max-width: 620px) {

--- a/tools/exif-editor/styles.css
+++ b/tools/exif-editor/styles.css
@@ -3,15 +3,6 @@
 /* The one button on the page big enough to be found without reading. */
 
 .error {
-  margin: 1rem 0 0;
-  padding: 0.7rem 0.9rem;
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
-  color: var(--danger);
-  font-size: 0.9rem;
-  /* Files that could not be read are reported one per line. */
-  white-space: pre-line;
   max-height: 12rem;
   overflow-y: auto;
 }

--- a/tools/exif-editor/tool.toml
+++ b/tools/exif-editor/tool.toml
@@ -28,7 +28,7 @@ roadmap_group = "images"
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. file-list is the drop-a-file-then-see-a-row widget that
 # more than one tool needs and that no tool should own.
-css_parts = ["file-list", "form", "checks"]
+css_parts = ["file-list", "form", "checks", "notes"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no

--- a/tools/extract-audio-from-video/styles.css
+++ b/tools/extract-audio-from-video/styles.css
@@ -90,13 +90,7 @@ input[type="range"] {
   gap: 0.7rem;
 }
 .field > label { font-size: 0.85rem; font-weight: 600; }
-.field-note { margin: 0.5rem 0 0; font-size: 0.78rem; color: var(--text-dim); }
-
-.settings {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 0.9rem;
-}
+.field-note { margin: 0.5rem 0 0; }
 
 .settings .field-note { margin-top: 0.15rem; }
 
@@ -121,10 +115,6 @@ input[type="range"] {
 
 .export-row {
   margin-top: 1.2rem;
-  display: flex;
-  gap: 0.6rem;
-  align-items: center;
-  flex-wrap: wrap;
 }
 
 @media (max-width: 620px) {

--- a/tools/gif-analyzer/styles.css
+++ b/tools/gif-analyzer/styles.css
@@ -356,13 +356,3 @@
 }
 
 /* -------------------------------------------------------------- messages */
-
-.error {
-  margin: 1rem 0 0;
-  padding: 0.6rem 0.8rem;
-  border-radius: 7px;
-  background: var(--surface-2);
-  border: 1px solid var(--danger);
-  color: var(--danger);
-  font-size: 0.88rem;
-}

--- a/tools/gif-analyzer/tool.toml
+++ b/tools/gif-analyzer/tool.toml
@@ -30,6 +30,10 @@ category = "video-and-animation"
 # It sits at the top of that group as a link, above the names still to be built.
 roadmap_group = "gif"
 
+# Optional stylesheets from shared/css, dropped in between the frame and this
+# tool's own rules.
+css_parts = ["notes"]
+
 # Shared modules this tool asks for. The same arrangement as css_parts, and for
 # the same reason: a component more than one tool needs and no tool should own.
 # file-picker brings in the drop zone.

--- a/tools/gif-maker/styles.css
+++ b/tools/gif-maker/styles.css
@@ -237,17 +237,9 @@
 
 /* ---------------------------------------------------------------- settings */
 
-.settings {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 0.9rem;
-}
-
 .field label { font-size: 0.85rem; font-weight: 600; }
-.field-note { margin: 0; font-size: 0.78rem; color: var(--text-dim); min-height: 1em; }
+.field-note { min-height: 1em; }
 
-/* Width x height, side by side. */
-.inline-pair { display: flex; align-items: center; gap: 0.4rem; }
 .inline-pair input { width: 100%; min-width: 0; }
 .inline-pair span { color: var(--text-dim); flex: none; }
 
@@ -317,14 +309,6 @@
 /* ------------------------------------------------------------------ export */
 
 .error {
-  margin: 1rem 0 0;
-  padding: 0.7rem 0.9rem;
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
-  color: var(--danger);
-  font-size: 0.9rem;
-  white-space: pre-line;
   max-height: 12rem;
   overflow-y: auto;
 }
@@ -351,4 +335,3 @@
   max-width: 100%;
   height: auto;
 }
-

--- a/tools/gif-maker/tool.toml
+++ b/tools/gif-maker/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "gif"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "results", "form"]
+css_parts = ["progress", "results", "form", "notes"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts, and for
 # the same reason: a component more than one tool needs and no tool should own.

--- a/tools/grab-frame/styles.css
+++ b/tools/grab-frame/styles.css
@@ -102,19 +102,11 @@
 
 /* ---------------------------------------------------------------- settings */
 
-.settings {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
-  gap: 0.9rem;
-  margin-bottom: 1.2rem;
-}
+.settings { margin-bottom: 1.2rem; }
 
 .field > label { font-size: 0.85rem; font-weight: 600; }
 
 .inline-pair {
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
   font-size: 0.85rem;
   color: var(--text-dim);
 }

--- a/tools/hash-checksum/styles.css
+++ b/tools/hash-checksum/styles.css
@@ -169,16 +169,6 @@
 
 /* -------------------------------------------------------------- messages */
 
-.error {
-  margin: 1rem 0 0;
-  padding: 0.6rem 0.8rem;
-  border-radius: 7px;
-  background: var(--surface-2);
-  border: 1px solid var(--danger);
-  color: var(--danger);
-  font-size: 0.88rem;
-}
-
 .stopped {
   display: flex;
   align-items: center;

--- a/tools/hash-checksum/tool.toml
+++ b/tools/hash-checksum/tool.toml
@@ -35,7 +35,7 @@ roadmap_group = "beyond"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress"]
+css_parts = ["progress", "notes"]
 
 # Shared modules this tool asks for. file-picker brings in the drop zone.
 js_parts = ["file-picker", "message-box"]

--- a/tools/heic-to-jpg/styles.css
+++ b/tools/heic-to-jpg/styles.css
@@ -5,15 +5,6 @@
 /* The one button on the page big enough to be found without reading. */
 
 .error {
-  margin: 1rem 0 0;
-  padding: 0.7rem 0.9rem;
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
-  color: var(--danger);
-  font-size: 0.9rem;
-  /* Files that could not be read are reported one per line. */
-  white-space: pre-line;
   max-height: 12rem;
   overflow-y: auto;
 }
@@ -41,8 +32,6 @@
      and for a <select> that is its longest option - a whole sentence here. */
   min-width: 0;
 }
-
-.inline-pair { display: flex; gap: 0.6rem; align-items: center; }
 
 .inline-pair input[type="range"] { flex: 1 1 12rem; min-width: 0; }
 
@@ -127,4 +116,3 @@
   color: var(--text-dim);
   max-width: 68ch;
 }
-

--- a/tools/heic-to-jpg/tool.toml
+++ b/tools/heic-to-jpg/tool.toml
@@ -31,7 +31,7 @@ roadmap_group = "images"
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. file-list is the drop-a-file-then-see-a-row widget that
 # more than one tool needs and that no tool should own.
-css_parts = ["file-list", "progress", "results", "form", "checks"]
+css_parts = ["file-list", "progress", "results", "form", "checks", "notes"]
 # Shared modules this tool asks for. file-picker brings in the drop zone.
 js_parts = ["file-picker", "zip", "crc32", "message-box", "download", "format", "errors"]
 lastmod = "2026-08-27"

--- a/tools/id-photo/styles.css
+++ b/tools/id-photo/styles.css
@@ -26,7 +26,7 @@
 
 /* `max-width` alone loses: a flex item's automatic minimum is min-content, and
    for a <select> that is its longest option - a whole sentence here. */
-.option-row select { min-width: 0; max-width: 100%; flex: 1 1 20rem; }
+.option-row select { flex: 1 1 20rem; }
 
 /* --------------------------------------------------------- the chosen file */
 
@@ -470,22 +470,11 @@
 /* ---------------------------------------------------------------- settings */
 
 .settings {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 1rem;
   align-items: start;
   margin-bottom: 1.1rem;
 }
 
-.field { display: flex; flex-direction: column; gap: 0.35rem; }
 .field > label { font-size: 0.85rem; font-weight: 600; }
-
-.field-note {
-  margin: 0;
-  font-size: 0.78rem;
-  line-height: 1.5;
-  color: var(--text-dim);
-}
 
 /* ----------------------------------------------------------------- running */
 

--- a/tools/image-to-data-uri/styles.css
+++ b/tools/image-to-data-uri/styles.css
@@ -3,24 +3,13 @@
    the file list is shared/css/file-list.css, both prepended by the build. */
 
 .error {
-  margin: 1rem 0 0;
-  padding: 0.7rem 0.9rem;
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
-  color: var(--danger);
-  font-size: 0.9rem;
-  /* Files that could not be read are reported one per line. */
-  white-space: pre-line;
   max-height: 12rem;
   overflow-y: auto;
 }
 
 .field-summary {
-  margin: 0.9rem 0 0;
   font-size: 0.85rem;
   line-height: 1.6;
-  color: var(--text-dim);
   max-width: 68ch;
 }
 
@@ -108,12 +97,9 @@
 /* ------------------------------------------------------------- the options */
 
 .options legend {
-  padding: 0 0.4rem;
   font-size: 0.8rem;
-  font-weight: 700;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: var(--text-dim);
 }
 
 /* ------------------------------------------------------------- the results */

--- a/tools/image-to-data-uri/tool.toml
+++ b/tools/image-to-data-uri/tool.toml
@@ -28,7 +28,7 @@ roadmap_group = "images"
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. file-list is the drop-a-file-then-see-a-row widget that
 # more than one tool needs and that no tool should own.
-css_parts = ["file-list", "form", "checks"]
+css_parts = ["file-list", "form", "checks", "notes"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no

--- a/tools/image-to-ico/styles.css
+++ b/tools/image-to-ico/styles.css
@@ -8,15 +8,6 @@
 /* The one button on the page big enough to be found without reading. */
 
 .error {
-  margin: 1rem 0 0;
-  padding: 0.7rem 0.9rem;
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
-  color: var(--danger);
-  font-size: 0.9rem;
-  /* Files that could not be read are reported one per line. */
-  white-space: pre-line;
   max-height: 12rem;
   overflow-y: auto;
 }

--- a/tools/image-to-ico/tool.toml
+++ b/tools/image-to-ico/tool.toml
@@ -28,7 +28,7 @@ roadmap_group = "images"
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. file-list is the drop-a-file-then-see-a-row widget that
 # more than one tool needs and that no tool should own.
-css_parts = ["file-list", "progress", "results", "form", "checks"]
+css_parts = ["file-list", "progress", "results", "form", "checks", "notes"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.

--- a/tools/images-to-pdf/styles.css
+++ b/tools/images-to-pdf/styles.css
@@ -170,12 +170,6 @@
 
 /* ---------------------------------------------------------------- settings */
 
-.settings {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 0.9rem;
-}
-
 .field label { font-size: 0.85rem; font-weight: 600; }
 
 .field input[type="text"] {
@@ -186,7 +180,6 @@
   min-width: 0;
 }
 
-.inline-pair { display: flex; align-items: center; gap: 0.4rem; }
 .inline-pair input { width: 100%; min-width: 0; }
 .inline-pair span { color: var(--text-dim); flex: none; }
 .inline-pair select { flex: none; }
@@ -299,15 +292,6 @@
 }
 
 .error {
-  margin: 1rem 0 0;
-  padding: 0.7rem 0.9rem;
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
-  color: var(--danger);
-  font-size: 0.9rem;
-  /* Files that could not be read are reported one per line. */
-  white-space: pre-line;
   max-height: 12rem;
   overflow-y: auto;
 }

--- a/tools/images-to-pdf/tool.toml
+++ b/tools/images-to-pdf/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "documents"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "form"]
+css_parts = ["progress", "form", "notes"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no

--- a/tools/images-to-video/styles.css
+++ b/tools/images-to-video/styles.css
@@ -340,17 +340,9 @@
 
 /* ---------------------------------------------------------------- settings */
 
-.settings {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 0.9rem;
-}
-
 .field label { font-size: 0.85rem; font-weight: 600; }
-.field-note { margin: 0; font-size: 0.78rem; color: var(--text-dim); min-height: 1em; }
+.field-note { min-height: 1em; }
 
-/* Width x height, side by side. */
-.inline-pair { display: flex; align-items: center; gap: 0.4rem; }
 .inline-pair input { width: 100%; min-width: 0; }
 .inline-pair span { color: var(--text-dim); flex: none; }
 
@@ -408,15 +400,6 @@
 /* ------------------------------------------------------------------ export */
 
 .error {
-  margin: 1rem 0 0;
-  padding: 0.7rem 0.9rem;
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
-  color: var(--danger);
-  font-size: 0.9rem;
-  /* Failed URLs are reported one per line. */
-  white-space: pre-line;
   max-height: 12rem;
   overflow-y: auto;
 }
@@ -427,4 +410,3 @@
   background: #000;
   display: block;
 }
-

--- a/tools/images-to-video/tool.toml
+++ b/tools/images-to-video/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "video"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "results", "form"]
+css_parts = ["progress", "results", "form", "notes"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no

--- a/tools/json-formatter/styles.css
+++ b/tools/json-formatter/styles.css
@@ -37,15 +37,10 @@
 /* ------------------------------------------------------------- the options */
 
 .field > label { font-size: 0.85rem; font-weight: 600; }
-.field-note { margin: 0.15rem 0 0; font-size: 0.78rem; color: var(--text-dim); }
+.field-note { margin: 0.15rem 0 0; }
 .field-note:empty { display: none; }
+.settings { align-items: start; }
 
-.settings {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 0.9rem 1.2rem;
-  align-items: start;
-}
 /* -------------------------------------------------------------- the boxes */
 
 textarea {
@@ -80,16 +75,7 @@ textarea:focus-visible, .output:focus-visible {
 
 .output:empty { display: none; }
 
-.error {
-  margin: 0 0 1rem;
-  padding: 0.7rem 0.9rem;
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
-  color: var(--danger);
-  font-size: 0.9rem;
-  white-space: pre-line;
-}
+.error { margin: 0 0 1rem; }
 
 @media (max-width: 620px) {
   textarea { min-height: 170px; font-size: 0.8rem; }

--- a/tools/json-formatter/tool.toml
+++ b/tools/json-formatter/tool.toml
@@ -35,7 +35,7 @@ roadmap_group = "beyond"
 
 # Shared stylesheet parts this tool asks for, put before its own rules by
 # the build so that its own can override them.
-css_parts = ["form", "panes", "checks"]
+css_parts = ["form", "panes", "checks", "notes"]
 
 # Shared modules this tool asks for. file-picker brings in the drop zone, which
 # is here for the file that is easier to drop than to open, select all and copy.

--- a/tools/merge-pdf/styles.css
+++ b/tools/merge-pdf/styles.css
@@ -7,16 +7,8 @@
 /* The one button on the page big enough to be found without reading. */
 
 .error {
-  margin: 1rem 0 0;
-  padding: 0.7rem 0.9rem;
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
-  color: var(--danger);
-  font-size: 0.9rem;
   line-height: 1.55;
   max-width: 72ch;
-  white-space: pre-line;
 }
 
 .card-lede .grip { letter-spacing: -2px; font-weight: 700; color: var(--accent); }
@@ -25,9 +17,6 @@
 
 .field-note {
   margin: 0.4rem 0 0;
-  font-size: 0.82rem;
-  line-height: 1.5;
-  color: var(--text-dim);
   max-width: 72ch;
 }
 

--- a/tools/merge-pdf/tool.toml
+++ b/tools/merge-pdf/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "documents"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "form", "checks"]
+css_parts = ["progress", "form", "checks", "notes"]
 
 # file-picker brings in the drop zone; zip is the archive a split comes back
 # in when it is more than one file, and crc32 is the checksum it needs. The

--- a/tools/password-generator/styles.css
+++ b/tools/password-generator/styles.css
@@ -62,15 +62,17 @@
   .segment span { transition: none; }
 }
 
-.card-lede { margin: 0; font-size: 0.88rem; color: var(--text-dim); }
+.card-lede { margin: 0; font-size: 0.88rem; }
 
 /* ------------------------------------------------------------- the options */
 
-.settings { display: grid; gap: 1.15rem; }
+/* One column at any width: the fields here are a list to read down, not a
+   grid to fill, and two side by side would put the length beside the
+   character sets as if they were of a kind. */
+.settings { grid-template-columns: 1fr; }
 
-.field { display: flex; flex-direction: column; gap: 0.3rem; }
 .field > label { font-size: 0.85rem; font-weight: 600; }
-.field-note { margin: 0.15rem 0 0; font-size: 0.78rem; color: var(--text-dim); }
+.field-note { margin: 0.15rem 0 0; }
 
 .checks-label { font-size: 0.85rem; font-weight: 600; }
 .check input { width: 1rem; height: 1rem; }
@@ -255,8 +257,6 @@
 
 .error {
   margin: 0 0 0.9rem;
-  color: var(--danger);
-  font-size: 0.88rem;
 }
 
 .note-card p { margin: 0; font-size: 0.9rem; color: var(--text-dim); }

--- a/tools/password-generator/tool.toml
+++ b/tools/password-generator/tool.toml
@@ -97,7 +97,7 @@ card = """
 
 # Shared stylesheet parts this tool asks for, put before its own rules by
 # the build so that its own can override them.
-css_parts = ["panes", "checks"]
+css_parts = ["panes", "checks", "form", "notes"]
 
 # The nouns this tool uses for the things it works on. They appear in the boot
 # warning, the pledge line and the analytics comment, which is why they are a

--- a/tools/qr-barcode-reader/styles.css
+++ b/tools/qr-barcode-reader/styles.css
@@ -8,22 +8,10 @@
   to stop somebody and calm enough not to look like the page has broken.
 */
 
-.error {
-  margin: 1rem 0 0;
-  padding: 0.7rem 0.9rem;
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
-  color: var(--danger);
-  font-size: 0.9rem;
-  line-height: 1.55;
-}
+.error { line-height: 1.55; }
 
 .run-row {
-  display: flex;
-  align-items: center;
   gap: 0.6rem;
-  flex-wrap: wrap;
   margin-top: 1.1rem;
 }
 

--- a/tools/qr-barcode-reader/tool.toml
+++ b/tools/qr-barcode-reader/tool.toml
@@ -37,7 +37,7 @@ lastmod = "2026-09-01"
 
 # Shared stylesheet parts this tool asks for, put before its own rules by
 # the build so that its own can override them.
-css_parts = ["form", "checks"]
+css_parts = ["form", "checks", "notes"]
 
 # The drop zone brings in shared/js/file-picker.js. Several files at once is
 # deliberate: a folder of screenshots, or a photograph of a page of codes, is a

--- a/tools/qr-barcode/styles.css
+++ b/tools/qr-barcode/styles.css
@@ -45,12 +45,7 @@
   grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
 }
 
-.field {
-  display: flex;
-  flex-direction: column;
-  gap: 0.3rem;
-  min-width: 0;
-}
+.field { min-width: 0; }
 
 .field label {
   font-size: 0.85rem;
@@ -174,9 +169,6 @@
 }
 
 .run-row {
-  display: flex;
-  align-items: center;
   gap: 0.6rem;
-  flex-wrap: wrap;
   margin-top: 1.2rem;
 }

--- a/tools/redact-image/styles.css
+++ b/tools/redact-image/styles.css
@@ -197,9 +197,6 @@ kbd {
    for a <select> that is its longest option. */
 
 .settings {
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
   margin-bottom: 1.1rem;
 }
 
@@ -217,17 +214,9 @@ kbd {
    `clip` rather than `hidden`: hidden would make this a scroll container,
    which forces the other axis to `auto` and would cut off anything that ever
    needs to escape upwards. */
-.field { display: flex; flex-direction: column; gap: 0.35rem; overflow-x: clip; }
+.field { overflow-x: clip; }
 .field > label { font-size: 0.85rem; font-weight: 600; }
 
-.field-note {
-  margin: 0;
-  font-size: 0.82rem;
-  line-height: 1.5;
-  color: var(--text-dim);
-}
-
-.inline-pair { display: flex; align-items: center; gap: 0.5rem; }
 .inline-pair input[type="range"] { flex: 1 1 10rem; min-width: 0; }
 .inline-pair output { font-variant-numeric: tabular-nums; font-weight: 600; }
 

--- a/tools/redact-pdf/styles.css
+++ b/tools/redact-pdf/styles.css
@@ -7,23 +7,12 @@
 /* The one button on the page big enough to be found without reading. */
 
 .error {
-  margin: 1rem 0 0;
-  padding: 0.7rem 0.9rem;
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
-  color: var(--danger);
-  font-size: 0.9rem;
   line-height: 1.55;
   max-width: 72ch;
-  white-space: pre-line;
 }
 
 .field-note {
   margin: 0.5rem 0 0;
-  font-size: 0.82rem;
-  line-height: 1.55;
-  color: var(--text-dim);
   max-width: 72ch;
 }
 

--- a/tools/redact-pdf/tool.toml
+++ b/tools/redact-pdf/tool.toml
@@ -33,7 +33,7 @@ roadmap_group = "documents"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "form", "checks"]
+css_parts = ["progress", "form", "checks", "notes"]
 
 # file-picker brings in the drop zone. The four pdf-* parts are the PDF itself
 # - the object grammar, the stream filters, the reader and the writer - and

--- a/tools/resize-image/styles.css
+++ b/tools/resize-image/styles.css
@@ -1,15 +1,6 @@
 /* The one button on the page big enough to be found without reading. */
 
 .error {
-  margin: 1rem 0 0;
-  padding: 0.7rem 0.9rem;
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
-  color: var(--danger);
-  font-size: 0.9rem;
-  /* Files that could not be read are reported one per line. */
-  white-space: pre-line;
   max-height: 12rem;
   overflow-y: auto;
 }
@@ -299,31 +290,16 @@ button.file-main-wrap:focus-visible {
   margin: 1.1rem 0 0;
   padding-top: 0.8rem;
   border-top: 1px dashed var(--border);
-  font-size: 0.86rem;
   line-height: 1.6;
-  color: var(--text-dim);
   max-width: 74ch;
   overflow-wrap: anywhere;
 }
 
 /* ---------------------------------------------------------------- settings */
 
-.settings {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
-  gap: 1rem;
-  align-items: start;
-}
+.settings { align-items: start; }
 
-.field { display: flex; flex-direction: column; gap: 0.35rem; }
 .field > label { font-size: 0.85rem; font-weight: 600; }
-
-.field-note {
-  margin: 0;
-  font-size: 0.78rem;
-  line-height: 1.5;
-  color: var(--text-dim);
-}
 
 .field output { font-variant-numeric: tabular-nums; }
 

--- a/tools/resize-image/tool.toml
+++ b/tools/resize-image/tool.toml
@@ -28,7 +28,7 @@ roadmap_group = "images"
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. file-list is the drop-a-file-then-see-a-row widget that
 # more than one tool needs and that no tool should own.
-css_parts = ["file-list", "progress", "results", "form", "checks", "cropper"]
+css_parts = ["file-list", "progress", "results", "form", "checks", "cropper", "notes"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.

--- a/tools/reverse-video/styles.css
+++ b/tools/reverse-video/styles.css
@@ -27,12 +27,6 @@
 
 /* ---------------------------------------------------------------- settings */
 
-.settings {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
-  gap: 0.9rem;
-}
-
 .field > label { font-size: 0.85rem; font-weight: 600; }
 .summary {
   margin: 1.2rem 0;

--- a/tools/split-gif/styles.css
+++ b/tools/split-gif/styles.css
@@ -5,19 +5,11 @@
 
 /* ---------------------------------------------------------------- settings */
 
-.settings {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
-  gap: 0.9rem;
-  margin-bottom: 1.2rem;
-}
+.settings { margin-bottom: 1.2rem; }
 
 .field > label { font-size: 0.85rem; font-weight: 600; }
 
 .inline-pair {
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
   font-size: 0.85rem;
   color: var(--text-dim);
 }

--- a/tools/stack-images/styles.css
+++ b/tools/stack-images/styles.css
@@ -97,27 +97,13 @@
 
 /* ----------------------------------------------------------- the settings */
 
-.settings {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 0.9rem;
-}
-
 /* The method decides what every other control means, so it gets the whole row
    and its explanation has room to be a sentence rather than a label. */
 .field-wide { grid-column: 1 / -1; }
 
 .field label { font-size: 0.85rem; font-weight: 600; }
 
-.field-note {
-  margin: 0;
-  font-size: 0.78rem;
-  color: var(--text-dim);
-  line-height: 1.5;
-  min-height: 1em;
-}
-
-.inline-pair { display: flex; align-items: center; gap: 0.5rem; }
+.field-note { min-height: 1em; }
 
 .inline-pair input[type="range"] { width: 100%; min-width: 0; }
 

--- a/tools/svg-to-image/styles.css
+++ b/tools/svg-to-image/styles.css
@@ -9,15 +9,6 @@
 /* The one button on the page big enough to be found without reading. */
 
 .error {
-  margin: 1rem 0 0;
-  padding: 0.7rem 0.9rem;
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
-  color: var(--danger);
-  font-size: 0.9rem;
-  /* Files that could not be read are reported one per line. */
-  white-space: pre-line;
   max-height: 12rem;
   overflow-y: auto;
 }
@@ -103,9 +94,7 @@
   margin: 1.1rem 0 0;
   padding-top: 0.8rem;
   border-top: 1px dashed var(--border);
-  font-size: 0.86rem;
   line-height: 1.6;
-  color: var(--text-dim);
   max-width: 74ch;
   overflow-wrap: anywhere;
 }
@@ -114,22 +103,9 @@
 
 /* ---------------------------------------------------------------- settings */
 
-.settings {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
-  gap: 1rem;
-  align-items: start;
-}
+.settings { align-items: start; }
 
-.field { display: flex; flex-direction: column; gap: 0.35rem; }
 .field > label { font-size: 0.85rem; font-weight: 600; }
-
-.field-note {
-  margin: 0;
-  font-size: 0.78rem;
-  line-height: 1.5;
-  color: var(--text-dim);
-}
 
 .field output { font-variant-numeric: tabular-nums; }
 

--- a/tools/svg-to-image/tool.toml
+++ b/tools/svg-to-image/tool.toml
@@ -28,7 +28,7 @@ roadmap_group = "images"
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. file-list is the drop-a-file-then-see-a-row widget that
 # more than one tool needs and that no tool should own.
-css_parts = ["file-list", "progress", "results", "form"]
+css_parts = ["file-list", "progress", "results", "form", "notes"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.

--- a/tools/text-diff/styles.css
+++ b/tools/text-diff/styles.css
@@ -4,15 +4,9 @@
 /* ------------------------------------------------------------- the options */
 
 .field > label { font-size: 0.85rem; font-weight: 600; }
-.field-note { margin: 0.15rem 0 0; font-size: 0.78rem; color: var(--text-dim); }
+.field-note { margin: 0.15rem 0 0; }
 .field-note:empty { display: none; }
-
-.settings {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 0.9rem 1.2rem;
-  align-items: start;
-}
+.settings { align-items: start; }
 /* -------------------------------------------------------------- the boxes */
 
 /* Two boxes side by side once there is room for both, and stacked before
@@ -36,16 +30,7 @@ textarea:focus-visible {
   outline-offset: 1px;
 }
 
-.error {
-  margin: 0 0 1rem;
-  padding: 0.7rem 0.9rem;
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
-  color: var(--danger);
-  font-size: 0.9rem;
-  white-space: pre-line;
-}
+.error { margin: 0 0 1rem; }
 
 /* ------------------------------------------------------------ the diff view */
 

--- a/tools/text-diff/tool.toml
+++ b/tools/text-diff/tool.toml
@@ -37,7 +37,7 @@ roadmap_group = "beyond"
 
 # Shared stylesheet parts this tool asks for, put before its own rules by
 # the build so that its own can override them.
-css_parts = ["form", "panes", "checks"]
+css_parts = ["form", "panes", "checks", "notes"]
 
 # Shared modules this tool asks for. file-picker brings in the drop zone, which
 # is here for the two files that are easier to drop than to open, select all

--- a/tools/timelapse-video/styles.css
+++ b/tools/timelapse-video/styles.css
@@ -79,12 +79,7 @@
 
 /* ---------------------------------------------------------------- settings */
 
-.settings {
-  margin-top: 1.2rem;
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
-  gap: 0.9rem;
-}
+.settings { margin-top: 1.2rem; }
 
 .field > label { font-size: 0.85rem; font-weight: 600; }
 
@@ -119,4 +114,3 @@
   background: #000;
   display: block;
 }
-

--- a/tools/trim-audio/styles.css
+++ b/tools/trim-audio/styles.css
@@ -360,12 +360,6 @@ audio.player {
 
 /* ---------------------------------------------------------------- settings */
 
-.settings {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 0.9rem;
-}
-
 .field > label { font-size: 0.85rem; font-weight: 600; }
 
 .summary {
@@ -383,10 +377,6 @@ audio.player {
 
 .export-row {
   margin-top: 1.2rem;
-  display: flex;
-  gap: 0.6rem;
-  align-items: center;
-  flex-wrap: wrap;
 }
 
 @media (max-width: 620px) {

--- a/tools/trim-video/styles.css
+++ b/tools/trim-video/styles.css
@@ -440,12 +440,6 @@ kbd {
 
 /* ---------------------------------------------------------------- settings */
 
-.settings {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
-  gap: 0.9rem;
-}
-
 .field > label { font-size: 0.85rem; font-weight: 600; }
 .summary {
   margin: 1.2rem 0 0;
@@ -462,10 +456,6 @@ kbd {
 
 .export-row {
   margin-top: 1.2rem;
-  display: flex;
-  gap: 0.6rem;
-  align-items: center;
-  flex-wrap: wrap;
 }
 
 .result video {

--- a/tools/video-to-gif/styles.css
+++ b/tools/video-to-gif/styles.css
@@ -163,12 +163,6 @@
 
 /* ---------------------------------------------------------------- settings */
 
-.settings {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
-  gap: 0.9rem;
-}
-
 .field > label { font-size: 0.85rem; font-weight: 600; }
 .summary {
   margin: 1.2rem 0;

--- a/tools/xml-formatter/styles.css
+++ b/tools/xml-formatter/styles.css
@@ -37,15 +37,10 @@
 /* ------------------------------------------------------------- the options */
 
 .field > label { font-size: 0.85rem; font-weight: 600; }
-.field-note { margin: 0.15rem 0 0; font-size: 0.78rem; color: var(--text-dim); }
+.field-note { margin: 0.15rem 0 0; }
 .field-note:empty { display: none; }
+.settings { align-items: start; }
 
-.settings {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 0.9rem 1.2rem;
-  align-items: start;
-}
 /* -------------------------------------------------------------- the boxes */
 
 textarea {
@@ -80,16 +75,7 @@ textarea:focus-visible, .output:focus-visible {
 
 .output:empty { display: none; }
 
-.error {
-  margin: 0 0 1rem;
-  padding: 0.7rem 0.9rem;
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
-  color: var(--danger);
-  font-size: 0.9rem;
-  white-space: pre-line;
-}
+.error { margin: 0 0 1rem; }
 
 @media (max-width: 620px) {
   textarea { min-height: 170px; font-size: 0.8rem; }

--- a/tools/xml-formatter/tool.toml
+++ b/tools/xml-formatter/tool.toml
@@ -56,7 +56,7 @@ roadmap_group = "beyond"
 
 # Shared stylesheet parts this tool asks for, put before its own rules by
 # the build so that its own can override them.
-css_parts = ["form", "panes", "checks"]
+css_parts = ["form", "panes", "checks", "notes"]
 
 # Shared modules this tool asks for. file-picker brings in the drop zone, which
 # is here for the file that is easier to drop than to open, select all and copy.

--- a/tools/yaml-to-json/styles.css
+++ b/tools/yaml-to-json/styles.css
@@ -37,15 +37,10 @@
 /* ------------------------------------------------------------- the options */
 
 .field > label { font-size: 0.85rem; font-weight: 600; }
-.field-note { margin: 0.15rem 0 0; font-size: 0.78rem; color: var(--text-dim); }
+.field-note { margin: 0.15rem 0 0; }
 .field-note:empty { display: none; }
+.settings { align-items: start; }
 
-.settings {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 0.9rem 1.2rem;
-  align-items: start;
-}
 /* -------------------------------------------------------------- the boxes */
 
 textarea {
@@ -80,16 +75,7 @@ textarea:focus-visible, .output:focus-visible {
 
 .output:empty { display: none; }
 
-.error {
-  margin: 0 0 1rem;
-  padding: 0.7rem 0.9rem;
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
-  color: var(--danger);
-  font-size: 0.9rem;
-  white-space: pre-line;
-}
+.error { margin: 0 0 1rem; }
 
 @media (max-width: 620px) {
   textarea { min-height: 170px; font-size: 0.8rem; }

--- a/tools/yaml-to-json/tool.toml
+++ b/tools/yaml-to-json/tool.toml
@@ -55,7 +55,7 @@ roadmap_group = "beyond"
 
 # Shared stylesheet parts this tool asks for, put before its own rules by
 # the build so that its own can override them.
-css_parts = ["form", "panes", "checks"]
+css_parts = ["form", "panes", "checks", "notes"]
 
 # Shared modules this tool asks for. file-picker brings in the drop zone, which
 # is here for the config file that is easier to drop than to open, select all


### PR DESCRIPTION
Stacked on #348 (`claude/one-check-two-shapes`): the two touch the same stylesheets, so this branch starts where that one ends. Merge that first and this retargets to `main` on its own.

`form.css` has a field and its note, the lede, the big button, the option rows, the options box and the run row — and not the grid those fields sit in, nor the pair of controls that read as one. So **eleven tools drew `.settings` for themselves with six different column widths**, twelve drew `.inline-pair` with three gaps, and nine drew `.field-note` with their own size, margin and line height, none of it for a reason a visitor could see. `notes.css` has the error line, and **twenty-three tools that show one did not ask for it**: nineteen had copied the box token for token, three had drawn a grey one with a red edge, one wrote bare red text.

So:

- `form.css` learns `.settings` (columns of 220px, the median of what was drawn) and `.inline-pair` (a 0.5rem gap), and `.field-note` gets the line height six tools were adding;
- every tool that draws any of them asks for the family — compress-pdf, document-scanner and password-generator had written the whole form vocabulary by hand without asking for it, and the twenty-three with an error line ask for `notes`;
- every declaration that only restated what the family now says comes out: **566 lines gone, 102 added**, across 39 tools.

What a tool chose differently stays as a rule of its own and still wins: the text tools' `align-items: start` and their error's margin the other way; the image tools' ceiling and scrollbar on the error; the PDF tools' 72ch; grab-frame's dim small print in the pair; the text tools' hidden empty note and the three tools that reserve a line for theirs instead — the family takes no side on that; and password-generator's single column, the one rule this adds, because the shared grid would have made it two.

The reducer removes a declaration only when it matches the shared one exactly, so the diff is restatements and nothing else. What is not restated is the column width, the gaps and the note's size that fold into the shared value — that is the visible change, measured below.

## Measured

Every `.settings`, `.inline-pair`, `.field-note` and `.error` on 38 pages, computed style on Desktop Chrome, production against this branch. Unchanged unless listed:

| what | where | before | after |
|---|---|---|---|
| settings columns at desktop width | crop-video, gif-maker, grab-frame, images-to-video, reverse-video, split-gif, timelapse-video, trim-video, video-to-gif | 4 | 3 |
| settings gap | id-photo, redact-image, resize-image, svg-to-image | 1rem | 0.9rem |
| settings column gap | the five text tools | 1.2rem | 0.9rem |
| settings gap | password-generator | 1.15rem, one column | 0.9rem, one column |
| inline pair gap | compress-image, gif-maker, grab-frame, images-to-pdf, images-to-video, split-gif | 0.4rem | 0.5rem |
| inline pair gap | document-scanner, heic-to-jpg | 0.6rem | 0.5rem |
| inline pair alignment | compress-image | none | centred |
| field note | merge-pdf, redact-pdf | 0.82rem | 0.78rem |
| field note line height | every tool with one | 1.55, inherited | 1.5, said |
| error box | dicom-viewer, gif-analyzer, hash-checksum | grey, red edge, 0.88rem | the family's box |
| error box | password-generator | bare red text | the family's box |
| error box | compress-pdf, qr-barcode-reader | `white-space: normal` | `pre-line`, one file per line |

## Before / After

gif-maker at desktop width: the settings grid at 200px columns, and at the family's 220px.

| Before | After |
|---|---|
| <img width="460" alt="form-before-gif-maker" src="https://github.com/user-attachments/assets/b763ad61-ae06-4361-b018-45cf3e946114" /> | <img width="460" alt="form-after-gif-maker" src="https://github.com/user-attachments/assets/bc0041de-955c-4ee1-acc0-cdb3fc228b9a" /> |

## Verified

- the table above, from a throwaway spec in the QA suite that reads every one of those elements on the 38 pages
- `python build.py --out _plain --clean --no-minify` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
