### PR TITLE
Answer only the site's own pages, and let one address knock only so often

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,5 +42,9 @@ __test-*.png
 .env
 *.token
 
+# Written by wrangler beside the worker on every deploy: its own state and
+# cache, nothing of ours.
+.wrangler/
+
 # Written by scripts/emit_media.py as the input to rendering media/*.png.
 media/src/

--- a/tests/README.md
+++ b/tests/README.md
@@ -86,6 +86,15 @@ a decision rather than a browser API: a mistake in it sends somebody to the
 wrong language, or sends a crawler out of the page it was asked to index, and
 neither raises anything.
 
+`rendezvous.test.js` is the other. It covers the door of
+`workers/rendezvous/worker.js` - the handler that decides whether a request
+reaches a room at all: it wants a websocket, from one of the site's own pages,
+from an address that has not been knocking all minute. Node has `Request` and
+`Response`, and the Durable Object and the rate limiter are a few lines of fake
+that record what they were asked, so each refusal can be pinned to the check
+that made it and the room shown never to have been touched. The room itself
+needs the Workers runtime and is tried in a browser instead.
+
 On the Python side the same reasoning points at the minifiers. `buildlib/`
 already refuses to write output whose tokens moved; `tests/python/` checks the
 refusals fire, and checks every stylesheet and every module in the repository

--- a/tests/js/rendezvous.test.js
+++ b/tests/js/rendezvous.test.js
@@ -1,0 +1,120 @@
+/**
+ * workers/rendezvous/worker.js - the door, not the room.
+ *
+ * The top-level handler decides who reaches a room at all: it wants a
+ * websocket, from one of the site's own pages, from an address that has not
+ * been knocking all minute. Those three decisions run here in Node, with a
+ * fake environment standing in for the Durable Object and the rate limiter,
+ * so a test can say which of them turned a request away and that the room
+ * was never asked. The room itself needs the Workers runtime - WebSocketPair,
+ * hibernation - and is exercised in a browser, not here.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import worker from '../../workers/rendezvous/worker.js';
+
+const HOST = 'https://rendezvous.example';
+const OURS = 'https://abox.tools';
+
+function env({ allow = true } = {}) {
+  const asked = { rooms: [], keys: [] };
+  return {
+    asked,
+    ROOMS: {
+      idFromName: (name) => `id:${name}`,
+      get: (id) => ({
+        fetch: async () => {
+          asked.rooms.push(id);
+          return new Response('room', { status: 200 });
+        },
+      }),
+    },
+    LIMIT: {
+      limit: async ({ key }) => {
+        asked.keys.push(key);
+        return { success: allow };
+      },
+    },
+  };
+}
+
+function upgrade(path, headers = {}) {
+  return new Request(HOST + path, {
+    headers: { Upgrade: 'websocket', 'CF-Connecting-IP': '203.0.113.7', ...headers },
+  });
+}
+
+test('the root describes itself in plain text', async () => {
+  const res = await worker.fetch(new Request(HOST + '/'), env());
+  assert.equal(res.status, 200);
+  assert.match(await res.text(), /abox\.tools\/share-text/);
+});
+
+test('a room path without an upgrade is told what it should have sent', async () => {
+  const e = env();
+  const plain = new Request(HOST + '/ws/brave-otter-42', { headers: { Origin: OURS } });
+  const res = await worker.fetch(plain, e);
+  assert.equal(res.status, 426);
+  assert.deepEqual(e.asked.rooms, []);
+});
+
+test("the site's own page reaches the room named in the path", async () => {
+  const e = env();
+  const res = await worker.fetch(upgrade('/ws/brave-otter-42', { Origin: OURS }), e);
+  assert.equal(res.status, 200);
+  assert.deepEqual(e.asked.rooms, ['id:brave-otter-42']);
+});
+
+test('a localhost page reaches the room too, on any port', async () => {
+  const e = env();
+  for (const origin of ['http://localhost:8080', 'http://localhost:3000', 'http://127.0.0.1:8123']) {
+    const res = await worker.fetch(upgrade('/ws/brave-otter-42', { Origin: origin }), e);
+    assert.equal(res.status, 200, origin);
+  }
+});
+
+test('any other origin, or none, is refused before a room is touched', async () => {
+  const e = env();
+  const cases = [
+    { Origin: 'https://example.com' },
+    { Origin: 'https://abox.tools.example.com' },
+    { Origin: 'https://notabox.tools' },
+    { Origin: 'http://abox.tools' },
+    { Origin: 'null' },
+    {},
+  ];
+  for (const headers of cases) {
+    const res = await worker.fetch(upgrade('/ws/brave-otter-42', headers), e);
+    assert.equal(res.status, 403, JSON.stringify(headers));
+  }
+  assert.deepEqual(e.asked.rooms, []);
+  assert.deepEqual(e.asked.keys, []);
+});
+
+test('an address over its limit is refused, and the room is not asked', async () => {
+  const e = env({ allow: false });
+  const res = await worker.fetch(upgrade('/ws/brave-otter-42', { Origin: OURS }), e);
+  assert.equal(res.status, 429);
+  assert.deepEqual(e.asked.keys, ['203.0.113.7']);
+  assert.deepEqual(e.asked.rooms, []);
+});
+
+test('the limit is counted per address, not per room', async () => {
+  const e = env();
+  await worker.fetch(upgrade('/ws/one', { Origin: OURS }), e);
+  await worker.fetch(upgrade('/ws/two', { Origin: OURS }), e);
+  assert.deepEqual(e.asked.keys, ['203.0.113.7', '203.0.113.7']);
+  assert.deepEqual(e.asked.rooms, ['id:one', 'id:two']);
+});
+
+test('a name outside the accepted shape is not a room', async () => {
+  const e = env();
+  const paths = ['/ws/Brave', '/ws/', '/ws/a b', '/ws/-leading', `/ws/${'x'.repeat(65)}`, '/elsewhere'];
+  for (const path of paths) {
+    const res = await worker.fetch(upgrade(path, { Origin: OURS }), e);
+    assert.equal(res.status, 404, path);
+  }
+  assert.deepEqual(e.asked.rooms, []);
+});

--- a/workers/rendezvous/README.md
+++ b/workers/rendezvous/README.md
@@ -18,12 +18,14 @@ channel, including the knock on a private share.
 That is what it sees. What it stores is a shorter list, and no longer an
 empty one: `observability.logs` in `wrangler.toml` asks Cloudflare to keep
 its own record of every invocation for seven days, readable in the Workers
-dashboard. The worker prints nothing itself, so that record is the request
-and its outcome - the URL, which carries the code word and the role, and
-the metadata Cloudflare attaches to it - and never a payload. It is a view
-of the switchboard working, not of anything passing through it. Tracing is
-written off in the same file rather than left to its default, so there is
-no second stream to account for.
+dashboard. That record is the request and its outcome - the URL, which
+carries the code word and the role, and the metadata Cloudflare attaches to
+it - and never a payload. The worker adds one line of its own, on a refusal,
+because a refused handshake completes the upgrade exactly like an admission
+and the record alone cannot tell them apart; the line carries the close code
+and nothing else. It is a view of the switchboard working, not of anything
+passing through it. Tracing is written off in the same file rather than left
+to its default, so there is no second stream to account for.
 
 ## Deploy
 
@@ -43,14 +45,25 @@ change.
 
 ## The protocol, in full
 
+- The handshake is answered only for the site's own pages: the browser's
+  `Origin` must be `https://abox.tools`, or localhost on any port for a build
+  being tried on a developer's machine. Anything else is refused with 403
+  before a room is touched. Origin is the one header a page cannot forge, so
+  this stops another site borrowing the switchboard; it does not stop a
+  script, which is what the next line is for.
+- One address may open thirty sockets a minute, counted per Cloudflare
+  location; the thirty-first is refused with 429. A host opens one socket
+  and each reader one, so a person never comes near it.
 - A host connects to `/ws/<code>?role=host`; a second host on a live code is
   refused with close code 4409.
 - A viewer connects with `?role=viewer`; with no host present it is refused
   4404, past the room cap 4429. Otherwise the host learns `{join, id}` and
-  the viewer gets `{ready}`.
+  the viewer gets `{ready}`. The id is opaque to the page and begins `v:`,
+  so that it can never spell a role.
 - Everything a viewer sends is wrapped as `{signal, from, data}` and handed
-  to the host; everything the host sends with a `to` goes to that viewer.
-  The payloads are WebRTC offers, answers and ICE candidates; the switchboard
+  to the host; everything the host sends with a `to` naming a viewer's id
+  goes to that viewer, and a `to` in any other shape goes nowhere. The
+  payloads are WebRTC offers, answers and ICE candidates; the switchboard
   does not read them.
 - When the host's socket drops, every viewer is closed with 4410
   "host-gone" - the instant, authoritative end-of-share signal, long before

--- a/workers/rendezvous/worker.js
+++ b/workers/rendezvous/worker.js
@@ -14,6 +14,28 @@
 // the site's Cloudflare account. The free plan carries it - the object
 // hibernates between messages and writes nothing to storage, so an idle
 // room costs nothing at all.
+//
+// It answers only the site's own pages, and lets one address knock only so
+// often. Both are the least that keeps a switchboard with no login from being
+// borrowed, and neither reads anything. The one line it ever prints is the
+// close code of a refusal.
+
+// A browser sends Origin on every WebSocket handshake and a page cannot forge
+// it, so checking it keeps the rendezvous from becoming free signalling for
+// somebody else's site. A script can send any Origin it likes; the rate limit
+// is for that. Local builds are served from localhost and need the live
+// rendezvous to try the tool at all, so localhost is let in on any port.
+const SITE = "https://abox.tools";
+
+function fromOurPage(origin) {
+  if (origin === SITE) return true;
+  try {
+    const host = new URL(origin).hostname;
+    return host === "localhost" || host === "127.0.0.1";
+  } catch {
+    return false;
+  }
+}
 
 export default {
   async fetch(request, env) {
@@ -30,6 +52,16 @@ export default {
       if (request.headers.get("Upgrade") !== "websocket") {
         return new Response("expected a websocket", { status: 426 });
       }
+      if (!fromOurPage(request.headers.get("Origin"))) {
+        return new Response("not for this page", { status: 403 });
+      }
+      // Keyed by address rather than by room: the nuisance this caps is one
+      // client opening rooms by the thousand, and the room name is theirs to
+      // vary. Counted per Cloudflare location, so it is a cap, not a wall.
+      const knock = await env.LIMIT.limit({ key: request.headers.get("CF-Connecting-IP") ?? "" });
+      if (!knock.success) {
+        return new Response("too many connections from this address", { status: 429 });
+      }
       return env.ROOMS.get(env.ROOMS.idFromName(room[1])).fetch(request);
     }
     return new Response("not found", { status: 404 });
@@ -37,6 +69,8 @@ export default {
 };
 
 const MAX_VIEWERS = 16;
+// UTF-16 units, not bytes, so up to three times this on the wire: a bound on
+// nonsense rather than a budget. A session description is a few kilobytes.
 const MAX_MESSAGE = 64 * 1024;
 
 // One room. Sockets are tagged with their role - viewers also with a random
@@ -57,6 +91,11 @@ export class Room {
     // attached, so rejections complete the upgrade and then close with a
     // 4xxx code the page can read.
     const refuse = (code, reason) => {
+      // The one line this worker prints. A refusal completes the upgrade with
+      // 101 exactly like an admission, so the invocation log cannot tell the
+      // two apart; this can, and it carries the code alone - no name, no
+      // address, nothing a person typed.
+      console.log(JSON.stringify({ refused: code, reason }));
       server.accept();
       server.close(code, reason);
       return new Response(null, { status: 101, webSocket: client });
@@ -70,7 +109,10 @@ export class Room {
     } else if (role === "viewer") {
       if (hosts.length === 0) return refuse(4404, "no-host");
       if (this.ctx.getWebSockets("viewer").length >= MAX_VIEWERS) return refuse(4429, "full");
-      const id = crypto.randomUUID();
+      // Tags are one namespace - "host", "viewer" and every id - so an id is
+      // prefixed to be unmistakable for a role, and a host's `to` is honoured
+      // only in that shape. Without both, `to: "viewer"` would reach the room.
+      const id = "v:" + crypto.randomUUID();
       this.ctx.acceptWebSocket(server, ["viewer", id]);
       server.serializeAttachment({ role: "viewer", id });
       this.toHost({ type: "join", id });
@@ -93,7 +135,7 @@ export class Room {
     if (who === null) return;
     if (who.role === "viewer") {
       this.toHost({ type: "signal", from: who.id, data: parsed.data });
-    } else if (typeof parsed.to === "string") {
+    } else if (typeof parsed.to === "string" && parsed.to.startsWith("v:")) {
       // The viewer's id doubles as its socket tag, so addressing a reply is
       // a lookup, not a scan.
       for (const peer of this.ctx.getWebSockets(parsed.to)) {

--- a/workers/rendezvous/wrangler.toml
+++ b/workers/rendezvous/wrangler.toml
@@ -16,6 +16,20 @@ class_name = "Room"
 tag = "v1"
 new_sqlite_classes = ["Room"]
 
+# One address may open thirty sockets a minute. A person never comes near it -
+# a host opens one, each reader one - and it is the difference between a script
+# spending the free plan's daily quota in an hour and spending its own patience.
+# Counted per Cloudflare location, so it is a cap on nuisance rather than a
+# wall. The namespace id is an arbitrary label that keeps this counter apart
+# from any other the account might declare.
+[[ratelimits]]
+name = "LIMIT"
+namespace_id = "1001"
+
+  [ratelimits.simple]
+  limit = 30
+  period = 60
+
 # Persisted logs, switched on in the dashboard and written down here so a later
 # `wrangler deploy` from this file agrees with it rather than quietly switching
 # them back off. The worker prints nothing of its own, so what is kept is


### PR DESCRIPTION
The rendezvous had no door. Any page anywhere could open a socket to it and
use it as free signalling, and any script could open rooms by the thousand
until the free plan's daily quota ran out and `/share-text/` went dark for the
rest of the day. Neither needed a code word: the switchboard has no login, and
nothing stood between the internet and its rooms but a regular expression.

**Three things, all at the door and none in the room.**

- **Origin.** The handshake now wants `https://abox.tools`. A browser sends
  Origin on every WebSocket handshake and a page cannot forge it, so this
  stops another site borrowing the switchboard, which is the cheap and likely
  abuse. Localhost on any port is let in too, because a build served from
  `serve.ps1` needs the live rendezvous to try the tool at all. Anything else
  is refused with 403 before a room is touched. A script can send any Origin
  it likes, so this is not the whole answer.
- **Rate limit.** A Cloudflare rate-limit binding keyed by the client's
  address, thirty handshakes a minute. A host opens one socket and each reader
  one, so nobody comes near it; counted per Cloudflare location, so it caps a
  nuisance rather than walling anything. The thirty-first is refused with 429.
- **One log line, on a refusal.** A refused handshake completes the upgrade
  with 101 exactly like an admission, so the invocation logs switched on in
  #351 cannot tell a reader who was let in from one told the share had ended.
  The line carries the close code and nothing else: no name, no address.

Two small things ride along. Viewer ids gain a `v:` prefix and a host's `to`
is honoured only in that shape, because ids and roles share one tag namespace
and `to: "viewer"` would otherwise reach the whole room. And `.wrangler/`,
which wrangler writes beside the worker on every deploy, is ignored before a
`git add` of the folder sweeps it in.

**Tests.** The door has them, because it can: Node has `Request` and
`Response`, and the Durable Object and the limiter are a few lines of fake
that record what they were asked, so each refusal is pinned to the check that
made it and the room is shown never to have been touched. Eight cases in
`tests/js/rendezvous.test.js`, passing. The room itself still needs the
Workers runtime and a browser.

**Verified locally.** wrangler's dry run accepts the config and lists the
binding as `30 requests/60s`; the config still parses with the observability
tables intact. The README carries the door in its protocol section and the
log line in its inventory of what the worker keeps.

**Nothing a visitor sees changes**, so there are no before and after
pictures. `workers/` and `tests/` are on the version rule's invisible list.
The worker deploys by hand after the merge, and the probe request must still
answer 426.

One thing to know about the page: a browser turned away with 403 or 429 sees
a failed connection, and the share-text page reports that with its existing
"could not reach the rendezvous" sentence rather than a new one. A specific
message would be fifteen translations for a case a visitor cannot reach from
the site's own pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
