### PR TITLE
Turn portrait frames the right way up before stacking them

### DIFF
--- a/tests/js/helpers.js
+++ b/tests/js/helpers.js
@@ -151,6 +151,70 @@ export const TIFF_BE = new Uint8Array([
   0x41, 0x63, 0x6d, 0x65, 0x00,
 ]);
 
+export const TIFF_TYPE = { ASCII: 2, SHORT: 3, LONG: 4, UNDEFINED: 7 };
+const TIFF_WIDTHS = { 2: 1, 3: 2, 4: 4, 7: 1 };
+
+/**
+ * Lay out a TIFF: a header, a run of directories, then the data too long to sit
+ * inside an entry.
+ *
+ * An entry's value is a number when it fits in the four bytes the entry has,
+ * and an offset into the data area when it does not. That indirection is the
+ * only awkward part of the format and it is the part worth exercising, so the
+ * fixtures built on this deliberately use both.
+ *
+ * `dirs` is a list of `{ entries, next }`. An entry's value may be a plain
+ * number, `{ blob: i }` for the offset of a data block, or `{ dir: i }` for the
+ * offset of another directory.
+ */
+export function tiffOf({ little = true, magic = 42, dirs, blobs = [] }) {
+  const dirSizes = dirs.map((dir) => 2 + dir.entries.length * 12 + 4);
+  const dirAt = [];
+  let at = 8;
+  for (const size of dirSizes) { dirAt.push(at); at += size; }
+
+  const blobAt = [];
+  for (const blob of blobs) { blobAt.push(at); at += blob.length; }
+
+  const out = new Uint8Array(at);
+  const view = new DataView(out.buffer);
+  const resolve = (value) => {
+    if (typeof value === 'number') return value;
+    if (value.blob !== undefined) return blobAt[value.blob];
+    return dirAt[value.dir];
+  };
+
+  out.set(ascii(little ? 'II' : 'MM'), 0);
+  view.setUint16(2, magic, little);
+  view.setUint32(4, dirAt[0], little);
+
+  dirs.forEach((dir, index) => {
+    let cursor = dirAt[index];
+    view.setUint16(cursor, dir.entries.length, little);
+    cursor += 2;
+    for (const entry of dir.entries) {
+      view.setUint16(cursor, entry.tag, little);
+      view.setUint16(cursor + 2, entry.type, little);
+      view.setUint32(cursor + 4, entry.count, little);
+      const needed = TIFF_WIDTHS[entry.type] * entry.count;
+      if (needed <= 4) {
+        // Left-justified inside the entry, whichever way round the file is.
+        if (entry.type === TIFF_TYPE.SHORT) view.setUint16(cursor + 8, resolve(entry.value), little);
+        else view.setUint32(cursor + 8, resolve(entry.value), little);
+      } else {
+        view.setUint32(cursor + 8, resolve(entry.value), little);
+      }
+      cursor += 12;
+    }
+    view.setUint32(cursor, dir.next === undefined ? 0 : dirAt[dir.next], little);
+  });
+
+  blobs.forEach((blob, index) => out.set(blob, blobAt[index]));
+  return out;
+}
+
+export const tiffEntry = (tag, type, count, value) => ({ tag, type, count, value });
+
 /** Read a Blob back as bytes, which is how every writer here hands over. */
 export async function blobBytes(blob) {
   return new Uint8Array(await blob.arrayBuffer());

--- a/tests/js/stack-images-orient.test.js
+++ b/tests/js/stack-images-orient.test.js
@@ -1,0 +1,275 @@
+/**
+ * tools/stack-images/src/orient.js - EXIF orientation, read and applied.
+ *
+ * Two things are pinned here and neither is "does it parse Exif".
+ *
+ * The first is the tri-state. The reader runs on the head of a file, and a
+ * head can end before the answer does: a 4 KB head that stops inside a long
+ * APP segment has not said "no Exif", it has said "not yet". The pipeline reads
+ * more on undefined and guesses on null, so the two must not be confused - a
+ * reader that returned null for a short head would turn every RAW preview with
+ * a big maker-note sideways, and only on cameras that write one.
+ *
+ * The second is the sign of the turn. `orientationMatrix` is applied to a
+ * decode the browser did not orient, and a matrix with the rotation the wrong
+ * way round does not throw, does not warn and does not look wrong in review; it
+ * puts one frame into the stack a half turn from the rest. So every value is
+ * pinned by where it sends the corners, against the specification's own
+ * wording of what each value means.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  EXIF_ID, TIFF_BE, TIFF_LE, XMP_ID, ascii, concat, segment, u16be,
+} from './helpers.js';
+import {
+  jpegOrientation, jpegSegments, orientationMatrix, orientedSize,
+} from '../../tools/stack-images/src/orient.js';
+import { jpegSize } from '../../tools/stack-images/src/raw.js';
+
+/* ------------------------------------------------------------------ fixtures */
+
+/** A baseline frame header for a picture of the size given. */
+const sof = (width, height) => concat(
+  [0xff, 0xc0], u16be(17), [8], u16be(height), u16be(width),
+  [3, 1, 0x22, 0, 2, 0x11, 1, 3, 0x11, 1],
+);
+
+/** SOI, the segments given, a frame header, then a scan nobody decodes. */
+const jpegWith = (...segments) => concat(
+  [0xff, 0xd8], segments, sof(640, 480), [0xff, 0xda], u16be(10), new Uint8Array(8),
+);
+
+/** An Exif APP1 wrapping the TIFF block given. */
+const exifSegment = (tiff) => segment(0xe1, concat(EXIF_ID, tiff));
+
+/** A TIFF block with IFD0 holding one SHORT orientation, in either byte order. */
+function tiffWithOrientation(value, little = true) {
+  const out = new Uint8Array(8 + 2 + 12 + 4);
+  const view = new DataView(out.buffer);
+  out.set(little ? [0x49, 0x49] : [0x4d, 0x4d], 0);
+  view.setUint16(2, 42, little);
+  view.setUint32(4, 8, little);
+  view.setUint16(8, 1, little);
+  view.setUint16(10, 0x0112, little);
+  view.setUint16(12, 3, little);
+  view.setUint32(14, 1, little);
+  view.setUint16(18, value, little);
+  return out;
+}
+
+/* ------------------------------------------------------------------- reader */
+
+test('the orientation is read off an Exif APP1 in either byte order', () => {
+  // helpers.js's hand-written blocks both say 6, and say it in both orders.
+  assert.equal(jpegOrientation(jpegWith(exifSegment(TIFF_LE))), 6);
+  assert.equal(jpegOrientation(jpegWith(exifSegment(TIFF_BE))), 6);
+  for (let value = 1; value <= 8; value += 1) {
+    assert.equal(jpegOrientation(jpegWith(exifSegment(tiffWithOrientation(value)))), value);
+    assert.equal(jpegOrientation(jpegWith(exifSegment(tiffWithOrientation(value, false)))), value);
+  }
+});
+
+test('an Exif block after a JFIF or an XMP one is still found', () => {
+  const jfif = segment(0xe0, concat([0x4a, 0x46, 0x49, 0x46, 0], [1, 2, 0, 0, 1, 0, 1, 0, 0]));
+  assert.equal(jpegOrientation(jpegWith(jfif, exifSegment(TIFF_LE))), 6);
+
+  // An editor's export puts its XMP in an APP1 of its own, often ahead of the
+  // Exif one. Stopping at the first APP1 would read every such file as having
+  // no orientation.
+  const xmp = segment(0xe1, concat(XMP_ID, ascii('<x/>')));
+  assert.equal(jpegOrientation(jpegWith(xmp, exifSegment(TIFF_LE))), 6);
+});
+
+test('a frame header reached with no Exif is null, not undefined', () => {
+  // null is the answer the pipeline acts on without reading more, so it must
+  // only come back once the head has proved there is nothing to find.
+  assert.equal(jpegOrientation(jpegWith()), null);
+
+  const jfif = segment(0xe0, concat([0x4a, 0x46, 0x49, 0x46, 0], [1, 2, 0, 0, 1, 0, 1, 0, 0]));
+  assert.equal(jpegOrientation(jpegWith(jfif)), null, 'an APP0 is not an Exif block');
+
+  const xmp = segment(0xe1, new Uint8Array(64).fill(0x20));
+  assert.equal(jpegOrientation(jpegWith(xmp)), null,
+    'an APP1 that is not Exif is not an orientation');
+});
+
+test('an Exif block without the tag is null once the frame header is reached', () => {
+  const bare = new Uint8Array([0x49, 0x49, 42, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+  assert.equal(jpegOrientation(jpegWith(exifSegment(bare))), null);
+});
+
+test('a head that ends inside a segment is undefined, so the caller reads more', () => {
+  const whole = jpegWith(segment(0xe2, new Uint8Array(3000)), exifSegment(TIFF_LE));
+  assert.equal(jpegOrientation(whole), 6, 'the whole file reads fine');
+  assert.equal(jpegOrientation(whole.subarray(0, 2048)), undefined,
+    'a head stopping inside the long segment has not answered');
+  assert.equal(jpegOrientation(whole.subarray(0, 4)), undefined);
+
+  // And the same cut inside the Exif segment's directory itself.
+  const exifFirst = jpegWith(exifSegment(TIFF_LE));
+  assert.equal(jpegOrientation(exifFirst.subarray(0, 12)), undefined);
+  assert.equal(jpegOrientation(exifFirst.subarray(0, 4 + 6 + 8 + 2 + 12 + 6)), undefined,
+    'a head ending in the middle of the entry that would have said');
+});
+
+test('an Exif block cut after its directory is read from what the head holds', () => {
+  // A camera's Exif segment is mostly maker note and thumbnail, behind IFD0,
+  // and runs past any sensible head. The tag is in the first few dozen bytes,
+  // so the head has the answer, and a reader that insisted on the whole
+  // segment would send every camera-written preview back for a second read.
+  const long = jpegWith(exifSegment(concat(TIFF_LE, new Uint8Array(6000))));
+  assert.equal(jpegOrientation(long), 6);
+  assert.equal(jpegOrientation(long.subarray(0, 4096)), 6,
+    'the head holds IFD0, and IFD0 holds the tag');
+
+  // The same head with no tag in the directory is not yet an answer: the
+  // segment that has one might still be behind the cut.
+  const bare = new Uint8Array([0x49, 0x49, 42, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+  const longBare = jpegWith(exifSegment(concat(bare, new Uint8Array(6000))));
+  assert.equal(jpegOrientation(longBare), null);
+  assert.equal(jpegOrientation(longBare.subarray(0, 4096)), undefined);
+});
+
+test('a value outside 1..8, or a tag of the wrong shape, is treated as absent', () => {
+  assert.equal(jpegOrientation(jpegWith(exifSegment(tiffWithOrientation(0)))), null);
+  assert.equal(jpegOrientation(jpegWith(exifSegment(tiffWithOrientation(9)))), null);
+
+  const long = tiffWithOrientation(6);
+  new DataView(long.buffer).setUint16(12, 4, true);
+  assert.equal(jpegOrientation(jpegWith(exifSegment(long))), null,
+    'a LONG where the specification says SHORT is not believed');
+});
+
+test('garbage yields null or undefined, never a throw', () => {
+  const lies = tiffWithOrientation(6);
+  new DataView(lies.buffer).setUint32(4, 0xfffffff0, true);
+  assert.equal(jpegOrientation(jpegWith(exifSegment(lies))), null,
+    'an IFD offset outside the block');
+
+  const many = tiffWithOrientation(6);
+  new DataView(many.buffer).setUint16(8, 0xffff, true);
+  assert.equal(jpegOrientation(jpegWith(exifSegment(many))), 6,
+    'a directory claiming more entries than it has still yields the one it has');
+
+  const badMagic = tiffWithOrientation(6);
+  new DataView(badMagic.buffer).setUint16(2, 99, true);
+  assert.equal(jpegOrientation(jpegWith(exifSegment(badMagic))), null);
+
+  assert.equal(jpegOrientation(new Uint8Array(0)), undefined);
+  assert.equal(jpegOrientation(new Uint8Array([0xff, 0xd8])), undefined);
+  assert.equal(jpegOrientation(new Uint8Array(64).fill(0x77)), undefined);
+  assert.equal(jpegOrientation(concat([0xff, 0xd8, 0xff, 0xe1], u16be(1))), null,
+    'a segment length under two is nonsense, and nonsense is null');
+  assert.equal(jpegOrientation(concat([0xff, 0xd8, 0xff, 0xe1], u16be(0))), null);
+});
+
+/* ------------------------------------------------------------------- walker */
+
+test('the size and the orientation are read off one walk of the same segments', () => {
+  // Both readers run on the same head, and a preview of one camera turned the
+  // wrong way is what it would look like if they ever disagreed about where
+  // the preamble ends. So there is one walker, and both consumers see the
+  // same list.
+  const jfif = segment(0xe0, concat([0x4a, 0x46, 0x49, 0x46, 0], [1, 2, 0, 0, 1, 0, 1, 0, 0]));
+  const file = jpegWith(jfif, exifSegment(TIFF_LE), segment(0xdb, new Uint8Array(65)));
+  assert.deepEqual(
+    Array.from(jpegSegments(file), (seg) => [seg.marker, seg.complete, seg.frame, seg.final]),
+    [[0xe0, true, false, false], [0xe1, true, false, false], [0xdb, true, false, false],
+      [0xc0, true, true, false]],
+  );
+  assert.deepEqual(jpegSize(file), { width: 640, height: 480 });
+  assert.equal(jpegOrientation(file), 6);
+
+  const cut = file.subarray(0, file.length - 40);
+  const last = Array.from(jpegSegments(cut)).at(-1);
+  assert.equal(last.marker, 0xdb);
+  assert.equal(last.complete, false, 'the head ended inside the tables');
+  assert.equal(jpegSize(cut), null);
+  assert.equal(jpegOrientation(cut), 6, 'but the Exif block before them was whole');
+});
+
+/* --------------------------------------------------------------------- size */
+
+test('the size swaps for the four quarter turns and only those', () => {
+  for (const value of [1, 2, 3, 4]) {
+    assert.deepEqual(orientedSize(3000, 2000, value), { width: 3000, height: 2000 });
+  }
+  for (const value of [5, 6, 7, 8]) {
+    assert.deepEqual(orientedSize(3000, 2000, value), { width: 2000, height: 3000 });
+  }
+  assert.deepEqual(orientedSize(3000, 2000, null), { width: 3000, height: 2000 });
+  assert.deepEqual(orientedSize(3000, 2000, undefined), { width: 3000, height: 2000 });
+});
+
+/* ------------------------------------------------------------------- matrix */
+
+/**
+ * Where the matrix sends a corner of a w by h decode, in the upright picture's
+ * own coordinates: about the decode's centre, then re-centred in the upright
+ * box, which is exactly what drawFrame in pipeline.js does with it.
+ */
+function landing(orientation, w, h, x, y) {
+  const [a, b, c, d] = orientationMatrix(orientation);
+  const px = x - w / 2;
+  const py = y - h / 2;
+  const upright = orientedSize(w, h, orientation);
+  return [a * px + c * py + upright.width / 2, b * px + d * py + upright.height / 2];
+}
+
+test('each orientation sends the corners where the specification says', () => {
+  // Exif's own wording for each value is "the 0th row is the visual X and the
+  // 0th column is the visual Y". So the stored top-left corner - start of row
+  // 0 and of column 0 - lands at the visual X-Y corner, and the stored
+  // top-right, end of row 0, lands at the other end of the visual X edge.
+  const w = 300;
+  const h = 200;
+  const stored = { TL: [0, 0], TR: [w, 0], BR: [w, h], BL: [0, h] };
+  const uprightCorner = (orientation, name) => {
+    const { width, height } = orientedSize(w, h, orientation);
+    return { TL: [0, 0], TR: [width, 0], BR: [width, height], BL: [0, height] }[name];
+  };
+
+  const expected = {
+    1: { TL: 'TL', TR: 'TR', BR: 'BR', BL: 'BL' },
+    2: { TL: 'TR', TR: 'TL', BR: 'BL', BL: 'BR' },
+    3: { TL: 'BR', TR: 'BL', BR: 'TL', BL: 'TR' },
+    4: { TL: 'BL', TR: 'BR', BR: 'TR', BL: 'TL' },
+    5: { TL: 'TL', TR: 'BL', BR: 'BR', BL: 'TR' },
+    // 6 is the one that matters: a phone held upright. Row 0 runs down the
+    // right-hand side, so the stored top-left lands top-right and the decode
+    // has been turned a quarter clockwise.
+    6: { TL: 'TR', TR: 'BR', BR: 'BL', BL: 'TL' },
+    7: { TL: 'BR', TR: 'TR', BR: 'TL', BL: 'BL' },
+    8: { TL: 'BL', TR: 'TL', BR: 'TR', BL: 'BR' },
+  };
+
+  for (const [orientation, corners] of Object.entries(expected)) {
+    for (const [from, to] of Object.entries(corners)) {
+      assert.deepEqual(
+        landing(Number(orientation), w, h, ...stored[from]),
+        uprightCorner(Number(orientation), to),
+        `orientation ${orientation} sends the stored ${from} corner somewhere other than ${to}`,
+      );
+    }
+  }
+});
+
+test('the identity is the answer for no orientation at all', () => {
+  assert.deepEqual(orientationMatrix(1), [1, 0, 0, 1]);
+  assert.deepEqual(orientationMatrix(null), [1, 0, 0, 1]);
+  assert.deepEqual(orientationMatrix(undefined), [1, 0, 0, 1]);
+  assert.deepEqual(orientationMatrix(0), [1, 0, 0, 1]);
+  assert.deepEqual(orientationMatrix(9), [1, 0, 0, 1]);
+});
+
+test('every matrix is a signed permutation, so no turn scales the picture', () => {
+  for (let value = 1; value <= 8; value += 1) {
+    const [a, b, c, d] = orientationMatrix(value);
+    assert.equal(Math.abs(a * d - b * c), 1, `orientation ${value} changes the area`);
+    assert.equal(Math.abs(a) + Math.abs(b), 1);
+    assert.equal(Math.abs(c) + Math.abs(d), 1);
+  }
+});

--- a/tests/js/stack-images-pipeline.test.js
+++ b/tests/js/stack-images-pipeline.test.js
@@ -1,0 +1,177 @@
+/**
+ * tools/stack-images/src/pipeline.js - the part of the run that needs no canvas.
+ *
+ * The pipeline is written for a worker and touches no DOM at module scope, so
+ * it loads here; what it does with a decoder and a surface is exercised in a
+ * browser and not in this file. Two things are worth pinning without either.
+ *
+ * `declaredSize`, because every later stage plans from the number it returns
+ * and the number has to be the size the decode will actually have. That is
+ * the bug this file exists to keep fixed: a portrait JPEG from a phone is
+ * stored sideways with an Exif tag saying so, the browser's decoder turns it
+ * upright, and a size read off the frame header alone is a quarter turn out
+ * from the bitmap. Three such frames used to come back as one squashed
+ * landscape.
+ *
+ * And `openFrame`, which needs a File and nothing else, because the rule it
+ * implements for a RAW preview has four arms - the preview's own Exif wins;
+ * with none, the RAW's directory is applied here; with the head unable to
+ * say, a longer read; and after that, none - and a wrong arm does not fail,
+ * it turns one frame twice or not at all.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  EXIF_ID, IHDR, PNG_SIGNATURE, TIFF_LE, TIFF_TYPE, ascii, concat, segment, tiffEntry, tiffOf,
+  u16be, u32be,
+} from './helpers.js';
+import { declaredSize, openFrame } from '../../tools/stack-images/src/pipeline.js';
+
+const sof = (width, height) => concat(
+  [0xff, 0xc0], u16be(17), [8], u16be(height), u16be(width),
+  [3, 1, 0x22, 0, 2, 0x11, 1, 3, 0x11, 1],
+);
+
+const jpegWith = (segments, width, height) => concat(
+  [0xff, 0xd8], segments, sof(width, height), [0xff, 0xda], u16be(2050), new Uint8Array(2048),
+);
+
+/** An Exif APP1 saying 6, padded out to the length a camera's would have. */
+const exifSegment = (tail = 0) => segment(0xe1, concat(EXIF_ID, TIFF_LE, new Uint8Array(tail)));
+
+/** A TIFF-shaped RAW whose IFD0 says `orientation` and points at `preview`. */
+function rawWith(preview, orientation, size = null) {
+  const entries = [
+    tiffEntry(0x0103, TIFF_TYPE.SHORT, 1, 6),
+    tiffEntry(0x0111, TIFF_TYPE.LONG, 1, { blob: 0 }),
+    tiffEntry(0x0117, TIFF_TYPE.LONG, 1, preview.length),
+    tiffEntry(0x0112, TIFF_TYPE.SHORT, 1, orientation),
+  ];
+  if (size) {
+    entries.push(tiffEntry(0x0100, TIFF_TYPE.LONG, 1, size.width));
+    entries.push(tiffEntry(0x0101, TIFF_TYPE.LONG, 1, size.height));
+  }
+  const bytes = tiffOf({ dirs: [{ entries }], blobs: [preview] });
+  return new File([bytes], 'shot.cr2');
+}
+
+/** A Fujifilm RAF: no directory, the preview's offset and length at 84 and 88. */
+function rafWith(preview) {
+  const offset = 2048;
+  const bytes = new Uint8Array(offset + preview.length);
+  bytes.set(ascii('FUJIFILMCCD-RAW '), 0);
+  bytes.set(u32be(offset), 84);
+  bytes.set(u32be(preview.length), 88);
+  bytes.set(preview, offset);
+  return new File([bytes], 'shot.raf');
+}
+
+test('a JPEG stored sideways declares the upright size the decoder will give', () => {
+  // TIFF_LE's orientation is 6: rows run down the right-hand side, and the
+  // decode is a quarter turn clockwise from the stored 3000 by 2000.
+  const sideways = jpegWith([segment(0xe1, concat(EXIF_ID, TIFF_LE))], 3000, 2000);
+  assert.deepEqual(declaredSize(sideways), { width: 2000, height: 3000, orientation: 6 });
+});
+
+test('a JPEG without Exif declares its stored size, and says it found nothing', () => {
+  assert.deepEqual(declaredSize(jpegWith([], 3000, 2000)),
+    { width: 3000, height: 2000, orientation: null });
+});
+
+test('an orientation that does not turn the picture leaves the size alone', () => {
+  const flipped = new Uint8Array(TIFF_LE);
+  flipped[0x1e] = 3;
+  const upsideDown = jpegWith([segment(0xe1, concat(EXIF_ID, flipped))], 3000, 2000);
+  assert.deepEqual(declaredSize(upsideDown), { width: 3000, height: 2000, orientation: 3 });
+});
+
+test('a PNG is read off IHDR and carries no orientation', () => {
+  // helpers.js's IHDR is 1 by 1; enough bytes follow it for the check that
+  // guards the DataView.
+  const png = concat(PNG_SIGNATURE, IHDR, new Uint8Array(16));
+  assert.deepEqual(declaredSize(png), { width: 1, height: 1 });
+});
+
+test('anything else declares nothing, so the decoder is asked instead', () => {
+  assert.equal(declaredSize(new Uint8Array(64).fill(0x77)), null);
+  assert.equal(declaredSize(new Uint8Array([0xff, 0xd8, 0xff])), null,
+    'a JPEG cut off before its frame header has no size to give');
+  assert.equal(declaredSize(new Uint8Array(0)), null);
+});
+
+/* ---------------------------------------------------------------- openFrame */
+
+test('a JPEG the browser will orient is opened at its upright size, unturned', async () => {
+  const frame = await openFrame(new File([jpegWith([exifSegment()], 3000, 2000)], 'a.jpg'));
+  assert.equal(frame.kind, 'image');
+  assert.equal(frame.turn, 1, 'the decoder reads the file\'s own Exif; nothing is left to do');
+  assert.deepEqual([frame.width, frame.height], [2000, 3000]);
+  assert.deepEqual(frame.decoded, { width: 2000, height: 3000 });
+});
+
+test('a preview with Exif of its own is left to the browser, whatever the RAW says', async () => {
+  const frame = await openFrame(rawWith(jpegWith([exifSegment()], 6000, 4000), 8));
+  assert.equal(frame.kind, 'raw');
+  assert.equal(frame.turn, 1, 'applying the directory\'s 8 as well would turn it twice');
+  assert.deepEqual([frame.width, frame.height], [4000, 6000], 'oriented by the preview\'s 6');
+  assert.deepEqual(frame.decoded, { width: 4000, height: 6000 });
+});
+
+test('a preview with no Exif is turned here, by the RAW directory', async () => {
+  const frame = await openFrame(rawWith(jpegWith([], 6000, 4000), 6));
+  assert.equal(frame.turn, 6);
+  assert.deepEqual([frame.width, frame.height], [4000, 6000]);
+  assert.deepEqual(frame.decoded, { width: 6000, height: 4000 },
+    'the decoder will hand back the stored, sideways picture');
+});
+
+test('a long Exif block is read from the head, with no second read', async () => {
+  // Six kilobytes of maker note behind IFD0, so the segment runs past the 4 KB
+  // head. The tag was in the first forty bytes, and the head is enough. The
+  // size comes from the directory's tags, as it does for a CR2, because the
+  // frame header is behind the maker note too.
+  const size = { width: 6000, height: 4000 };
+  const short = await openFrame(rawWith(jpegWith([exifSegment()], 6000, 4000), 8, size));
+  const long = await openFrame(rawWith(jpegWith([exifSegment(6000)], 6000, 4000), 8, size));
+  assert.equal(long.turn, 1);
+  assert.deepEqual([long.width, long.height], [4000, 6000]);
+  assert.equal(long.bytesRead, short.bytesRead, 'nothing beyond the usual head was read');
+});
+
+test('a head that ends before the Exif block is followed by one longer read', async () => {
+  // An ICC profile ahead of the Exif block pushes it past the 4 KB head. The
+  // head cannot say either way, so the pipeline reads more - once, and no
+  // more of the preview than an Exif block could be behind - and finds it.
+  const icc = segment(0xe2, new Uint8Array(6000));
+  const preview = jpegWith([icc, exifSegment()], 6000, 4000);
+  const short = await openFrame(rawWith(jpegWith([exifSegment()], 6000, 4000), 8));
+  const frame = await openFrame(rawWith(preview, 8, { width: 6000, height: 4000 }));
+  assert.equal(frame.turn, 1, 'the preview\'s 6 was found on the second read');
+  assert.deepEqual([frame.width, frame.height], [4000, 6000]);
+  assert.equal(frame.bytesRead, short.bytesRead + Math.min(preview.length, 65536));
+});
+
+test('an Exif block the longer read cannot reach is treated as none', async () => {
+  // Two maximal segments before the Exif block put it past 64 KB. That is not
+  // a file a camera writes, so the pipeline stops reading and applies the
+  // directory, which for a real preview is the right answer.
+  const far = [segment(0xe2, new Uint8Array(40000)), segment(0xe2, new Uint8Array(40000))];
+  const frame = await openFrame(rawWith(jpegWith([...far, exifSegment()], 6000, 4000), 6));
+  assert.equal(frame.turn, 6);
+});
+
+test('a preview whose frame header lay past the head declares no size, not a size of nulls', async () => {
+  // A RAF arrives without size tags, and its frame header sits behind the
+  // camera's Exif block, past what the 4 KB head reached. The survey decode
+  // then fills the size in from the bitmap - but only if what it finds is
+  // null. A pair of nulls is an object, survives every `??`, and reaches the
+  // stack as a 1 by 1 working size that asks for a full decode on every band.
+  const frame = await openFrame(rafWith(jpegWith([exifSegment(6000)], 6000, 4000)));
+  assert.equal(frame.kind, 'raw');
+  assert.equal(frame.width, null);
+  assert.equal(frame.height, null);
+  assert.equal(frame.decoded, null);
+  assert.equal(frame.turn, 1, 'the RAF preview\'s own Exif, read off the head, does the turning');
+});

--- a/tests/js/stack-images-raw.test.js
+++ b/tests/js/stack-images-raw.test.js
@@ -24,7 +24,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { ascii, concat, u16be, u32be, u32le } from './helpers.js';
+import {
+  EXIF_ID, TIFF_LE, TIFF_TYPE as TYPE, ascii, concat, segment, tiffEntry as entry, tiffOf,
+  u16be, u32be, u32le,
+} from './helpers.js';
 import {
   RAW_EXTENSIONS, findPreview, jpegSize, looksRaw, paged, tiffHeader,
 } from '../../tools/stack-images/src/raw.js';
@@ -53,70 +56,6 @@ const jpegOf = (width, height, filler = 64, marker = 0xc0) => concat(
 
 /** Bytes that are not a JPEG, for the cases where a tag lies about what it points at. */
 const notJpeg = (length) => new Uint8Array(length).fill(0x77);
-
-const TYPE = { ASCII: 2, SHORT: 3, LONG: 4, UNDEFINED: 7 };
-const WIDTHS = { 2: 1, 3: 2, 4: 4, 7: 1 };
-
-/**
- * Lay out a TIFF: a header, a run of directories, then the data too long to sit
- * inside an entry.
- *
- * An entry's value is a number when it fits in the four bytes the entry has,
- * and an offset into the data area when it does not. That indirection is the
- * only awkward part of the format and it is the part worth exercising, so the
- * fixtures below deliberately use both.
- *
- * `dirs` is a list of `{ entries, next }`. An entry's value may be a plain
- * number, `{ blob: i }` for the offset of a data block, or `{ dir: i }` for the
- * offset of another directory.
- */
-function tiffOf({ little = true, magic = 42, dirs, blobs = [] }) {
-  const dirSizes = dirs.map((dir) => 2 + dir.entries.length * 12 + 4);
-  const dirAt = [];
-  let at = 8;
-  for (const size of dirSizes) { dirAt.push(at); at += size; }
-
-  const blobAt = [];
-  for (const blob of blobs) { blobAt.push(at); at += blob.length; }
-
-  const out = new Uint8Array(at);
-  const view = new DataView(out.buffer);
-  const resolve = (value) => {
-    if (typeof value === 'number') return value;
-    if (value.blob !== undefined) return blobAt[value.blob];
-    return dirAt[value.dir];
-  };
-
-  out.set(ascii(little ? 'II' : 'MM'), 0);
-  view.setUint16(2, magic, little);
-  view.setUint32(4, dirAt[0], little);
-
-  dirs.forEach((dir, index) => {
-    let cursor = dirAt[index];
-    view.setUint16(cursor, dir.entries.length, little);
-    cursor += 2;
-    for (const entry of dir.entries) {
-      view.setUint16(cursor, entry.tag, little);
-      view.setUint16(cursor + 2, entry.type, little);
-      view.setUint32(cursor + 4, entry.count, little);
-      const needed = WIDTHS[entry.type] * entry.count;
-      if (needed <= 4) {
-        // Left-justified inside the entry, whichever way round the file is.
-        if (entry.type === TYPE.SHORT) view.setUint16(cursor + 8, resolve(entry.value), little);
-        else view.setUint32(cursor + 8, resolve(entry.value), little);
-      } else {
-        view.setUint32(cursor + 8, resolve(entry.value), little);
-      }
-      cursor += 12;
-    }
-    view.setUint32(cursor, dir.next === undefined ? 0 : dirAt[dir.next], little);
-  });
-
-  blobs.forEach((blob, index) => out.set(blob, blobAt[index]));
-  return out;
-}
-
-const entry = (tag, type, count, value) => ({ tag, type, count, value });
 
 /** Read a whole in-memory fixture, counting what was asked for. */
 function readerFor(bytes) {
@@ -187,8 +126,37 @@ test('a CR2 gives up its full-size preview, not its thumbnail', () => {
     assert.equal(found.make, 'Canon');
     assert.equal(found.model, 'EOS 5D');
     assert.equal(found.orientation, 6, 'a sideways camera is worth knowing about');
+    assert.equal(found.previewOrientation, null,
+      'the preview carries no Exif of its own, and the pipeline must be told so');
     assert.deepEqual(Array.from(bytes.subarray(found.offset, found.offset + 3)),
       [0xff, 0xd8, 0xff], 'the offset does not land on a JPEG');
+  });
+});
+
+test('a preview that carries its own Exif reports its own orientation', () => {
+  // The two orientations answer different questions and both come back. The
+  // browser's decoder honours the preview's tag and never sees the RAW's, so
+  // which one the pipeline applies itself depends on knowing which was there.
+  const preview = concat(
+    [0xff, 0xd8], segment(0xe1, concat(EXIF_ID, TIFF_LE)), sof(0xc0, 6000, 4000),
+    [0xff, 0xda], u16be(2048 + 2), new Uint8Array(2048).fill(0x5a),
+  );
+  const bytes = tiffOf({
+    dirs: [{
+      entries: [
+        entry(0x0103, TYPE.SHORT, 1, 6),
+        entry(0x0111, TYPE.LONG, 1, { blob: 0 }),
+        entry(0x0117, TYPE.LONG, 1, preview.length),
+        entry(0x0112, TYPE.SHORT, 1, 8),
+      ],
+    }],
+    blobs: [preview],
+  });
+
+  return findIn(bytes).then((found) => {
+    assert.equal(found.width, 6000, 'the size is still the stored one; the pipeline orients it');
+    assert.equal(found.orientation, 8, 'the RAW says one thing');
+    assert.equal(found.previewOrientation, 6, 'and the preview says another');
   });
 });
 
@@ -224,6 +192,7 @@ test('a NEF gives up the preview hidden in a sub-directory', () => {
     assert.equal(found.width, 4928);
     assert.equal(found.from, 'sub');
     assert.equal(found.make, 'NIKON');
+    assert.equal(found.previewOrientation, null);
   });
 });
 
@@ -368,6 +337,8 @@ test('a Fujifilm RAF is read from the two numbers in its header', () => {
     assert.equal(found.offset, offset);
     assert.equal(found.width, 4896);
     assert.equal(found.make, 'FUJIFILM');
+    assert.equal(found.orientation, 1, 'a RAF has no directory to read one from');
+    assert.equal(found.previewOrientation, null, 'so the preview is the only place it could be');
   });
 });
 
@@ -406,6 +377,35 @@ test('a CR3 gives up the track whose sample turns out to be a JPEG', () => {
     assert.equal(found.offset, mdatAt);
     assert.equal(found.width, 6000);
     assert.equal(found.make, 'Canon');
+    assert.equal(found.orientation, 1, 'no CMT1 box, so upright is the only honest answer');
+  });
+});
+
+test('a CR3 reads its orientation out of the CMT1 box', () => {
+  // The JPEGs a CR3 embeds carry no Exif of their own, so the camera's IFD0,
+  // written whole into a CMT1 box behind the uuid, is the only place the
+  // orientation is. Without it a portrait CR3 stacks sideways and nothing says
+  // why - the preview-orientation rule reports null, honestly, and there is no
+  // directory value to fall back on.
+  const preview = jpegOf(6000, 4000, 2048);
+  const ftyp = box('ftyp', concat(ascii('crx '), u32be(1), ascii('crx isom')));
+  const mdat = box('mdat', preview);
+  const mdatAt = ftyp.length + 8;
+  const ifd0 = tiffOf({
+    dirs: [{ entries: [entry(0x010f, TYPE.ASCII, 6, { blob: 0 }), entry(0x0112, TYPE.SHORT, 1, 6)] }],
+    blobs: [ascii('Canon\0')],
+  });
+  const uuid = box('uuid', concat(new Uint8Array(16), box('CMT1', ifd0)));
+  const trak = box('trak', box('mdia', box('minf', box('stbl', concat(
+    box('stco', concat(u32be(0), u32be(1), u32be(mdatAt))),
+    box('stsz', concat(u32be(0), u32be(0), u32be(1), u32be(preview.length))),
+  )))));
+  const bytes = concat(ftyp, mdat, box('moov', concat(uuid, trak)));
+
+  return findIn(bytes).then((found) => {
+    assert.equal(found.from, 'trak');
+    assert.equal(found.orientation, 6);
+    assert.equal(found.previewOrientation, null, 'the preview itself still says nothing');
   });
 });
 

--- a/tools/stack-images/README.md
+++ b/tools/stack-images/README.md
@@ -82,13 +82,65 @@ surface in the pipeline is one. A document canvas cannot go to a worker.
 | `src/worker.js` | a shim around the pipeline, and the cancel flag |
 | `src/pipeline.js` | the run — open, survey, measure, stack, encode |
 | `src/raw.js` | finding the preview inside a RAW file. Reads offsets; never a pixel |
+| `src/orient.js` | the EXIF orientation: reading it off a JPEG head, and the turn that applies it |
 | `src/plan.js` | how much memory and how many decodes, before anything runs |
 | `src/stack.js` | the seven methods, as accumulators over plain RGBA |
 | `src/align.js` | phase correlation, and log-polar for rotation and scale |
 | `src/fft.js` | the transform the alignment is built on |
 
-`plan.js`, `stack.js`, `align.js`, `fft.js` and `raw.js` hold no DOM and no
-canvas, which is what lets them be tested without either.
+`plan.js`, `stack.js`, `align.js`, `fft.js`, `raw.js` and `orient.js` hold no
+DOM and no canvas, which is what lets them be tested without either.
+
+## Which way up a frame is
+
+A phone held upright stores its JPEG sideways and writes an EXIF orientation
+saying which way to turn it. The browser's decoder honours that tag:
+`createImageBitmap` hands back the upright picture, 3000 tall, from a file
+whose frame header says 3000 wide. So **every size the pipeline holds is the
+size the decode will actually have**, not the size the header declares.
+`declaredSize` swaps the header's numbers for the four quarter-turn values
+before anything plans from them, because everything downstream — the survey
+resize, the output box, the placement, the full-size decode — is asking what
+the bitmap will be. Before it did, three portrait frames came back as one
+landscape stack the shape of the reference forced sideways.
+
+A RAW file's embedded preview is the awkward case, because the orientation
+lives in the RAW's own IFD0, where the decoder never looks, and the preview
+JPEG usually carries no EXIF of its own. That frame arrives sideways and the
+pipeline has to turn it: `openFrame` gives it a `turn` (the IFD0 value) and a
+`decoded` size (the stored one), and a single `drawFrame` helper — the only
+`drawImage` of a frame bitmap in the file — applies `orientationMatrix` about
+the box's centre with the sides swapped, as the innermost step of whatever
+alignment transform is already on the context. The turn is synthesised **only
+when the preview has no EXIF of its own**: when it does, the browser will
+apply that, and applying the RAW's tag as well would turn the frame twice.
+
+That decision needs the reader to distinguish three answers, which is why
+`jpegOrientation` is tri-state. It walks the head of a JPEG over the same
+segment walker `jpegSize` uses — one walker, so the two cannot disagree about
+where a preamble ends — and returns the value when an Exif APP1 says so,
+`null` when the frame header or the scan is reached without one, and
+`undefined` when the bytes ran out first. It reads IFD0 from whatever of the
+Exif block the head holds, because the tag sits in the block's first few
+dozen bytes and the maker-note behind it can run to sixty kilobytes: a 4 KB
+head that ends inside the block has almost always already passed the answer.
+`undefined` is left for the head ending inside the directory itself, or before
+a segment that might still hold the tag. It is not a failure, and a reader
+that said "none" there would turn every such preview sideways. On `undefined`
+the pipeline reads a 64 KB head of the preview — enough to reach an Exif block
+written at the front, which is where every camera puts it — once, and only on
+that path; a preview whose Exif sits behind more than that of other segments
+is treated as having none.
+
+A CR3 is the one RAW whose preview never carries Exif and whose directory is
+not at the front of the file: its IFD0 sits whole in a `CMT1` box, and
+`walkBmff` reads the orientation out of it for the same rule to apply. A RAF
+needs nothing of the kind, because the JPEG it embeds carries its own.
+
+`tests/js/stack-images-orient.test.js` pins each of the eight matrices by
+where it sends the corners, against the specification's own wording of each
+value, because a rotation the wrong way round does not throw or look wrong in
+review: it puts one frame into the stack a half turn from the rest.
 
 ## Why six of the seven methods are free and one is not
 

--- a/tools/stack-images/src/orient.js
+++ b/tools/stack-images/src/orient.js
@@ -1,0 +1,206 @@
+/**
+ * EXIF orientation: reading it off a JPEG, and what to do about it.
+ *
+ * A phone held upright writes its JPEG sideways - the rows run down the long
+ * edge of the sensor - and puts a number in the Exif block saying which way to
+ * turn it. The browser's decoder honours that number: createImageBitmap hands
+ * back the upright picture, 3000 tall, from a file whose frame header says
+ * 3000 wide. So a pipeline that reads sizes off the header and pixels off the
+ * decoder is working from two different pictures, and everything it plans -
+ * the output box, the thumbnail, the resize it asks the decoder for - is a
+ * quarter turn out. Three portrait frames come back as one squashed landscape.
+ *
+ * The rule this file exists to serve is that every size the pipeline holds is
+ * the size the decode will actually have. For a JPEG the browser will orient,
+ * that means swapping the header's numbers here. For a RAW file's embedded
+ * preview it is subtler: the preview usually carries no Exif of its own, the
+ * orientation lives in the RAW's IFD0 where the decoder never looks, and so
+ * the pipeline has to turn that frame itself. `orientationMatrix` is that turn.
+ *
+ * THE CONVENTION
+ *
+ * An EXIF orientation says how the stored rows relate to the scene. Value 6 -
+ * the common one, a phone or a camera held upright - means the stored image's
+ * row 0 runs down the *right-hand* side of the scene: to display it, turn the
+ * decode a quarter turn clockwise. `orientationMatrix` returns, for each value,
+ * the 2D matrix that takes an UNORIENTED decode to its upright form when
+ * applied about the image's centre, in canvas terms (y down, setTransform
+ * order [a, b, c, d]). tests/js/stack-images-orient.test.js pins each of the
+ * eight by mapping the corners, because a wrong sign here does not throw: it
+ * produces a stack of one frame turned the other way from the rest.
+ *
+ * THE TRI-STATE
+ *
+ * `jpegOrientation` reads the Exif block off a head of the file, and a head can
+ * run out. It distinguishes three answers: a value, because the Exif said so;
+ * null, because the frame header or the scan was reached and there is no
+ * orientation to find; and undefined, because the bytes ended first. The last
+ * one is what lets a caller read more rather than guess - a 4 KB head that
+ * stops inside a long APP segment has not said "no Exif", only "not yet".
+ *
+ * This is a leaf: no DOM, no canvas, nothing it cannot be tested without.
+ */
+
+/* 'E' 'x' 'i' 'f' NUL NUL - the six bytes that open an Exif APP1 payload. */
+const EXIF_ID = [0x45, 0x78, 0x69, 0x66, 0x00, 0x00];
+
+const ORIENTATION_TAG = 0x0112;
+
+/**
+ * The 2D matrix, in setTransform order, that turns an unoriented decode
+ * upright for each EXIF value. Indexed by the value itself; 0 is unused.
+ */
+const MATRICES = [
+  null,
+  [1, 0, 0, 1],
+  [-1, 0, 0, 1],
+  [-1, 0, 0, -1],
+  [1, 0, 0, -1],
+  [0, 1, 1, 0],
+  [0, 1, -1, 0],
+  [0, -1, -1, 0],
+  [0, -1, 1, 0],
+];
+
+/**
+ * Walk a JPEG's segments from its SOI, yielding each header found until the
+ * walk is over: at a frame header, at the scan, or at a length that cannot be.
+ *
+ * This is the one walker. `jpegSize` in raw.js and `jpegOrientation` below are
+ * both run on the same head of the same file and both need to know where its
+ * preamble ends; two copies of the walk is how they would come to disagree, and
+ * nothing would notice, because the disagreement is a preview of one camera
+ * turned the wrong way. Fill bytes are skipped, standalone markers - SOI, TEM,
+ * the restart markers - are stepped over, and every other marker carries a
+ * two-byte length. `complete` says whether the whole segment lies inside the
+ * bytes given, so that a consumer can tell "not here" from "not yet".
+ *
+ * @param {Uint8Array} bytes  the head of a JPEG, from its SOI
+ * @returns {Generator<{marker: number, at: number, length: number,
+ *   complete: boolean, frame: boolean, final: boolean}>}
+ */
+export function* jpegSegments(bytes) {
+  let at = 2;
+  while (at + 4 <= bytes.length) {
+    if (bytes[at] !== 0xff) { at += 1; continue; }
+    const marker = bytes[at + 1];
+    if (marker === 0xff) { at += 1; continue; }
+    if (marker === 0xd8 || marker === 0x01 || (marker >= 0xd0 && marker <= 0xd7)) {
+      at += 2;
+      continue;
+    }
+    const length = (bytes[at + 2] << 8) | bytes[at + 3];
+    // C4 is the Huffman tables, C8 is a JPEG extension and CC is arithmetic
+    // conditioning. Everything else in C0..CF starts a frame, and everything
+    // a preamble can say - the size, the Exif block - comes before it.
+    const frame = marker >= 0xc0 && marker <= 0xcf
+      && marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc;
+    // The scan, or an end-of-image with no scan at all: either way there is
+    // nothing more to read as a segment.
+    const final = marker === 0xda || marker === 0xd9;
+    yield {
+      marker, at, length, complete: at + 2 + length <= bytes.length, frame, final,
+    };
+    if (frame || final || length < 2) return;
+    at += 2 + length;
+  }
+}
+
+/**
+ * The EXIF orientation a JPEG declares, or null, or undefined.
+ *
+ * The Exif block is read from whatever of it the head holds, because IFD0 sits
+ * in the first few dozen bytes of a segment that can run to sixty kilobytes of
+ * maker note and thumbnail: a 4 KB head that ends inside the segment has
+ * usually already passed the tag, and a reader that demanded the whole segment
+ * first would send every camera-written preview back for a second read. So
+ * undefined means the bytes ended before the answer did - inside the directory
+ * itself, or before a segment that might still hold the tag - and nothing
+ * else. Nothing here throws on garbage: a length or an offset that points
+ * outside what was read yields null or undefined, never an exception, since
+ * the caller is opening somebody's file and has a decoder to fall back on.
+ *
+ * @param {Uint8Array} bytes  the head of a JPEG, from its SOI
+ * @returns {number | null | undefined}
+ */
+export function jpegOrientation(bytes) {
+  for (const seg of jpegSegments(bytes)) {
+    if (seg.frame || seg.final || seg.length < 2) return null;
+    if (seg.marker !== 0xe1) {
+      if (!seg.complete) return undefined;
+      continue;
+    }
+    const start = seg.at + 4;
+    const end = Math.min(seg.at + 2 + seg.length, bytes.length);
+    if (start + EXIF_ID.length > bytes.length) return undefined;
+    if (isExif(bytes, start)) {
+      const found = tiffOrientation(bytes.subarray(start + EXIF_ID.length, end), !seg.complete);
+      if (found !== null) return found;
+    }
+    if (!seg.complete) return undefined;
+  }
+  // The head ended inside a segment, before anything that could have settled
+  // the question either way.
+  return undefined;
+}
+
+function isExif(bytes, at) {
+  return EXIF_ID.every((byte, i) => bytes[at + i] === byte);
+}
+
+/**
+ * IFD0's orientation out of a TIFF block, or null, or undefined.
+ *
+ * Only the first directory is read, because that is where the specification
+ * puts the tag and where every camera writes it. The tag has to be a SHORT
+ * with a count of one to be believed; a value outside 1..8 is treated as
+ * absent rather than as a ninth way up. `truncated` says the block given is
+ * the front of a longer one, and turns "ran off the end" from the null it
+ * means for a whole block into the undefined that asks for more bytes.
+ */
+function tiffOrientation(tiff, truncated) {
+  const ranOut = () => (truncated ? undefined : null);
+  if (tiff.length < 8) return ranOut();
+  let little;
+  if (tiff[0] === 0x49 && tiff[1] === 0x49) little = true;
+  else if (tiff[0] === 0x4d && tiff[1] === 0x4d) little = false;
+  else return null;
+
+  const view = new DataView(tiff.buffer, tiff.byteOffset, tiff.byteLength);
+  if (view.getUint16(2, little) !== 42) return null;
+  const first = view.getUint32(4, little);
+  if (first < 8) return null;
+  if (first + 2 > tiff.length) return ranOut();
+
+  const count = view.getUint16(first, little);
+  for (let i = 0; i < count; i += 1) {
+    const entry = first + 2 + i * 12;
+    if (entry + 12 > tiff.length) return ranOut();
+    if (view.getUint16(entry, little) !== ORIENTATION_TAG) continue;
+    if (view.getUint16(entry + 2, little) !== 3 || view.getUint32(entry + 4, little) !== 1) {
+      return null;
+    }
+    const value = view.getUint16(entry + 8, little);
+    return value >= 1 && value <= 8 ? value : null;
+  }
+  return null;
+}
+
+/**
+ * The size a picture has once its orientation is applied: the stored width
+ * and height swapped for the four values that involve a quarter turn.
+ */
+export function orientedSize(width, height, orientation) {
+  return orientation >= 5 && orientation <= 8
+    ? { width: height, height: width }
+    : { width, height };
+}
+
+/**
+ * The [a, b, c, d] that turns an unoriented decode upright, about its centre.
+ * See the convention in the header comment. Anything that is not a value
+ * from 1 to 8 is the identity, which is what an absent orientation means.
+ */
+export function orientationMatrix(orientation) {
+  return MATRICES[orientation] ?? MATRICES[1];
+}

--- a/tools/stack-images/src/pipeline.js
+++ b/tools/stack-images/src/pipeline.js
@@ -40,6 +40,7 @@ import { WEAK_PEAK, estimate, phaseCorrelate, window2d } from './align.js';
 import {
   bands, commonArea, outputSize, placement, planRun, refineMargin, refineWindow, workingSize,
 } from './plan.js';
+import { jpegOrientation, orientationMatrix, orientedSize } from './orient.js';
 import { findPreview, jpegSize, looksRaw } from './raw.js';
 import { createStack } from './stack.js';
 
@@ -78,6 +79,15 @@ class Cancelled extends Error {}
  * actually use it - which on a set of twenty 24-megapixel frames is twenty
  * decodes thrown away. Anything neither of these recognises falls back to a
  * decode, so this is an optimisation rather than a restriction.
+ *
+ * For a JPEG the size returned is the ORIENTED one. The frame header says how
+ * the rows are stored; the browser's decoder reads the Exif orientation and
+ * hands back the picture turned upright, so a portrait phone photograph is
+ * 3000 wide in the header and 3000 tall in the bitmap. Every consumer of this
+ * number - the survey resize, the output box, the placement, the full-size
+ * decode - is asking what the decode will be, so that is what it gets. The
+ * orientation itself rides along (a value, null for none, undefined when the
+ * head ended before it could be settled) for the caller that wants to know.
  */
 export function declaredSize(bytes) {
   if (bytes.length > 24 && PNG_SIGNATURE.every((byte, i) => bytes[i] === byte)) {
@@ -87,9 +97,29 @@ export function declaredSize(bytes) {
       return { width: view.getUint32(16, false), height: view.getUint32(20, false) };
     }
   }
-  if (bytes[0] === 0xff && bytes[1] === 0xd8) return jpegSize(bytes);
+  if (bytes[0] === 0xff && bytes[1] === 0xd8) {
+    const stored = jpegSize(bytes);
+    if (!stored) return null;
+    const orientation = jpegOrientation(bytes);
+    return { ...orientedSize(stored.width, stored.height, orientation ?? 1), orientation };
+  }
   return null;
 }
+
+/** An IFD0 orientation a camera could have written; anything else means upright. */
+const validTurn = (value) => (value >= 1 && value <= 8 ? value : 1);
+
+/**
+ * How much of a RAW preview to read when 4 KB was not enough to tell whether
+ * it carries an orientation of its own. The reader takes IFD0 from whatever
+ * of the Exif block it has, so this path is reached only when something
+ * longer than the head sits *before* the Exif block, or when the preview has
+ * no Exif and a long segment before its frame header. Sixty-four kilobytes is
+ * enough to reach an Exif block written at the front of the preview, which is
+ * where every camera puts it; a preview whose Exif sits behind more than that
+ * of other segments is treated as having none.
+ */
+const PREVIEW_HEAD_RETRY = 65536;
 
 /**
  * What to decode for one chosen file.
@@ -98,6 +128,19 @@ export function declaredSize(bytes) {
  * file - the camera's own preview - and finding it costs a few reads of a few
  * kilobytes each. Either way the result is a Blob the browser's own decoder can
  * open, and at no point is a whole RAW file pulled into memory.
+ *
+ * Two fields describe which way up the frame is, and the rest of the pipeline
+ * holds them apart. `width` and `height` are always the upright size. `turn`
+ * is an EXIF orientation the pipeline must apply itself, 1 meaning none, and
+ * `decoded` is the size of the bitmap the decoder will hand back - which is
+ * the upright size when the browser does the turning and the stored size when
+ * this code does. For an ordinary picture the browser always does: it reads
+ * the file's own Exif. A RAW preview is the case that needs the second pair.
+ * The orientation lives in the RAW's IFD0, where the decoder never looks, and
+ * the preview JPEG usually carries no Exif of its own, so the sideways preview
+ * arrives sideways and the turn has to be made here. When the preview *does*
+ * carry Exif the browser applies that and the RAW's tag is left alone - two
+ * turns would be one too many.
  */
 export async function openFrame(file) {
   const read = async (offset, length) => new Uint8Array(
@@ -106,14 +149,36 @@ export async function openFrame(file) {
 
   const raw = looksRaw(file.name) ? await findPreview(read, file.size, MIN_PREVIEW_PIXELS) : null;
   if (raw) {
+    let fromPreview = raw.previewOrientation;
+    let bytesRead = raw.read;
+    if (fromPreview === undefined) {
+      // The 4 KB that confirmed the preview ended before its Exif block, or
+      // before the frame header that would have said there is none. One
+      // longer read settles it; still kilobytes, and only on this path.
+      const more = Math.min(raw.length, PREVIEW_HEAD_RETRY);
+      fromPreview = jpegOrientation(await read(raw.offset, more)) ?? null;
+      bytesRead += more;
+    }
+    const turn = fromPreview === null ? validTurn(raw.orientation) : 1;
+    // A preview found through a track or a RAF header, whose frame header
+    // lay past the 4 KB head, arrives with no size at all; then there is no
+    // upright size to give and no decoded one either, and the survey fills
+    // both from the bitmap. A pair of nulls in `decoded` would not be filled,
+    // and would ask the decoder for a 1 by 1 working size on every band.
+    const known = Boolean(raw.width && raw.height);
+    const upright = known ? orientedSize(raw.width, raw.height, fromPreview ?? turn) : null;
+    let decoded = null;
+    if (known) decoded = turn === 1 ? upright : { width: raw.width, height: raw.height };
     return {
       name: file.name,
       blob: file.slice(raw.offset, raw.offset + raw.length, 'image/jpeg'),
-      width: raw.width,
-      height: raw.height,
+      width: upright?.width ?? null,
+      height: upright?.height ?? null,
+      turn,
+      decoded,
       kind: 'raw',
       camera: [raw.make, raw.model].filter(Boolean).join(' ') || null,
-      bytesRead: raw.read,
+      bytesRead,
       sourceBytes: file.size,
     };
   }
@@ -128,6 +193,8 @@ export async function openFrame(file) {
     blob: file,
     width: declared?.width ?? null,
     height: declared?.height ?? null,
+    turn: 1,
+    decoded: declared ? { width: declared.width, height: declared.height } : null,
     kind: looksRaw(file.name) ? 'raw-unreadable' : 'image',
     camera: null,
     bytesRead: head.length,
@@ -150,6 +217,36 @@ function surface(width, height) {
 }
 
 /**
+ * Draw one frame's bitmap into a box, the right way up.
+ *
+ * Every drawImage of a frame in this file goes through here, because a frame
+ * the browser did not orient - a RAW preview whose orientation lives in the
+ * RAW's directory rather than in the preview - has to be turned by whoever
+ * draws it, and a draw that forgot would put one sideways frame into a stack
+ * of upright ones without anything failing. With no turn it is exactly the
+ * plain draw into the box. With one, the bitmap is drawn about the box's
+ * centre through the orientation's matrix, at the box's size with its sides
+ * swapped where the turn is a quarter one, so the stored rows land where the
+ * upright picture has them. The turn composes with whatever transform is
+ * already on the context - the alignment, in drawAligned - as the innermost
+ * step, which is what makes it a property of the frame rather than of the
+ * output.
+ */
+function drawFrame(context, bitmap, spot, turn) {
+  if (turn === 1) {
+    context.drawImage(bitmap, spot.x, spot.y, spot.width, spot.height);
+    return;
+  }
+  const stored = orientedSize(spot.width, spot.height, turn);
+  const [a, b, c, d] = orientationMatrix(turn);
+  context.save();
+  context.translate(spot.x + spot.width / 2, spot.y + spot.height / 2);
+  context.transform(a, b, c, d, 0, 0);
+  context.drawImage(bitmap, -stored.width / 2, -stored.height / 2, stored.width, stored.height);
+  context.restore();
+}
+
+/**
  * Draw one frame into a destination box, with its alignment applied.
  *
  * The three parts of the transform are applied about the middle of the output -
@@ -163,7 +260,7 @@ function surface(width, height) {
  * is about to read. The centre the transform turns about stays the *uncropped*
  * output's, because that is the space the movement was measured in.
  */
-function drawAligned(context, bitmap, spot, output, move, crop, bandY) {
+function drawAligned(context, bitmap, spot, output, move, crop, bandY, turn) {
   const cx = output.width / 2;
   const cy = output.height / 2;
   context.setTransform(1, 0, 0, 1, -crop.x, -crop.y - bandY);
@@ -171,7 +268,7 @@ function drawAligned(context, bitmap, spot, output, move, crop, bandY) {
   context.rotate((move.angle * Math.PI) / 180);
   context.scale(move.scale, move.scale);
   context.translate(-cx, -cy);
-  context.drawImage(bitmap, spot.x, spot.y, spot.width, spot.height);
+  drawFrame(context, bitmap, spot, turn);
 }
 
 /**
@@ -183,12 +280,16 @@ function drawAligned(context, bitmap, spot, output, move, crop, bandY) {
  * the next thing it does is correlate it.
  */
 async function surveyFrame(frame) {
+  const known = Boolean(frame.width && frame.height);
   let bitmap;
-  if (frame.width && frame.height) {
+  if (known) {
+    // The resize is asked for in the decoder's own terms - the stored size,
+    // for a frame this code turns itself - or a sideways preview would be
+    // squeezed into an upright box before it was ever turned.
     const fit = Math.min(1, THUMB_SIZE / Math.max(frame.width, frame.height));
     bitmap = await createImageBitmap(frame.blob, {
-      resizeWidth: Math.max(1, Math.round(frame.width * fit)),
-      resizeHeight: Math.max(1, Math.round(frame.height * fit)),
+      resizeWidth: Math.max(1, Math.round(frame.decoded.width * fit)),
+      resizeHeight: Math.max(1, Math.round(frame.decoded.height * fit)),
       resizeQuality: 'medium',
     });
   } else {
@@ -197,16 +298,23 @@ async function surveyFrame(frame) {
     bitmap = await createImageBitmap(frame.blob);
   }
 
-  const shown = surface(bitmap.width, bitmap.height);
-  shown.context.drawImage(bitmap, 0, 0);
+  // The list shows the picture upright, whichever of the two did the turning.
+  const upright = orientedSize(bitmap.width, bitmap.height, frame.turn);
+  const shown = surface(upright.width, upright.height);
+  drawFrame(shown.context, bitmap, { x: 0, y: 0, ...upright }, frame.turn);
   const thumb = await shown.canvas.convertToBlob({ type: 'image/jpeg', quality: 0.8 });
   shown.canvas.width = 0;
 
+  // A frame that declared no size gets all three from the bitmap, in the same
+  // terms as the rest: the upright size for the box it will occupy, and the
+  // bitmap's own for what the decoder hands back. A frame that declared one
+  // keeps it, because a survey decode that was resized is no witness to it.
   return {
     described: {
       ...frame,
-      width: frame.width ?? bitmap.width,
-      height: frame.height ?? bitmap.height,
+      width: known ? frame.width : upright.width,
+      height: known ? frame.height : upright.height,
+      decoded: known ? frame.decoded : { width: bitmap.width, height: bitmap.height },
     },
     bitmap,
     thumb,
@@ -250,11 +358,11 @@ export async function inspect(files, hooks) {
  * separately would make that number different per frame, and different in each
  * axis for any frame of a different shape.
  */
-function lumaSquare(bitmap, spot, output, fit) {
+function lumaSquare(bitmap, spot, output, fit, turn) {
   const { canvas, context } = surface(ALIGN_SIZE, ALIGN_SIZE);
   context.setTransform(1, 0, 0, 1, fit.x, fit.y);
   context.scale(fit.scale, fit.scale);
-  context.drawImage(bitmap, spot.x, spot.y, spot.width, spot.height);
+  drawFrame(context, bitmap, spot, turn);
 
   const pixels = context.getImageData(0, 0, ALIGN_SIZE, ALIGN_SIZE).data;
   const out = new Float64Array(ALIGN_SIZE * ALIGN_SIZE);
@@ -275,9 +383,9 @@ function lumaSquare(bitmap, spot, output, fit) {
  * with nothing to multiply back up. That is the whole point of measuring
  * twice: here, an error of a twentieth of a pixel is a twentieth of a pixel.
  */
-function refineSquare(bitmap, spot, output, move, at, size) {
+function refineSquare(bitmap, spot, output, move, at, size, turn) {
   const { canvas, context } = surface(size, size);
-  drawAligned(context, bitmap, spot, output, move, at, 0);
+  drawAligned(context, bitmap, spot, output, move, at, 0, turn);
   const pixels = context.getImageData(0, 0, size, size).data;
   const out = new Float64Array(size * size);
   for (let i = 0, p = 0; i < out.length; i += 1, p += 4) {
@@ -360,7 +468,7 @@ export async function runStack(request, hooks) {
     // copy of. Its own size never enters the arithmetic.
     const square = lumaSquare(frame.thumb, {
       x: spot.x, y: spot.y, width: spot.width, height: spot.height,
-    }, output, fit);
+    }, output, fit, frame.turn);
 
     if (!reference) {
       reference = square;
@@ -442,8 +550,8 @@ export async function runStack(request, hooks) {
         });
 
         const spot = placement(frame, output);
-        const working = workingSize(frame.width, frame.height, 1);
-        const bitmap = await decodeAt(frame.blob, working, spot);
+        const working = workingSize(frame.decoded.width, frame.decoded.height, 1);
+        const bitmap = await decodeAt(frame.blob, working, spot, frame.turn);
 
         // Each frame's first full-size appearance settles its final position.
         // Later bands and passes reuse the answer, so a banded run stays
@@ -453,7 +561,9 @@ export async function runStack(request, hooks) {
         // wrong by, leaves the frame where the coarse measurement put it.
         if (refine && !refined[index]) {
           refined[index] = true;
-          const square = refineSquare(bitmap, spot, output, moves[index], refineAt, refine);
+          const square = refineSquare(
+            bitmap, spot, output, moves[index], refineAt, refine, frame.turn,
+          );
           if (index === 0) {
             referenceWindow = square;
           } else if (referenceWindow) {
@@ -468,7 +578,7 @@ export async function runStack(request, hooks) {
 
         context.setTransform(1, 0, 0, 1, 0, 0);
         context.clearRect(0, 0, crop.width, band.readRows);
-        drawAligned(context, bitmap, spot, output, moves[index], crop, band.readY);
+        drawAligned(context, bitmap, spot, output, moves[index], crop, band.readY, frame.turn);
         bitmap.close();
 
         stack.add(context.getImageData(0, 0, crop.width, band.readRows).data, index, pass);
@@ -520,10 +630,16 @@ export async function runStack(request, hooks) {
  * scaling afterwards, is the cheapest resampling available: it happens inside
  * the browser's own decoder, and for a JPEG being halved or quartered it can be
  * done in the frequency domain without ever building the full-size image.
+ *
+ * `natural` is the size the decoder will produce and `spot` is the upright box
+ * the frame is going into, so for a frame this code turns itself the request
+ * is the box with its sides swapped: the decoder does not know about the turn
+ * and would otherwise be asked for a portrait picture from a landscape stream.
  */
-function decodeAt(blob, natural, spot) {
-  const width = Math.max(1, Math.round(spot.width));
-  const height = Math.max(1, Math.round(spot.height));
+function decodeAt(blob, natural, spot, turn) {
+  const wanted = orientedSize(spot.width, spot.height, turn);
+  const width = Math.max(1, Math.round(wanted.width));
+  const height = Math.max(1, Math.round(wanted.height));
   if (width >= natural.width && height >= natural.height) {
     // Upscaling, or no change. Let the draw do it rather than the decoder, so
     // nothing is resampled twice.

--- a/tools/stack-images/src/raw.js
+++ b/tools/stack-images/src/raw.js
@@ -35,6 +35,8 @@
  * decoder a slice of packed sensor data and believing whatever it says.
  */
 
+import { jpegOrientation, jpegSegments } from './orient.js';
+
 /** Where a preview was found, used to break ties between equal-looking ones. */
 const FULL_SIZE_FIRST = ['ifd0', 'sub', 'jpgfromraw', 'raf', 'trak', 'ifd', 'prvw'];
 
@@ -334,6 +336,9 @@ async function walkRaf(file) {
   const offset = view.getUint32(84, false);
   const length = view.getUint32(88, false);
   if (!offset || !length || offset + length > file.size) return null;
+  // No directory to read an orientation from, and none is needed: the JPEG a
+  // RAF embeds carries its own Exif block, so it reaches the pipeline through
+  // the preview-orientation rule in findPreview rather than through this one.
   return {
     candidates: [{ offset, length, width: null, height: null, from: 'raf', scan: true }],
     make: 'FUJIFILM',
@@ -384,6 +389,7 @@ async function walkBmff(file) {
   if (new TextDecoder('latin1').decode(head.subarray(4, 8)) !== 'ftyp') return null;
 
   const found = [];
+  let orientation = 1;
 
   /** Descend, filling `tables` for the track being walked. */
   async function descend(start, end, depth, tables) {
@@ -399,6 +405,11 @@ async function walkBmff(file) {
         await descend(box.body + 16, box.end, depth + 1, tables);
       } else if (tables && (box.type === 'stco' || box.type === 'co64' || box.type === 'stsz')) {
         tables[box.type] = box.body;
+      } else if (box.type === 'CMT1') {
+        // The camera's IFD0, as a whole TIFF block in a box of its own. The
+        // JPEGs a CR3 embeds carry no Exif, so unlike a RAF this is the only
+        // place the orientation is written, and the pipeline has to be told.
+        orientation = await ifd0Orientation(file, box.body) ?? orientation;
       } else if (box.type === 'PRVW' || box.type === 'THMB') {
         // Both hold a whole JPEG behind a short fixed header. Rather than pin
         // that header's length per box and per firmware, the candidate starts
@@ -438,7 +449,23 @@ async function walkBmff(file) {
   }
 
   if (!found.length) return null;
-  return { candidates: found, make: 'Canon', model: null, orientation: 1 };
+  return { candidates: found, make: 'Canon', model: null, orientation };
+}
+
+/** The orientation tag out of a TIFF block found at `at`, or null. */
+async function ifd0Orientation(file, at) {
+  if (at + 8 > file.size) return null;
+  const header = tiffHeader(await file.at(at, 8));
+  if (!header) return null;
+  let dir = null;
+  try {
+    dir = await readDirectory(file, at, header.first, header.little);
+  } catch {
+    return null;
+  }
+  if (!dir) return null;
+  const value = await number(file, dir.entries.get(TAG.ORIENTATION), header.little);
+  return value >= 1 && value <= 8 ? value : null;
 }
 
 /** Where a track's first sample is, and how long. */
@@ -483,32 +510,22 @@ async function firstSample(file, tables) {
  * no tags beside it, and ranking previews by byte length alone picks the wrong
  * one the moment a camera writes a small preview at high quality. Every frame
  * marker - baseline, progressive, lossless, arithmetic - carries the same two
- * numbers in the same two places, so which one it is does not matter.
+ * numbers in the same two places, so which one it is does not matter. The walk
+ * to the frame header is orient.js's, shared with the orientation reader that
+ * runs on the same head, so the two cannot disagree about where it is.
  */
 export function jpegSize(bytes) {
-  let at = 2;
-  while (at + 9 < bytes.length) {
-    if (bytes[at] !== 0xff) { at += 1; continue; }
-    const marker = bytes[at + 1];
-    if (marker === 0xff) { at += 1; continue; }
-    if (marker === 0xd8 || marker === 0x01 || (marker >= 0xd0 && marker <= 0xd7)) {
-      at += 2;
+  for (const seg of jpegSegments(bytes)) {
+    if (!seg.frame) {
+      if (seg.final || seg.length < 2) return null;
       continue;
     }
-    if (marker === 0xda || marker === 0xd9) return null;
-    const length = (bytes[at + 2] << 8) | bytes[at + 3];
-    if (length < 2) return null;
-    // C4 is the Huffman tables, C8 is a JPEG extension and CC is arithmetic
-    // conditioning. Everything else in C0..CF starts a frame.
-    const frame = marker >= 0xc0 && marker <= 0xcf
-      && marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc;
-    if (frame) {
-      return {
-        height: (bytes[at + 5] << 8) | bytes[at + 6],
-        width: (bytes[at + 7] << 8) | bytes[at + 8],
-      };
-    }
-    at += 2 + length;
+    const { at } = seg;
+    if (at + 9 > bytes.length) return null;
+    return {
+      height: (bytes[at + 5] << 8) | bytes[at + 6],
+      width: (bytes[at + 7] << 8) | bytes[at + 8],
+    };
   }
   return null;
 }
@@ -549,7 +566,16 @@ export function looksRaw(name) {
  * @param {number} [minimumPixels]  below this a preview is not worth stacking
  * @returns {Promise<null | {offset: number, length: number, width: number|null,
  *   height: number|null, from: string, make: string|null, model: string|null,
- *   orientation: number, read: number}>}
+ *   orientation: number, previewOrientation: number|null|undefined, read: number}>}
+ *
+ * Two orientations come back and they answer different questions. `orientation`
+ * is the RAW's own, from IFD0, and is how the camera was held. `previewOrientation`
+ * is what the preview JPEG says about itself, read off the same head that
+ * confirmed it: a value when it carries Exif, null when it reaches its frame
+ * header without any, and undefined when 4 KB was not enough to tell. The
+ * distinction matters because the browser's decoder honours the second and
+ * never sees the first, so whichever of the two the pipeline applies itself
+ * depends on what the preview already had.
  */
 export async function findPreview(read, size, minimumPixels = 640 * 480) {
   const file = paged(read, size);
@@ -586,6 +612,7 @@ export async function findPreview(read, size, minimumPixels = 640 * 480) {
       width: declared?.width ?? candidate.width ?? null,
       height: declared?.height ?? candidate.height ?? null,
       from: candidate.from,
+      previewOrientation: jpegOrientation(head.subarray(start)),
     });
   }
 

--- a/tools/stack-images/tool.toml
+++ b/tools/stack-images/tool.toml
@@ -38,7 +38,7 @@ js_parts = ["file-picker", "message-box"]
 # tools whose picker takes what this page produces; checked against the tools
 # that exist by the build.
 handoff = ["compress-image", "resize-image"]
-lastmod = "2026-08-28"
+lastmod = "2026-09-06"
 
 # --- what search engines and chat apps are told ------------------------------
 


### PR DESCRIPTION
## What was wrong

A portrait photograph came out of the stacker squashed into landscape. `declaredSize` read the JPEG frame header, which gives the size of the *stored* rows, while `createImageBitmap` applies the file's EXIF orientation and hands back the upright picture. Three frames that decode as 2000 × 3000 were planned, resized and drawn as 3000 × 2000, and the result is the reference forced sideways (it matches that to 0.03 levels).

A RAW file has the opposite problem. `raw.js` already read the orientation out of IFD0, but `openFrame` dropped it, and the preview JPEG a camera embeds usually carries no EXIF of its own, so a portrait RAW stacked on its side.

## What changed

- **`src/orient.js`**, a new leaf: `jpegOrientation` reads the EXIF orientation off a JPEG head and is tri-state (a value; `null` when the frame header or the scan is reached without one; `undefined` when the bytes ran out first, so the caller can read more rather than guess). It reads IFD0 from whatever of the Exif block the head holds, so a 4 KB head that ends inside a 60 KB maker note has usually already passed the tag. `orientedSize` and `orientationMatrix` are the two facts about each of the eight values, pinned by mapping corners. `jpegSegments` is the one segment walker, which `jpegSize` in `raw.js` now uses too, so the two readers cannot disagree about where a preamble ends.
- **`declaredSize`** returns the oriented size for a JPEG, so every consumer (the survey resize, the output box, the placement, the full-size decode) sees the size the decode will actually have.
- **`openFrame`** gives every frame a `turn` and a `decoded` size. For an ordinary picture the browser does the turning. For a RAW preview the turn is synthesised from IFD0 **only when the preview has no EXIF of its own**; when it does, the browser applies that and applying the RAW's tag as well would turn the frame twice. A preview whose head was too short to tell gets one 64 KB read, counted in the bytes-read figure.
- **`drawFrame`** is now the only `drawImage` of a frame bitmap in the pipeline (thumbnail, alignment square, refinement window, and the stack draw all go through it), applying the turn as the innermost step of whatever alignment transform is on the context.
- **`walkBmff`** reads a CR3's orientation out of its `CMT1` box, the one place a CR3 writes it; a RAF needs nothing because its embedded JPEG carries its own Exif.
- A RAW preview that declared no size (its frame header past the 4 KB head) now reaches the stack with `decoded: null` and is filled from the survey bitmap, rather than a pair of nulls that would have asked the decoder for a 1 × 1 working size on every band. That was caught in review of this change, not in production.

Tests: `stack-images-orient.test.js` and `stack-images-pipeline.test.js` are new; the raw tests gain fixtures for a preview that carries its own orientation, a CR3 with `CMT1`, and the two-orientations rule. 113 stack-images tests pass. No visitor-facing string changed, so no locale is touched; `lastmod` is bumped.

## Before / after

Three copies of one portrait frame, stacked with no alignment. The left panel is the input as any viewer shows it, the right panel is the tool's result. The pictures are the tool's actual output composed beside its input by a scratch page against the built site, before and after this change.

| | Before | After |
|---|---|---|
| JPEG, EXIF orientation 6 | <img width="700" alt="orientation-jpeg-before" src="https://github.com/user-attachments/assets/f4ed8372-e1f1-4e9f-9025-dfa537cde8fd" /> | <img width="700" alt="orientation-jpeg-after" src="https://github.com/user-attachments/assets/6cdf784a-f6cb-420b-a26d-bd737e635d9d" /> |
| RAW-shaped TIFF, IFD0 orientation 6, preview without EXIF | <img width="700" alt="orientation-raw-before" src="https://github.com/user-attachments/assets/cd9d3b8f-2fe1-410c-8584-0bb7ae13fce4" /> | <img width="700" alt="orientation-raw-after" src="https://github.com/user-attachments/assets/e182f00f-bd19-4e89-ad57-e8014404537b" /> |

Verified in the browser against the built page for orientations 3, 6 and 8 as JPEG, for a synthetic RAW with IFD0 6 and 8 whose preview has no EXIF, for a RAW whose preview carries EXIF 6 beside IFD0 6 (turned once, not twice), and at half working scale; every result matches the upright reference to 0.55 levels (JPEG noise). Sub-pixel alignment accuracy on landscape frames is unchanged.

This is the first of three PRs from the output-quality audit of this tool; the next two rework the alignment's confidence gate and its rotation estimate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
