### PR TITLE
One chip row for the five tools that offer a choice of a few

### DIFF
--- a/docs/adding-a-tool.md
+++ b/docs/adding-a-tool.md
@@ -90,6 +90,7 @@ A component more than one tool needs, and that no tool should own, lives under
 | `shared/css/results.css` | `css_parts = ["results"]` | the source panel, the summary rows, the result and its meta line, the results list; put before the tool's own rules, so a tool that wants one of them different keeps its own |
 | `shared/css/form.css` | `css_parts = ["form"]` | the controls' vocabulary: fields and their notes, the settings grid they sit in, the inline pair, the card lede, the big button, option rows, the options box, the run and export rows, number fields |
 | `shared/css/checks.css` | `css_parts = ["checks"]` | a checkbox row, in both its shapes: a bold title with a dim note beneath, or a few words on one line |
+| `shared/css/chips.css` | `css_parts = ["chips"]` | a row of small buttons for choosing one of a few — a speed, a shape — with the chosen one lit by `.active` or `aria-pressed` |
 | `shared/css/notes.css` | `css_parts = ["notes"]` | the error line, and the note that says which path a file took |
 | `shared/css/panes.css` | `css_parts = ["panes"]` | the two text panes of a formatter page and the head above each |
 | `shared/css/modes.css` | `css_parts = ["modes"]` | a choice between two ways of working, as radio rows with a title and an explanation |

--- a/locales/ar/tools/crop-video.html
+++ b/locales/ar/tools/crop-video.html
@@ -77,16 +77,16 @@
     <p id="stage-note" class="stage-note" hidden></p>
 
     <div class="crop-controls">
-      <div class="aspect-row" role="group" aria-label="ثبِّت الاقتصاص على نسبة">
-        <button type="button" data-aspect="free" class="active">حر</button>
-        <button type="button" data-aspect="source">الأصل</button>
-        <button type="button" data-aspect="1:1">1:1</button>
-        <button type="button" data-aspect="4:5">4:5</button>
-        <button type="button" data-aspect="9:16">9:16</button>
-        <button type="button" data-aspect="16:9">16:9</button>
-        <button type="button" data-aspect="4:3">4:3</button>
-        <button type="button" data-aspect="3:2">3:2</button>
-        <button type="button" id="swap-aspect" class="ghost" title="اقلب النسبة المثبَّتة على جنبها">
+      <div class="chips aspect-row" role="group" aria-label="ثبِّت الاقتصاص على نسبة">
+        <button type="button" class="chip" data-aspect="free" class="active">حر</button>
+        <button type="button" class="chip" data-aspect="source">الأصل</button>
+        <button type="button" class="chip" data-aspect="1:1">1:1</button>
+        <button type="button" class="chip" data-aspect="4:5">4:5</button>
+        <button type="button" class="chip" data-aspect="9:16">9:16</button>
+        <button type="button" class="chip" data-aspect="16:9">16:9</button>
+        <button type="button" class="chip" data-aspect="4:3">4:3</button>
+        <button type="button" class="chip" data-aspect="3:2">3:2</button>
+        <button type="button" id="swap-aspect" class="chip" title="اقلب النسبة المثبَّتة على جنبها">
           اقلب
         </button>
       </div>

--- a/locales/ar/tools/resize-image.html
+++ b/locales/ar/tools/resize-image.html
@@ -57,16 +57,16 @@
       <p id="stage-note" class="stage-note" hidden></p>
 
       <div class="crop-controls">
-        <div class="aspect-row" id="aspect-row" role="group" aria-label="ثبِّت القص على نسبة">
-          <button type="button" data-aspect="free" class="active">حر</button>
-          <button type="button" data-aspect="source">الأصل</button>
-          <button type="button" data-aspect="1:1">1:1</button>
-          <button type="button" data-aspect="4:5">4:5</button>
-          <button type="button" data-aspect="9:16">9:16</button>
-          <button type="button" data-aspect="16:9">16:9</button>
-          <button type="button" data-aspect="4:3">4:3</button>
-          <button type="button" data-aspect="3:2">3:2</button>
-          <button type="button" id="swap-aspect" class="ghost" title="اقلب النسبة المثبَّتة على جنبها">
+        <div class="chips aspect-row" id="aspect-row" role="group" aria-label="ثبِّت القص على نسبة">
+          <button type="button" class="chip" data-aspect="free" class="active">حر</button>
+          <button type="button" class="chip" data-aspect="source">الأصل</button>
+          <button type="button" class="chip" data-aspect="1:1">1:1</button>
+          <button type="button" class="chip" data-aspect="4:5">4:5</button>
+          <button type="button" class="chip" data-aspect="9:16">9:16</button>
+          <button type="button" class="chip" data-aspect="16:9">16:9</button>
+          <button type="button" class="chip" data-aspect="4:3">4:3</button>
+          <button type="button" class="chip" data-aspect="3:2">3:2</button>
+          <button type="button" id="swap-aspect" class="chip" title="اقلب النسبة المثبَّتة على جنبها">
             اقلب
           </button>
         </div>

--- a/locales/ar/tools/timelapse-video.html
+++ b/locales/ar/tools/timelapse-video.html
@@ -33,15 +33,15 @@
   <section class="card" id="speed-card">
     <h2><span class="step">2</span> اختر السرعة</h2>
 
-    <div class="speed-row" role="group" aria-label="كم يُسرَّع المقطع">
-      <button type="button" data-speed="2">2&times;</button>
-      <button type="button" data-speed="5">5&times;</button>
-      <button type="button" data-speed="10" class="active">10&times;</button>
-      <button type="button" data-speed="20">20&times;</button>
-      <button type="button" data-speed="30">30&times;</button>
-      <button type="button" data-speed="60">60&times;</button>
-      <button type="button" data-speed="120">120&times;</button>
-      <button type="button" data-speed="300">300&times;</button>
+    <div class="chips speed-row" role="group" aria-label="كم يُسرَّع المقطع">
+      <button type="button" class="chip" data-speed="2">2&times;</button>
+      <button type="button" class="chip" data-speed="5">5&times;</button>
+      <button type="button" class="chip" data-speed="10" class="active">10&times;</button>
+      <button type="button" class="chip" data-speed="20">20&times;</button>
+      <button type="button" class="chip" data-speed="30">30&times;</button>
+      <button type="button" class="chip" data-speed="60">60&times;</button>
+      <button type="button" class="chip" data-speed="120">120&times;</button>
+      <button type="button" class="chip" data-speed="300">300&times;</button>
     </div>
 
     <!--

--- a/locales/ar/tools/trim-audio.html
+++ b/locales/ar/tools/trim-audio.html
@@ -58,14 +58,14 @@
       <button type="button" id="undo" class="ghost"><kbd>U</kbd> تراجَع</button>
     </div>
 
-    <div class="speed-row" role="group" aria-label="سرعة التشغيل">
-      <span class="speed-label">السرعة</span>
-      <button type="button" class="speed" data-speed="0.5">0.5&times;</button>
-      <button type="button" class="speed" data-speed="0.75">0.75&times;</button>
-      <button type="button" class="speed active" data-speed="1">عادية</button>
-      <button type="button" class="speed" data-speed="1.25">1.25&times;</button>
-      <button type="button" class="speed" data-speed="1.5">1.5&times;</button>
-      <button type="button" class="speed" data-speed="2">2&times;</button>
+    <div class="chips speed-row" role="group" aria-label="سرعة التشغيل">
+      <span class="chips-label speed-label">السرعة</span>
+      <button type="button" class="chip speed" data-speed="0.5">0.5&times;</button>
+      <button type="button" class="chip speed" data-speed="0.75">0.75&times;</button>
+      <button type="button" class="chip speed active" data-speed="1">عادية</button>
+      <button type="button" class="chip speed" data-speed="1.25">1.25&times;</button>
+      <button type="button" class="chip speed" data-speed="1.5">1.5&times;</button>
+      <button type="button" class="chip speed" data-speed="2">2&times;</button>
     </div>
 
     <!-- The parts themselves. This is the tool. -->

--- a/locales/ar/tools/trim-video.html
+++ b/locales/ar/tools/trim-video.html
@@ -60,15 +60,15 @@
       <button type="button" id="undo" class="ghost"><kbd>U</kbd> تراجَع</button>
     </div>
 
-    <div class="speed-row" role="group" aria-label="سرعة التشغيل">
-      <span class="speed-label">السرعة</span>
-      <button type="button" class="speed" data-speed="0.25">0.25&times;</button>
-      <button type="button" class="speed" data-speed="0.5">0.5&times;</button>
-      <button type="button" class="speed" data-speed="0.75">0.75&times;</button>
-      <button type="button" class="speed active" data-speed="1">عادية</button>
-      <button type="button" class="speed" data-speed="1.25">1.25&times;</button>
-      <button type="button" class="speed" data-speed="1.5">1.5&times;</button>
-      <button type="button" class="speed" data-speed="2">2&times;</button>
+    <div class="chips speed-row" role="group" aria-label="سرعة التشغيل">
+      <span class="chips-label speed-label">السرعة</span>
+      <button type="button" class="chip speed" data-speed="0.25">0.25&times;</button>
+      <button type="button" class="chip speed" data-speed="0.5">0.5&times;</button>
+      <button type="button" class="chip speed" data-speed="0.75">0.75&times;</button>
+      <button type="button" class="chip speed active" data-speed="1">عادية</button>
+      <button type="button" class="chip speed" data-speed="1.25">1.25&times;</button>
+      <button type="button" class="chip speed" data-speed="1.5">1.5&times;</button>
+      <button type="button" class="chip speed" data-speed="2">2&times;</button>
     </div>
 
     <!-- The segments themselves. This is the tool. -->

--- a/locales/de/tools/crop-video.html
+++ b/locales/de/tools/crop-video.html
@@ -78,16 +78,16 @@
     <p id="stage-note" class="stage-note" hidden></p>
 
     <div class="crop-controls">
-      <div class="aspect-row" role="group" aria-label="Den Zuschnitt auf ein Seitenverhältnis festlegen">
-        <button type="button" data-aspect="free" class="active">Frei</button>
-        <button type="button" data-aspect="source">Original</button>
-        <button type="button" data-aspect="1:1">1:1</button>
-        <button type="button" data-aspect="4:5">4:5</button>
-        <button type="button" data-aspect="9:16">9:16</button>
-        <button type="button" data-aspect="16:9">16:9</button>
-        <button type="button" data-aspect="4:3">4:3</button>
-        <button type="button" data-aspect="3:2">3:2</button>
-        <button type="button" id="swap-aspect" class="ghost" title="Das festgelegte Format hochkant kippen">
+      <div class="chips aspect-row" role="group" aria-label="Den Zuschnitt auf ein Seitenverhältnis festlegen">
+        <button type="button" class="chip" data-aspect="free" class="active">Frei</button>
+        <button type="button" class="chip" data-aspect="source">Original</button>
+        <button type="button" class="chip" data-aspect="1:1">1:1</button>
+        <button type="button" class="chip" data-aspect="4:5">4:5</button>
+        <button type="button" class="chip" data-aspect="9:16">9:16</button>
+        <button type="button" class="chip" data-aspect="16:9">16:9</button>
+        <button type="button" class="chip" data-aspect="4:3">4:3</button>
+        <button type="button" class="chip" data-aspect="3:2">3:2</button>
+        <button type="button" id="swap-aspect" class="chip" title="Das festgelegte Format hochkant kippen">
           Tauschen
         </button>
       </div>

--- a/locales/de/tools/resize-image.html
+++ b/locales/de/tools/resize-image.html
@@ -60,16 +60,16 @@
       <p id="stage-note" class="stage-note" hidden></p>
 
       <div class="crop-controls">
-        <div class="aspect-row" id="aspect-row" role="group" aria-label="Den Zuschnitt auf ein Seitenverhältnis festlegen">
-          <button type="button" data-aspect="free" class="active">Frei</button>
-          <button type="button" data-aspect="source">Original</button>
-          <button type="button" data-aspect="1:1">1:1</button>
-          <button type="button" data-aspect="4:5">4:5</button>
-          <button type="button" data-aspect="9:16">9:16</button>
-          <button type="button" data-aspect="16:9">16:9</button>
-          <button type="button" data-aspect="4:3">4:3</button>
-          <button type="button" data-aspect="3:2">3:2</button>
-          <button type="button" id="swap-aspect" class="ghost" title="Das festgelegte Seitenverhältnis auf die Seite legen">
+        <div class="chips aspect-row" id="aspect-row" role="group" aria-label="Den Zuschnitt auf ein Seitenverhältnis festlegen">
+          <button type="button" class="chip" data-aspect="free" class="active">Frei</button>
+          <button type="button" class="chip" data-aspect="source">Original</button>
+          <button type="button" class="chip" data-aspect="1:1">1:1</button>
+          <button type="button" class="chip" data-aspect="4:5">4:5</button>
+          <button type="button" class="chip" data-aspect="9:16">9:16</button>
+          <button type="button" class="chip" data-aspect="16:9">16:9</button>
+          <button type="button" class="chip" data-aspect="4:3">4:3</button>
+          <button type="button" class="chip" data-aspect="3:2">3:2</button>
+          <button type="button" id="swap-aspect" class="chip" title="Das festgelegte Seitenverhältnis auf die Seite legen">
             Tauschen
           </button>
         </div>

--- a/locales/de/tools/timelapse-video.html
+++ b/locales/de/tools/timelapse-video.html
@@ -33,15 +33,15 @@
   <section class="card" id="speed-card">
     <h2><span class="step">2</span> Das Tempo wählen</h2>
 
-    <div class="speed-row" role="group" aria-label="Um wie viel der Clip beschleunigt wird">
-      <button type="button" data-speed="2">2&times;</button>
-      <button type="button" data-speed="5">5&times;</button>
-      <button type="button" data-speed="10" class="active">10&times;</button>
-      <button type="button" data-speed="20">20&times;</button>
-      <button type="button" data-speed="30">30&times;</button>
-      <button type="button" data-speed="60">60&times;</button>
-      <button type="button" data-speed="120">120&times;</button>
-      <button type="button" data-speed="300">300&times;</button>
+    <div class="chips speed-row" role="group" aria-label="Um wie viel der Clip beschleunigt wird">
+      <button type="button" class="chip" data-speed="2">2&times;</button>
+      <button type="button" class="chip" data-speed="5">5&times;</button>
+      <button type="button" class="chip" data-speed="10" class="active">10&times;</button>
+      <button type="button" class="chip" data-speed="20">20&times;</button>
+      <button type="button" class="chip" data-speed="30">30&times;</button>
+      <button type="button" class="chip" data-speed="60">60&times;</button>
+      <button type="button" class="chip" data-speed="120">120&times;</button>
+      <button type="button" class="chip" data-speed="300">300&times;</button>
     </div>
 
     <!--

--- a/locales/de/tools/trim-audio.html
+++ b/locales/de/tools/trim-audio.html
@@ -60,14 +60,14 @@
       <button type="button" id="undo" class="ghost"><kbd>U</kbd> Rückgängig</button>
     </div>
 
-    <div class="speed-row" role="group" aria-label="Abspielgeschwindigkeit">
-      <span class="speed-label">Tempo</span>
-      <button type="button" class="speed" data-speed="0.5">0,5&times;</button>
-      <button type="button" class="speed" data-speed="0.75">0,75&times;</button>
-      <button type="button" class="speed active" data-speed="1">Normal</button>
-      <button type="button" class="speed" data-speed="1.25">1,25&times;</button>
-      <button type="button" class="speed" data-speed="1.5">1,5&times;</button>
-      <button type="button" class="speed" data-speed="2">2&times;</button>
+    <div class="chips speed-row" role="group" aria-label="Abspielgeschwindigkeit">
+      <span class="chips-label speed-label">Tempo</span>
+      <button type="button" class="chip speed" data-speed="0.5">0,5&times;</button>
+      <button type="button" class="chip speed" data-speed="0.75">0,75&times;</button>
+      <button type="button" class="chip speed active" data-speed="1">Normal</button>
+      <button type="button" class="chip speed" data-speed="1.25">1,25&times;</button>
+      <button type="button" class="chip speed" data-speed="1.5">1,5&times;</button>
+      <button type="button" class="chip speed" data-speed="2">2&times;</button>
     </div>
 
     <!-- The parts themselves. This is the tool. -->

--- a/locales/de/tools/trim-video.html
+++ b/locales/de/tools/trim-video.html
@@ -62,15 +62,15 @@
       <button type="button" id="undo" class="ghost"><kbd>U</kbd> Rückgängig</button>
     </div>
 
-    <div class="speed-row" role="group" aria-label="Wiedergabetempo">
-      <span class="speed-label">Tempo</span>
-      <button type="button" class="speed" data-speed="0.25">0,25&times;</button>
-      <button type="button" class="speed" data-speed="0.5">0,5&times;</button>
-      <button type="button" class="speed" data-speed="0.75">0,75&times;</button>
-      <button type="button" class="speed active" data-speed="1">Normal</button>
-      <button type="button" class="speed" data-speed="1.25">1,25&times;</button>
-      <button type="button" class="speed" data-speed="1.5">1,5&times;</button>
-      <button type="button" class="speed" data-speed="2">2&times;</button>
+    <div class="chips speed-row" role="group" aria-label="Wiedergabetempo">
+      <span class="chips-label speed-label">Tempo</span>
+      <button type="button" class="chip speed" data-speed="0.25">0,25&times;</button>
+      <button type="button" class="chip speed" data-speed="0.5">0,5&times;</button>
+      <button type="button" class="chip speed" data-speed="0.75">0,75&times;</button>
+      <button type="button" class="chip speed active" data-speed="1">Normal</button>
+      <button type="button" class="chip speed" data-speed="1.25">1,25&times;</button>
+      <button type="button" class="chip speed" data-speed="1.5">1,5&times;</button>
+      <button type="button" class="chip speed" data-speed="2">2&times;</button>
     </div>
 
     <!-- The segments themselves. This is the tool. -->

--- a/locales/es/tools/crop-video.html
+++ b/locales/es/tools/crop-video.html
@@ -77,16 +77,16 @@
     <p id="stage-note" class="stage-note" hidden></p>
 
     <div class="crop-controls">
-      <div class="aspect-row" role="group" aria-label="Fijar el recorte a una forma">
-        <button type="button" data-aspect="free" class="active">Libre</button>
-        <button type="button" data-aspect="source">Original</button>
-        <button type="button" data-aspect="1:1">1:1</button>
-        <button type="button" data-aspect="4:5">4:5</button>
-        <button type="button" data-aspect="9:16">9:16</button>
-        <button type="button" data-aspect="16:9">16:9</button>
-        <button type="button" data-aspect="4:3">4:3</button>
-        <button type="button" data-aspect="3:2">3:2</button>
-        <button type="button" id="swap-aspect" class="ghost" title="Poner de lado la forma fijada">
+      <div class="chips aspect-row" role="group" aria-label="Fijar el recorte a una forma">
+        <button type="button" class="chip" data-aspect="free" class="active">Libre</button>
+        <button type="button" class="chip" data-aspect="source">Original</button>
+        <button type="button" class="chip" data-aspect="1:1">1:1</button>
+        <button type="button" class="chip" data-aspect="4:5">4:5</button>
+        <button type="button" class="chip" data-aspect="9:16">9:16</button>
+        <button type="button" class="chip" data-aspect="16:9">16:9</button>
+        <button type="button" class="chip" data-aspect="4:3">4:3</button>
+        <button type="button" class="chip" data-aspect="3:2">3:2</button>
+        <button type="button" id="swap-aspect" class="chip" title="Poner de lado la forma fijada">
           Girar
         </button>
       </div>

--- a/locales/es/tools/resize-image.html
+++ b/locales/es/tools/resize-image.html
@@ -58,16 +58,16 @@
       <p id="stage-note" class="stage-note" hidden></p>
 
       <div class="crop-controls">
-        <div class="aspect-row" id="aspect-row" role="group" aria-label="Fijar el recorte a una forma">
-          <button type="button" data-aspect="free" class="active">Libre</button>
-          <button type="button" data-aspect="source">Original</button>
-          <button type="button" data-aspect="1:1">1:1</button>
-          <button type="button" data-aspect="4:5">4:5</button>
-          <button type="button" data-aspect="9:16">9:16</button>
-          <button type="button" data-aspect="16:9">16:9</button>
-          <button type="button" data-aspect="4:3">4:3</button>
-          <button type="button" data-aspect="3:2">3:2</button>
-          <button type="button" id="swap-aspect" class="ghost" title="Poner de lado la forma fijada">
+        <div class="chips aspect-row" id="aspect-row" role="group" aria-label="Fijar el recorte a una forma">
+          <button type="button" class="chip" data-aspect="free" class="active">Libre</button>
+          <button type="button" class="chip" data-aspect="source">Original</button>
+          <button type="button" class="chip" data-aspect="1:1">1:1</button>
+          <button type="button" class="chip" data-aspect="4:5">4:5</button>
+          <button type="button" class="chip" data-aspect="9:16">9:16</button>
+          <button type="button" class="chip" data-aspect="16:9">16:9</button>
+          <button type="button" class="chip" data-aspect="4:3">4:3</button>
+          <button type="button" class="chip" data-aspect="3:2">3:2</button>
+          <button type="button" id="swap-aspect" class="chip" title="Poner de lado la forma fijada">
             Girar
           </button>
         </div>

--- a/locales/es/tools/timelapse-video.html
+++ b/locales/es/tools/timelapse-video.html
@@ -33,15 +33,15 @@
   <section class="card" id="speed-card">
     <h2><span class="step">2</span> Elige la velocidad</h2>
 
-    <div class="speed-row" role="group" aria-label="Cuánto se acelera el clip">
-      <button type="button" data-speed="2">2&times;</button>
-      <button type="button" data-speed="5">5&times;</button>
-      <button type="button" data-speed="10" class="active">10&times;</button>
-      <button type="button" data-speed="20">20&times;</button>
-      <button type="button" data-speed="30">30&times;</button>
-      <button type="button" data-speed="60">60&times;</button>
-      <button type="button" data-speed="120">120&times;</button>
-      <button type="button" data-speed="300">300&times;</button>
+    <div class="chips speed-row" role="group" aria-label="Cuánto se acelera el clip">
+      <button type="button" class="chip" data-speed="2">2&times;</button>
+      <button type="button" class="chip" data-speed="5">5&times;</button>
+      <button type="button" class="chip" data-speed="10" class="active">10&times;</button>
+      <button type="button" class="chip" data-speed="20">20&times;</button>
+      <button type="button" class="chip" data-speed="30">30&times;</button>
+      <button type="button" class="chip" data-speed="60">60&times;</button>
+      <button type="button" class="chip" data-speed="120">120&times;</button>
+      <button type="button" class="chip" data-speed="300">300&times;</button>
     </div>
 
     <!--

--- a/locales/es/tools/trim-audio.html
+++ b/locales/es/tools/trim-audio.html
@@ -59,14 +59,14 @@
       <button type="button" id="undo" class="ghost"><kbd>U</kbd> Deshacer</button>
     </div>
 
-    <div class="speed-row" role="group" aria-label="Velocidad de reproducción">
-      <span class="speed-label">Velocidad</span>
-      <button type="button" class="speed" data-speed="0.5">0,5&times;</button>
-      <button type="button" class="speed" data-speed="0.75">0,75&times;</button>
-      <button type="button" class="speed active" data-speed="1">Normal</button>
-      <button type="button" class="speed" data-speed="1.25">1,25&times;</button>
-      <button type="button" class="speed" data-speed="1.5">1,5&times;</button>
-      <button type="button" class="speed" data-speed="2">2&times;</button>
+    <div class="chips speed-row" role="group" aria-label="Velocidad de reproducción">
+      <span class="chips-label speed-label">Velocidad</span>
+      <button type="button" class="chip speed" data-speed="0.5">0,5&times;</button>
+      <button type="button" class="chip speed" data-speed="0.75">0,75&times;</button>
+      <button type="button" class="chip speed active" data-speed="1">Normal</button>
+      <button type="button" class="chip speed" data-speed="1.25">1,25&times;</button>
+      <button type="button" class="chip speed" data-speed="1.5">1,5&times;</button>
+      <button type="button" class="chip speed" data-speed="2">2&times;</button>
     </div>
 
     <!-- The parts themselves. This is the tool. -->

--- a/locales/es/tools/trim-video.html
+++ b/locales/es/tools/trim-video.html
@@ -62,15 +62,15 @@
       <button type="button" id="undo" class="ghost"><kbd>U</kbd> Deshacer</button>
     </div>
 
-    <div class="speed-row" role="group" aria-label="Velocidad de reproducción">
-      <span class="speed-label">Velocidad</span>
-      <button type="button" class="speed" data-speed="0.25">0,25&times;</button>
-      <button type="button" class="speed" data-speed="0.5">0,5&times;</button>
-      <button type="button" class="speed" data-speed="0.75">0,75&times;</button>
-      <button type="button" class="speed active" data-speed="1">Normal</button>
-      <button type="button" class="speed" data-speed="1.25">1,25&times;</button>
-      <button type="button" class="speed" data-speed="1.5">1,5&times;</button>
-      <button type="button" class="speed" data-speed="2">2&times;</button>
+    <div class="chips speed-row" role="group" aria-label="Velocidad de reproducción">
+      <span class="chips-label speed-label">Velocidad</span>
+      <button type="button" class="chip speed" data-speed="0.25">0,25&times;</button>
+      <button type="button" class="chip speed" data-speed="0.5">0,5&times;</button>
+      <button type="button" class="chip speed" data-speed="0.75">0,75&times;</button>
+      <button type="button" class="chip speed active" data-speed="1">Normal</button>
+      <button type="button" class="chip speed" data-speed="1.25">1,25&times;</button>
+      <button type="button" class="chip speed" data-speed="1.5">1,5&times;</button>
+      <button type="button" class="chip speed" data-speed="2">2&times;</button>
     </div>
 
     <!-- The segments themselves. This is the tool. -->

--- a/locales/fr/tools/crop-video.html
+++ b/locales/fr/tools/crop-video.html
@@ -78,16 +78,16 @@
     <p id="stage-note" class="stage-note" hidden></p>
 
     <div class="crop-controls">
-      <div class="aspect-row" role="group" aria-label="Verrouiller le recadrage sur une forme">
-        <button type="button" data-aspect="free" class="active">Libre</button>
-        <button type="button" data-aspect="source">Original</button>
-        <button type="button" data-aspect="1:1">1:1</button>
-        <button type="button" data-aspect="4:5">4:5</button>
-        <button type="button" data-aspect="9:16">9:16</button>
-        <button type="button" data-aspect="16:9">16:9</button>
-        <button type="button" data-aspect="4:3">4:3</button>
-        <button type="button" data-aspect="3:2">3:2</button>
-        <button type="button" id="swap-aspect" class="ghost" title="Basculer la forme verrouillée sur le côté">
+      <div class="chips aspect-row" role="group" aria-label="Verrouiller le recadrage sur une forme">
+        <button type="button" class="chip" data-aspect="free" class="active">Libre</button>
+        <button type="button" class="chip" data-aspect="source">Original</button>
+        <button type="button" class="chip" data-aspect="1:1">1:1</button>
+        <button type="button" class="chip" data-aspect="4:5">4:5</button>
+        <button type="button" class="chip" data-aspect="9:16">9:16</button>
+        <button type="button" class="chip" data-aspect="16:9">16:9</button>
+        <button type="button" class="chip" data-aspect="4:3">4:3</button>
+        <button type="button" class="chip" data-aspect="3:2">3:2</button>
+        <button type="button" id="swap-aspect" class="chip" title="Basculer la forme verrouillée sur le côté">
           Basculer
         </button>
       </div>

--- a/locales/fr/tools/resize-image.html
+++ b/locales/fr/tools/resize-image.html
@@ -60,16 +60,16 @@
       <p id="stage-note" class="stage-note" hidden></p>
 
       <div class="crop-controls">
-        <div class="aspect-row" id="aspect-row" role="group" aria-label="Verrouiller le recadrage sur une forme">
-          <button type="button" data-aspect="free" class="active">Libre</button>
-          <button type="button" data-aspect="source">Original</button>
-          <button type="button" data-aspect="1:1">1:1</button>
-          <button type="button" data-aspect="4:5">4:5</button>
-          <button type="button" data-aspect="9:16">9:16</button>
-          <button type="button" data-aspect="16:9">16:9</button>
-          <button type="button" data-aspect="4:3">4:3</button>
-          <button type="button" data-aspect="3:2">3:2</button>
-          <button type="button" id="swap-aspect" class="ghost" title="Basculer la forme verrouillée sur le côté">
+        <div class="chips aspect-row" id="aspect-row" role="group" aria-label="Verrouiller le recadrage sur une forme">
+          <button type="button" class="chip" data-aspect="free" class="active">Libre</button>
+          <button type="button" class="chip" data-aspect="source">Original</button>
+          <button type="button" class="chip" data-aspect="1:1">1:1</button>
+          <button type="button" class="chip" data-aspect="4:5">4:5</button>
+          <button type="button" class="chip" data-aspect="9:16">9:16</button>
+          <button type="button" class="chip" data-aspect="16:9">16:9</button>
+          <button type="button" class="chip" data-aspect="4:3">4:3</button>
+          <button type="button" class="chip" data-aspect="3:2">3:2</button>
+          <button type="button" id="swap-aspect" class="chip" title="Basculer la forme verrouillée sur le côté">
             Basculer
           </button>
         </div>

--- a/locales/fr/tools/timelapse-video.html
+++ b/locales/fr/tools/timelapse-video.html
@@ -33,15 +33,15 @@
   <section class="card" id="speed-card">
     <h2><span class="step">2</span> Choisissez la vitesse</h2>
 
-    <div class="speed-row" role="group" aria-label="De combien le clip est accéléré">
-      <button type="button" data-speed="2">2&times;</button>
-      <button type="button" data-speed="5">5&times;</button>
-      <button type="button" data-speed="10" class="active">10&times;</button>
-      <button type="button" data-speed="20">20&times;</button>
-      <button type="button" data-speed="30">30&times;</button>
-      <button type="button" data-speed="60">60&times;</button>
-      <button type="button" data-speed="120">120&times;</button>
-      <button type="button" data-speed="300">300&times;</button>
+    <div class="chips speed-row" role="group" aria-label="De combien le clip est accéléré">
+      <button type="button" class="chip" data-speed="2">2&times;</button>
+      <button type="button" class="chip" data-speed="5">5&times;</button>
+      <button type="button" class="chip" data-speed="10" class="active">10&times;</button>
+      <button type="button" class="chip" data-speed="20">20&times;</button>
+      <button type="button" class="chip" data-speed="30">30&times;</button>
+      <button type="button" class="chip" data-speed="60">60&times;</button>
+      <button type="button" class="chip" data-speed="120">120&times;</button>
+      <button type="button" class="chip" data-speed="300">300&times;</button>
     </div>
 
     <!--

--- a/locales/fr/tools/trim-audio.html
+++ b/locales/fr/tools/trim-audio.html
@@ -59,14 +59,14 @@
       <button type="button" id="undo" class="ghost"><kbd>U</kbd> Annuler</button>
     </div>
 
-    <div class="speed-row" role="group" aria-label="Vitesse de lecture">
-      <span class="speed-label">Vitesse</span>
-      <button type="button" class="speed" data-speed="0.5">0,5&times;</button>
-      <button type="button" class="speed" data-speed="0.75">0,75&times;</button>
-      <button type="button" class="speed active" data-speed="1">Normale</button>
-      <button type="button" class="speed" data-speed="1.25">1,25&times;</button>
-      <button type="button" class="speed" data-speed="1.5">1,5&times;</button>
-      <button type="button" class="speed" data-speed="2">2&times;</button>
+    <div class="chips speed-row" role="group" aria-label="Vitesse de lecture">
+      <span class="chips-label speed-label">Vitesse</span>
+      <button type="button" class="chip speed" data-speed="0.5">0,5&times;</button>
+      <button type="button" class="chip speed" data-speed="0.75">0,75&times;</button>
+      <button type="button" class="chip speed active" data-speed="1">Normale</button>
+      <button type="button" class="chip speed" data-speed="1.25">1,25&times;</button>
+      <button type="button" class="chip speed" data-speed="1.5">1,5&times;</button>
+      <button type="button" class="chip speed" data-speed="2">2&times;</button>
     </div>
 
     <!-- The parts themselves. This is the tool. -->

--- a/locales/fr/tools/trim-video.html
+++ b/locales/fr/tools/trim-video.html
@@ -62,15 +62,15 @@
       <button type="button" id="undo" class="ghost"><kbd>U</kbd> Annuler</button>
     </div>
 
-    <div class="speed-row" role="group" aria-label="Vitesse de lecture">
-      <span class="speed-label">Vitesse</span>
-      <button type="button" class="speed" data-speed="0.25">0,25&times;</button>
-      <button type="button" class="speed" data-speed="0.5">0,5&times;</button>
-      <button type="button" class="speed" data-speed="0.75">0,75&times;</button>
-      <button type="button" class="speed active" data-speed="1">Normale</button>
-      <button type="button" class="speed" data-speed="1.25">1,25&times;</button>
-      <button type="button" class="speed" data-speed="1.5">1,5&times;</button>
-      <button type="button" class="speed" data-speed="2">2&times;</button>
+    <div class="chips speed-row" role="group" aria-label="Vitesse de lecture">
+      <span class="chips-label speed-label">Vitesse</span>
+      <button type="button" class="chip speed" data-speed="0.25">0,25&times;</button>
+      <button type="button" class="chip speed" data-speed="0.5">0,5&times;</button>
+      <button type="button" class="chip speed" data-speed="0.75">0,75&times;</button>
+      <button type="button" class="chip speed active" data-speed="1">Normale</button>
+      <button type="button" class="chip speed" data-speed="1.25">1,25&times;</button>
+      <button type="button" class="chip speed" data-speed="1.5">1,5&times;</button>
+      <button type="button" class="chip speed" data-speed="2">2&times;</button>
     </div>
 
     <!-- The segments themselves. This is the tool. -->

--- a/locales/hi/tools/crop-video.html
+++ b/locales/hi/tools/crop-video.html
@@ -77,16 +77,16 @@
     <p id="stage-note" class="stage-note" hidden></p>
 
     <div class="crop-controls">
-      <div class="aspect-row" role="group" aria-label="क्रॉप को किसी आकार पर लॉक कीजिए">
-        <button type="button" data-aspect="free" class="active">मनचाहा</button>
-        <button type="button" data-aspect="source">असली</button>
-        <button type="button" data-aspect="1:1">1:1</button>
-        <button type="button" data-aspect="4:5">4:5</button>
-        <button type="button" data-aspect="9:16">9:16</button>
-        <button type="button" data-aspect="16:9">16:9</button>
-        <button type="button" data-aspect="4:3">4:3</button>
-        <button type="button" data-aspect="3:2">3:2</button>
-        <button type="button" id="swap-aspect" class="ghost" title="लॉक किए आकार को करवट पर लिटा दीजिए">
+      <div class="chips aspect-row" role="group" aria-label="क्रॉप को किसी आकार पर लॉक कीजिए">
+        <button type="button" class="chip" data-aspect="free" class="active">मनचाहा</button>
+        <button type="button" class="chip" data-aspect="source">असली</button>
+        <button type="button" class="chip" data-aspect="1:1">1:1</button>
+        <button type="button" class="chip" data-aspect="4:5">4:5</button>
+        <button type="button" class="chip" data-aspect="9:16">9:16</button>
+        <button type="button" class="chip" data-aspect="16:9">16:9</button>
+        <button type="button" class="chip" data-aspect="4:3">4:3</button>
+        <button type="button" class="chip" data-aspect="3:2">3:2</button>
+        <button type="button" id="swap-aspect" class="chip" title="लॉक किए आकार को करवट पर लिटा दीजिए">
           अदल-बदल
         </button>
       </div>

--- a/locales/hi/tools/resize-image.html
+++ b/locales/hi/tools/resize-image.html
@@ -59,16 +59,16 @@
       <p id="stage-note" class="stage-note" hidden></p>
 
       <div class="crop-controls">
-        <div class="aspect-row" id="aspect-row" role="group" aria-label="क्रॉप को किसी आकार पर लॉक कीजिए">
-          <button type="button" data-aspect="free" class="active">मनचाहा</button>
-          <button type="button" data-aspect="source">असली</button>
-          <button type="button" data-aspect="1:1">1:1</button>
-          <button type="button" data-aspect="4:5">4:5</button>
-          <button type="button" data-aspect="9:16">9:16</button>
-          <button type="button" data-aspect="16:9">16:9</button>
-          <button type="button" data-aspect="4:3">4:3</button>
-          <button type="button" data-aspect="3:2">3:2</button>
-          <button type="button" id="swap-aspect" class="ghost" title="लॉक किए आकार को करवट पर लिटा दीजिए">
+        <div class="chips aspect-row" id="aspect-row" role="group" aria-label="क्रॉप को किसी आकार पर लॉक कीजिए">
+          <button type="button" class="chip" data-aspect="free" class="active">मनचाहा</button>
+          <button type="button" class="chip" data-aspect="source">असली</button>
+          <button type="button" class="chip" data-aspect="1:1">1:1</button>
+          <button type="button" class="chip" data-aspect="4:5">4:5</button>
+          <button type="button" class="chip" data-aspect="9:16">9:16</button>
+          <button type="button" class="chip" data-aspect="16:9">16:9</button>
+          <button type="button" class="chip" data-aspect="4:3">4:3</button>
+          <button type="button" class="chip" data-aspect="3:2">3:2</button>
+          <button type="button" id="swap-aspect" class="chip" title="लॉक किए आकार को करवट पर लिटा दीजिए">
             अदल-बदल
           </button>
         </div>

--- a/locales/hi/tools/timelapse-video.html
+++ b/locales/hi/tools/timelapse-video.html
@@ -33,15 +33,15 @@
   <section class="card" id="speed-card">
     <h2><span class="step">2</span> रफ़्तार चुनिए</h2>
 
-    <div class="speed-row" role="group" aria-label="क्लिप को कितना तेज़ करना है">
-      <button type="button" data-speed="2">2&times;</button>
-      <button type="button" data-speed="5">5&times;</button>
-      <button type="button" data-speed="10" class="active">10&times;</button>
-      <button type="button" data-speed="20">20&times;</button>
-      <button type="button" data-speed="30">30&times;</button>
-      <button type="button" data-speed="60">60&times;</button>
-      <button type="button" data-speed="120">120&times;</button>
-      <button type="button" data-speed="300">300&times;</button>
+    <div class="chips speed-row" role="group" aria-label="क्लिप को कितना तेज़ करना है">
+      <button type="button" class="chip" data-speed="2">2&times;</button>
+      <button type="button" class="chip" data-speed="5">5&times;</button>
+      <button type="button" class="chip" data-speed="10" class="active">10&times;</button>
+      <button type="button" class="chip" data-speed="20">20&times;</button>
+      <button type="button" class="chip" data-speed="30">30&times;</button>
+      <button type="button" class="chip" data-speed="60">60&times;</button>
+      <button type="button" class="chip" data-speed="120">120&times;</button>
+      <button type="button" class="chip" data-speed="300">300&times;</button>
     </div>
 
     <!--

--- a/locales/hi/tools/trim-audio.html
+++ b/locales/hi/tools/trim-audio.html
@@ -58,14 +58,14 @@
       <button type="button" id="undo" class="ghost"><kbd>U</kbd> वापस</button>
     </div>
 
-    <div class="speed-row" role="group" aria-label="चलने की रफ़्तार">
-      <span class="speed-label">रफ़्तार</span>
-      <button type="button" class="speed" data-speed="0.5">0.5&times;</button>
-      <button type="button" class="speed" data-speed="0.75">0.75&times;</button>
-      <button type="button" class="speed active" data-speed="1">सामान्य</button>
-      <button type="button" class="speed" data-speed="1.25">1.25&times;</button>
-      <button type="button" class="speed" data-speed="1.5">1.5&times;</button>
-      <button type="button" class="speed" data-speed="2">2&times;</button>
+    <div class="chips speed-row" role="group" aria-label="चलने की रफ़्तार">
+      <span class="chips-label speed-label">रफ़्तार</span>
+      <button type="button" class="chip speed" data-speed="0.5">0.5&times;</button>
+      <button type="button" class="chip speed" data-speed="0.75">0.75&times;</button>
+      <button type="button" class="chip speed active" data-speed="1">सामान्य</button>
+      <button type="button" class="chip speed" data-speed="1.25">1.25&times;</button>
+      <button type="button" class="chip speed" data-speed="1.5">1.5&times;</button>
+      <button type="button" class="chip speed" data-speed="2">2&times;</button>
     </div>
 
     <!-- The parts themselves. This is the tool. -->

--- a/locales/hi/tools/trim-video.html
+++ b/locales/hi/tools/trim-video.html
@@ -62,15 +62,15 @@
       <button type="button" id="undo" class="ghost"><kbd>U</kbd> वापस लीजिए</button>
     </div>
 
-    <div class="speed-row" role="group" aria-label="चलने की रफ़्तार">
-      <span class="speed-label">रफ़्तार</span>
-      <button type="button" class="speed" data-speed="0.25">0.25&times;</button>
-      <button type="button" class="speed" data-speed="0.5">0.5&times;</button>
-      <button type="button" class="speed" data-speed="0.75">0.75&times;</button>
-      <button type="button" class="speed active" data-speed="1">सामान्य</button>
-      <button type="button" class="speed" data-speed="1.25">1.25&times;</button>
-      <button type="button" class="speed" data-speed="1.5">1.5&times;</button>
-      <button type="button" class="speed" data-speed="2">2&times;</button>
+    <div class="chips speed-row" role="group" aria-label="चलने की रफ़्तार">
+      <span class="chips-label speed-label">रफ़्तार</span>
+      <button type="button" class="chip speed" data-speed="0.25">0.25&times;</button>
+      <button type="button" class="chip speed" data-speed="0.5">0.5&times;</button>
+      <button type="button" class="chip speed" data-speed="0.75">0.75&times;</button>
+      <button type="button" class="chip speed active" data-speed="1">सामान्य</button>
+      <button type="button" class="chip speed" data-speed="1.25">1.25&times;</button>
+      <button type="button" class="chip speed" data-speed="1.5">1.5&times;</button>
+      <button type="button" class="chip speed" data-speed="2">2&times;</button>
     </div>
 
     <!-- The segments themselves. This is the tool. -->

--- a/locales/id/tools/crop-video.html
+++ b/locales/id/tools/crop-video.html
@@ -84,16 +84,16 @@
     <p id="stage-note" class="stage-note" hidden></p>
 
     <div class="crop-controls">
-      <div class="aspect-row" role="group" aria-label="Kunci pangkasan ke sebuah bentuk">
-        <button type="button" data-aspect="free" class="active">Bebas</button>
-        <button type="button" data-aspect="source">Asli</button>
-        <button type="button" data-aspect="1:1">1:1</button>
-        <button type="button" data-aspect="4:5">4:5</button>
-        <button type="button" data-aspect="9:16">9:16</button>
-        <button type="button" data-aspect="16:9">16:9</button>
-        <button type="button" data-aspect="4:3">4:3</button>
-        <button type="button" data-aspect="3:2">3:2</button>
-        <button type="button" id="swap-aspect" class="ghost" title="Balikkan bentuk yang terkunci">
+      <div class="chips aspect-row" role="group" aria-label="Kunci pangkasan ke sebuah bentuk">
+        <button type="button" class="chip" data-aspect="free" class="active">Bebas</button>
+        <button type="button" class="chip" data-aspect="source">Asli</button>
+        <button type="button" class="chip" data-aspect="1:1">1:1</button>
+        <button type="button" class="chip" data-aspect="4:5">4:5</button>
+        <button type="button" class="chip" data-aspect="9:16">9:16</button>
+        <button type="button" class="chip" data-aspect="16:9">16:9</button>
+        <button type="button" class="chip" data-aspect="4:3">4:3</button>
+        <button type="button" class="chip" data-aspect="3:2">3:2</button>
+        <button type="button" id="swap-aspect" class="chip" title="Balikkan bentuk yang terkunci">
           Balik
         </button>
       </div>

--- a/locales/id/tools/resize-image.html
+++ b/locales/id/tools/resize-image.html
@@ -66,16 +66,16 @@
       <p id="stage-note" class="stage-note" hidden></p>
 
       <div class="crop-controls">
-        <div class="aspect-row" id="aspect-row" role="group" aria-label="Kunci pemangkasan ke sebuah bentuk">
-          <button type="button" data-aspect="free" class="active">Bebas</button>
-          <button type="button" data-aspect="source">Asli</button>
-          <button type="button" data-aspect="1:1">1:1</button>
-          <button type="button" data-aspect="4:5">4:5</button>
-          <button type="button" data-aspect="9:16">9:16</button>
-          <button type="button" data-aspect="16:9">16:9</button>
-          <button type="button" data-aspect="4:3">4:3</button>
-          <button type="button" data-aspect="3:2">3:2</button>
-          <button type="button" id="swap-aspect" class="ghost" title="Balikkan bentuk yang terkunci">
+        <div class="chips aspect-row" id="aspect-row" role="group" aria-label="Kunci pemangkasan ke sebuah bentuk">
+          <button type="button" class="chip" data-aspect="free" class="active">Bebas</button>
+          <button type="button" class="chip" data-aspect="source">Asli</button>
+          <button type="button" class="chip" data-aspect="1:1">1:1</button>
+          <button type="button" class="chip" data-aspect="4:5">4:5</button>
+          <button type="button" class="chip" data-aspect="9:16">9:16</button>
+          <button type="button" class="chip" data-aspect="16:9">16:9</button>
+          <button type="button" class="chip" data-aspect="4:3">4:3</button>
+          <button type="button" class="chip" data-aspect="3:2">3:2</button>
+          <button type="button" id="swap-aspect" class="chip" title="Balikkan bentuk yang terkunci">
             Balik
           </button>
         </div>

--- a/locales/id/tools/timelapse-video.html
+++ b/locales/id/tools/timelapse-video.html
@@ -39,15 +39,15 @@
   <section class="card" id="speed-card">
     <h2><span class="step">2</span> Pilih kecepatannya</h2>
 
-    <div class="speed-row" role="group" aria-label="Seberapa jauh klipnya dipercepat">
-      <button type="button" data-speed="2">2&times;</button>
-      <button type="button" data-speed="5">5&times;</button>
-      <button type="button" data-speed="10" class="active">10&times;</button>
-      <button type="button" data-speed="20">20&times;</button>
-      <button type="button" data-speed="30">30&times;</button>
-      <button type="button" data-speed="60">60&times;</button>
-      <button type="button" data-speed="120">120&times;</button>
-      <button type="button" data-speed="300">300&times;</button>
+    <div class="chips speed-row" role="group" aria-label="Seberapa jauh klipnya dipercepat">
+      <button type="button" class="chip" data-speed="2">2&times;</button>
+      <button type="button" class="chip" data-speed="5">5&times;</button>
+      <button type="button" class="chip" data-speed="10" class="active">10&times;</button>
+      <button type="button" class="chip" data-speed="20">20&times;</button>
+      <button type="button" class="chip" data-speed="30">30&times;</button>
+      <button type="button" class="chip" data-speed="60">60&times;</button>
+      <button type="button" class="chip" data-speed="120">120&times;</button>
+      <button type="button" class="chip" data-speed="300">300&times;</button>
     </div>
 
     <!--

--- a/locales/id/tools/trim-audio.html
+++ b/locales/id/tools/trim-audio.html
@@ -66,14 +66,14 @@
       <button type="button" id="undo" class="ghost"><kbd>U</kbd> Batalkan</button>
     </div>
 
-    <div class="speed-row" role="group" aria-label="Kecepatan pemutaran">
-      <span class="speed-label">Kecepatan</span>
-      <button type="button" class="speed" data-speed="0.5">0,5&times;</button>
-      <button type="button" class="speed" data-speed="0.75">0,75&times;</button>
-      <button type="button" class="speed active" data-speed="1">Normal</button>
-      <button type="button" class="speed" data-speed="1.25">1,25&times;</button>
-      <button type="button" class="speed" data-speed="1.5">1,5&times;</button>
-      <button type="button" class="speed" data-speed="2">2&times;</button>
+    <div class="chips speed-row" role="group" aria-label="Kecepatan pemutaran">
+      <span class="chips-label speed-label">Kecepatan</span>
+      <button type="button" class="chip speed" data-speed="0.5">0,5&times;</button>
+      <button type="button" class="chip speed" data-speed="0.75">0,75&times;</button>
+      <button type="button" class="chip speed active" data-speed="1">Normal</button>
+      <button type="button" class="chip speed" data-speed="1.25">1,25&times;</button>
+      <button type="button" class="chip speed" data-speed="1.5">1,5&times;</button>
+      <button type="button" class="chip speed" data-speed="2">2&times;</button>
     </div>
 
     <!-- The parts themselves. This is the tool. -->

--- a/locales/id/tools/trim-video.html
+++ b/locales/id/tools/trim-video.html
@@ -69,15 +69,15 @@
       <button type="button" id="undo" class="ghost"><kbd>U</kbd> Batalkan</button>
     </div>
 
-    <div class="speed-row" role="group" aria-label="Kecepatan pemutaran">
-      <span class="speed-label">Kecepatan</span>
-      <button type="button" class="speed" data-speed="0.25">0,25&times;</button>
-      <button type="button" class="speed" data-speed="0.5">0,5&times;</button>
-      <button type="button" class="speed" data-speed="0.75">0,75&times;</button>
-      <button type="button" class="speed active" data-speed="1">Normal</button>
-      <button type="button" class="speed" data-speed="1.25">1,25&times;</button>
-      <button type="button" class="speed" data-speed="1.5">1,5&times;</button>
-      <button type="button" class="speed" data-speed="2">2&times;</button>
+    <div class="chips speed-row" role="group" aria-label="Kecepatan pemutaran">
+      <span class="chips-label speed-label">Kecepatan</span>
+      <button type="button" class="chip speed" data-speed="0.25">0,25&times;</button>
+      <button type="button" class="chip speed" data-speed="0.5">0,5&times;</button>
+      <button type="button" class="chip speed" data-speed="0.75">0,75&times;</button>
+      <button type="button" class="chip speed active" data-speed="1">Normal</button>
+      <button type="button" class="chip speed" data-speed="1.25">1,25&times;</button>
+      <button type="button" class="chip speed" data-speed="1.5">1,5&times;</button>
+      <button type="button" class="chip speed" data-speed="2">2&times;</button>
     </div>
 
     <!-- The segments themselves. This is the tool. -->

--- a/locales/it/tools/crop-video.html
+++ b/locales/it/tools/crop-video.html
@@ -77,16 +77,16 @@
     <p id="stage-note" class="stage-note" hidden></p>
 
     <div class="crop-controls">
-      <div class="aspect-row" role="group" aria-label="Blocca il ritaglio su una forma">
-        <button type="button" data-aspect="free" class="active">Libero</button>
-        <button type="button" data-aspect="source">Originale</button>
-        <button type="button" data-aspect="1:1">1:1</button>
-        <button type="button" data-aspect="4:5">4:5</button>
-        <button type="button" data-aspect="9:16">9:16</button>
-        <button type="button" data-aspect="16:9">16:9</button>
-        <button type="button" data-aspect="4:3">4:3</button>
-        <button type="button" data-aspect="3:2">3:2</button>
-        <button type="button" id="swap-aspect" class="ghost" title="Gira di lato la forma bloccata">
+      <div class="chips aspect-row" role="group" aria-label="Blocca il ritaglio su una forma">
+        <button type="button" class="chip" data-aspect="free" class="active">Libero</button>
+        <button type="button" class="chip" data-aspect="source">Originale</button>
+        <button type="button" class="chip" data-aspect="1:1">1:1</button>
+        <button type="button" class="chip" data-aspect="4:5">4:5</button>
+        <button type="button" class="chip" data-aspect="9:16">9:16</button>
+        <button type="button" class="chip" data-aspect="16:9">16:9</button>
+        <button type="button" class="chip" data-aspect="4:3">4:3</button>
+        <button type="button" class="chip" data-aspect="3:2">3:2</button>
+        <button type="button" id="swap-aspect" class="chip" title="Gira di lato la forma bloccata">
           Gira
         </button>
       </div>

--- a/locales/it/tools/resize-image.html
+++ b/locales/it/tools/resize-image.html
@@ -59,16 +59,16 @@
       <p id="stage-note" class="stage-note" hidden></p>
 
       <div class="crop-controls">
-        <div class="aspect-row" id="aspect-row" role="group" aria-label="Blocca il ritaglio su una forma">
-          <button type="button" data-aspect="free" class="active">Libero</button>
-          <button type="button" data-aspect="source">Originale</button>
-          <button type="button" data-aspect="1:1">1:1</button>
-          <button type="button" data-aspect="4:5">4:5</button>
-          <button type="button" data-aspect="9:16">9:16</button>
-          <button type="button" data-aspect="16:9">16:9</button>
-          <button type="button" data-aspect="4:3">4:3</button>
-          <button type="button" data-aspect="3:2">3:2</button>
-          <button type="button" id="swap-aspect" class="ghost" title="Metti di lato la forma bloccata">
+        <div class="chips aspect-row" id="aspect-row" role="group" aria-label="Blocca il ritaglio su una forma">
+          <button type="button" class="chip" data-aspect="free" class="active">Libero</button>
+          <button type="button" class="chip" data-aspect="source">Originale</button>
+          <button type="button" class="chip" data-aspect="1:1">1:1</button>
+          <button type="button" class="chip" data-aspect="4:5">4:5</button>
+          <button type="button" class="chip" data-aspect="9:16">9:16</button>
+          <button type="button" class="chip" data-aspect="16:9">16:9</button>
+          <button type="button" class="chip" data-aspect="4:3">4:3</button>
+          <button type="button" class="chip" data-aspect="3:2">3:2</button>
+          <button type="button" id="swap-aspect" class="chip" title="Metti di lato la forma bloccata">
             Ruota
           </button>
         </div>

--- a/locales/it/tools/timelapse-video.html
+++ b/locales/it/tools/timelapse-video.html
@@ -33,15 +33,15 @@
   <section class="card" id="speed-card">
     <h2><span class="step">2</span> Scegli la velocità</h2>
 
-    <div class="speed-row" role="group" aria-label="Di quanto viene velocizzata la clip">
-      <button type="button" data-speed="2">2&times;</button>
-      <button type="button" data-speed="5">5&times;</button>
-      <button type="button" data-speed="10" class="active">10&times;</button>
-      <button type="button" data-speed="20">20&times;</button>
-      <button type="button" data-speed="30">30&times;</button>
-      <button type="button" data-speed="60">60&times;</button>
-      <button type="button" data-speed="120">120&times;</button>
-      <button type="button" data-speed="300">300&times;</button>
+    <div class="chips speed-row" role="group" aria-label="Di quanto viene velocizzata la clip">
+      <button type="button" class="chip" data-speed="2">2&times;</button>
+      <button type="button" class="chip" data-speed="5">5&times;</button>
+      <button type="button" class="chip" data-speed="10" class="active">10&times;</button>
+      <button type="button" class="chip" data-speed="20">20&times;</button>
+      <button type="button" class="chip" data-speed="30">30&times;</button>
+      <button type="button" class="chip" data-speed="60">60&times;</button>
+      <button type="button" class="chip" data-speed="120">120&times;</button>
+      <button type="button" class="chip" data-speed="300">300&times;</button>
     </div>
 
     <!--

--- a/locales/it/tools/trim-audio.html
+++ b/locales/it/tools/trim-audio.html
@@ -58,14 +58,14 @@
       <button type="button" id="undo" class="ghost"><kbd>U</kbd> Annulla</button>
     </div>
 
-    <div class="speed-row" role="group" aria-label="Velocità di riproduzione">
-      <span class="speed-label">Velocità</span>
-      <button type="button" class="speed" data-speed="0.5">0,5&times;</button>
-      <button type="button" class="speed" data-speed="0.75">0,75&times;</button>
-      <button type="button" class="speed active" data-speed="1">Normale</button>
-      <button type="button" class="speed" data-speed="1.25">1,25&times;</button>
-      <button type="button" class="speed" data-speed="1.5">1,5&times;</button>
-      <button type="button" class="speed" data-speed="2">2&times;</button>
+    <div class="chips speed-row" role="group" aria-label="Velocità di riproduzione">
+      <span class="chips-label speed-label">Velocità</span>
+      <button type="button" class="chip speed" data-speed="0.5">0,5&times;</button>
+      <button type="button" class="chip speed" data-speed="0.75">0,75&times;</button>
+      <button type="button" class="chip speed active" data-speed="1">Normale</button>
+      <button type="button" class="chip speed" data-speed="1.25">1,25&times;</button>
+      <button type="button" class="chip speed" data-speed="1.5">1,5&times;</button>
+      <button type="button" class="chip speed" data-speed="2">2&times;</button>
     </div>
 
     <!-- The parts themselves. This is the tool. -->

--- a/locales/it/tools/trim-video.html
+++ b/locales/it/tools/trim-video.html
@@ -61,15 +61,15 @@
       <button type="button" id="undo" class="ghost"><kbd>U</kbd> Annulla</button>
     </div>
 
-    <div class="speed-row" role="group" aria-label="Velocità di riproduzione">
-      <span class="speed-label">Velocità</span>
-      <button type="button" class="speed" data-speed="0.25">0,25&times;</button>
-      <button type="button" class="speed" data-speed="0.5">0,5&times;</button>
-      <button type="button" class="speed" data-speed="0.75">0,75&times;</button>
-      <button type="button" class="speed active" data-speed="1">Normale</button>
-      <button type="button" class="speed" data-speed="1.25">1,25&times;</button>
-      <button type="button" class="speed" data-speed="1.5">1,5&times;</button>
-      <button type="button" class="speed" data-speed="2">2&times;</button>
+    <div class="chips speed-row" role="group" aria-label="Velocità di riproduzione">
+      <span class="chips-label speed-label">Velocità</span>
+      <button type="button" class="chip speed" data-speed="0.25">0,25&times;</button>
+      <button type="button" class="chip speed" data-speed="0.5">0,5&times;</button>
+      <button type="button" class="chip speed" data-speed="0.75">0,75&times;</button>
+      <button type="button" class="chip speed active" data-speed="1">Normale</button>
+      <button type="button" class="chip speed" data-speed="1.25">1,25&times;</button>
+      <button type="button" class="chip speed" data-speed="1.5">1,5&times;</button>
+      <button type="button" class="chip speed" data-speed="2">2&times;</button>
     </div>
 
     <!-- The segments themselves. This is the tool. -->

--- a/locales/ja/tools/crop-video.html
+++ b/locales/ja/tools/crop-video.html
@@ -73,16 +73,16 @@
     <p id="stage-note" class="stage-note" hidden></p>
 
     <div class="crop-controls">
-      <div class="aspect-row" role="group" aria-label="切り抜きの形を固定する">
-        <button type="button" data-aspect="free" class="active">自由</button>
-        <button type="button" data-aspect="source">元のまま</button>
-        <button type="button" data-aspect="1:1">1:1</button>
-        <button type="button" data-aspect="4:5">4:5</button>
-        <button type="button" data-aspect="9:16">9:16</button>
-        <button type="button" data-aspect="16:9">16:9</button>
-        <button type="button" data-aspect="4:3">4:3</button>
-        <button type="button" data-aspect="3:2">3:2</button>
-        <button type="button" id="swap-aspect" class="ghost" title="固定した形を縦横入れ替える">
+      <div class="chips aspect-row" role="group" aria-label="切り抜きの形を固定する">
+        <button type="button" class="chip" data-aspect="free" class="active">自由</button>
+        <button type="button" class="chip" data-aspect="source">元のまま</button>
+        <button type="button" class="chip" data-aspect="1:1">1:1</button>
+        <button type="button" class="chip" data-aspect="4:5">4:5</button>
+        <button type="button" class="chip" data-aspect="9:16">9:16</button>
+        <button type="button" class="chip" data-aspect="16:9">16:9</button>
+        <button type="button" class="chip" data-aspect="4:3">4:3</button>
+        <button type="button" class="chip" data-aspect="3:2">3:2</button>
+        <button type="button" id="swap-aspect" class="chip" title="固定した形を縦横入れ替える">
           縦横を入れ替え
         </button>
       </div>

--- a/locales/ja/tools/resize-image.html
+++ b/locales/ja/tools/resize-image.html
@@ -51,16 +51,16 @@
       <p id="stage-note" class="stage-note" hidden></p>
 
       <div class="crop-controls">
-        <div class="aspect-row" id="aspect-row" role="group" aria-label="切り抜きの形を固定する">
-          <button type="button" data-aspect="free" class="active">自由</button>
-          <button type="button" data-aspect="source">元のまま</button>
-          <button type="button" data-aspect="1:1">1:1</button>
-          <button type="button" data-aspect="4:5">4:5</button>
-          <button type="button" data-aspect="9:16">9:16</button>
-          <button type="button" data-aspect="16:9">16:9</button>
-          <button type="button" data-aspect="4:3">4:3</button>
-          <button type="button" data-aspect="3:2">3:2</button>
-          <button type="button" id="swap-aspect" class="ghost" title="固定した形を縦横入れ替える">
+        <div class="chips aspect-row" id="aspect-row" role="group" aria-label="切り抜きの形を固定する">
+          <button type="button" class="chip" data-aspect="free" class="active">自由</button>
+          <button type="button" class="chip" data-aspect="source">元のまま</button>
+          <button type="button" class="chip" data-aspect="1:1">1:1</button>
+          <button type="button" class="chip" data-aspect="4:5">4:5</button>
+          <button type="button" class="chip" data-aspect="9:16">9:16</button>
+          <button type="button" class="chip" data-aspect="16:9">16:9</button>
+          <button type="button" class="chip" data-aspect="4:3">4:3</button>
+          <button type="button" class="chip" data-aspect="3:2">3:2</button>
+          <button type="button" id="swap-aspect" class="chip" title="固定した形を縦横入れ替える">
             縦横を入れ替え
           </button>
         </div>

--- a/locales/ja/tools/timelapse-video.html
+++ b/locales/ja/tools/timelapse-video.html
@@ -40,15 +40,15 @@
   <section class="card" id="speed-card">
     <h2><span class="step">2</span> 倍率を決める</h2>
 
-    <div class="speed-row" role="group" aria-label="映像をどれだけ速くするか">
-      <button type="button" data-speed="2">2&times;</button>
-      <button type="button" data-speed="5">5&times;</button>
-      <button type="button" data-speed="10" class="active">10&times;</button>
-      <button type="button" data-speed="20">20&times;</button>
-      <button type="button" data-speed="30">30&times;</button>
-      <button type="button" data-speed="60">60&times;</button>
-      <button type="button" data-speed="120">120&times;</button>
-      <button type="button" data-speed="300">300&times;</button>
+    <div class="chips speed-row" role="group" aria-label="映像をどれだけ速くするか">
+      <button type="button" class="chip" data-speed="2">2&times;</button>
+      <button type="button" class="chip" data-speed="5">5&times;</button>
+      <button type="button" class="chip" data-speed="10" class="active">10&times;</button>
+      <button type="button" class="chip" data-speed="20">20&times;</button>
+      <button type="button" class="chip" data-speed="30">30&times;</button>
+      <button type="button" class="chip" data-speed="60">60&times;</button>
+      <button type="button" class="chip" data-speed="120">120&times;</button>
+      <button type="button" class="chip" data-speed="300">300&times;</button>
     </div>
 
     <!--

--- a/locales/ja/tools/trim-audio.html
+++ b/locales/ja/tools/trim-audio.html
@@ -53,14 +53,14 @@
       <button type="button" id="undo" class="ghost"><kbd>U</kbd>取り消し</button>
     </div>
 
-    <div class="speed-row" role="group" aria-label="再生速度">
-      <span class="speed-label">速度</span>
-      <button type="button" class="speed" data-speed="0.5">0.5&times;</button>
-      <button type="button" class="speed" data-speed="0.75">0.75&times;</button>
-      <button type="button" class="speed active" data-speed="1">標準</button>
-      <button type="button" class="speed" data-speed="1.25">1.25&times;</button>
-      <button type="button" class="speed" data-speed="1.5">1.5&times;</button>
-      <button type="button" class="speed" data-speed="2">2&times;</button>
+    <div class="chips speed-row" role="group" aria-label="再生速度">
+      <span class="chips-label speed-label">速度</span>
+      <button type="button" class="chip speed" data-speed="0.5">0.5&times;</button>
+      <button type="button" class="chip speed" data-speed="0.75">0.75&times;</button>
+      <button type="button" class="chip speed active" data-speed="1">標準</button>
+      <button type="button" class="chip speed" data-speed="1.25">1.25&times;</button>
+      <button type="button" class="chip speed" data-speed="1.5">1.5&times;</button>
+      <button type="button" class="chip speed" data-speed="2">2&times;</button>
     </div>
 
     <!-- The parts themselves. This is the tool. -->

--- a/locales/ja/tools/trim-video.html
+++ b/locales/ja/tools/trim-video.html
@@ -57,15 +57,15 @@
       <button type="button" id="undo" class="ghost"><kbd>U</kbd>取り消し</button>
     </div>
 
-    <div class="speed-row" role="group" aria-label="再生速度">
-      <span class="speed-label">速さ</span>
-      <button type="button" class="speed" data-speed="0.25">0.25&times;</button>
-      <button type="button" class="speed" data-speed="0.5">0.5&times;</button>
-      <button type="button" class="speed" data-speed="0.75">0.75&times;</button>
-      <button type="button" class="speed active" data-speed="1">等倍</button>
-      <button type="button" class="speed" data-speed="1.25">1.25&times;</button>
-      <button type="button" class="speed" data-speed="1.5">1.5&times;</button>
-      <button type="button" class="speed" data-speed="2">2&times;</button>
+    <div class="chips speed-row" role="group" aria-label="再生速度">
+      <span class="chips-label speed-label">速さ</span>
+      <button type="button" class="chip speed" data-speed="0.25">0.25&times;</button>
+      <button type="button" class="chip speed" data-speed="0.5">0.5&times;</button>
+      <button type="button" class="chip speed" data-speed="0.75">0.75&times;</button>
+      <button type="button" class="chip speed active" data-speed="1">等倍</button>
+      <button type="button" class="chip speed" data-speed="1.25">1.25&times;</button>
+      <button type="button" class="chip speed" data-speed="1.5">1.5&times;</button>
+      <button type="button" class="chip speed" data-speed="2">2&times;</button>
     </div>
 
     <!-- The segments themselves. This is the tool. -->

--- a/locales/ko/tools/crop-video.html
+++ b/locales/ko/tools/crop-video.html
@@ -77,16 +77,16 @@
     <p id="stage-note" class="stage-note" hidden></p>
 
     <div class="crop-controls">
-      <div class="aspect-row" role="group" aria-label="자를 영역의 비율 고정">
-        <button type="button" data-aspect="free" class="active">자유</button>
-        <button type="button" data-aspect="source">원본</button>
-        <button type="button" data-aspect="1:1">1:1</button>
-        <button type="button" data-aspect="4:5">4:5</button>
-        <button type="button" data-aspect="9:16">9:16</button>
-        <button type="button" data-aspect="16:9">16:9</button>
-        <button type="button" data-aspect="4:3">4:3</button>
-        <button type="button" data-aspect="3:2">3:2</button>
-        <button type="button" id="swap-aspect" class="ghost" title="고정한 비율을 가로세로 바꾸기">
+      <div class="chips aspect-row" role="group" aria-label="자를 영역의 비율 고정">
+        <button type="button" class="chip" data-aspect="free" class="active">자유</button>
+        <button type="button" class="chip" data-aspect="source">원본</button>
+        <button type="button" class="chip" data-aspect="1:1">1:1</button>
+        <button type="button" class="chip" data-aspect="4:5">4:5</button>
+        <button type="button" class="chip" data-aspect="9:16">9:16</button>
+        <button type="button" class="chip" data-aspect="16:9">16:9</button>
+        <button type="button" class="chip" data-aspect="4:3">4:3</button>
+        <button type="button" class="chip" data-aspect="3:2">3:2</button>
+        <button type="button" id="swap-aspect" class="chip" title="고정한 비율을 가로세로 바꾸기">
           가로세로 바꾸기
         </button>
       </div>

--- a/locales/ko/tools/resize-image.html
+++ b/locales/ko/tools/resize-image.html
@@ -58,16 +58,16 @@
       <p id="stage-note" class="stage-note" hidden></p>
 
       <div class="crop-controls">
-        <div class="aspect-row" id="aspect-row" role="group" aria-label="자를 영역의 비율 고정">
-          <button type="button" data-aspect="free" class="active">자유</button>
-          <button type="button" data-aspect="source">원본</button>
-          <button type="button" data-aspect="1:1">1:1</button>
-          <button type="button" data-aspect="4:5">4:5</button>
-          <button type="button" data-aspect="9:16">9:16</button>
-          <button type="button" data-aspect="16:9">16:9</button>
-          <button type="button" data-aspect="4:3">4:3</button>
-          <button type="button" data-aspect="3:2">3:2</button>
-          <button type="button" id="swap-aspect" class="ghost" title="고정한 비율을 가로세로 바꾸기">
+        <div class="chips aspect-row" id="aspect-row" role="group" aria-label="자를 영역의 비율 고정">
+          <button type="button" class="chip" data-aspect="free" class="active">자유</button>
+          <button type="button" class="chip" data-aspect="source">원본</button>
+          <button type="button" class="chip" data-aspect="1:1">1:1</button>
+          <button type="button" class="chip" data-aspect="4:5">4:5</button>
+          <button type="button" class="chip" data-aspect="9:16">9:16</button>
+          <button type="button" class="chip" data-aspect="16:9">16:9</button>
+          <button type="button" class="chip" data-aspect="4:3">4:3</button>
+          <button type="button" class="chip" data-aspect="3:2">3:2</button>
+          <button type="button" id="swap-aspect" class="chip" title="고정한 비율을 가로세로 바꾸기">
             가로세로 바꾸기
           </button>
         </div>

--- a/locales/ko/tools/timelapse-video.html
+++ b/locales/ko/tools/timelapse-video.html
@@ -33,15 +33,15 @@
   <section class="card" id="speed-card">
     <h2><span class="step">2</span> 배속 정하기</h2>
 
-    <div class="speed-row" role="group" aria-label="영상을 얼마나 빠르게 할지">
-      <button type="button" data-speed="2">2&times;</button>
-      <button type="button" data-speed="5">5&times;</button>
-      <button type="button" data-speed="10" class="active">10&times;</button>
-      <button type="button" data-speed="20">20&times;</button>
-      <button type="button" data-speed="30">30&times;</button>
-      <button type="button" data-speed="60">60&times;</button>
-      <button type="button" data-speed="120">120&times;</button>
-      <button type="button" data-speed="300">300&times;</button>
+    <div class="chips speed-row" role="group" aria-label="영상을 얼마나 빠르게 할지">
+      <button type="button" class="chip" data-speed="2">2&times;</button>
+      <button type="button" class="chip" data-speed="5">5&times;</button>
+      <button type="button" class="chip" data-speed="10" class="active">10&times;</button>
+      <button type="button" class="chip" data-speed="20">20&times;</button>
+      <button type="button" class="chip" data-speed="30">30&times;</button>
+      <button type="button" class="chip" data-speed="60">60&times;</button>
+      <button type="button" class="chip" data-speed="120">120&times;</button>
+      <button type="button" class="chip" data-speed="300">300&times;</button>
     </div>
 
     <!--

--- a/locales/ko/tools/trim-audio.html
+++ b/locales/ko/tools/trim-audio.html
@@ -57,14 +57,14 @@
       <button type="button" id="undo" class="ghost"><kbd>U</kbd> 되돌리기</button>
     </div>
 
-    <div class="speed-row" role="group" aria-label="재생 속도">
-      <span class="speed-label">속도</span>
-      <button type="button" class="speed" data-speed="0.5">0.5&times;</button>
-      <button type="button" class="speed" data-speed="0.75">0.75&times;</button>
-      <button type="button" class="speed active" data-speed="1">보통</button>
-      <button type="button" class="speed" data-speed="1.25">1.25&times;</button>
-      <button type="button" class="speed" data-speed="1.5">1.5&times;</button>
-      <button type="button" class="speed" data-speed="2">2&times;</button>
+    <div class="chips speed-row" role="group" aria-label="재생 속도">
+      <span class="chips-label speed-label">속도</span>
+      <button type="button" class="chip speed" data-speed="0.5">0.5&times;</button>
+      <button type="button" class="chip speed" data-speed="0.75">0.75&times;</button>
+      <button type="button" class="chip speed active" data-speed="1">보통</button>
+      <button type="button" class="chip speed" data-speed="1.25">1.25&times;</button>
+      <button type="button" class="chip speed" data-speed="1.5">1.5&times;</button>
+      <button type="button" class="chip speed" data-speed="2">2&times;</button>
     </div>
 
     <!-- The parts themselves. This is the tool. -->

--- a/locales/ko/tools/trim-video.html
+++ b/locales/ko/tools/trim-video.html
@@ -61,15 +61,15 @@
       <button type="button" id="undo" class="ghost"><kbd>U</kbd> 되돌리기</button>
     </div>
 
-    <div class="speed-row" role="group" aria-label="재생 속도">
-      <span class="speed-label">속도</span>
-      <button type="button" class="speed" data-speed="0.25">0.25&times;</button>
-      <button type="button" class="speed" data-speed="0.5">0.5&times;</button>
-      <button type="button" class="speed" data-speed="0.75">0.75&times;</button>
-      <button type="button" class="speed active" data-speed="1">보통</button>
-      <button type="button" class="speed" data-speed="1.25">1.25&times;</button>
-      <button type="button" class="speed" data-speed="1.5">1.5&times;</button>
-      <button type="button" class="speed" data-speed="2">2&times;</button>
+    <div class="chips speed-row" role="group" aria-label="재생 속도">
+      <span class="chips-label speed-label">속도</span>
+      <button type="button" class="chip speed" data-speed="0.25">0.25&times;</button>
+      <button type="button" class="chip speed" data-speed="0.5">0.5&times;</button>
+      <button type="button" class="chip speed" data-speed="0.75">0.75&times;</button>
+      <button type="button" class="chip speed active" data-speed="1">보통</button>
+      <button type="button" class="chip speed" data-speed="1.25">1.25&times;</button>
+      <button type="button" class="chip speed" data-speed="1.5">1.5&times;</button>
+      <button type="button" class="chip speed" data-speed="2">2&times;</button>
     </div>
 
     <!-- The segments themselves. This is the tool. -->

--- a/locales/nl/tools/crop-video.html
+++ b/locales/nl/tools/crop-video.html
@@ -77,16 +77,16 @@
     <p id="stage-note" class="stage-note" hidden></p>
 
     <div class="crop-controls">
-      <div class="aspect-row" role="group" aria-label="Het kader op een vorm vastzetten">
-        <button type="button" data-aspect="free" class="active">Vrij</button>
-        <button type="button" data-aspect="source">Origineel</button>
-        <button type="button" data-aspect="1:1">1:1</button>
-        <button type="button" data-aspect="4:5">4:5</button>
-        <button type="button" data-aspect="9:16">9:16</button>
-        <button type="button" data-aspect="16:9">16:9</button>
-        <button type="button" data-aspect="4:3">4:3</button>
-        <button type="button" data-aspect="3:2">3:2</button>
-        <button type="button" id="swap-aspect" class="ghost" title="Zet de vaste vorm op zijn kant">
+      <div class="chips aspect-row" role="group" aria-label="Het kader op een vorm vastzetten">
+        <button type="button" class="chip" data-aspect="free" class="active">Vrij</button>
+        <button type="button" class="chip" data-aspect="source">Origineel</button>
+        <button type="button" class="chip" data-aspect="1:1">1:1</button>
+        <button type="button" class="chip" data-aspect="4:5">4:5</button>
+        <button type="button" class="chip" data-aspect="9:16">9:16</button>
+        <button type="button" class="chip" data-aspect="16:9">16:9</button>
+        <button type="button" class="chip" data-aspect="4:3">4:3</button>
+        <button type="button" class="chip" data-aspect="3:2">3:2</button>
+        <button type="button" id="swap-aspect" class="chip" title="Zet de vaste vorm op zijn kant">
           Omdraaien
         </button>
       </div>

--- a/locales/nl/tools/resize-image.html
+++ b/locales/nl/tools/resize-image.html
@@ -59,16 +59,16 @@
       <p id="stage-note" class="stage-note" hidden></p>
 
       <div class="crop-controls">
-        <div class="aspect-row" id="aspect-row" role="group" aria-label="Het kader op een vorm vastzetten">
-          <button type="button" data-aspect="free" class="active">Vrij</button>
-          <button type="button" data-aspect="source">Origineel</button>
-          <button type="button" data-aspect="1:1">1:1</button>
-          <button type="button" data-aspect="4:5">4:5</button>
-          <button type="button" data-aspect="9:16">9:16</button>
-          <button type="button" data-aspect="16:9">16:9</button>
-          <button type="button" data-aspect="4:3">4:3</button>
-          <button type="button" data-aspect="3:2">3:2</button>
-          <button type="button" id="swap-aspect" class="ghost" title="Zet de vaste vorm op zijn kant">
+        <div class="chips aspect-row" id="aspect-row" role="group" aria-label="Het kader op een vorm vastzetten">
+          <button type="button" class="chip" data-aspect="free" class="active">Vrij</button>
+          <button type="button" class="chip" data-aspect="source">Origineel</button>
+          <button type="button" class="chip" data-aspect="1:1">1:1</button>
+          <button type="button" class="chip" data-aspect="4:5">4:5</button>
+          <button type="button" class="chip" data-aspect="9:16">9:16</button>
+          <button type="button" class="chip" data-aspect="16:9">16:9</button>
+          <button type="button" class="chip" data-aspect="4:3">4:3</button>
+          <button type="button" class="chip" data-aspect="3:2">3:2</button>
+          <button type="button" id="swap-aspect" class="chip" title="Zet de vaste vorm op zijn kant">
             Omdraaien
           </button>
         </div>

--- a/locales/nl/tools/timelapse-video.html
+++ b/locales/nl/tools/timelapse-video.html
@@ -33,15 +33,15 @@
   <section class="card" id="speed-card">
     <h2><span class="step">2</span> Kies de snelheid</h2>
 
-    <div class="speed-row" role="group" aria-label="Hoeveel sneller het filmpje wordt">
-      <button type="button" data-speed="2">2&times;</button>
-      <button type="button" data-speed="5">5&times;</button>
-      <button type="button" data-speed="10" class="active">10&times;</button>
-      <button type="button" data-speed="20">20&times;</button>
-      <button type="button" data-speed="30">30&times;</button>
-      <button type="button" data-speed="60">60&times;</button>
-      <button type="button" data-speed="120">120&times;</button>
-      <button type="button" data-speed="300">300&times;</button>
+    <div class="chips speed-row" role="group" aria-label="Hoeveel sneller het filmpje wordt">
+      <button type="button" class="chip" data-speed="2">2&times;</button>
+      <button type="button" class="chip" data-speed="5">5&times;</button>
+      <button type="button" class="chip" data-speed="10" class="active">10&times;</button>
+      <button type="button" class="chip" data-speed="20">20&times;</button>
+      <button type="button" class="chip" data-speed="30">30&times;</button>
+      <button type="button" class="chip" data-speed="60">60&times;</button>
+      <button type="button" class="chip" data-speed="120">120&times;</button>
+      <button type="button" class="chip" data-speed="300">300&times;</button>
     </div>
 
     <!--

--- a/locales/nl/tools/trim-audio.html
+++ b/locales/nl/tools/trim-audio.html
@@ -59,14 +59,14 @@
       <button type="button" id="undo" class="ghost"><kbd>U</kbd> Ongedaan</button>
     </div>
 
-    <div class="speed-row" role="group" aria-label="Afspeelsnelheid">
-      <span class="speed-label">Snelheid</span>
-      <button type="button" class="speed" data-speed="0.5">0,5&times;</button>
-      <button type="button" class="speed" data-speed="0.75">0,75&times;</button>
-      <button type="button" class="speed active" data-speed="1">Normaal</button>
-      <button type="button" class="speed" data-speed="1.25">1,25&times;</button>
-      <button type="button" class="speed" data-speed="1.5">1,5&times;</button>
-      <button type="button" class="speed" data-speed="2">2&times;</button>
+    <div class="chips speed-row" role="group" aria-label="Afspeelsnelheid">
+      <span class="chips-label speed-label">Snelheid</span>
+      <button type="button" class="chip speed" data-speed="0.5">0,5&times;</button>
+      <button type="button" class="chip speed" data-speed="0.75">0,75&times;</button>
+      <button type="button" class="chip speed active" data-speed="1">Normaal</button>
+      <button type="button" class="chip speed" data-speed="1.25">1,25&times;</button>
+      <button type="button" class="chip speed" data-speed="1.5">1,5&times;</button>
+      <button type="button" class="chip speed" data-speed="2">2&times;</button>
     </div>
 
     <!-- The parts themselves. This is the tool. -->

--- a/locales/nl/tools/trim-video.html
+++ b/locales/nl/tools/trim-video.html
@@ -62,15 +62,15 @@
       <button type="button" id="undo" class="ghost"><kbd>U</kbd> Ongedaan maken</button>
     </div>
 
-    <div class="speed-row" role="group" aria-label="Afspeelsnelheid">
-      <span class="speed-label">Snelheid</span>
-      <button type="button" class="speed" data-speed="0.25">0,25&times;</button>
-      <button type="button" class="speed" data-speed="0.5">0,5&times;</button>
-      <button type="button" class="speed" data-speed="0.75">0,75&times;</button>
-      <button type="button" class="speed active" data-speed="1">Normaal</button>
-      <button type="button" class="speed" data-speed="1.25">1,25&times;</button>
-      <button type="button" class="speed" data-speed="1.5">1,5&times;</button>
-      <button type="button" class="speed" data-speed="2">2&times;</button>
+    <div class="chips speed-row" role="group" aria-label="Afspeelsnelheid">
+      <span class="chips-label speed-label">Snelheid</span>
+      <button type="button" class="chip speed" data-speed="0.25">0,25&times;</button>
+      <button type="button" class="chip speed" data-speed="0.5">0,5&times;</button>
+      <button type="button" class="chip speed" data-speed="0.75">0,75&times;</button>
+      <button type="button" class="chip speed active" data-speed="1">Normaal</button>
+      <button type="button" class="chip speed" data-speed="1.25">1,25&times;</button>
+      <button type="button" class="chip speed" data-speed="1.5">1,5&times;</button>
+      <button type="button" class="chip speed" data-speed="2">2&times;</button>
     </div>
 
     <!-- The segments themselves. This is the tool. -->

--- a/locales/pt/tools/crop-video.html
+++ b/locales/pt/tools/crop-video.html
@@ -77,16 +77,16 @@
     <p id="stage-note" class="stage-note" hidden></p>
 
     <div class="crop-controls">
-      <div class="aspect-row" role="group" aria-label="Travar o corte numa proporção">
-        <button type="button" data-aspect="free" class="active">Livre</button>
-        <button type="button" data-aspect="source">Original</button>
-        <button type="button" data-aspect="1:1">1:1</button>
-        <button type="button" data-aspect="4:5">4:5</button>
-        <button type="button" data-aspect="9:16">9:16</button>
-        <button type="button" data-aspect="16:9">16:9</button>
-        <button type="button" data-aspect="4:3">4:3</button>
-        <button type="button" data-aspect="3:2">3:2</button>
-        <button type="button" id="swap-aspect" class="ghost" title="Virar a proporção travada de lado">
+      <div class="chips aspect-row" role="group" aria-label="Travar o corte numa proporção">
+        <button type="button" class="chip" data-aspect="free" class="active">Livre</button>
+        <button type="button" class="chip" data-aspect="source">Original</button>
+        <button type="button" class="chip" data-aspect="1:1">1:1</button>
+        <button type="button" class="chip" data-aspect="4:5">4:5</button>
+        <button type="button" class="chip" data-aspect="9:16">9:16</button>
+        <button type="button" class="chip" data-aspect="16:9">16:9</button>
+        <button type="button" class="chip" data-aspect="4:3">4:3</button>
+        <button type="button" class="chip" data-aspect="3:2">3:2</button>
+        <button type="button" id="swap-aspect" class="chip" title="Virar a proporção travada de lado">
           Inverter
         </button>
       </div>

--- a/locales/pt/tools/resize-image.html
+++ b/locales/pt/tools/resize-image.html
@@ -58,16 +58,16 @@
       <p id="stage-note" class="stage-note" hidden></p>
 
       <div class="crop-controls">
-        <div class="aspect-row" id="aspect-row" role="group" aria-label="Travar o corte numa proporção">
-          <button type="button" data-aspect="free" class="active">Livre</button>
-          <button type="button" data-aspect="source">Original</button>
-          <button type="button" data-aspect="1:1">1:1</button>
-          <button type="button" data-aspect="4:5">4:5</button>
-          <button type="button" data-aspect="9:16">9:16</button>
-          <button type="button" data-aspect="16:9">16:9</button>
-          <button type="button" data-aspect="4:3">4:3</button>
-          <button type="button" data-aspect="3:2">3:2</button>
-          <button type="button" id="swap-aspect" class="ghost" title="Virar a proporção travada de lado">
+        <div class="chips aspect-row" id="aspect-row" role="group" aria-label="Travar o corte numa proporção">
+          <button type="button" class="chip" data-aspect="free" class="active">Livre</button>
+          <button type="button" class="chip" data-aspect="source">Original</button>
+          <button type="button" class="chip" data-aspect="1:1">1:1</button>
+          <button type="button" class="chip" data-aspect="4:5">4:5</button>
+          <button type="button" class="chip" data-aspect="9:16">9:16</button>
+          <button type="button" class="chip" data-aspect="16:9">16:9</button>
+          <button type="button" class="chip" data-aspect="4:3">4:3</button>
+          <button type="button" class="chip" data-aspect="3:2">3:2</button>
+          <button type="button" id="swap-aspect" class="chip" title="Virar a proporção travada de lado">
             Inverter
           </button>
         </div>

--- a/locales/pt/tools/timelapse-video.html
+++ b/locales/pt/tools/timelapse-video.html
@@ -33,15 +33,15 @@
   <section class="card" id="speed-card">
     <h2><span class="step">2</span> Escolha a velocidade</h2>
 
-    <div class="speed-row" role="group" aria-label="Quanto o clipe é acelerado">
-      <button type="button" data-speed="2">2&times;</button>
-      <button type="button" data-speed="5">5&times;</button>
-      <button type="button" data-speed="10" class="active">10&times;</button>
-      <button type="button" data-speed="20">20&times;</button>
-      <button type="button" data-speed="30">30&times;</button>
-      <button type="button" data-speed="60">60&times;</button>
-      <button type="button" data-speed="120">120&times;</button>
-      <button type="button" data-speed="300">300&times;</button>
+    <div class="chips speed-row" role="group" aria-label="Quanto o clipe é acelerado">
+      <button type="button" class="chip" data-speed="2">2&times;</button>
+      <button type="button" class="chip" data-speed="5">5&times;</button>
+      <button type="button" class="chip" data-speed="10" class="active">10&times;</button>
+      <button type="button" class="chip" data-speed="20">20&times;</button>
+      <button type="button" class="chip" data-speed="30">30&times;</button>
+      <button type="button" class="chip" data-speed="60">60&times;</button>
+      <button type="button" class="chip" data-speed="120">120&times;</button>
+      <button type="button" class="chip" data-speed="300">300&times;</button>
     </div>
 
     <!--

--- a/locales/pt/tools/trim-audio.html
+++ b/locales/pt/tools/trim-audio.html
@@ -58,14 +58,14 @@
       <button type="button" id="undo" class="ghost"><kbd>U</kbd> Desfazer</button>
     </div>
 
-    <div class="speed-row" role="group" aria-label="Velocidade de reprodução">
-      <span class="speed-label">Velocidade</span>
-      <button type="button" class="speed" data-speed="0.5">0,5&times;</button>
-      <button type="button" class="speed" data-speed="0.75">0,75&times;</button>
-      <button type="button" class="speed active" data-speed="1">Normal</button>
-      <button type="button" class="speed" data-speed="1.25">1,25&times;</button>
-      <button type="button" class="speed" data-speed="1.5">1,5&times;</button>
-      <button type="button" class="speed" data-speed="2">2&times;</button>
+    <div class="chips speed-row" role="group" aria-label="Velocidade de reprodução">
+      <span class="chips-label speed-label">Velocidade</span>
+      <button type="button" class="chip speed" data-speed="0.5">0,5&times;</button>
+      <button type="button" class="chip speed" data-speed="0.75">0,75&times;</button>
+      <button type="button" class="chip speed active" data-speed="1">Normal</button>
+      <button type="button" class="chip speed" data-speed="1.25">1,25&times;</button>
+      <button type="button" class="chip speed" data-speed="1.5">1,5&times;</button>
+      <button type="button" class="chip speed" data-speed="2">2&times;</button>
     </div>
 
     <!-- The parts themselves. This is the tool. -->

--- a/locales/pt/tools/trim-video.html
+++ b/locales/pt/tools/trim-video.html
@@ -61,15 +61,15 @@
       <button type="button" id="undo" class="ghost"><kbd>U</kbd> Desfazer</button>
     </div>
 
-    <div class="speed-row" role="group" aria-label="Velocidade de reprodução">
-      <span class="speed-label">Velocidade</span>
-      <button type="button" class="speed" data-speed="0.25">0,25&times;</button>
-      <button type="button" class="speed" data-speed="0.5">0,5&times;</button>
-      <button type="button" class="speed" data-speed="0.75">0,75&times;</button>
-      <button type="button" class="speed active" data-speed="1">Normal</button>
-      <button type="button" class="speed" data-speed="1.25">1,25&times;</button>
-      <button type="button" class="speed" data-speed="1.5">1,5&times;</button>
-      <button type="button" class="speed" data-speed="2">2&times;</button>
+    <div class="chips speed-row" role="group" aria-label="Velocidade de reprodução">
+      <span class="chips-label speed-label">Velocidade</span>
+      <button type="button" class="chip speed" data-speed="0.25">0,25&times;</button>
+      <button type="button" class="chip speed" data-speed="0.5">0,5&times;</button>
+      <button type="button" class="chip speed" data-speed="0.75">0,75&times;</button>
+      <button type="button" class="chip speed active" data-speed="1">Normal</button>
+      <button type="button" class="chip speed" data-speed="1.25">1,25&times;</button>
+      <button type="button" class="chip speed" data-speed="1.5">1,5&times;</button>
+      <button type="button" class="chip speed" data-speed="2">2&times;</button>
     </div>
 
     <!-- The segments themselves. This is the tool. -->

--- a/locales/tr/tools/crop-video.html
+++ b/locales/tr/tools/crop-video.html
@@ -83,16 +83,16 @@
     <p id="stage-note" class="stage-note" hidden></p>
 
     <div class="crop-controls">
-      <div class="aspect-row" role="group" aria-label="Kırpmayı bir şekle kilitle">
-        <button type="button" data-aspect="free" class="active">Serbest</button>
-        <button type="button" data-aspect="source">Orijinal</button>
-        <button type="button" data-aspect="1:1">1:1</button>
-        <button type="button" data-aspect="4:5">4:5</button>
-        <button type="button" data-aspect="9:16">9:16</button>
-        <button type="button" data-aspect="16:9">16:9</button>
-        <button type="button" data-aspect="4:3">4:3</button>
-        <button type="button" data-aspect="3:2">3:2</button>
-        <button type="button" id="swap-aspect" class="ghost" title="Kilitli şekli yan çevir">
+      <div class="chips aspect-row" role="group" aria-label="Kırpmayı bir şekle kilitle">
+        <button type="button" class="chip" data-aspect="free" class="active">Serbest</button>
+        <button type="button" class="chip" data-aspect="source">Orijinal</button>
+        <button type="button" class="chip" data-aspect="1:1">1:1</button>
+        <button type="button" class="chip" data-aspect="4:5">4:5</button>
+        <button type="button" class="chip" data-aspect="9:16">9:16</button>
+        <button type="button" class="chip" data-aspect="16:9">16:9</button>
+        <button type="button" class="chip" data-aspect="4:3">4:3</button>
+        <button type="button" class="chip" data-aspect="3:2">3:2</button>
+        <button type="button" id="swap-aspect" class="chip" title="Kilitli şekli yan çevir">
           Çevir
         </button>
       </div>

--- a/locales/tr/tools/resize-image.html
+++ b/locales/tr/tools/resize-image.html
@@ -65,16 +65,16 @@
       <p id="stage-note" class="stage-note" hidden></p>
 
       <div class="crop-controls">
-        <div class="aspect-row" id="aspect-row" role="group" aria-label="Kırpmayı bir şekle kilitle">
-          <button type="button" data-aspect="free" class="active">Serbest</button>
-          <button type="button" data-aspect="source">Özgün</button>
-          <button type="button" data-aspect="1:1">1:1</button>
-          <button type="button" data-aspect="4:5">4:5</button>
-          <button type="button" data-aspect="9:16">9:16</button>
-          <button type="button" data-aspect="16:9">16:9</button>
-          <button type="button" data-aspect="4:3">4:3</button>
-          <button type="button" data-aspect="3:2">3:2</button>
-          <button type="button" id="swap-aspect" class="ghost" title="Kilitli şekli yan çevir">
+        <div class="chips aspect-row" id="aspect-row" role="group" aria-label="Kırpmayı bir şekle kilitle">
+          <button type="button" class="chip" data-aspect="free" class="active">Serbest</button>
+          <button type="button" class="chip" data-aspect="source">Özgün</button>
+          <button type="button" class="chip" data-aspect="1:1">1:1</button>
+          <button type="button" class="chip" data-aspect="4:5">4:5</button>
+          <button type="button" class="chip" data-aspect="9:16">9:16</button>
+          <button type="button" class="chip" data-aspect="16:9">16:9</button>
+          <button type="button" class="chip" data-aspect="4:3">4:3</button>
+          <button type="button" class="chip" data-aspect="3:2">3:2</button>
+          <button type="button" id="swap-aspect" class="chip" title="Kilitli şekli yan çevir">
             Çevir
           </button>
         </div>

--- a/locales/tr/tools/timelapse-video.html
+++ b/locales/tr/tools/timelapse-video.html
@@ -39,15 +39,15 @@
   <section class="card" id="speed-card">
     <h2><span class="step">2</span> Hızı seçin</h2>
 
-    <div class="speed-row" role="group" aria-label="Klip ne kadar hızlandırılsın">
-      <button type="button" data-speed="2">2&times;</button>
-      <button type="button" data-speed="5">5&times;</button>
-      <button type="button" data-speed="10" class="active">10&times;</button>
-      <button type="button" data-speed="20">20&times;</button>
-      <button type="button" data-speed="30">30&times;</button>
-      <button type="button" data-speed="60">60&times;</button>
-      <button type="button" data-speed="120">120&times;</button>
-      <button type="button" data-speed="300">300&times;</button>
+    <div class="chips speed-row" role="group" aria-label="Klip ne kadar hızlandırılsın">
+      <button type="button" class="chip" data-speed="2">2&times;</button>
+      <button type="button" class="chip" data-speed="5">5&times;</button>
+      <button type="button" class="chip" data-speed="10" class="active">10&times;</button>
+      <button type="button" class="chip" data-speed="20">20&times;</button>
+      <button type="button" class="chip" data-speed="30">30&times;</button>
+      <button type="button" class="chip" data-speed="60">60&times;</button>
+      <button type="button" class="chip" data-speed="120">120&times;</button>
+      <button type="button" class="chip" data-speed="300">300&times;</button>
     </div>
 
     <!--

--- a/locales/tr/tools/trim-audio.html
+++ b/locales/tr/tools/trim-audio.html
@@ -65,14 +65,14 @@
       <button type="button" id="undo" class="ghost"><kbd>U</kbd> Geri al</button>
     </div>
 
-    <div class="speed-row" role="group" aria-label="Oynatma hızı">
-      <span class="speed-label">Hız</span>
-      <button type="button" class="speed" data-speed="0.5">0,5&times;</button>
-      <button type="button" class="speed" data-speed="0.75">0,75&times;</button>
-      <button type="button" class="speed active" data-speed="1">Normal</button>
-      <button type="button" class="speed" data-speed="1.25">1,25&times;</button>
-      <button type="button" class="speed" data-speed="1.5">1,5&times;</button>
-      <button type="button" class="speed" data-speed="2">2&times;</button>
+    <div class="chips speed-row" role="group" aria-label="Oynatma hızı">
+      <span class="chips-label speed-label">Hız</span>
+      <button type="button" class="chip speed" data-speed="0.5">0,5&times;</button>
+      <button type="button" class="chip speed" data-speed="0.75">0,75&times;</button>
+      <button type="button" class="chip speed active" data-speed="1">Normal</button>
+      <button type="button" class="chip speed" data-speed="1.25">1,25&times;</button>
+      <button type="button" class="chip speed" data-speed="1.5">1,5&times;</button>
+      <button type="button" class="chip speed" data-speed="2">2&times;</button>
     </div>
 
     <!-- The parts themselves. This is the tool. -->

--- a/locales/tr/tools/trim-video.html
+++ b/locales/tr/tools/trim-video.html
@@ -67,15 +67,15 @@
       <button type="button" id="undo" class="ghost"><kbd>U</kbd> Geri al</button>
     </div>
 
-    <div class="speed-row" role="group" aria-label="Oynatma hızı">
-      <span class="speed-label">Hız</span>
-      <button type="button" class="speed" data-speed="0.25">0,25&times;</button>
-      <button type="button" class="speed" data-speed="0.5">0,5&times;</button>
-      <button type="button" class="speed" data-speed="0.75">0,75&times;</button>
-      <button type="button" class="speed active" data-speed="1">Normal</button>
-      <button type="button" class="speed" data-speed="1.25">1,25&times;</button>
-      <button type="button" class="speed" data-speed="1.5">1,5&times;</button>
-      <button type="button" class="speed" data-speed="2">2&times;</button>
+    <div class="chips speed-row" role="group" aria-label="Oynatma hızı">
+      <span class="chips-label speed-label">Hız</span>
+      <button type="button" class="chip speed" data-speed="0.25">0,25&times;</button>
+      <button type="button" class="chip speed" data-speed="0.5">0,5&times;</button>
+      <button type="button" class="chip speed" data-speed="0.75">0,75&times;</button>
+      <button type="button" class="chip speed active" data-speed="1">Normal</button>
+      <button type="button" class="chip speed" data-speed="1.25">1,25&times;</button>
+      <button type="button" class="chip speed" data-speed="1.5">1,5&times;</button>
+      <button type="button" class="chip speed" data-speed="2">2&times;</button>
     </div>
 
     <!-- The segments themselves. This is the tool. -->

--- a/locales/zh-TW/tools/crop-video.html
+++ b/locales/zh-TW/tools/crop-video.html
@@ -80,16 +80,16 @@
     <p id="stage-note" class="stage-note" hidden></p>
 
     <div class="crop-controls">
-      <div class="aspect-row" role="group" aria-label="把裁剪框鎖成某個比例">
-        <button type="button" data-aspect="free" class="active">自由</button>
-        <button type="button" data-aspect="source">原比例</button>
-        <button type="button" data-aspect="1:1">1:1</button>
-        <button type="button" data-aspect="4:5">4:5</button>
-        <button type="button" data-aspect="9:16">9:16</button>
-        <button type="button" data-aspect="16:9">16:9</button>
-        <button type="button" data-aspect="4:3">4:3</button>
-        <button type="button" data-aspect="3:2">3:2</button>
-        <button type="button" id="swap-aspect" class="ghost" title="把鎖定的比例橫直對調">
+      <div class="chips aspect-row" role="group" aria-label="把裁剪框鎖成某個比例">
+        <button type="button" class="chip" data-aspect="free" class="active">自由</button>
+        <button type="button" class="chip" data-aspect="source">原比例</button>
+        <button type="button" class="chip" data-aspect="1:1">1:1</button>
+        <button type="button" class="chip" data-aspect="4:5">4:5</button>
+        <button type="button" class="chip" data-aspect="9:16">9:16</button>
+        <button type="button" class="chip" data-aspect="16:9">16:9</button>
+        <button type="button" class="chip" data-aspect="4:3">4:3</button>
+        <button type="button" class="chip" data-aspect="3:2">3:2</button>
+        <button type="button" id="swap-aspect" class="chip" title="把鎖定的比例橫直對調">
           橫直對調
         </button>
       </div>

--- a/locales/zh-TW/tools/resize-image.html
+++ b/locales/zh-TW/tools/resize-image.html
@@ -58,16 +58,16 @@
       <p id="stage-note" class="stage-note" hidden></p>
 
       <div class="crop-controls">
-        <div class="aspect-row" id="aspect-row" role="group" aria-label="把裁剪框鎖成某個比例">
-          <button type="button" data-aspect="free" class="active">自由</button>
-          <button type="button" data-aspect="source">原比例</button>
-          <button type="button" data-aspect="1:1">1:1</button>
-          <button type="button" data-aspect="4:5">4:5</button>
-          <button type="button" data-aspect="9:16">9:16</button>
-          <button type="button" data-aspect="16:9">16:9</button>
-          <button type="button" data-aspect="4:3">4:3</button>
-          <button type="button" data-aspect="3:2">3:2</button>
-          <button type="button" id="swap-aspect" class="ghost" title="把鎖定的比例橫直對調">
+        <div class="chips aspect-row" id="aspect-row" role="group" aria-label="把裁剪框鎖成某個比例">
+          <button type="button" class="chip" data-aspect="free" class="active">自由</button>
+          <button type="button" class="chip" data-aspect="source">原比例</button>
+          <button type="button" class="chip" data-aspect="1:1">1:1</button>
+          <button type="button" class="chip" data-aspect="4:5">4:5</button>
+          <button type="button" class="chip" data-aspect="9:16">9:16</button>
+          <button type="button" class="chip" data-aspect="16:9">16:9</button>
+          <button type="button" class="chip" data-aspect="4:3">4:3</button>
+          <button type="button" class="chip" data-aspect="3:2">3:2</button>
+          <button type="button" id="swap-aspect" class="chip" title="把鎖定的比例橫直對調">
             橫直對調
           </button>
         </div>

--- a/locales/zh-TW/tools/timelapse-video.html
+++ b/locales/zh-TW/tools/timelapse-video.html
@@ -40,15 +40,15 @@
   <section class="card" id="speed-card">
     <h2><span class="step">2</span> 選倍數</h2>
 
-    <div class="speed-row" role="group" aria-label="片子要加速多少">
-      <button type="button" data-speed="2">2&times;</button>
-      <button type="button" data-speed="5">5&times;</button>
-      <button type="button" data-speed="10" class="active">10&times;</button>
-      <button type="button" data-speed="20">20&times;</button>
-      <button type="button" data-speed="30">30&times;</button>
-      <button type="button" data-speed="60">60&times;</button>
-      <button type="button" data-speed="120">120&times;</button>
-      <button type="button" data-speed="300">300&times;</button>
+    <div class="chips speed-row" role="group" aria-label="片子要加速多少">
+      <button type="button" class="chip" data-speed="2">2&times;</button>
+      <button type="button" class="chip" data-speed="5">5&times;</button>
+      <button type="button" class="chip" data-speed="10" class="active">10&times;</button>
+      <button type="button" class="chip" data-speed="20">20&times;</button>
+      <button type="button" class="chip" data-speed="30">30&times;</button>
+      <button type="button" class="chip" data-speed="60">60&times;</button>
+      <button type="button" class="chip" data-speed="120">120&times;</button>
+      <button type="button" class="chip" data-speed="300">300&times;</button>
     </div>
 
     <!--

--- a/locales/zh-TW/tools/trim-audio.html
+++ b/locales/zh-TW/tools/trim-audio.html
@@ -53,14 +53,14 @@
       <button type="button" id="undo" class="ghost"><kbd>U</kbd> 撤銷</button>
     </div>
 
-    <div class="speed-row" role="group" aria-label="播放速度">
-      <span class="speed-label">速度</span>
-      <button type="button" class="speed" data-speed="0.5">0.5&times;</button>
-      <button type="button" class="speed" data-speed="0.75">0.75&times;</button>
-      <button type="button" class="speed active" data-speed="1">正常</button>
-      <button type="button" class="speed" data-speed="1.25">1.25&times;</button>
-      <button type="button" class="speed" data-speed="1.5">1.5&times;</button>
-      <button type="button" class="speed" data-speed="2">2&times;</button>
+    <div class="chips speed-row" role="group" aria-label="播放速度">
+      <span class="chips-label speed-label">速度</span>
+      <button type="button" class="chip speed" data-speed="0.5">0.5&times;</button>
+      <button type="button" class="chip speed" data-speed="0.75">0.75&times;</button>
+      <button type="button" class="chip speed active" data-speed="1">正常</button>
+      <button type="button" class="chip speed" data-speed="1.25">1.25&times;</button>
+      <button type="button" class="chip speed" data-speed="1.5">1.5&times;</button>
+      <button type="button" class="chip speed" data-speed="2">2&times;</button>
     </div>
 
     <!-- The parts themselves. This is the tool. -->

--- a/locales/zh-TW/tools/trim-video.html
+++ b/locales/zh-TW/tools/trim-video.html
@@ -64,15 +64,15 @@
       <button type="button" id="undo" class="ghost"><kbd>U</kbd> 撤銷</button>
     </div>
 
-    <div class="speed-row" role="group" aria-label="播放速度">
-      <span class="speed-label">速度</span>
-      <button type="button" class="speed" data-speed="0.25">0.25&times;</button>
-      <button type="button" class="speed" data-speed="0.5">0.5&times;</button>
-      <button type="button" class="speed" data-speed="0.75">0.75&times;</button>
-      <button type="button" class="speed active" data-speed="1">正常</button>
-      <button type="button" class="speed" data-speed="1.25">1.25&times;</button>
-      <button type="button" class="speed" data-speed="1.5">1.5&times;</button>
-      <button type="button" class="speed" data-speed="2">2&times;</button>
+    <div class="chips speed-row" role="group" aria-label="播放速度">
+      <span class="chips-label speed-label">速度</span>
+      <button type="button" class="chip speed" data-speed="0.25">0.25&times;</button>
+      <button type="button" class="chip speed" data-speed="0.5">0.5&times;</button>
+      <button type="button" class="chip speed" data-speed="0.75">0.75&times;</button>
+      <button type="button" class="chip speed active" data-speed="1">正常</button>
+      <button type="button" class="chip speed" data-speed="1.25">1.25&times;</button>
+      <button type="button" class="chip speed" data-speed="1.5">1.5&times;</button>
+      <button type="button" class="chip speed" data-speed="2">2&times;</button>
     </div>
 
     <!-- The segments themselves. This is the tool. -->

--- a/locales/zh/tools/crop-video.html
+++ b/locales/zh/tools/crop-video.html
@@ -80,16 +80,16 @@
     <p id="stage-note" class="stage-note" hidden></p>
 
     <div class="crop-controls">
-      <div class="aspect-row" role="group" aria-label="把裁剪框锁成某个比例">
-        <button type="button" data-aspect="free" class="active">自由</button>
-        <button type="button" data-aspect="source">原比例</button>
-        <button type="button" data-aspect="1:1">1:1</button>
-        <button type="button" data-aspect="4:5">4:5</button>
-        <button type="button" data-aspect="9:16">9:16</button>
-        <button type="button" data-aspect="16:9">16:9</button>
-        <button type="button" data-aspect="4:3">4:3</button>
-        <button type="button" data-aspect="3:2">3:2</button>
-        <button type="button" id="swap-aspect" class="ghost" title="把锁定的比例横竖对调">
+      <div class="chips aspect-row" role="group" aria-label="把裁剪框锁成某个比例">
+        <button type="button" class="chip" data-aspect="free" class="active">自由</button>
+        <button type="button" class="chip" data-aspect="source">原比例</button>
+        <button type="button" class="chip" data-aspect="1:1">1:1</button>
+        <button type="button" class="chip" data-aspect="4:5">4:5</button>
+        <button type="button" class="chip" data-aspect="9:16">9:16</button>
+        <button type="button" class="chip" data-aspect="16:9">16:9</button>
+        <button type="button" class="chip" data-aspect="4:3">4:3</button>
+        <button type="button" class="chip" data-aspect="3:2">3:2</button>
+        <button type="button" id="swap-aspect" class="chip" title="把锁定的比例横竖对调">
           横竖对调
         </button>
       </div>

--- a/locales/zh/tools/resize-image.html
+++ b/locales/zh/tools/resize-image.html
@@ -58,16 +58,16 @@
       <p id="stage-note" class="stage-note" hidden></p>
 
       <div class="crop-controls">
-        <div class="aspect-row" id="aspect-row" role="group" aria-label="把裁剪框锁成某个比例">
-          <button type="button" data-aspect="free" class="active">自由</button>
-          <button type="button" data-aspect="source">原比例</button>
-          <button type="button" data-aspect="1:1">1:1</button>
-          <button type="button" data-aspect="4:5">4:5</button>
-          <button type="button" data-aspect="9:16">9:16</button>
-          <button type="button" data-aspect="16:9">16:9</button>
-          <button type="button" data-aspect="4:3">4:3</button>
-          <button type="button" data-aspect="3:2">3:2</button>
-          <button type="button" id="swap-aspect" class="ghost" title="把锁定的比例横竖对调">
+        <div class="chips aspect-row" id="aspect-row" role="group" aria-label="把裁剪框锁成某个比例">
+          <button type="button" class="chip" data-aspect="free" class="active">自由</button>
+          <button type="button" class="chip" data-aspect="source">原比例</button>
+          <button type="button" class="chip" data-aspect="1:1">1:1</button>
+          <button type="button" class="chip" data-aspect="4:5">4:5</button>
+          <button type="button" class="chip" data-aspect="9:16">9:16</button>
+          <button type="button" class="chip" data-aspect="16:9">16:9</button>
+          <button type="button" class="chip" data-aspect="4:3">4:3</button>
+          <button type="button" class="chip" data-aspect="3:2">3:2</button>
+          <button type="button" id="swap-aspect" class="chip" title="把锁定的比例横竖对调">
             横竖对调
           </button>
         </div>

--- a/locales/zh/tools/timelapse-video.html
+++ b/locales/zh/tools/timelapse-video.html
@@ -40,15 +40,15 @@
   <section class="card" id="speed-card">
     <h2><span class="step">2</span> 选倍数</h2>
 
-    <div class="speed-row" role="group" aria-label="片子要加速多少">
-      <button type="button" data-speed="2">2&times;</button>
-      <button type="button" data-speed="5">5&times;</button>
-      <button type="button" data-speed="10" class="active">10&times;</button>
-      <button type="button" data-speed="20">20&times;</button>
-      <button type="button" data-speed="30">30&times;</button>
-      <button type="button" data-speed="60">60&times;</button>
-      <button type="button" data-speed="120">120&times;</button>
-      <button type="button" data-speed="300">300&times;</button>
+    <div class="chips speed-row" role="group" aria-label="片子要加速多少">
+      <button type="button" class="chip" data-speed="2">2&times;</button>
+      <button type="button" class="chip" data-speed="5">5&times;</button>
+      <button type="button" class="chip" data-speed="10" class="active">10&times;</button>
+      <button type="button" class="chip" data-speed="20">20&times;</button>
+      <button type="button" class="chip" data-speed="30">30&times;</button>
+      <button type="button" class="chip" data-speed="60">60&times;</button>
+      <button type="button" class="chip" data-speed="120">120&times;</button>
+      <button type="button" class="chip" data-speed="300">300&times;</button>
     </div>
 
     <!--

--- a/locales/zh/tools/trim-audio.html
+++ b/locales/zh/tools/trim-audio.html
@@ -53,14 +53,14 @@
       <button type="button" id="undo" class="ghost"><kbd>U</kbd> 撤销</button>
     </div>
 
-    <div class="speed-row" role="group" aria-label="播放速度">
-      <span class="speed-label">速度</span>
-      <button type="button" class="speed" data-speed="0.5">0.5&times;</button>
-      <button type="button" class="speed" data-speed="0.75">0.75&times;</button>
-      <button type="button" class="speed active" data-speed="1">正常</button>
-      <button type="button" class="speed" data-speed="1.25">1.25&times;</button>
-      <button type="button" class="speed" data-speed="1.5">1.5&times;</button>
-      <button type="button" class="speed" data-speed="2">2&times;</button>
+    <div class="chips speed-row" role="group" aria-label="播放速度">
+      <span class="chips-label speed-label">速度</span>
+      <button type="button" class="chip speed" data-speed="0.5">0.5&times;</button>
+      <button type="button" class="chip speed" data-speed="0.75">0.75&times;</button>
+      <button type="button" class="chip speed active" data-speed="1">正常</button>
+      <button type="button" class="chip speed" data-speed="1.25">1.25&times;</button>
+      <button type="button" class="chip speed" data-speed="1.5">1.5&times;</button>
+      <button type="button" class="chip speed" data-speed="2">2&times;</button>
     </div>
 
     <!-- The parts themselves. This is the tool. -->

--- a/locales/zh/tools/trim-video.html
+++ b/locales/zh/tools/trim-video.html
@@ -64,15 +64,15 @@
       <button type="button" id="undo" class="ghost"><kbd>U</kbd> 撤销</button>
     </div>
 
-    <div class="speed-row" role="group" aria-label="播放速度">
-      <span class="speed-label">速度</span>
-      <button type="button" class="speed" data-speed="0.25">0.25&times;</button>
-      <button type="button" class="speed" data-speed="0.5">0.5&times;</button>
-      <button type="button" class="speed" data-speed="0.75">0.75&times;</button>
-      <button type="button" class="speed active" data-speed="1">正常</button>
-      <button type="button" class="speed" data-speed="1.25">1.25&times;</button>
-      <button type="button" class="speed" data-speed="1.5">1.5&times;</button>
-      <button type="button" class="speed" data-speed="2">2&times;</button>
+    <div class="chips speed-row" role="group" aria-label="播放速度">
+      <span class="chips-label speed-label">速度</span>
+      <button type="button" class="chip speed" data-speed="0.25">0.25&times;</button>
+      <button type="button" class="chip speed" data-speed="0.5">0.5&times;</button>
+      <button type="button" class="chip speed" data-speed="0.75">0.75&times;</button>
+      <button type="button" class="chip speed active" data-speed="1">正常</button>
+      <button type="button" class="chip speed" data-speed="1.25">1.25&times;</button>
+      <button type="button" class="chip speed" data-speed="1.5">1.5&times;</button>
+      <button type="button" class="chip speed" data-speed="2">2&times;</button>
     </div>
 
     <!-- The segments themselves. This is the tool. -->

--- a/shared/css/chips.css
+++ b/shared/css/chips.css
@@ -1,0 +1,54 @@
+/* ----------------------------------------------------------------- chips
+   A row of small buttons for choosing one of a few - an aspect ratio, a
+   playback speed, a target size, an output scale - with the chosen one lit.
+
+   Asked for with `css_parts = ["chips"]`. Five tools drew this row before
+   this file, four ways between them: three paddings, two font sizes, the
+   figures tabular on some and not others, and the lit one marked `.active`
+   on every page and `aria-pressed` as well on one. Both marks light a chip
+   here, because the JavaScript on those pages sets one or the other and a
+   stylesheet is not the place to make them agree. The build puts this
+   before a tool's own stylesheet, so a tool that needs one of these
+   different writes its own rule and wins, provided it sets every property
+   the rule here sets. The rows of ghost buttons that apply a preset and
+   stay unlit - a target size, a common width - are buttons, not chips, and
+   do not use this. */
+
+.chips {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.chips-label {
+  color: var(--text-dim);
+  font-size: 0.8rem;
+  margin-inline-end: 0.2rem;
+}
+
+.chip {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  color: var(--text);
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-variant-numeric: tabular-nums;
+  padding: 0.32rem 0.75rem;
+}
+
+.chip:hover:not(:disabled) { border-color: var(--accent); }
+
+.chip:disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+
+.chip.active,
+.chip[aria-pressed="true"] {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--accent-text);
+  font-weight: 600;
+}

--- a/tools/crop-video/body.html
+++ b/tools/crop-video/body.html
@@ -77,16 +77,16 @@
     <p id="stage-note" class="stage-note" hidden></p>
 
     <div class="crop-controls">
-      <div class="aspect-row" role="group" aria-label="Lock the crop to a shape">
-        <button type="button" data-aspect="free" class="active">Free</button>
-        <button type="button" data-aspect="source">Original</button>
-        <button type="button" data-aspect="1:1">1:1</button>
-        <button type="button" data-aspect="4:5">4:5</button>
-        <button type="button" data-aspect="9:16">9:16</button>
-        <button type="button" data-aspect="16:9">16:9</button>
-        <button type="button" data-aspect="4:3">4:3</button>
-        <button type="button" data-aspect="3:2">3:2</button>
-        <button type="button" id="swap-aspect" class="ghost" title="Turn the locked shape on its side">
+      <div class="chips aspect-row" role="group" aria-label="Lock the crop to a shape">
+        <button type="button" class="chip" data-aspect="free" class="active">Free</button>
+        <button type="button" class="chip" data-aspect="source">Original</button>
+        <button type="button" class="chip" data-aspect="1:1">1:1</button>
+        <button type="button" class="chip" data-aspect="4:5">4:5</button>
+        <button type="button" class="chip" data-aspect="9:16">9:16</button>
+        <button type="button" class="chip" data-aspect="16:9">16:9</button>
+        <button type="button" class="chip" data-aspect="4:3">4:3</button>
+        <button type="button" class="chip" data-aspect="3:2">3:2</button>
+        <button type="button" id="swap-aspect" class="chip" title="Turn the locked shape on its side">
           Swap
         </button>
       </div>

--- a/tools/crop-video/styles.css
+++ b/tools/crop-video/styles.css
@@ -144,31 +144,6 @@
 
 /* --------------------------------------------------------- crop controls */
 
-.aspect-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.35rem;
-}
-
-.aspect-row button {
-  padding: 0.32rem 0.7rem;
-  font-size: 0.85rem;
-  border: 1px solid var(--border);
-  border-radius: 7px;
-  background: var(--surface-2);
-  color: var(--text);
-  cursor: pointer;
-}
-
-.aspect-row button:hover { border-color: var(--accent); }
-
-.aspect-row button.active {
-  background: var(--accent);
-  border-color: var(--accent);
-  color: var(--accent-text);
-  font-weight: 600;
-}
-
 .numbers {
   display: flex;
   flex-wrap: wrap;

--- a/tools/crop-video/tool.toml
+++ b/tools/crop-video/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "video"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "results", "form", "notes", "cropper", "checks"]
+css_parts = ["progress", "results", "form", "notes", "cropper", "checks", "chips"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no

--- a/tools/resize-image/body.html
+++ b/tools/resize-image/body.html
@@ -58,16 +58,16 @@
       <p id="stage-note" class="stage-note" hidden></p>
 
       <div class="crop-controls">
-        <div class="aspect-row" id="aspect-row" role="group" aria-label="Lock the crop to a shape">
-          <button type="button" data-aspect="free" class="active">Free</button>
-          <button type="button" data-aspect="source">Original</button>
-          <button type="button" data-aspect="1:1">1:1</button>
-          <button type="button" data-aspect="4:5">4:5</button>
-          <button type="button" data-aspect="9:16">9:16</button>
-          <button type="button" data-aspect="16:9">16:9</button>
-          <button type="button" data-aspect="4:3">4:3</button>
-          <button type="button" data-aspect="3:2">3:2</button>
-          <button type="button" id="swap-aspect" class="ghost" title="Turn the locked shape on its side">
+        <div class="chips aspect-row" id="aspect-row" role="group" aria-label="Lock the crop to a shape">
+          <button type="button" class="chip" data-aspect="free" class="active">Free</button>
+          <button type="button" class="chip" data-aspect="source">Original</button>
+          <button type="button" class="chip" data-aspect="1:1">1:1</button>
+          <button type="button" class="chip" data-aspect="4:5">4:5</button>
+          <button type="button" class="chip" data-aspect="9:16">9:16</button>
+          <button type="button" class="chip" data-aspect="16:9">16:9</button>
+          <button type="button" class="chip" data-aspect="4:3">4:3</button>
+          <button type="button" class="chip" data-aspect="3:2">3:2</button>
+          <button type="button" id="swap-aspect" class="chip" title="Turn the locked shape on its side">
             Swap
           </button>
         </div>

--- a/tools/resize-image/styles.css
+++ b/tools/resize-image/styles.css
@@ -194,32 +194,6 @@ button.file-main-wrap:focus-visible {
 
 /* --------------------------------------------------------------- controls */
 
-.aspect-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.35rem;
-}
-
-.aspect-row button {
-  padding: 0.32rem 0.7rem;
-  font-size: 0.85rem;
-  border: 1px solid var(--border);
-  border-radius: 7px;
-  background: var(--surface-2);
-  color: var(--text);
-  cursor: pointer;
-}
-
-.aspect-row button:hover:not(:disabled) { border-color: var(--accent); }
-.aspect-row button:disabled { opacity: 0.45; cursor: default; }
-
-.aspect-row button.active {
-  background: var(--accent);
-  border-color: var(--accent);
-  color: var(--accent-text);
-  font-weight: 600;
-}
-
 .numbers {
   display: flex;
   flex-wrap: wrap;

--- a/tools/resize-image/tool.toml
+++ b/tools/resize-image/tool.toml
@@ -28,7 +28,7 @@ roadmap_group = "images"
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. file-list is the drop-a-file-then-see-a-row widget that
 # more than one tool needs and that no tool should own.
-css_parts = ["file-list", "progress", "results", "form", "checks", "cropper", "notes"]
+css_parts = ["file-list", "progress", "results", "form", "checks", "cropper", "notes", "chips"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.

--- a/tools/timelapse-video/body.html
+++ b/tools/timelapse-video/body.html
@@ -33,15 +33,15 @@
   <section class="card" id="speed-card">
     <h2><span class="step">2</span> Choose the speed</h2>
 
-    <div class="speed-row" role="group" aria-label="How much to speed the clip up">
-      <button type="button" data-speed="2">2&times;</button>
-      <button type="button" data-speed="5">5&times;</button>
-      <button type="button" data-speed="10" class="active">10&times;</button>
-      <button type="button" data-speed="20">20&times;</button>
-      <button type="button" data-speed="30">30&times;</button>
-      <button type="button" data-speed="60">60&times;</button>
-      <button type="button" data-speed="120">120&times;</button>
-      <button type="button" data-speed="300">300&times;</button>
+    <div class="chips speed-row" role="group" aria-label="How much to speed the clip up">
+      <button type="button" class="chip" data-speed="2">2&times;</button>
+      <button type="button" class="chip" data-speed="5">5&times;</button>
+      <button type="button" class="chip" data-speed="10" class="active">10&times;</button>
+      <button type="button" class="chip" data-speed="20">20&times;</button>
+      <button type="button" class="chip" data-speed="30">30&times;</button>
+      <button type="button" class="chip" data-speed="60">60&times;</button>
+      <button type="button" class="chip" data-speed="120">120&times;</button>
+      <button type="button" class="chip" data-speed="300">300&times;</button>
     </div>
 
     <!--

--- a/tools/timelapse-video/styles.css
+++ b/tools/timelapse-video/styles.css
@@ -24,32 +24,6 @@
 
 /* --------------------------------------------------------------- the speed */
 
-.speed-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.35rem;
-}
-
-.speed-row button {
-  padding: 0.32rem 0.75rem;
-  font-size: 0.85rem;
-  border: 1px solid var(--border);
-  border-radius: 7px;
-  background: var(--surface-2);
-  color: var(--text);
-  cursor: pointer;
-  font-variant-numeric: tabular-nums;
-}
-
-.speed-row button:hover { border-color: var(--accent); }
-
-.speed-row button.active {
-  background: var(--accent);
-  border-color: var(--accent);
-  color: var(--accent-text);
-  font-weight: 600;
-}
-
 .numbers {
   margin-top: 0.9rem;
   display: flex;

--- a/tools/timelapse-video/tool.toml
+++ b/tools/timelapse-video/tool.toml
@@ -27,7 +27,7 @@ roadmap_group = "video"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "results", "form", "notes"]
+css_parts = ["progress", "results", "form", "notes", "chips"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no

--- a/tools/trim-audio/body.html
+++ b/tools/trim-audio/body.html
@@ -58,14 +58,14 @@
       <button type="button" id="undo" class="ghost"><kbd>U</kbd> Undo</button>
     </div>
 
-    <div class="speed-row" role="group" aria-label="Playback speed">
-      <span class="speed-label">Speed</span>
-      <button type="button" class="speed" data-speed="0.5">0.5&times;</button>
-      <button type="button" class="speed" data-speed="0.75">0.75&times;</button>
-      <button type="button" class="speed active" data-speed="1">Normal</button>
-      <button type="button" class="speed" data-speed="1.25">1.25&times;</button>
-      <button type="button" class="speed" data-speed="1.5">1.5&times;</button>
-      <button type="button" class="speed" data-speed="2">2&times;</button>
+    <div class="chips speed-row" role="group" aria-label="Playback speed">
+      <span class="chips-label speed-label">Speed</span>
+      <button type="button" class="chip speed" data-speed="0.5">0.5&times;</button>
+      <button type="button" class="chip speed" data-speed="0.75">0.75&times;</button>
+      <button type="button" class="chip speed active" data-speed="1">Normal</button>
+      <button type="button" class="chip speed" data-speed="1.25">1.25&times;</button>
+      <button type="button" class="chip speed" data-speed="1.5">1.5&times;</button>
+      <button type="button" class="chip speed" data-speed="2">2&times;</button>
     </div>
 
     <!-- The parts themselves. This is the tool. -->

--- a/tools/trim-audio/styles.css
+++ b/tools/trim-audio/styles.css
@@ -198,6 +198,7 @@ audio.player {
 }
 
 .transport button { padding: 0.4rem 0.9rem; font-size: 0.86rem; }
+
 /* The play button shows a glyph, not a word, so the glyph gets a size a
    thumb can find and the padding is retuned to keep the row one height. */
 .transport #play { min-width: 3.2rem; font-size: 1rem; line-height: 1; padding-block: 0.55rem; }
@@ -205,31 +206,6 @@ audio.player {
 
 .speed-row {
   margin-top: 0.6rem;
-  display: flex;
-  gap: 0.3rem;
-  flex-wrap: wrap;
-  align-items: center;
-}
-
-.speed-label { font-size: 0.8rem; color: var(--text-dim); margin-inline-end: 0.2rem; }
-
-.speed {
-  padding: 0.25rem 0.6rem;
-  font-size: 0.8rem;
-  border: 1px solid var(--border);
-  border-radius: 7px;
-  background: var(--surface-2);
-  color: var(--text);
-  cursor: pointer;
-}
-
-.speed:hover { border-color: var(--accent); }
-
-.speed.active {
-  background: var(--accent);
-  border-color: var(--accent);
-  color: var(--accent-text);
-  font-weight: 600;
 }
 
 /* ----------------------------------------------------------------- the parts */

--- a/tools/trim-audio/tool.toml
+++ b/tools/trim-audio/tool.toml
@@ -35,7 +35,7 @@ roadmap_group = "audio"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "results", "form", "notes", "modes"]
+css_parts = ["progress", "results", "form", "notes", "modes", "chips"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts, and for
 # the same reason: a component more than one tool needs and no tool should own.

--- a/tools/trim-video/body.html
+++ b/tools/trim-video/body.html
@@ -61,15 +61,15 @@
       <button type="button" id="undo" class="ghost"><kbd>U</kbd> Undo</button>
     </div>
 
-    <div class="speed-row" role="group" aria-label="Playback speed">
-      <span class="speed-label">Speed</span>
-      <button type="button" class="speed" data-speed="0.25">0.25&times;</button>
-      <button type="button" class="speed" data-speed="0.5">0.5&times;</button>
-      <button type="button" class="speed" data-speed="0.75">0.75&times;</button>
-      <button type="button" class="speed active" data-speed="1">Normal</button>
-      <button type="button" class="speed" data-speed="1.25">1.25&times;</button>
-      <button type="button" class="speed" data-speed="1.5">1.5&times;</button>
-      <button type="button" class="speed" data-speed="2">2&times;</button>
+    <div class="chips speed-row" role="group" aria-label="Playback speed">
+      <span class="chips-label speed-label">Speed</span>
+      <button type="button" class="chip speed" data-speed="0.25">0.25&times;</button>
+      <button type="button" class="chip speed" data-speed="0.5">0.5&times;</button>
+      <button type="button" class="chip speed" data-speed="0.75">0.75&times;</button>
+      <button type="button" class="chip speed active" data-speed="1">Normal</button>
+      <button type="button" class="chip speed" data-speed="1.25">1.25&times;</button>
+      <button type="button" class="chip speed" data-speed="1.5">1.5&times;</button>
+      <button type="button" class="chip speed" data-speed="2">2&times;</button>
     </div>
 
     <!-- The segments themselves. This is the tool. -->

--- a/tools/trim-video/styles.css
+++ b/tools/trim-video/styles.css
@@ -285,6 +285,7 @@ kbd {
 }
 
 .transport button { padding: 0.4rem 0.9rem; font-size: 0.86rem; }
+
 /* The play button shows a glyph, not a word, so the glyph gets a size a
    thumb can find and the padding is retuned to keep the row one height. */
 .transport #play { min-width: 3.2rem; font-size: 1rem; line-height: 1; padding-block: 0.55rem; }
@@ -292,31 +293,6 @@ kbd {
 
 .speed-row {
   margin-top: 0.6rem;
-  display: flex;
-  gap: 0.3rem;
-  flex-wrap: wrap;
-  align-items: center;
-}
-
-.speed-label { font-size: 0.8rem; color: var(--text-dim); margin-inline-end: 0.2rem; }
-
-.speed {
-  padding: 0.25rem 0.6rem;
-  font-size: 0.8rem;
-  border: 1px solid var(--border);
-  border-radius: 7px;
-  background: var(--surface-2);
-  color: var(--text);
-  cursor: pointer;
-}
-
-.speed:hover { border-color: var(--accent); }
-
-.speed.active {
-  background: var(--accent);
-  border-color: var(--accent);
-  color: var(--accent-text);
-  font-weight: 600;
 }
 
 /* -------------------------------------------------------------- segments */

--- a/tools/trim-video/tool.toml
+++ b/tools/trim-video/tool.toml
@@ -28,7 +28,7 @@ roadmap_group = "video"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. progress is the bar this tool draws while it works.
-css_parts = ["progress", "results", "form", "notes", "modes", "checks"]
+css_parts = ["progress", "results", "form", "notes", "modes", "checks", "chips"]
 
 # Shared modules this tool asks for. The same arrangement as css_parts, and for
 # the same reason: a component more than one tool needs and no tool should own.


### PR DESCRIPTION
Supersedes #350, which GitHub closed when #349's branch was deleted under it; same commit, rebased onto `main`.

Five tools put a row of small buttons in front of a visitor to pick one of a few — a playback speed on trim-video and trim-audio, how much to speed a clip up on timelapse-video, a shape to lock the crop to on crop-video and resize-image — and **drew that row four ways**: 0.8rem on the trimmers and 0.85rem elsewhere, three paddings, the figures tabular on one page and not the others, the lit one found by `.active` everywhere and `aria-pressed` as well on one. The same control, on tools a visitor moves between, in four coats.

So the row is a shared family, `shared/css/chips.css`: `.chips` for the row, `.chip` for a button in it, `.chips-label` for the word in front, and the lit one by either mark — the scripts on those pages set one or the other, and a stylesheet is not the place to make them agree. The look is the one three of the five already had, plus the tabular figures timelapse-video had chosen, since *0.75×* and *1.25×* should line up.

**Nothing in `src/` moves.** The rows and their buttons carry the new classes beside the ones they had, in the English body and all fourteen locale copies (`scripts/check_locales.py` reports no structural difference), so `.speed-row`, `.speed`, `[data-aspect]` and the rest still find what the scripts look for. The Swap button that sits among the shapes on the cropper and the resizer wears the chip's coat too, unlit, as it did when the row's own rule dressed every button in it. The private drawings come out; a margin a tool put on the row stays. The parts table in `docs/adding-a-tool.md` gains the row.

**Left alone on purpose:** the rows of ghost buttons that apply a preset and stay unlit — a target size on compress-image, a common width on resize-image, a scale on svg-to-image, a speed preset on the audio tools. Those are buttons, not a choice held, and a lit state would be a lie.

## Measured

Every button in the five rows, with a file loaded so the row is on screen, computed style on Mobile Chrome, production against this branch:

| | trim-video, trim-audio before | timelapse before | crop-video, resize-image before | all five after |
|---|---|---|---|---|
| font | 0.8rem | 0.85rem | 0.85rem | 0.85rem |
| padding | 0.25rem 0.6rem | 0.32rem 0.75rem | 0.32rem 0.7rem | 0.32rem 0.75rem |
| tabular figures | no | yes | no | yes |
| row gap | 0.3rem | 0.35rem | 0.35rem | 0.35rem |
| row alignment | centred | none | none | centred |
| lit chip | accent, bold | accent, bold | accent, bold | accent, bold |

The measurement was taken on a build cut before #344 merged, so its heights are the chips' own (33px) where production already shows the 44px touch floor; the stack has since been rebased onto main, and the floor applies to chips as to any button.

## Before / After

| Before | After |
|---|---|
| <img width="320" alt="chips-before-trim-audio" src="https://github.com/user-attachments/assets/99f2bfef-e8e0-4b10-a162-0cfd3e4e61f9" /> | <img width="320" alt="chips-after-trim-audio" src="https://github.com/user-attachments/assets/af649d6c-1d9d-42db-8893-05348d76dab6" /> |
| <img width="320" alt="chips-before-resize-image" src="https://github.com/user-attachments/assets/8a64dd6f-f03b-47a5-af66-082fd2eb0056" /> | <img width="320" alt="chips-after-resize-image" src="https://github.com/user-attachments/assets/10837a3a-384c-41a0-b530-edb16d8659e0" /> |

## Verified

- the table above, from a throwaway spec in the QA suite that feeds each tool a file and reads every button in the row
- `scripts/check_locales.py` — no structural difference on the five
- `python build.py --out _plain --clean --no-minify` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
