### PR TITLE
Let the rendezvous admit a pull request's preview

### DIFF
--- a/tests/js/rendezvous.test.js
+++ b/tests/js/rendezvous.test.js
@@ -75,6 +75,14 @@ test('a localhost page reaches the room too, on any port', async () => {
   }
 });
 
+test("a pull request's preview reaches the room, whichever number it is", async () => {
+  const e = env();
+  for (const origin of ['https://pr-358.abox-preview.pages.dev', 'https://pr-1.abox-preview.pages.dev', 'https://94869022.abox-preview.pages.dev']) {
+    const res = await worker.fetch(upgrade('/ws/brave-otter-42', { Origin: origin }), e);
+    assert.equal(res.status, 200, origin);
+  }
+});
+
 test('any other origin, or none, is refused before a room is touched', async () => {
   const e = env();
   const cases = [
@@ -82,6 +90,13 @@ test('any other origin, or none, is refused before a room is touched', async () 
     { Origin: 'https://abox.tools.example.com' },
     { Origin: 'https://notabox.tools' },
     { Origin: 'http://abox.tools' },
+    // The preview suffix is the project's, not the platform's, and only over
+    // https: another Pages project, a lookalike, and a plain-http preview
+    // are all somebody else's page.
+    { Origin: 'https://other.pages.dev' },
+    { Origin: 'https://pr-1.abox-preview.pages.dev.example.com' },
+    { Origin: 'https://abox-preview.pages.dev.evil.example' },
+    { Origin: 'http://pr-1.abox-preview.pages.dev' },
     { Origin: 'null' },
     {},
   ];

--- a/workers/rendezvous/worker.js
+++ b/workers/rendezvous/worker.js
@@ -37,12 +37,20 @@
 // is for that. Local builds are served from localhost and need the live
 // rendezvous to try the tool at all, so localhost is let in on any port.
 const SITE = "https://abox.tools";
+// Every pull request is deployed to a preview of its own on Cloudflare Pages
+// (see the `preview` job in .github/workflows/build.yml), at
+// https://pr-<n>.abox-preview.pages.dev, and the QA suite is run against it -
+// share-text included, which is the one tool that cannot work without this
+// worker's say-so. The suffix is the project's, so no other Pages project on
+// the same platform is let in by it.
+const PREVIEWS = ".abox-preview.pages.dev";
 
 function fromOurPage(origin) {
   if (origin === SITE) return true;
   try {
-    const host = new URL(origin).hostname;
-    return host === "localhost" || host === "127.0.0.1";
+    const { protocol, hostname } = new URL(origin);
+    if (hostname === "localhost" || hostname === "127.0.0.1") return true;
+    return protocol === "https:" && hostname.endsWith(PREVIEWS);
   } catch {
     return false;
   }


### PR DESCRIPTION
Every pull request is now deployed to a preview of its own and the QA suite runs against it - share-text included, the one tool that cannot work without this worker's say-so. The worker took a socket only from `abox.tools` and localhost, so on a preview the page never got a link and six tests failed on every engine (qa run 33823156581: 24 failures, all share-text).

The preview project's hosts are let in: https, and a hostname ending in `.abox-preview.pages.dev`, the project's suffix and nobody else's on that platform. The worker's tests say what is admitted and what still is not: another Pages project, a lookalike suffix, a plain-http preview.

**Takes effect when the worker is deployed**, which the workflow does not do: `npx wrangler deploy` from `workers/rendezvous`, logged in to the account, as its README says. Until then the share-text tests on a preview stand down with a message saying so (A-Box-of-Tools/qa), and run again by themselves once the deployed worker admits the origin.

## Verified

- `tests/js/rendezvous.test.js`: all pass, with the three admitted preview origins and four refused lookalikes added

🤖 Generated with [Claude Code](https://claude.com/claude-code)