### PR TITLE
Say where the Pages tab is, and give the terminal way round it

### DIFF
--- a/cloudflare/README.md
+++ b/cloudflare/README.md
@@ -99,11 +99,23 @@ visits either.
 
 ### Setting it up, once
 
-1. In the Cloudflare dashboard, **Workers & Pages → Create → Pages → Upload
-   assets**. Name the project `abox-preview` and upload anything - the first
-   deployment from the workflow replaces it. Leave the production branch as
-   `main`: the workflow deploys to branches named `pr-<number>`, which is what
-   makes each one a preview rather than the project's production.
+1. In the Cloudflare dashboard, **Workers & Pages → Create application**, then
+   the **Pages** tab rather than Workers, then **Upload assets**. Name the
+   project `abox-preview` and upload anything - the first deployment from the
+   workflow replaces it. Leave the production branch as `main`: the workflow
+   deploys to branches named `pr-<number>`, which is what makes each one a
+   preview rather than the project's production.
+
+   The same from a terminal, with no placeholder to upload, once the token
+   below exists:
+
+   ```bash
+   npx wrangler@3 pages project create abox-preview --production-branch main
+   ```
+
+   The Pages tab is easy to miss: the dashboard leads with the Workers flow,
+   and a git-connected Worker is not what this wants - it would build the
+   site on Cloudflare's side and refuse the workflow's direct uploads.
 2. Create an API token under *My Profile → API Tokens* with
    **Account → Cloudflare Pages → Edit**, scoped to this account.
 3. In the website repository's settings, add two secrets:


### PR DESCRIPTION
The dashboard leads with the Workers flow, and the first attempt at setting the preview project up landed in it: a git-connected Worker, which would build the site on Cloudflare's side and refuse the workflow's direct uploads. The notes now say which tab to pick, and give the one-line wrangler command that needs no tab and no placeholder upload.

Documentation only. It is also the first pull request since the secrets were added, so its checks are the first end-to-end run of the preview: the `preview` job should upload, comment the address below, and the `qa/preview` check should follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)