### PR TITLE
Ask for every module by a URL that changes when the code does

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,9 @@ own page at length, which is the pattern any future network feature must follow
 (see the guarantees comment in `config/site.toml`).
 
 No dependencies, no lockfile, no build step for the JavaScript. What is in
-`tools/<slug>/src/` is byte for byte what the browser runs.
+`tools/<slug>/src/` is what the browser runs, minified for deployment and with
+`?v=<hash>` on every relative import so a deploy never pairs a new page with a
+cached old module (`sitelib.version_imports`); nothing else is transformed.
 
 ## Commands
 

--- a/build.py
+++ b/build.py
@@ -1060,11 +1060,21 @@ def build_tool(out, templates, locale, locales, site, tool, footer, links,
     src_dir = tool['dir'] / 'src'
     assets = tool_assets(tool)
 
+    # One version for the whole graph, from the sources rather than the
+    # emitted copies, so that a copy carrying the version inside it is not
+    # part of what the version is taken from. Every page tag, every import
+    # and every precache entry asks for a module by this - see
+    # sitelib.version_imports for why. The modules are the same bytes in
+    # every language, so the version is too.
+    sources = [(name, path.read_text(encoding='utf-8')) for name, path in assets]
+    js_v = sitelib.text_hash(''.join(text for _, text in sources))
+    module_hrefs = [f'{name}?v={js_v}' for name, _ in assets]
+
     emitted = []
-    for name, path in assets:
+    for name, text in sources:
         (dest / name).parent.mkdir(parents=True, exist_ok=True)
         emitted.append((name, emit.js(
-            dest / name, path.read_text(encoding='utf-8'),
+            dest / name, sitelib.version_imports(text, js_v),
             where=f'{locale["prefix"]}{tool["out_slug"]}/{name}')))
 
     for extra in sorted(src_dir.iterdir()):
@@ -1151,7 +1161,8 @@ def build_tool(out, templates, locale, locales, site, tool, footer, links,
             'guide': guide,
             'related': related,
             'ui': ui,
-            'modules': [name for name, _ in assets],
+            'modules': module_hrefs,
+            'js_v': js_v,
             'footer': footer,
             'csp': sitelib.render_csp(root['csp'], root.get('app_csp', {}),
                                       root.get('tool_csp', {}),
@@ -1210,7 +1221,7 @@ def build_tool(out, templates, locale, locales, site, tool, footer, links,
     emit.js(dest / 'sw.js', templates.render('sw.js', {
         'words': tool['words'],
         'assets': (['index.html', css_href, 'manifest.json']
-                   + [name for name, _ in assets] + vendored),
+                   + module_hrefs + vendored),
         'cache_scope': f'/{locale["prefix"]}{tool["out_slug"]}/',
         'cache_hash': sitelib.cache_hash(cached),
     }), where=f'{locale["prefix"]}{tool["out_slug"]}/sw.js')

--- a/buildlib/site.py
+++ b/buildlib/site.py
@@ -588,6 +588,36 @@ def text_hash(text):
     return hashlib.sha256(text.encode('utf-8')).hexdigest()[:10]
 
 
+# A relative module specifier, wherever one can appear: `import './x.js'`,
+# `import {..} from './x.js'`, `export .. from './x.js'`, `import('./x.js')`,
+# and `new URL('./x.js', import.meta.url)`, which is how a worker is named.
+# Only ./ and ../ paths ending in .js, and only ones not already carrying a
+# query: a bare name is a package and a URL is somebody else's.
+_MODULE_SPECIFIER = re.compile(
+    r"""(\b(?:import|from)\s+|\bimport\s*\(\s*|\bnew URL\(\s*)(['"])(\.\.?/[^'"?]+\.js)\2""")
+
+
+def version_imports(text, version):
+    """Puts `?v=<version>` on every relative import in a module, so the whole
+    graph a page loads is asked for by URLs that change when the code does.
+
+    The page's own script tags are versioned the same way, for the reason
+    text_hash gives: scripts are cached for four hours and pages for ten
+    minutes, so a deploy that changes a tool's script and its page together
+    reaches a visitor as the new page running the old script. share-text
+    showed how that ends - the page's Content-Security-Policy named the
+    rendezvous at its new address while the cached script still dialled the
+    old one, and nothing could be shared until the cache turned over.
+
+    Versioning the tag alone would move the problem one import down: a new
+    main.js importing `./shared/x.js` would get whichever x.js the edge held.
+    So every specifier in the emitted copy carries the version too, and the
+    service worker precaches those exact URLs. The source in src/ is
+    untouched; only the deployed copies say where they are in time."""
+    return _MODULE_SPECIFIER.sub(
+        lambda m: f'{m.group(1)}{m.group(2)}{m.group(3)}?v={version}{m.group(2)}', text)
+
+
 # ---------------------------------------------------------------------------
 # Shared parts
 #

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -110,6 +110,18 @@ It matches on the whole request, query string included, so a worker that cached
 styled online and bare offline. `build.py` passes the same string to both, which
 is the only reason they cannot drift.
 
+**The modules are versioned the same way, imports included.** A tool's page
+asks for `src/main.js?v=<hash>` and `src/shared/trust.js?v=<hash>`, its
+modulepreloads say the same, and inside every emitted module each relative
+import - `from './x.js'`, `import('./x.js')`, `new URL('./x.js', ...)` - carries
+the same `?v=`. One hash per tool, taken from the module sources, so a change
+to any one of them moves every URL in the graph. Versioning the tag alone
+would move the stale copy one import down. This one was found the hard way
+too: the rendezvous moved to a new address, the page's policy moved with it,
+and for a while the cached `main.js` dialled the old address under a page that
+forbade it. The files in `src/` are untouched; only the deployed copies carry
+the query, and `sitelib.version_imports` is the whole of the rewrite.
+
 ## The 404 page
 
 `build.py` writes `404.html` to the root of the output, which is where

--- a/templates/tool.html
+++ b/templates/tool.html
@@ -476,8 +476,12 @@
   script that fills it in is the frame's too - copied into src/shared/ by the
   build like phrases.js, and loaded here rather than imported by main.js, so a
   tool whose own script fails to boot still gets an honest panel.
+
+  Versioned, like the stylesheet above and every import inside these modules,
+  so a deploy that changes a script and this page together cannot reach a
+  visitor as the new page running the old script. See sitelib.version_imports.
 -->
-<script type="module" src="src/shared/trust.js"></script>
-<script type="module" src="src/main.js"></script>
+<script type="module" src="src/shared/trust.js?v={{ js_v }}"></script>
+<script type="module" src="src/main.js?v={{ js_v }}"></script>
 </body>
 </html>

--- a/tests/python/test_build.py
+++ b/tests/python/test_build.py
@@ -55,6 +55,46 @@ def warm(tree):
 
 
 
+class VersionedImports(unittest.TestCase):
+    """sitelib.version_imports: every way a module names another, and the
+    ways a string that looks like one is not."""
+
+    def rewrite(self, text):
+        return buildmod.sitelib.version_imports(text, 'abc123')
+
+    def test_every_kind_of_relative_specifier_gets_the_version(self):
+        cases = {
+            "import { a } from './x.js';": "import { a } from './x.js?v=abc123';",
+            'import b from "../y.js";': 'import b from "../y.js?v=abc123";',
+            "import './side-effect.js';": "import './side-effect.js?v=abc123';",
+            "export { c } from './shared/z.js';": "export { c } from './shared/z.js?v=abc123';",
+            "const m = await import('./late.js');": "const m = await import('./late.js?v=abc123');",
+            "import( './spaced.js' )": "import( './spaced.js?v=abc123' )",
+            "new Worker(new URL('./worker.js', import.meta.url), { type: 'module' })":
+                "new Worker(new URL('./worker.js?v=abc123', import.meta.url), { type: 'module' })",
+        }
+        for source, expected in cases.items():
+            with self.subTest(source=source):
+                self.assertEqual(self.rewrite(source), expected)
+
+    def test_what_is_not_a_relative_module_is_left_alone(self):
+        untouched = [
+            "import x from 'https://example.com/x.js';",
+            "import y from 'package';",
+            "import z from './already.js?v=0';",
+            "const p = './not-an-import.js';",
+            "fetch('./data.json')",
+            "import.meta.url",
+        ]
+        for source in untouched:
+            with self.subTest(source=source):
+                self.assertEqual(self.rewrite(source), source)
+
+    def test_the_rewrite_is_the_same_twice(self):
+        once = self.rewrite("import { a } from './x.js';")
+        self.assertEqual(self.rewrite(once), once)
+
+
 class GuideGroups(unittest.TestCase):
     """Every way a guide could be written and then linked to from nowhere.
 
@@ -624,6 +664,32 @@ class BuildTheSite(unittest.TestCase):
         version = page.split('styles.css?v=')[1].split('"')[0].split("'")[0]
         self.assertIn(f'styles.css?v={version}', worker)
 
+    def test_every_module_is_asked_for_by_one_versioned_url_everywhere(self):
+        """The page's two module tags, its modulepreloads, every relative
+        import inside the emitted modules, and the worker's precache list all
+        name a module by the same `?v=<hash>`. Any one of them bare, or on a
+        different version, is a way for a deploy to pair a new page with a
+        stale module - see sitelib.version_imports."""
+        for slug in ('stack-images', self.a_tool()):
+            if not (self.out / slug / 'index.html').is_file():
+                continue
+            with self.subTest(tool=slug):
+                page = (self.out / slug / 'index.html').read_text(encoding='utf-8')
+                worker = (self.out / slug / 'sw.js').read_text(encoding='utf-8')
+                version = page.split('src="src/main.js?v=')[1].split('"')[0]
+                self.assertRegex(version, r'^[0-9a-f]{10}$')
+                self.assertIn(f'src="src/shared/trust.js?v={version}"', page)
+                self.assertIn(f'href="src/main.js?v={version}"', page)
+                self.assertIn(f"'src/main.js?v={version}'", worker)
+                self.assertNotIn("'src/main.js'", worker)
+                for module in sorted((self.out / slug / 'src').rglob('*.js')):
+                    text = module.read_text(encoding='utf-8')
+                    bare = re.findall(r"""(?:import|from)\s*\(?\s*['"](\.\.?/[^'"]+)['"]""", text)
+                    with self.subTest(module=module.name):
+                        for specifier in bare:
+                            self.assertTrue(specifier.endswith(f'?v={version}'),
+                                            f'{specifier} is not on this deploy\'s version')
+
     def test_a_tool_pages_links_leave_in_a_new_tab_except_the_switcher(self):
         """Every link away from a tool page opens elsewhere - see frame().
 
@@ -858,7 +924,7 @@ class BuildTheSite(unittest.TestCase):
             text = (self.out / name).read_text(encoding='utf-8')
             with self.subTest(page=name):
                 self.assertIn(asked, text)
-                self.assertLess(text.index(asked), text.index('src="src/main.js"'),
+                self.assertLess(text.index(asked), text.index('src="src/main.js?v='),
                                 'it has to be listening before the picker is')
 
         for name in self.written:


### PR DESCRIPTION
Scripts are cached at the edge for four hours and pages for ten minutes, so a deploy that changes a tool's script and its page together reaches a visitor as the new page running the old script. The stylesheets were given a hash in their URL for exactly this, after the footer once arrived unstyled; the modules never were, and #361 showed how that ends: the page's Content-Security-Policy named the rendezvous at its new address while the cached `main.js` still dialled the old one, and nothing could be shared until the edge turned over.

**So a tool's modules are versioned the way its stylesheet is** — and not only the two tags on the page, because that would move the stale copy one import down: a new `main.js` importing `./shared/x.js` would get whichever `x.js` the edge held. In the emitted copies:

- the page's two module tags and its modulepreloads carry `?v=<hash>`;
- every relative import inside every module carries the same one — `from`, `import()`, `export … from`, and the `new URL('./worker.js', import.meta.url)` stack-images names its worker by;
- the service worker precaches those exact URLs, which is the only reason the offline copy cannot drift from the page that asks for it (it matches on the whole request, query included, as the deploying notes already say of `styles.css`).

One hash per tool, taken from the module sources rather than the emitted copies, so a copy carrying the version inside it is not part of what the version is taken from. The files in `src/` are untouched; `sitelib.version_imports` is the whole of the rewrite, and the readable build carries it too, so the two builds still name the same files. CLAUDE.md's "byte for byte" now says what is transformed and that nothing else is.

## Verified

- `VersionedImports`, three unit tests: every kind of relative specifier is versioned; URLs, packages, already-versioned specifiers, plain strings and `import.meta` are left alone; the rewrite is idempotent
- `test_every_module_is_asked_for_by_one_versioned_url_everywhere`: tags, preloads, imports and precache agree on one version, on stack-images and the first tool; the lang-keep ordering test updated for the versioned tag
- built share-text and stack-images: all eleven modules parse after minifying; the readable build carries the same versions
- in a browser against that build: the tool-pages boot and CSP checks, the whole stack-images suite (its worker loads from the versioned URL), and the whole share-text suite on the local origin — all pass
- `python build.py --out _plain --clean --no-minify` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
