### PR TITLE
Fetch the version tags by name, and refuse to count from nothing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,22 +166,33 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      # `fetch-tags` because the version is a tag now. Without it the default
-      # checkout brings none, `git tag --list` on the runner is empty, and
-      # scripts/next_version.py takes its "nothing has ever been tagged"
-      # branch and proposes the FIRST version on every single deploy - which
-      # the remote then rejects, because 1.0.0 has existed since the day the
-      # scheme started. That is not a hypothetical: it failed nine deploys in
-      # a row, starting with the one that introduced the script.
+      # The version is a tag, so the deploy has to be able to see the tags. The
+      # default checkout brings none: it fetches the one commit being deployed
+      # at depth 1, `git tag --list` on the runner is empty, and
+      # scripts/next_version.py has no span to measure. Two fixes have been
+      # tried here, and the first did not work.
       #
-      # `fetch-depth` stays at the default 1. The tags come with the commits
-      # they point at, and `git diff <tag>..HEAD` compares two commit objects
-      # rather than walking between them, so the shallow history is enough.
-      # `fetch-depth: 0` would work too and would drag in the whole of the
-      # dist branch to do it.
+      # `fetch-tags: true` on the checkout action was the first. All it does is
+      # drop `--no-tags` from the fetch and leave git to follow tags by itself,
+      # and git follows only the tags that point at a commit it fetched - which
+      # at depth 1 is the head alone, and no version tag points at the head. So
+      # the runner stayed blind: the script proposed 1.0.0 on every deploy, the
+      # rerun guard below found 1.0.0 already on the remote, and the step
+      # exited 0 saying there was nothing to do. A hundred and seventy-seven
+      # commits and five new tools went out under 1.0.2 before anyone read the
+      # line it printed.
+      #
+      # The fetch below is the second. It names the tags as a refspec, which
+      # git fetches whether or not their commits are in the shallow history:
+      # each tagged commit arrives as a shallow root of its own, and `git diff
+      # <tag>..HEAD` compares two commit objects rather than walking between
+      # them, so depth 1 is still enough. `fetch-depth: 0` would work too and
+      # would drag in the whole of the dist branch to do it. And the script now
+      # refuses to name the first version while the remote holds one, so if
+      # this fetch ever stops working the step fails instead of agreeing.
       - uses: actions/checkout@v4
-        with:
-          fetch-tags: true
+      - name: Fetch the version tags the checkout leaves behind
+        run: git fetch --depth=1 origin '+refs/tags/*:refs/tags/*'
 
       # The build uses tomllib, which is standard library from 3.11 onwards.
       # Python alone produces a working, readable site: that is what plain

--- a/scripts/next_version.py
+++ b/scripts/next_version.py
@@ -15,6 +15,8 @@ Prints the version to tag and its reason, as two lines:
 and prints nothing at all - exiting 0 - when the rule says the version does
 not move. "Nothing to do" is the ordinary case, not a failure: a change to the
 tests, to CI or to the documentation is required to leave the version alone.
+The one exit code other than 0 is for the one question it cannot answer
+honestly, described in the last section below.
 
 WHY IT MEASURES FROM THE LAST TAG
 
@@ -31,6 +33,20 @@ Because a script that prints an answer can be run by anybody, on any checkout,
 to see what the next deploy will do - and one that also pushes a ref cannot.
 The workflow does the pushing, where the permission to do it is granted and
 visible.
+
+WHY IT WILL NOT NAME THE FIRST VERSION ON A CHECKOUT THAT CANNOT SEE ANY
+
+A checkout with no tags looks exactly like a repository that has never been
+tagged, and the deploy runs on a shallow checkout that has to fetch its tags
+on purpose. For a week that fetch was silently doing nothing, and this script
+proposed 1.0.0 on every deploy; the workflow found 1.0.0 already on the remote,
+took that for a rerun, and exited 0 - so the version stood still through a
+hundred and seventy-seven commits and five new tools. Now, before naming the
+first version, the script asks origin whether it already holds one. If it
+does, the answer is a sentence on stderr and exit code 1, because a deploy
+that cannot measure must say so rather than measure from nothing. A
+repository with no remote at all - a local experiment, the tests - is still
+allowed its first version.
 """
 
 import subprocess
@@ -66,14 +82,46 @@ def changed_since(ref, head):
     return everything, added
 
 
+def remote_versions():
+    """The tag names origin holds, or None when there is no origin to ask.
+
+    Asked only when this checkout has no version tag, to tell "never tagged"
+    from "cannot see the tags". An annotated tag lists twice in ls-remote,
+    once as itself and once peeled to its commit with `^{}` on the end; the
+    peeled line names the same tag and is dropped.
+    """
+    if 'origin' not in git('remote').split():
+        return None
+    names = []
+    for line in git('ls-remote', '--tags', 'origin').splitlines():
+        if 'refs/tags/' not in line:
+            continue
+        name = line.split('refs/tags/', 1)[1]
+        if not name.endswith('^{}'):
+            names.append(name)
+    return names
+
+
 def main(argv):
     head = argv[1] if len(argv) > 1 else 'HEAD'
 
     current = rule.latest(git('tag', '--list').splitlines())
     if current is None:
-        # Nothing has ever been tagged, so there is no span to measure and
-        # nothing to compare against. The first deploy names the starting
-        # point rather than trying to work out what came before it.
+        elsewhere = remote_versions()
+        held = rule.latest(elsewhere) if elsewhere else None
+        if held is not None:
+            # Not a first deploy: a checkout that did not fetch its tags. The
+            # workflow would find the first version already on the remote,
+            # call that a rerun and exit 0, which is how the version stood
+            # still for a week - so this is the one answer that is an error.
+            print(f'No version tag in this checkout, but origin holds '
+                  f'{rule.dotted(held)}. The tags were not fetched, so there '
+                  f'is nothing to measure from; fetch them and ask again.',
+                  file=sys.stderr)
+            return 1
+        # Nothing has ever been tagged, anywhere, so there is no span to
+        # measure and nothing to compare against. The first deploy names the
+        # starting point rather than trying to work out what came before it.
         print(rule.dotted(rule.FIRST))
         print(f'{rule.dotted(rule.FIRST)}: the first version.')
         return 0

--- a/tests/python/test_next_version.py
+++ b/tests/python/test_next_version.py
@@ -53,12 +53,15 @@ def load_script():
 
 
 class FakeGit:
-    """Enough of git to answer the three questions the script asks."""
+    """Enough of git to answer the four questions the script asks."""
 
-    def __init__(self, tags, changed=(), added=()):
+    def __init__(self, tags, changed=(), added=(), remote_tags=None):
         self.tags = list(tags)
         self.changed = list(changed)
         self.added = list(added)
+        # None is a repository with no remote at all; a list is what origin
+        # would answer, handed back in the shape ls-remote prints it.
+        self.remote_tags = remote_tags
         self.spans = []
 
     def __call__(self, *args):
@@ -69,6 +72,10 @@ class FakeGit:
             if '--diff-filter=A' in args:
                 return '\n'.join(self.added) + '\n'
             return '\n'.join(self.changed) + '\n'
+        if args[0] == 'remote':
+            return '' if self.remote_tags is None else 'origin\n'
+        if args[0] == 'ls-remote':
+            return ''.join(f'{"0" * 40}\trefs/tags/{name}\n' for name in self.remote_tags)
         raise AssertionError(f'the script asked git something unexpected: {args}')
 
 
@@ -85,9 +92,28 @@ class WhatItDecides(unittest.TestCase):
         self.module = load_script()
 
     def test_the_first_deploy_names_a_starting_point(self):
-        # Nothing tagged yet: there is no span to measure, so there is nothing
-        # to work out and the answer is the first version rather than an error.
+        # Nothing tagged yet and no remote to ask: there is no span to measure,
+        # so there is nothing to work out and the answer is the first version
+        # rather than an error.
         self.module.git = FakeGit(tags=[])
+        code, out, _ = run(self.module)
+        self.assertEqual(code, 0)
+        self.assertEqual(out.splitlines()[0], '1.0.0')
+
+    def test_a_checkout_that_cannot_see_the_tags_origin_holds_is_an_error(self):
+        # No local tag but a version on the remote is not a first deploy; it is
+        # a checkout that did not fetch its tags. Naming 1.0.0 here is what let
+        # the version stand still for a week, so the answer is exit 1 with
+        # nothing on stdout - the workflow must not tag anything from it.
+        self.module.git = FakeGit(tags=[], remote_tags=['1.0.0', '1.0.2'])
+        code, out, err = run(self.module)
+        self.assertNotEqual(code, 0)
+        self.assertEqual(out, '')
+        self.assertIn('1.0.2', err)
+
+    def test_a_remote_with_no_version_tag_still_allows_the_first(self):
+        # Tags that are not versions do not make the remote a versioned one.
+        self.module.git = FakeGit(tags=[], remote_tags=['split-safety-e80668985'])
         code, out, _ = run(self.module)
         self.assertEqual(code, 0)
         self.assertEqual(out.splitlines()[0], '1.0.0')
@@ -242,6 +268,26 @@ class AgainstARealRepository(unittest.TestCase):
         code, out, _ = self.ask()
         self.assertEqual(code, 0)
         self.assertEqual(out.splitlines()[0], '1.0.1')
+
+    def test_a_clone_that_left_the_tags_behind_refuses_to_start_over(self):
+        # The deploy's own failure, reproduced: an annotated version tag on the
+        # remote, a shallow clone made without tags, and the script run inside
+        # the clone. Annotated on purpose - ls-remote lists such a tag twice,
+        # once peeled, and the script must count it once. The clone carries
+        # the script and the rule from the commit, so nothing is copied in.
+        self.git('tag', '-a', '1.0.0', '-m', 'the first version')
+        clone = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, clone, ignore_errors=True)
+        subprocess.run(['git', 'clone', '-q', '--no-tags', '--depth=1',
+                        self.dir.as_uri(), str(clone)],
+                       check=True, capture_output=True, encoding='utf-8')
+
+        done = subprocess.run(
+            [sys.executable, str(clone / 'scripts' / 'next_version.py')],
+            cwd=clone, capture_output=True, encoding='utf-8')
+        self.assertNotEqual(done.returncode, 0)
+        self.assertEqual(done.stdout, '')
+        self.assertIn('1.0.0', done.stderr)
 
 
 if __name__ == '__main__':

--- a/tests/python/test_version.py
+++ b/tests/python/test_version.py
@@ -190,6 +190,15 @@ class TheCheckoutTheDeployRunsOn(unittest.TestCase):
     wrong thing was the ground it stood on, and the only place that is written
     down is the workflow.
 
+    Then the fix for that did not work either, and this time nothing failed.
+    `fetch-tags: true` on the checkout only lets git follow tags by itself, and
+    at depth 1 git follows just the tags on the one commit it fetched, which
+    is never a version. The script proposed 1.0.0 again, the rerun guard found
+    1.0.0 on the remote, and the step exited 0 for a week while five tools
+    shipped under the old number. So the tags are now fetched by name, in a
+    step of their own, and the assertion below is on that step - and against
+    the option that looked like it worked.
+
     Read as text rather than parsed. The test job installs Python and Node and
     nothing else, so there is no YAML parser here to reach for - and the
     alternative to a crude assertion is the one the workflow's own comments
@@ -207,11 +216,16 @@ class TheCheckoutTheDeployRunsOn(unittest.TestCase):
         assert sep, 'build.yml has no build job'
         cls.build = tail
 
-    def test_it_asks_for_the_tags(self):
-        # Without this the version is worked out on a checkout that cannot see
-        # a single tag, and the answer is always FIRST.
-        checkout = self.build.partition('actions/checkout')[2]
-        self.assertIn('fetch-tags: true', checkout.partition('- name:')[0])
+    def test_it_fetches_the_tags_by_name(self):
+        # Between the checkout and the next action there has to be a fetch
+        # that names the tags as a refspec; without it the version is worked
+        # out on a checkout that cannot see a single tag, and the answer is
+        # always FIRST. And `fetch-tags` must not creep back onto the checkout
+        # in its place: it reads as the same thing and is not.
+        after_checkout = self.build.partition('actions/checkout')[2]
+        between = after_checkout.partition('actions/setup-python')[0]
+        self.assertIn("git fetch --depth=1 origin '+refs/tags/*:refs/tags/*'", between)
+        self.assertNotIn('fetch-tags', between)
 
     def test_the_tag_guard_asks_the_remote(self):
         # A local `git rev-parse refs/tags/...` is worth nothing on a checkout


### PR DESCRIPTION
Every deploy since 27 August has printed the same line from its tag step:

```
Version 1.0.0 is already tagged; nothing to do.
```

That is the answer for a repository that has never been tagged, and it means
the runner sees no tags at all. #218 set `fetch-tags: true` on the checkout to
fix exactly this, and it did not work: at depth 1 the action only drops
`--no-tags` and leaves git to follow tags on its own, and git follows only the
tags that point at a commit it fetched, which is the head alone. The rerun
guard then found 1.0.0 already on the remote and exited 0, so the failure was
silent. The version has stood at 1.0.2 through 177 commits and five new tools.

**Two changes, one for the fetch and one for the silence.**

The build job now fetches the tags by refspec, at depth 1, in a step of its
own. Named refs are fetched whether or not their commits are in the shallow
history, so each tagged commit arrives as a shallow root and the diff the
script asks for works on it. No `fetch-depth: 0`, so the dist branch stays out
of the checkout.

`scripts/next_version.py` now asks origin before naming the first version. No
local tag but a version on the remote is not a first deploy; it is a checkout
that cannot see, and the script says so on stderr and exits 1 rather than
propose 1.0.0 again. A repository with no remote at all still gets its first
version, which is what the tests and a local experiment need. The guard lives
in the script rather than the workflow so that it has tests: two against the
fake git, and one that makes an annotated tag, shallow-clones without it, and
runs the script inside the clone, which is the deploy's failure in miniature.

**Reproduced against the real remote**, in a scratch clone doing exactly what
the runner does:

| state | `git tag --list` | script says |
|---|---|---|
| after the checkout's own fetch | nothing | refuses: `origin holds 1.0.2`, exit 1 |
| after the new fetch step | `1.0.0 1.0.2` | `1.0.2 -> 1.1.0: a new tool (…five…)`, exit 0 |

The sixteen tests in `test_next_version` pass locally. On this checkout, which
has the tags, the script's answer is unchanged.

**Nothing a visitor sees changes**, so there are no before and after pictures.
Every path here is on the version rule's invisible list, so this merge tags
nothing on its own; the next merge that reaches a page should tag 1.1.0, and
its release note will name that merge rather than the five tools, which is
harmless and one-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
