### PR TITLE
Give every pull request a preview, and run the browser suite against it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,10 @@
 # only meaningful if the served files are committed somewhere a reader can see.
 #
 # On a pull request this builds but does not publish, so a change that breaks
-# the build is caught before it reaches main.
+# the build is caught before it reaches main. It does put the build somewhere
+# a browser can reach - a preview of its own on Cloudflare Pages, see the
+# `preview` job - and asks the QA suite to run against that, so the browser
+# tests see a change before visitors do rather than twenty minutes after.
 #
 # The unit tests run first, in their own job, and the build waits on them. They
 # cover the hand-written code on both sides: the generator in Python and the
@@ -252,6 +255,18 @@ jobs:
 
           exit $status
 
+      # On a pull request the deployed build goes to the preview job instead
+      # of the dist branch. A day is plenty: the preview is uploaded within
+      # minutes, and the next push to the pull request builds again.
+      - name: Hand the build to the preview
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: site-preview
+          path: _site/
+          include-hidden-files: true
+          retention-days: 1
+
       - name: Publish to the dist branch
         id: publish
         if: github.event_name != 'pull_request'
@@ -453,4 +468,175 @@ jobs:
             echo '```'
             find _site -type f | sort | sed 's|^_site/|  |'
             echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # A PREVIEW OF EVERY PULL REQUEST, AND THE QA SUITE RUN AGAINST IT
+  #
+  # Until this job existed the browser suite only ever saw a change after it
+  # was live: merge, build, push to dist, Pages, and then QA (post-deploy)
+  # asked the qa repository to run. The first browser test of a change ran
+  # some twenty minutes after visitors had it, and the net was a report and
+  # an issue rather than a gate. Everything that suite found in its first
+  # months, it found on production.
+  #
+  # So a pull request gets a deployment of its own. Not a standing staging
+  # server - the site is static and stateless, and a server to keep in step
+  # can hold one change at a time - but a preview per pull request on
+  # Cloudflare Pages, a second project there, uploaded directly from the
+  # build above. The site already sits behind Cloudflare; Pages reads the
+  # `_headers` the repository keeps "in case the site ever moves to a host
+  # that reads it", so a preview carries the security headers from the file;
+  # Pages marks every non-production deployment noindex on its own; and each
+  # preview is an origin of its own, so root-absolute paths and the offline
+  # worker behave exactly as on production. The bytes are the ones the build
+  # job made - the same `_site` that would have gone to dist - which is the
+  # point: what is tested is what ships.
+  #
+  # The suite itself runs in the qa repository, as it does after a deploy,
+  # dispatched with the preview's address and this pull request's head
+  # commit. Its result comes back as a commit status, `qa/preview`, on that
+  # commit, with the run as its link. Report-only for now; once it has been
+  # green for a while, branch protection can require it.
+  #
+  # SETUP, ONCE: a Cloudflare Pages project (direct upload) and two secrets
+  # here, CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID; a WEBSITE_STATUS_TOKEN
+  # in the qa repository for the status; QA_DISPATCH_TOKEN as before. The
+  # steps are in cloudflare/README.md. Until the Cloudflare secrets exist this
+  # job says so and stops, and the pull request stays green.
+  #
+  # A pull request from a fork gets no secrets and therefore no preview. That
+  # is GitHub's rule, and the right one: a fork's workflow must not be able to
+  # deploy with this repository's credentials.
+  preview:
+    needs: build
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # For the sticky comment that carries the preview's address.
+      pull-requests: write
+    env:
+      PR: ${{ github.event.pull_request.number }}
+      SHA: ${{ github.event.pull_request.head.sha }}
+      PROJECT: ${{ vars.CLOUDFLARE_PAGES_PROJECT || 'abox-preview' }}
+    steps:
+      - name: Is there somewhere to put it?
+        id: gate
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          if [ -n "$CLOUDFLARE_API_TOKEN" ] && [ -n "$CLOUDFLARE_ACCOUNT_ID" ]; then
+            echo 'ready=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'ready=false' >> "$GITHUB_OUTPUT"
+            echo '::notice::No preview: CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID are not both set. See cloudflare/README.md, "Previews".'
+          fi
+
+      - name: Take the build
+        if: steps.gate.outputs.ready == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: site-preview
+          path: _site
+
+      - uses: actions/setup-node@v4
+        if: steps.gate.outputs.ready == 'true'
+        with:
+          node-version: '20'
+
+      # `--branch pr-<n>` is what makes this a preview rather than the
+      # project's production: Pages gives every non-production branch an
+      # alias of its own, <branch>.<project>.pages.dev, stable across the
+      # pull request's pushes, which is the address the comment and the QA
+      # run use. There is no git checkout in this job, so the commit is
+      # named by hand.
+      - name: Upload it to Cloudflare Pages
+        if: steps.gate.outputs.ready == 'true'
+        id: upload
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          npx --yes wrangler@3 pages deploy _site \
+            --project-name "$PROJECT" \
+            --branch "pr-$PR" \
+            --commit-hash "$SHA" \
+            --commit-message "Preview of pull request #$PR at ${SHA:0:7}" \
+            --commit-dirty=true
+          echo "url=https://pr-$PR.$PROJECT.pages.dev/" >> "$GITHUB_OUTPUT"
+
+      # The alias takes a moment to answer after the first upload for a
+      # branch. Waiting here, as QA (post-deploy) waits for production, keeps
+      # the qa repository's workflow honest about what it tests.
+      - name: Wait until it answers
+        if: steps.gate.outputs.ready == 'true'
+        env:
+          URL: ${{ steps.upload.outputs.url }}
+        run: |
+          set -euo pipefail
+          for _ in $(seq 1 30); do
+            if curl -fsS -o /dev/null "$URL"; then
+              echo "Answering: $URL"
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "::error::$URL never answered after five minutes."
+          exit 1
+
+      # One comment per pull request, edited on every push rather than added
+      # to, so the address is always at the top of the conversation and never
+      # repeated down it.
+      - name: Say where it is, on the pull request
+        if: steps.gate.outputs.ready == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          URL: ${{ steps.upload.outputs.url }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          marker='<!-- preview-address -->'
+          body=$(printf '%s\n**Preview:** %s\n\nBuilt from %s. The QA suite runs against it; its result is the `qa/preview` check below.' \
+            "$marker" "$URL" "${SHA:0:7}")
+          existing=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+            --jq ".[] | select(.body | startswith(\"$marker\")) | .id" | head -n1)
+          if [ -n "$existing" ]; then
+            gh api --method PATCH "repos/$REPO/issues/comments/$existing" -f body="$body" > /dev/null
+          else
+            gh api --method POST "repos/$REPO/issues/$PR/comments" -f body="$body" > /dev/null
+          fi
+
+      # The same token QA (post-deploy) uses; see that workflow's header for
+      # why the default token cannot start a run in another repository.
+      - name: Ask the QA suite to run against it
+        if: steps.gate.outputs.ready == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.QA_DISPATCH_TOKEN }}
+          URL: ${{ steps.upload.outputs.url }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN}" ]; then
+            echo '::error::QA_DISPATCH_TOKEN is not set - see .github/workflows/qa-on-deploy.yml.'
+            exit 1
+          fi
+          gh workflow run report.yml --repo A-Box-of-Tools/qa \
+            -f "base_url=$URL" -f "pr=$PR" -f "sha=$SHA"
+          echo "Dispatched against $URL"
+
+      - name: Summary
+        if: always()
+        env:
+          URL: ${{ steps.upload.outputs.url }}
+        run: |
+          {
+            echo '### Preview'
+            echo
+            if [ -n "$URL" ]; then
+              echo "- $URL"
+              echo '- The QA suite runs against it in [A-Box-of-Tools/qa](https://github.com/A-Box-of-Tools/qa/actions); the result is the `qa/preview` status on this commit.'
+            else
+              echo 'Not deployed: the Cloudflare secrets are not set. See cloudflare/README.md, "Previews".'
+            fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/cloudflare/README.md
+++ b/cloudflare/README.md
@@ -81,3 +81,39 @@ rule fights that control. Same for **Always Use HTTPS**.
   what the dashboard calls "All incoming requests".
 - **Editing in the dashboard is fine, but temporary.** The next apply overwrites
   it. Change the JSON and re-run instead, so the change survives and gets reviewed.
+
+## Previews, for a pull request
+
+Production stays on GitHub Pages. A pull request, though, gets a build of its
+own on **Cloudflare Pages** - a second, separate project, direct upload, no
+git integration - at `https://pr-<number>.abox-preview.pages.dev/`, and the QA
+suite is run against that before anything reaches `main`. See the `preview`
+job in `.github/workflows/build.yml` for what it does and why.
+
+Pages reads `_headers`, so a preview carries the same security headers as
+production without the transform rule above; and Pages marks every deployment
+that is not the project's production branch `noindex` by itself, so a preview
+cannot be indexed. The site's own analytics switch themselves off away from
+the production domain (`templates/analytics.js`), so a preview counts no
+visits either.
+
+### Setting it up, once
+
+1. In the Cloudflare dashboard, **Workers & Pages → Create → Pages → Upload
+   assets**. Name the project `abox-preview` and upload anything - the first
+   deployment from the workflow replaces it. Leave the production branch as
+   `main`: the workflow deploys to branches named `pr-<number>`, which is what
+   makes each one a preview rather than the project's production.
+2. Create an API token under *My Profile → API Tokens* with
+   **Account → Cloudflare Pages → Edit**, scoped to this account.
+3. In the website repository's settings, add two secrets:
+   `CLOUDFLARE_API_TOKEN` (the token) and `CLOUDFLARE_ACCOUNT_ID` (from the
+   dashboard's account home, right-hand column). A different project name goes
+   in a repository variable `CLOUDFLARE_PAGES_PROJECT`; without one the
+   workflow assumes `abox-preview`.
+4. In the QA repository's settings, add `WEBSITE_STATUS_TOKEN`: a fine-grained
+   token for this repository with **Commit statuses: write**. It is what lets
+   a QA run against a preview show up as a check on the pull request.
+
+Until the secrets exist the `preview` job says so and skips, and pull
+requests stay green; nothing else changes.

--- a/templates/analytics.js
+++ b/templates/analytics.js
@@ -48,7 +48,14 @@ window.gtag = gtag;
 // the tag script above is async and sends nothing on its own. Deliberately
 // not an inline script in the head, for the same CSP reason this whole file
 // exists.
-if (navigator.webdriver) {
+//
+// The same switch, thrown for the same reason, when this file is running
+// anywhere but the site's own domain: a pull request's preview on Cloudflare
+// Pages, a build served from a laptop. Those are the same bytes as
+// production - which is what makes testing them worth anything - so the file
+// cannot be built differently there; it has to notice where it is. A visit
+// to a preview is a developer checking their work, not a visitor.
+if (navigator.webdriver || location.origin + '/' !== '{{ site.domain }}') {
   window['ga-disable-{{ site.analytics_id }}'] = true;
 }
 


### PR DESCRIPTION
Until now the browser suite only ever saw a change after it was live: merge, Build, push to `dist`, Pages, and then *QA (post-deploy)* asked the qa repository to run. The first browser test of a change ran some twenty minutes after visitors had it, and the net was a report and an issue rather than a gate. Everything that suite found in its first months, it found on production.

**A pull request now gets a deployment of its own** — not a standing staging server, but a preview per pull request on Cloudflare Pages, a second project there, uploaded directly from the build job's own `_site`:

- The site already sits behind Cloudflare. Pages reads the `_headers` this repository keeps "in case the site ever moves to a host that reads it", so a preview carries the security headers from the file. Pages marks every non-production deployment `noindex` by itself.
- Each preview is an origin of its own (`https://pr-<n>.abox-preview.pages.dev/`), so root-absolute paths and the offline worker behave as on production.
- The bytes are the ones that would have gone to `dist`. What is tested is what ships.

The new `preview` job hands the address to the pull request as one comment, edited on every push, and dispatches the qa repository's report with the address and the head commit. The result comes back as a commit status, **`qa/preview`**, on that commit, with the run as its link. Report-only for now; branch protection can require it once it has been green a while. The companion change is A-Box-of-Tools/qa: `report.yml` learns what a preview run is.

**One change to the site itself.** `templates/analytics.js` throws its own opt-out switch — the one it already throws for an automated browser — anywhere but the site's domain, so a preview counts no visits. The file cannot be built differently for a preview without the preview ceasing to be the build under test, so it notices where it is.

## Setting it up, once

The job is fail-soft: without the secrets it says so and stops, and pull requests stay green — this pull request's own run shows that path. To switch it on, `cloudflare/README.md` → *Previews*:

1. a Cloudflare Pages project, direct upload, named `abox-preview` (or set the repository variable `CLOUDFLARE_PAGES_PROJECT`);
2. secrets `CLOUDFLARE_API_TOKEN` (Account → Cloudflare Pages → Edit) and `CLOUDFLARE_ACCOUNT_ID` in this repository;
3. secret `WEBSITE_STATUS_TOKEN` (Commit statuses: write, on this repository) in the qa repository, so the result shows on the pull request.

`QA_DISPATCH_TOKEN` is reused as it is. A pull request from a fork gets no secrets and therefore no preview, which is GitHub's rule and the right one.

## Verified

- both workflows parse; `preview` follows `build` on pull requests only, with `pull-requests: write` and nothing more
- the gated `analytics.js` renders and parses; against a local build the qa suite's "this suite is not counted as visitors" passes and its control skips by design, against production both pass as before
- `python build.py --out _plain --clean --no-minify` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
