### PR TITLE
Answer the rendezvous at a name under the site's own domain

### DIFF
--- a/tests/js/trust.test.js
+++ b/tests/js/trust.test.js
@@ -72,7 +72,7 @@ test('anything else is external, and a look-alike is not the platform', () => {
 });
 
 test('a host the page declared is counted and not reported', () => {
-  const rendezvous = 'rendezvous.a-box-of-tools.workers.dev';
+  const rendezvous = 'rendezvous.abox.tools';
   const sorted = sortHosts(entries(`wss://${rendezvous}/`, `${ORIGIN}/share-text/`),
     page([rendezvous]));
   assert.equal(sorted.total, 2);

--- a/tools/share-text/README.md
+++ b/tools/share-text/README.md
@@ -32,7 +32,10 @@ cannot see: the text, the files, who was admitted, or what a knock said —
 all of that travels the peer channel.
 
 The endpoint is a constant at the top of `src/main.js` and one line in
-`tool.toml`'s `[csp]`; those two places change together or not at all.
+`tool.toml`'s `[csp]`; those two places change together or not at all. It is
+a subdomain of the site, `rendezvous.abox.tools`, rather than the worker's
+own `workers.dev` name, because that whole domain is blocked inside mainland
+China and the site's is not; the worker answers at both.
 STUN (Cloudflare's and Google's public servers) helps the browsers discover
 their own addresses; ICE traffic — STUN and, when a reader chooses it, the
 TURN relay — is outside `connect-src`'s vocabulary, which is why CSP alone

--- a/tools/share-text/src/main.js
+++ b/tools/share-text/src/main.js
@@ -8,8 +8,10 @@ import { CODE_PATTERN, formatSize, makeCode, normalize } from './names.js';
 // Content-Security-Policy: the rendezvous that introduces the two browsers.
 // It carries WebRTC negotiation and nothing else - the text and the files
 // travel the direct channel it sets up. See workers/rendezvous/ in the
-// repository for the whole of what runs there.
-const RENDEZVOUS = 'wss://rendezvous.a-box-of-tools.workers.dev';
+// repository for the whole of what runs there. A subdomain of the site rather
+// than the worker's workers.dev name: that whole domain is blocked inside
+// mainland China, and this one is not.
+const RENDEZVOUS = 'wss://rendezvous.abox.tools';
 const RTC = { iceServers: [{ urls: ['stun:stun.cloudflare.com:3478', 'stun:stun.l.google.com:19302'] }] };
 
 // A direct connection is what this page is, and it is also what a minority of

--- a/tools/share-text/tool.toml
+++ b/tools/share-text/tool.toml
@@ -101,7 +101,7 @@ card = """
 
 # The one directive this tool widens: its own rendezvous. See csp_note.
 [csp]
-"connect-src" = ["wss://rendezvous.a-box-of-tools.workers.dev"]
+"connect-src" = ["wss://rendezvous.abox.tools"]
 
 [words]
 plural = "shared text and files"

--- a/workers/rendezvous/README.md
+++ b/workers/rendezvous/README.md
@@ -33,10 +33,17 @@ to its default, so there is no second stream to account for.
 npx wrangler deploy
 ```
 
-from this directory, logged in to the site's Cloudflare account. The tool
-page names this worker's hostname in its `connect-src` and in one constant
-in `tools/share-text/src/main.js`; if the worker is ever renamed or moved to
-a custom domain, those are the two places that change.
+from this directory, logged in to the site's Cloudflare account. The worker
+answers at `rendezvous.abox.tools`, a custom domain that `wrangler.toml`
+declares and the deploy creates in the zone - the DNS record and the
+certificate both - so no dashboard step exists. It also still answers at
+the `workers.dev` name it was born with, and should keep doing so: a page
+cached before the switch dials the old name. The custom domain is not a
+nicety. The whole `workers.dev` domain is blocked inside mainland China, and
+a reader there saw the page load and then wait forever for an introduction,
+while the site's own domain resolves fine. The tool page names the hostname
+in its `connect-src` and in one constant in `tools/share-text/src/main.js`;
+if the worker ever moves again, those are the two places that change.
 
 This folder is invisible to `build.py` - the deploy is by hand, and rare,
 because nearly every feature the tool has gained since the first version has

--- a/workers/rendezvous/wrangler.toml
+++ b/workers/rendezvous/wrangler.toml
@@ -5,6 +5,21 @@ name = "rendezvous"
 main = "worker.js"
 compatibility_date = "2026-08-01"
 
+# The worker answers on a name under the site's own domain, not only on the
+# workers.dev one it was born with. The whole workers.dev domain is blocked
+# inside mainland China, and a reader there saw the page load and then wait
+# forever for an introduction that could never arrive; abox.tools itself is
+# reachable, so its subdomain is too. `custom_domain = true` has the deploy
+# create the DNS record and the certificate in the zone, which is on the same
+# account, so there is nothing to click. The workers.dev address keeps
+# answering alongside it - a page cached before the switch still finds the
+# switchboard - and the page names this hostname in exactly two places:
+# the constant at the top of tools/share-text/src/main.js and the connect-src
+# line of its tool.toml.
+routes = [
+  { pattern = "rendezvous.abox.tools", custom_domain = true },
+]
+
 [[durable_objects.bindings]]
 name = "ROOMS"
 class_name = "Room"

--- a/workers/rendezvous/wrangler.toml
+++ b/workers/rendezvous/wrangler.toml
@@ -16,6 +16,12 @@ compatibility_date = "2026-08-01"
 # switchboard - and the page names this hostname in exactly two places:
 # the constant at the top of tools/share-text/src/main.js and the connect-src
 # line of its tool.toml.
+#
+# `workers_dev` has to be said out loud: the moment a worker declares a route,
+# wrangler turns the workers.dev name off unless told otherwise, and the first
+# deploy of this file did exactly that - every page already out there dialled
+# the old name and found nothing. Both names stay on, deliberately.
+workers_dev = true
 routes = [
   { pattern = "rendezvous.abox.tools", custom_domain = true },
 ]


### PR DESCRIPTION
## What was wrong

A reader inside mainland China replied to the share-text thread: "墙内没法用" — it cannot be used behind the firewall. The page itself loads there: abox.tools sits behind Cloudflare on its own domain, which resolves fine. Its one server did not. The rendezvous answered only at the `workers.dev` name it was born with, and that whole domain is blocked inside the firewall, so "Looking for the sharer…" waited forever for an introduction that could never arrive. (Google's STUN server is blocked there too, but it is the second of two and only slows discovery.)

## What this does

- `workers/rendezvous/wrangler.toml` declares `rendezvous.abox.tools` as a custom domain. The deploy creates the DNS record and the certificate in the zone — no dashboard step.
- The page dials that name: the constant at the top of `main.js` and the `connect-src` line in `tool.toml`, the two places the READMEs always said change together. The hostname is in no locale file, so fifteen languages follow for free.
- The `workers.dev` address keeps answering alongside the new one, so a page cached before the switch still finds the switchboard. This has to be written down as `workers_dev = true`: the first deploy of this branch lacked it, wrangler switched the old name off the moment a route existed, and the live page found no switchboard until the second deploy. The second commit here is that line and its comment.

## Landing order

1. **Deploy the worker first**, from `workers/rendezvous/` on this branch: `npx wrangler deploy`. The one precondition is that the abox.tools zone and the worker are in the same Cloudflare account; if not, wrangler says so and a manual DNS record takes its place.
2. Merge. Both names are live throughout, and rolling back is reverting two lines.

## How it was verified

- The page builds and its CSP carries the new name; nothing in `dist/` still names `workers.dev`.
- `wrangler deploy --dry-run` accepts the route. The domain itself cannot exist until the real deploy runs, so the page has not been exercised against it yet — that is the first thing to do after step 1, and I will do it.
- Reachability from inside China cannot be tested from here. This removes the one thing known to be blocked; the reply to the reader says so and asks them to report back.

Nothing on screen changes, so there are no before/after pictures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
