### PR TITLE
Measure whether a peak means anything before moving a frame by it

### DIFF
--- a/tests/js/stack-images-align.test.js
+++ b/tests/js/stack-images-align.test.js
@@ -22,8 +22,8 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
-  ALIGN_MODES, MAX_ROTATION, NO_MOVE,
-  estimate, logPolar, logSpectrum, phaseCorrelate, rotateScale, window2d,
+  ALIGN_MODES, MAX_ROTATION, NO_MOVE, N_MAX, P_MAX,
+  estimate, isMeasured, logPolar, logSpectrum, phaseCorrelate, rotateScale, window2d,
 } from '../../tools/stack-images/src/align.js';
 
 const close = (actual, expected, tolerance, what) => assert.ok(
@@ -31,13 +31,17 @@ const close = (actual, expected, tolerance, what) => assert.ok(
   `${what}: ${actual} is not within ${tolerance} of ${expected}`,
 );
 
-/** A picture with enough structure at enough orientations to correlate. */
-function field(size, fn) {
+/**
+ * A picture with enough structure at enough orientations to correlate,
+ * sampled `dx`, `dy` pixels over when asked - a shift by any real amount,
+ * exact because the scene is defined at every coordinate.
+ */
+function field(size, fn, dx = 0, dy = 0) {
   const centre = (size - 1) / 2;
   const out = new Float64Array(size * size);
   for (let y = 0; y < size; y += 1) {
     for (let x = 0; x < size; x += 1) {
-      out[y * size + x] = fn(x - centre, y - centre);
+      out[y * size + x] = fn(x - centre - dx, y - centre - dy);
     }
   }
   return out;
@@ -78,6 +82,134 @@ const scene = (u, v) => (
   + 35 * octave(u - 40, v + 25, 2.2)
 );
 
+/**
+ * The same scene without its two finer octaves: a wall in soft light, a sky
+ * with some cloud in it. Everything the correlation has to hold onto is
+ * thirteen pixels across or larger, so the peak is broad and the noise is not.
+ */
+const lowScene = (u, v) => 90 * octave(u, v, 13);
+
+/**
+ * A different picture, on lattices that share no pitch with the first. Two
+ * value-noise scenes on the same lattice are not unrelated - the whitened
+ * correlation finds the lattice - and that was the first version of this.
+ */
+const otherScene = (u, v) => (
+  90 * octave(u + 1000, v + 777, 11.3)
+  + 60 * octave(u - 300, v + 60, 4.7)
+  + 35 * octave(u + 40, v - 25, 1.9)
+);
+
+/** A featureless frame: nothing in it but a slope. */
+const gradient = (u, v) => 100 + 0.3 * u + 0.15 * v;
+
+/** A different wall: the low-texture octave of otherScene, on its own. */
+const otherLow = (u, v) => 90 * octave(u + 1000, v + 777, 11.3);
+
+/**
+ * A clear sky as the survey square sees it: a slope of about sixty levels
+ * across the whole square, which is what a 3000-pixel gradient with twelve
+ * per cent noise comes down to after the JPEG and the resize, with one per
+ * cent of noise left on it. Rounded to 8 bits below, because that is what
+ * getImageData does and the banding it leaves is what correlates.
+ */
+const diagonal = (u, v) => 150 + 0.15 * u + 0.09 * v;
+const horizontal = (u, v) => 150 + 0.235 * u;
+
+/** A night sky: small bright spots on a dark ground, a few hundred unless asked. */
+function starField(size, count = 300) {
+  let state = 99;
+  const next = () => {
+    state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+    return state / 4294967296;
+  };
+  const stars = [];
+  for (let i = 0; i < count; i += 1) {
+    stars.push({
+      x: (next() - 0.5) * size, y: (next() - 0.5) * size,
+      brightness: 60 + 190 * next(), spread: 0.8 + 1.2 * next(),
+    });
+  }
+  return (u, v) => {
+    let out = 8;
+    for (const star of stars) {
+      const d2 = (u - star.x) ** 2 + (v - star.y) ** 2;
+      if (d2 < 30) out += star.brightness * Math.exp(-d2 / (2 * star.spread ** 2));
+    }
+    return Math.min(255, out);
+  };
+}
+
+/**
+ * Gaussian noise of a given deviation, from a seeded generator so that the
+ * numbers recorded beside the assertions below are the numbers a run sees.
+ * Each frame gets its own seed: the noise on one frame must not correlate with
+ * the noise on the other, or the noise itself is a feature at zero shift.
+ */
+function noisy(values, sigma, seed) {
+  let state = seed >>> 0;
+  const next = () => {
+    state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+    return state / 4294967296;
+  };
+  for (let i = 0; i < values.length; i += 1) {
+    values[i] += sigma * Math.sqrt(-2 * Math.log(1 - next())) * Math.cos(2 * Math.PI * next());
+  }
+  return values;
+}
+
+/**
+ * What a JPEG does to a square: the 8x8 DCT of every block quantised with
+ * the standard luminance table at quality `q` and transformed back. The
+ * block grid it leaves is the feature every JPEG frame of a burst shares.
+ */
+const LUMA_TABLE = [
+  16, 11, 10, 16, 24, 40, 51, 61, 12, 12, 14, 19, 26, 58, 60, 55,
+  14, 13, 16, 24, 40, 57, 69, 56, 14, 17, 22, 29, 51, 87, 80, 62,
+  18, 22, 37, 56, 68, 109, 103, 77, 24, 35, 55, 64, 81, 104, 113, 92,
+  49, 64, 78, 87, 103, 121, 120, 101, 72, 92, 95, 98, 112, 100, 103, 99,
+];
+function jpeg(values, size, q) {
+  const scale = q < 50 ? 5000 / q : 200 - 2 * q;
+  const table = LUMA_TABLE.map((t) => Math.max(1, Math.floor((t * scale + 50) / 100)));
+  const c = (k) => (k === 0 ? Math.SQRT1_2 : 1);
+  const cosine = [];
+  for (let x = 0; x < 8; x += 1) {
+    cosine[x] = [];
+    for (let k = 0; k < 8; k += 1) cosine[x][k] = Math.cos(((2 * x + 1) * k * Math.PI) / 16);
+  }
+  const out = new Float64Array(size * size);
+  const coefficient = new Float64Array(64);
+  for (let by = 0; by < size; by += 8) {
+    for (let bx = 0; bx < size; bx += 8) {
+      for (let v = 0; v < 8; v += 1) {
+        for (let u = 0; u < 8; u += 1) {
+          let sum = 0;
+          for (let y = 0; y < 8; y += 1) {
+            for (let x = 0; x < 8; x += 1) {
+              sum += (values[(by + y) * size + bx + x] - 128) * cosine[x][u] * cosine[y][v];
+            }
+          }
+          const step = table[v * 8 + u];
+          coefficient[v * 8 + u] = Math.round((0.25 * c(u) * c(v) * sum) / step) * step;
+        }
+      }
+      for (let y = 0; y < 8; y += 1) {
+        for (let x = 0; x < 8; x += 1) {
+          let sum = 0;
+          for (let v = 0; v < 8; v += 1) {
+            for (let u = 0; u < 8; u += 1) {
+              sum += c(u) * c(v) * coefficient[v * 8 + u] * cosine[x][u] * cosine[y][v];
+            }
+          }
+          out[(by + y) * size + bx + x] = 0.25 * sum + 128;
+        }
+      }
+    }
+  }
+  return out;
+}
+
 /** Move a square by whole pixels, wrapping - an exact shift, with no resampling. */
 function circularShift(values, size, dx, dy) {
   const out = new Float64Array(size * size);
@@ -101,7 +233,12 @@ test('the shift reported is the one that puts the frame back', () => {
 
   close(found.dx, -7, 1e-6, 'horizontal correction');
   close(found.dy, 5, 1e-6, 'vertical correction');
-  assert.ok(found.confidence > 10, `an exact shift should correlate strongly, got ${found.confidence}`);
+  // Every weighted bin agrees on an exact shift, so the whole spectrum lands
+  // on one point. Measured 1.0000; and the rest of the surface is nothing,
+  // so the tallest point outside the peak's box is 0.040 of it.
+  close(found.coherence, 1, 1e-6, 'the coherence of an exact match');
+  assert.ok(found.next < 0.1, `the uniqueness of an exact match: ${found.next}`);
+  assert.ok(isMeasured(found), 'an exact shift is measured');
 });
 
 test('two identical frames need no correction at all', () => {
@@ -119,20 +256,19 @@ test('a shift is found to better than a whole pixel', () => {
   // softness the alignment exists to prevent. A half-pixel shift is built by
   // sampling the scene half a pixel over, so the answer is known exactly.
   const size = 64;
-  const centre = (size - 1) / 2;
   const reference = field(size, scene);
-  const frame = new Float64Array(size * size);
-  for (let y = 0; y < size; y += 1) {
-    for (let x = 0; x < size; x += 1) {
-      frame[y * size + x] = scene(x - centre - 2.5, y - centre);
-    }
-  }
+  const frame = field(size, scene, 2.5, 0);
 
   const found = phaseCorrelate(window2d(reference, size), window2d(frame, size), size);
 
   // The frame samples the scene two and a half pixels over, so it is the
   // reference moved right by that much and the correction is to move it back.
-  close(found.dx, -2.5, 0.35, 'a half-pixel shift');
+  // Measured -2.466. The tolerance is a bound on the estimator at this size,
+  // not on this one fixture: over fractions from 2.0 to 3.0 the regularised
+  // peak's error ran 0.003 (at 2.6) to 0.059 (at 2.3), biased towards a
+  // smaller shift, so 2.5 is not its worst case; the fully whitened peak
+  // needed 0.35 here.
+  close(found.dx, -2.5, 0.1, 'a half-pixel shift');
   assert.notEqual(found.dx, Math.round(found.dx), 'the answer snapped to an integer');
 });
 
@@ -145,6 +281,627 @@ test('a windowed shift survives the taper', () => {
 
   close(found.dx, 11, 0.5, 'horizontal correction');
   close(found.dy, -6, 0.5, 'vertical correction');
+});
+
+/**
+ * THE GATE, PINNED FROM BOTH SIDES
+ *
+ * These fixtures are the ones the constants in align.js were calibrated on,
+ * at the 256 square the coarse pass uses and then at the windows the
+ * refinement uses, windowed as the pipeline windows them. The noise is fifteen
+ * per cent of each scene's own range (six for the stars), on each frame
+ * independently. The number beside each assertion is what this seed measured;
+ * the constants were chosen over ten seeds, and the ranges are in the
+ * comments on P_MAX and N_MAX. Coherence is written beside them because it
+ * travels with the move and the page may one day show it; nothing here pins
+ * it to a floor, and the comment on L_MIN says why it stopped being one.
+ */
+const GATE_SIZE = 256;
+
+function gateFixture(a, b, size = GATE_SIZE) {
+  return phaseCorrelate(window2d(a, size), window2d(b, size), size);
+}
+
+/** What getImageData does to every square the pipeline builds. */
+function eightBit(values) {
+  for (let i = 0; i < values.length; i += 1) {
+    values[i] = Math.max(0, Math.min(255, Math.round(values[i])));
+  }
+  return values;
+}
+
+/**
+ * What lumaSquare does to every 3:2 frame: the picture fills 256 by 171 of
+ * the square and the rest is the canvas's transparent black. The hard edge
+ * along row 171 is shared by both frames wherever the camera moved, and it
+ * is the difference between a gradient that measures 0.08 coherence and one
+ * that measures 0.56 - the edge pins the vertical, and the slope, which
+ * matches itself at any offset, leaves a ridge along the other axis.
+ */
+function letterbox(values, size, rows = 171) {
+  for (let y = rows; y < size; y += 1) {
+    for (let x = 0; x < size; x += 1) values[y * size + x] = 0;
+  }
+  return values;
+}
+
+test('identical textured frames pass the gate', () => {
+  const found = gateFixture(field(GATE_SIZE, scene), field(GATE_SIZE, scene));
+  // live 0.133, coherence 1.000, plateau 0.002, next 0.020
+  assert.ok(isMeasured(found), `live ${found.live}, plateau ${found.plateau}, next ${found.next}`);
+  close(found.dx, 0, 1e-6, 'horizontal');
+  close(found.dy, 0, 1e-6, 'vertical');
+});
+
+test('a noisy textured frame passes the gate and lands where it should', () => {
+  const found = gateFixture(
+    noisy(field(GATE_SIZE, scene), 28, 1),
+    noisy(field(GATE_SIZE, scene, 3.3, -2.6), 28, 2),
+  );
+  // live 0.014, coherence 0.369, plateau 0.221, next 0.140; found
+  // (-3.268, 2.663), 0.07 px off
+  assert.ok(isMeasured(found), `live ${found.live}, plateau ${found.plateau}, next ${found.next}`);
+  close(found.dx, -3.3, 0.15, 'horizontal correction');
+  close(found.dy, 2.6, 0.15, 'vertical correction');
+});
+
+test('a noisy low-texture frame passes the gate and lands within a pixel', () => {
+  // The fixture the whitening constant was chosen on. With the spectrum fully
+  // whitened this was 1.3 to 2.8 pixels off, because the thousands of bins
+  // holding nothing but noise voted with the same weight as the few holding
+  // the picture.
+  const found = gateFixture(
+    noisy(field(GATE_SIZE, lowScene), 13.5, 3),
+    noisy(field(GATE_SIZE, lowScene, 2.4, -1.7), 13.5, 4),
+  );
+  // live 0.015, coherence 0.384, plateau 0.417, next 0.137; found
+  // (-2.683, 1.692), 0.28 px off
+  assert.ok(isMeasured(found), `live ${found.live}, plateau ${found.plateau}, next ${found.next}`);
+  close(found.dx, -2.4, 1, 'horizontal correction');
+  close(found.dy, 1.7, 1, 'vertical correction');
+});
+
+test('the noisiest real scenes keep their peaks under the plateau floor', () => {
+  // The plateau floor is pinned from the real side by the scenes whose peaks
+  // are broadest: little texture and a lot of noise. Over ten seeds the
+  // low-texture scene at thirty per cent noise reached 0.58 on the full
+  // square and 0.68 letterboxed, against P_MAX of 0.7; the comment on P_MAX
+  // has every range.
+  const low = gateFixture(
+    noisy(field(GATE_SIZE, lowScene), 27, 3),
+    noisy(field(GATE_SIZE, lowScene, 2.4, -1.7), 27, 4),
+  );
+  // live 0.012, coherence 0.247, plateau 0.515, next 0.270; found
+  // (-2.754, 1.710)
+  assert.ok(isMeasured(low), `plateau ${low.plateau}, next ${low.next}`);
+  close(low.dx, -2.4, 1, 'horizontal correction');
+  close(low.dy, 1.7, 1, 'vertical correction');
+
+  const texture = gateFixture(
+    noisy(field(GATE_SIZE, scene), 56, 1),
+    noisy(field(GATE_SIZE, scene, 3.3, -2.6), 56, 2),
+  );
+  // live 0.011, coherence 0.166, plateau 0.368, next 0.291; found
+  // (-3.070, 2.754)
+  assert.ok(isMeasured(texture), `plateau ${texture.plateau}, next ${texture.next}`);
+  close(texture.dx, -3.3, 0.5, 'horizontal correction');
+  close(texture.dy, 2.6, 0.5, 'vertical correction');
+
+  // The same two with the survey square's letterbox under them, since its
+  // edge lifts every plateau: the textured pair to 0.488 and the low-texture
+  // pair to 0.589, both still measured. The letterbox is not free on the
+  // low-texture pair - the ridge pulls its vertical towards zero, to 0.41
+  // against 1.7 - which is a cost of the survey square, not of the gate, and
+  // is recorded here rather than asserted away. It lifts the uniqueness
+  // reading too, to 0.46 and 0.37 from 0.29 and 0.27, because the ridge is
+  // a second place the surface stands high.
+  const boxedTexture = gateFixture(
+    letterbox(noisy(field(GATE_SIZE, scene), 56, 1), GATE_SIZE),
+    letterbox(noisy(field(GATE_SIZE, scene, 3.3, -2.6), 56, 2), GATE_SIZE),
+  );
+  // live 0.012, coherence 0.184, plateau 0.488, next 0.460; found
+  // (-2.949, 2.531)
+  assert.ok(isMeasured(boxedTexture), `plateau ${boxedTexture.plateau}, next ${boxedTexture.next}`);
+  const boxedLow = gateFixture(
+    letterbox(noisy(field(GATE_SIZE, lowScene), 27, 3), GATE_SIZE),
+    letterbox(noisy(field(GATE_SIZE, lowScene, 2.4, -1.7), 27, 4), GATE_SIZE),
+  );
+  // live 0.013, coherence 0.267, plateau 0.589, next 0.371; found
+  // (-2.809, 0.414)
+  assert.ok(isMeasured(boxedLow), `plateau ${boxedLow.plateau}, next ${boxedLow.next}`);
+  assert.ok(boxedLow.plateau < P_MAX, 'the nearest real fixture to the plateau floor');
+});
+
+test('a featureless frame fails the gate', () => {
+  // A gradient with independent noise on each frame. There is nothing here to
+  // align on, and what the peak reports is where the noise happened to pile
+  // up: this seed says (5.2, -6.9). The old z-score gave it 27 and the
+  // pipeline moved it. What refuses it is uniqueness: the surface is noise
+  // peaks of much the same height, and the next tallest is 0.944 of the one
+  // the argmax chose - 0.87-1.00 over ten seeds.
+  const found = gateFixture(
+    noisy(field(GATE_SIZE, gradient), 17, 5),
+    noisy(field(GATE_SIZE, gradient), 17, 6),
+  );
+  // live 0.010, coherence 0.052, plateau 0.517, next 0.944
+  assert.ok(found.next > N_MAX, `next ${found.next}`);
+  assert.ok(!isMeasured(found), `live ${found.live}, plateau ${found.plateau}, next ${found.next}`);
+
+  // And without the noise, a bare slope: the window takes the mean out and
+  // what is left is numerically nothing, so every bin above rounding error
+  // "agrees" and the coherence is a perfect 1. That is what the live floor
+  // is for; the plateau, 0.832, would refuse it too, and the next reading
+  // of 0.712 would not.
+  const bare = gateFixture(field(GATE_SIZE, gradient), field(GATE_SIZE, gradient, 3, 0));
+  // live 0.0014, coherence 1.000, plateau 0.832, next 0.712
+  assert.ok(!isMeasured(bare), `live ${bare.live}, plateau ${bare.plateau}, next ${bare.next}`);
+  assert.ok(!isMeasured({ live: bare.live }), 'refused by live alone');
+
+  // And the one the coarse square actually sees of a clear sky: the slope
+  // rounded to 8 bits, with one per cent of noise. The contour lines of a
+  // quantised slope are a lattice, and a lattice correlates with itself at
+  // every offset it repeats at, which is what a uniqueness reading of 0.965
+  // is: 0.82-1.00 over ten seeds, against a floor of 0.8.
+  const sky = gateFixture(
+    eightBit(noisy(field(GATE_SIZE, gradient), 1.15, 5)),
+    eightBit(noisy(field(GATE_SIZE, gradient), 1.15, 6)),
+  );
+  // live 0.010, coherence 0.093, plateau 0.671, next 0.965, at (-0.9, 5.1)
+  assert.ok(sky.next > N_MAX, `next ${sky.next}`);
+  assert.ok(!isMeasured(sky), `live ${sky.live}, plateau ${sky.plateau}, next ${sky.next}`);
+});
+
+test('a smooth gradient is refused although it correlates with itself', () => {
+  // The case coherence cannot see. In the browser, four frames of one
+  // gradient came back measured at coherence 0.47-0.51 and were moved by
+  // -12.9, +35.6 and -0.4 output pixels from an identity that was the
+  // truth. What the survey square holds of a clear sky is the slope's 8-bit
+  // banding over a letterbox, and the letterbox's edge is shared by both
+  // frames, so the two do correlate - at 0.56 here, nearly four times what
+  // was then the coherence floor, and the assertion on it below is there to
+  // say the fixture still reproduces the browser. But the surface is a
+  // ridge along the slope: the peak is still at 0.98 of its height eight
+  // pixels away, and where its argmax lands on the ridge is the noise's
+  // choice. Both modes must refuse it, and neither may call it clamped,
+  // because no rotation was read. The ridge is also a place the surface
+  // stands high outside the peak's box, so uniqueness refuses it as well,
+  // at 0.96-0.99.
+  const boxed = (fn, seed, dx = 0) => window2d(
+    letterbox(eightBit(noisy(field(GATE_SIZE, fn, dx), 1.3, seed)), GATE_SIZE), GATE_SIZE,
+  );
+  const cases = [
+    // coherence 0.563, plateau 0.976, next 0.959, at (-0.10, 0.00) in both modes
+    ['identical', boxed(diagonal, 11), boxed(diagonal, 21)],
+    // translate: coherence 0.568, plateau 0.976, next 0.978, at (4.19, 0.00)
+    // for a true shift of -3. similarity: the log-polar peak passed and was
+    // applied as a scale of 0.944, and the translation peak then measured
+    // 0.492, 0.998 and 0.972 - refused, which discards the scale with it.
+    ['shifted three pixels', boxed(diagonal, 12), boxed(diagonal, 22, 3)],
+    // translate: coherence 0.573, plateau 0.994, next 0.988, at (-2.61, 0.00);
+    // similarity: 0.572, 0.987 and 0.956, with a scale of 0.974 discarded
+    // the same way
+    ['horizontal', boxed(horizontal, 13), boxed(horizontal, 23)],
+  ];
+  for (const [name, reference, frame] of cases) {
+    for (const mode of ['translate', 'similarity']) {
+      const found = estimate(reference, frame, GATE_SIZE, mode);
+      assert.ok(
+        found.coherence >= 0.4,
+        `${name}, ${mode}: coherence ${found.coherence} - this fixture no longer reproduces the browser`,
+      );
+      assert.ok(found.plateau > P_MAX, `${name}, ${mode}: plateau ${found.plateau}`);
+      assert.ok(found.next > N_MAX, `${name}, ${mode}: next ${found.next}`);
+      assert.equal(found.measured, false, `${name}, ${mode}: measured`);
+      assert.equal(found.clamped, false, `${name}, ${mode}: clamped`);
+    }
+  }
+
+  // The same slope over the whole square, without the letterbox, has no
+  // ridge - the plateau is 0.676, under the floor - and is refused by
+  // uniqueness alone, at 0.940: its contour lattice repeats. The letterbox
+  // is what the browser case is made of, not a detail of it.
+  const plain = gateFixture(
+    eightBit(noisy(field(GATE_SIZE, diagonal), 1.3, 11)),
+    eightBit(noisy(field(GATE_SIZE, diagonal), 1.3, 21)),
+  );
+  // live 0.010, coherence 0.075, plateau 0.676, next 0.940
+  assert.ok(plain.plateau < P_MAX, `plateau ${plain.plateau}`);
+  assert.ok(plain.next > N_MAX, `next ${plain.next}`);
+  assert.ok(!isMeasured(plain));
+});
+
+test('two unrelated pictures fail the gate', () => {
+  const found = gateFixture(field(GATE_SIZE, scene), field(GATE_SIZE, otherScene));
+  // live 0.099, coherence 0.060, plateau 0.640, next 0.863; the peak is at
+  // (37.9, -7.9), which is nothing, and the next tallest noise peak is
+  // within a seventh of it
+  assert.ok(found.next > N_MAX, `next ${found.next}`);
+  assert.ok(!isMeasured(found), `live ${found.live}, plateau ${found.plateau}, next ${found.next}`);
+
+  // Two unrelated low-texture pictures sharing a letterbox: the browser read
+  // the pair at coherence 0.28 and plateau 0.81 and refused it. The fixture
+  // sits on both floors at once - at fifteen per cent noise plateau
+  // 0.64-0.78 against 0.7 and next 0.72-0.82 against 0.8, so four seeds in
+  // ten pass and are moved by one to four pixels; at five per cent 0.72-0.80
+  // and 0.79-0.83, refused every time. The comments on P_MAX and N_MAX record
+  // the pass-through and the taper that would remove it. What is pinned is
+  // a seed both floors refuse, and the browser's own readings - the survey
+  // square's, and the refinement window's next of 0.98.
+  const boxedLow = gateFixture(
+    letterbox(noisy(field(GATE_SIZE, lowScene), 13.5, 3), GATE_SIZE),
+    letterbox(noisy(field(GATE_SIZE, otherLow), 13.5, 4), GATE_SIZE),
+  );
+  // live 0.016, coherence 0.153, plateau 0.776, next 0.823, at (-2.81, -0.03)
+  assert.ok(boxedLow.plateau > P_MAX, `plateau ${boxedLow.plateau}`);
+  assert.ok(boxedLow.next > N_MAX, `next ${boxedLow.next}`);
+  assert.ok(!isMeasured(boxedLow));
+  assert.ok(!isMeasured({ live: 0.01, coherence: 0.28, plateau: 0.81 }), 'the browser reading, survey');
+  assert.ok(!isMeasured({ live: 0.01, coherence: 0.03, plateau: 0.21, next: 0.98 }), 'the browser reading, refinement');
+});
+
+test('a star field passes the gate', () => {
+  // Almost all dark, so almost all of the spectrum is noise - the case a gate
+  // on how much spectrum there is would refuse, and the case that matters
+  // most to a tool that stacks night skies.
+  const sky = starField(GATE_SIZE);
+  const found = gateFixture(
+    noisy(field(GATE_SIZE, sky), 15, 7),
+    noisy(field(GATE_SIZE, sky, 5.4, -3.2), 15, 8),
+  );
+  // live 0.029, coherence 0.737, plateau 0.035, next 0.076 - the sharpest
+  // and the most alone peak of any fixture, a star being a point; found
+  // (-5.388, 3.179), 0.02 px off
+  assert.ok(isMeasured(found), `live ${found.live}, plateau ${found.plateau}, next ${found.next}`);
+  close(found.dx, -5.4, 0.1, 'horizontal correction');
+  close(found.dy, 3.2, 0.1, 'vertical correction');
+
+  // At fifteen per cent noise the coherence has halved and the answer has
+  // not moved: live 0.014, coherence 0.401, plateau 0.067, next 0.144, at
+  // (-5.504, 3.179).
+  const noisier = gateFixture(
+    noisy(field(GATE_SIZE, sky), 38, 7),
+    noisy(field(GATE_SIZE, sky, 5.4, -3.2), 38, 8),
+  );
+  assert.ok(isMeasured(noisier), `plateau ${noisier.plateau}, next ${noisier.next}`);
+  close(noisier.dx, -5.4, 0.15, 'horizontal correction');
+  close(noisier.dy, 3.2, 0.15, 'vertical correction');
+});
+
+test('the gate holds at the refinement windows', () => {
+  // Both floors are ratios of the surface to its own peak, so neither
+  // scales with the side of the square; the tables on P_MAX and N_MAX show
+  // them holding from 128 to 512. At 128 a noisy textured pair is measured
+  // and the junk is not.
+  const texture = gateFixture(
+    noisy(field(128, scene), 28, 3),
+    noisy(field(128, scene, 3.3, -2.6), 28, 4),
+    128,
+  );
+  // live 0.013, coherence 0.376, plateau 0.202, next 0.190
+  assert.ok(isMeasured(texture), `plateau ${texture.plateau}, next ${texture.next}`);
+  // The plateau is read eight pixels out at every size, and at 128 that
+  // keeps the low-texture pair: its thirteen-pixel features have fallen to
+  // 0.33-0.47 of the peak by then, over ten seeds. The first version read
+  // the plateau at a thirty-second of the side, four pixels here, where the
+  // same pair stood at 0.76-0.91 and was refused with its peak in the right
+  // place; plateauRadius in align.js says why the radius is fixed.
+  const low = gateFixture(
+    noisy(field(128, lowScene), 13.5, 3),
+    noisy(field(128, lowScene, 2.4, -1.7), 13.5, 4),
+    128,
+  );
+  // live 0.015, coherence 0.394, plateau 0.327, next 0.156; found
+  // (-2.006, 1.917)
+  assert.ok(isMeasured(low), `plateau ${low.plateau}, next ${low.next}`);
+  close(low.dx, -2.4, 1, 'horizontal correction');
+  close(low.dy, 1.7, 1, 'vertical correction');
+  const junk = gateFixture(
+    noisy(field(128, gradient), 17, 5), noisy(field(128, gradient), 17, 6), 128,
+  );
+  // live 0.010, coherence 0.089, plateau 0.902, next 0.916 - both floors
+  assert.ok(!isMeasured(junk), `plateau ${junk.plateau}, next ${junk.next}`);
+  const unrelated = gateFixture(
+    noisy(field(128, scene), 9, 5), noisy(field(128, otherScene), 9, 6), 128,
+  );
+  // live 0.025, coherence 0.140, plateau 0.216, next 0.948 - uniqueness
+  // alone, the peak being sharp and one of many
+  assert.ok(unrelated.plateau < P_MAX && unrelated.next > N_MAX, `plateau ${unrelated.plateau}, next ${unrelated.next}`);
+  assert.ok(!isMeasured(unrelated));
+
+  // At 64 the low-texture pair is measured too, 0.76 pixels off - the old
+  // floor refused it there. But the window is too small for the junk to
+  // read as junk: this unrelated pair is refused at 0.896, and the same
+  // pair on seeds 11 and 12 reads 0.788 and passes. The comment on N_MAX
+  // says why that is accepted - plan.js gives the 64 window only to crops
+  // under 272 pixels on the short side, and refineMargin caps what a
+  // residual can move a frame that did not move at one pixel. What is
+  // pinned is the pair the fixture table has.
+  const small64 = gateFixture(
+    noisy(field(64, lowScene), 13.5, 3), noisy(field(64, lowScene, 2.4, -1.7), 13.5, 4), 64,
+  );
+  // live 0.017, coherence 0.458, plateau 0.283, next 0.135; found (-1.903, 1.119)
+  assert.ok(isMeasured(small64), `plateau ${small64.plateau}, next ${small64.next}`);
+  const small = gateFixture(
+    noisy(field(64, scene), 9, 5), noisy(field(64, otherScene), 9, 6), 64,
+  );
+  // live 0.027, coherence 0.243, plateau 0.393, next 0.896
+  assert.ok(!isMeasured(small), `plateau ${small.plateau}, next ${small.next}`);
+
+  // Without a plateau the peak is taken to be a point, and without a next
+  // to be alone - that is the reference move. Either given is read, and
+  // coherence is not.
+  assert.ok(isMeasured({ live: 1 }), 'a statistics object built by hand');
+  assert.ok(!isMeasured({ live: 1, plateau: 0.9 }), 'a ridge built by hand');
+  assert.ok(!isMeasured({ live: 1, next: 0.9 }), 'a crowd built by hand');
+  assert.ok(isMeasured({ live: 1, coherence: 0.01 }), 'coherence is reported, not read');
+});
+
+test('a sparse sky is refined at the refinement window', () => {
+  // Twenty stars in a 512 window with six per cent noise is the tool's own
+  // subject at full-resolution noise, and the case the coherence floor
+  // could not keep: it read 0.041 there, level with junk, because a sparse
+  // spectrum's weight belongs to the noise bins - the comment on L_MIN. The
+  // peak was right all along, and the two readings that decide now say so:
+  // it is alone (next 0.488 against 0.8, 0.40-0.53 over ten seeds) and it
+  // is a point (plateau 0.114). In the browser the 400-star field's window
+  // reads 0.25 at six per cent noise and 0.69 at fifteen, and both are
+  // refined to under 0.3 pixels; the old floor admitted the first (coherence
+  // 0.139 against 0.075) and refused the second at 0.042, leaving its frames
+  // 1-2.7 pixels off. The coarse square is unchanged.
+  const sky = starField(GATE_SIZE, 20);
+  const coarse = gateFixture(
+    noisy(field(GATE_SIZE, sky), 15, 7),
+    noisy(field(GATE_SIZE, sky, 5.4, -3.2), 15, 8),
+  );
+  // live 0.010, coherence 0.154, plateau 0.115, next 0.233; found (-5.630, 3.181)
+  assert.ok(isMeasured(coarse), `plateau ${coarse.plateau}, next ${coarse.next}`);
+  close(coarse.dx, -5.4, 0.35, 'horizontal correction');
+  close(coarse.dy, 3.2, 0.35, 'vertical correction');
+
+  const bigger = starField(512, 20);
+  const fine = gateFixture(
+    noisy(field(512, bigger), 15, 7),
+    noisy(field(512, bigger, 5.4, -3.2), 15, 8),
+    512,
+  );
+  // live 0.010, coherence 0.041, plateau 0.114, next 0.488; found
+  // (-5.233, 3.123), 0.19 px off
+  assert.ok(isMeasured(fine), `live ${fine.live}, plateau ${fine.plateau}, next ${fine.next}`);
+  close(fine.dx, -5.4, 0.3, 'horizontal correction');
+  close(fine.dy, 3.2, 0.3, 'vertical correction');
+
+  // And where the same sky stops being measurable, the gate follows the
+  // answer: at fifteen per cent noise these twenty stars are wrong by 10 to
+  // 105 pixels over ten seeds - this one lands at (29.9, 12.1) - and
+  // uniqueness refuses every seed at 0.80-0.99, where the plateau
+  // (0.18-0.64) would not have. A different draw of twenty-two stars, the
+  // browser's own field, is right at fifteen per cent on every seed at
+  // 0.36-0.57: at this density the window is at the edge of what can be
+  // measured, and what is pinned is that the wrong answer is refused.
+  const drowned = gateFixture(
+    noisy(field(512, bigger), 38, 7),
+    noisy(field(512, bigger, 5.4, -3.2), 38, 8),
+    512,
+  );
+  // live 0.010, coherence 0.019, plateau 0.370, next 0.950
+  assert.ok(drowned.next > N_MAX, `next ${drowned.next}`);
+  assert.ok(!isMeasured(drowned));
+});
+
+test('two unrelated pictures locked on a JPEG lattice are refused by uniqueness', () => {
+  // Every JPEG carries the same 8-pixel block grid, so two frames that
+  // share nothing else still share that, and on smooth content the whitened
+  // correlation finds it: a row of equal peaks eight pixels apart. In the
+  // browser two unrelated smooth pictures both compressed read coherence
+  // 0.088 at 512, over what was then the floor, and next 1.00 - a lattice
+  // has no single peak, which is what uniqueness measures. Over eighty seed
+  // pairs - two unrelated scenes at qualities 95, 75, 50 and 20 - the fixture
+  // reads 0.72-1.00 and eight of the eighty are admitted, about one in ten,
+  // worst on the smooth pair at quality 50 where three of ten pass. The
+  // comment on N_MAX says why the leak is there and why it is harmless as
+  // the pipeline stands. This pair is pinned at 0.962.
+  const size = 512;
+  const smoothA = (u, v) => 128 + 60 * octave(u, v, 120);
+  const smoothB = (u, v) => 128 + 60 * octave(u + 5000, v + 3000, 133);
+  const found = gateFixture(
+    jpeg(eightBit(noisy(field(size, smoothA), 1.2, 2002)), size, 75),
+    jpeg(eightBit(noisy(field(size, smoothB), 1.2, 2003)), size, 75),
+    size,
+  );
+  // coherence 0.064, plateau 0.532, next 0.962, at (48.3, 43.6)
+  assert.ok(found.plateau < P_MAX, `plateau ${found.plateau}`);
+  assert.ok(found.next > N_MAX, `next ${found.next}`);
+  assert.ok(!isMeasured(found));
+
+  // The refinement's own scenario: both frames of *one* smooth scene
+  // compressed, the frame taken 3.3 pixels over and the coarse pass having
+  // moved it back by three, so the truth is -0.3 and the lattice's alias is
+  // +3. Uniqueness cannot see this one. The lattice's peaks are eight pixels
+  // apart, inside the ten-pixel box, so what next reads is the noise beyond
+  // them (0.46-0.93 at quality 75, 0.27-0.40 at 20) and not the lattice.
+  // What refuses it at most qualities is the plateau, by a coincidence
+  // rather than by design: its radius is eight because that is the
+  // refinement's margin, and eight is also the block pitch, so the shoulder
+  // is read on the lattice's first alias and spikes there. At quality 75
+  // that reads 0.71-0.98 over ten seed pairs and the lock is refused on
+  // every one; the same at 95 and 50. plateauRadius in align.js records the
+  // coincidence, and this is the assertion that would fail if the radius
+  // moved off eight.
+  const refused = gateFixture(
+    jpeg(eightBit(noisy(field(size, smoothA), 1.2, 2002)), size, 75),
+    circularShift(jpeg(eightBit(noisy(field(size, smoothA, 3.3, 0), 1.2, 2003)), size, 75), size, -3, 0),
+    size,
+  );
+  // plateau 0.861, next 0.677, at (3.02, 0.00); the thinnest of the ten
+  // seed pairs is 0.711, on 2000/2001
+  assert.ok(refused.plateau > P_MAX, `plateau ${refused.plateau}`);
+  assert.ok(refused.next < N_MAX, `next ${refused.next}`);
+  assert.ok(!isMeasured(refused));
+
+  // And the quality where the coincidence runs out: at 20 the blocking
+  // buries the alias, the shoulder falls back under the floor, and the
+  // residual lands on the alias and is applied - eight of ten seed pairs.
+  // Pinned so that whatever catches this - the consensus check - has to say
+  // so here.
+  const lock = gateFixture(
+    jpeg(eightBit(noisy(field(size, smoothA), 1.2, 2000)), size, 20),
+    circularShift(jpeg(eightBit(noisy(field(size, smoothA, 3.3, 0), 1.2, 2001)), size, 20), size, -3, 0),
+    size,
+  );
+  // coherence 0.447, plateau 0.453, next 0.382, at (2.98, 0.00) for a
+  // truth of -0.30
+  assert.ok(isMeasured(lock), `plateau ${lock.plateau}, next ${lock.next}`);
+  close(lock.dx, 3, 0.3, 'the alias, applied');
+});
+
+test('a wall at output resolution is a plateau the refinement refuses', () => {
+  // The refinement's own version of the sky: a low-texture window at 512
+  // whose features are sixty pixels across, which is what a wall in soft
+  // light is at output resolution. Its peak is sixty pixels wide too, so
+  // eight pixels out the surface is still at three quarters of the peak or
+  // more, and the argmax is one to seven pixels off a shift of (2.4, -1.7)
+  // - inside the eight-pixel margin, so nothing else would have refused it.
+  // Over ten seeds the plateau ran 0.77-0.96 at fifteen per cent noise and
+  // 0.82-0.90 at five, every seed refused; at the sixteen-pixel radius the
+  // first version read at 512, the five per cent wall stood at 0.59-0.71 and
+  // passed nine seeds in ten.
+  const wall = (u, v) => 90 * octave(u, v, 60);
+  const found = gateFixture(
+    noisy(field(512, wall), 13.5, 5),
+    noisy(field(512, wall, 2.4, -1.7), 13.5, 6),
+    512,
+  );
+  // live 0.010, coherence 0.077, plateau 0.832, next 0.923; found (4.981, 0.972)
+  assert.ok(found.plateau > P_MAX, `plateau ${found.plateau}`);
+  assert.ok(!isMeasured(found));
+
+  // The realistic one: the same wall at five per cent noise. This seed is
+  // the plateau's alone: a broad peak's skirt is not a second peak, so
+  // uniqueness reads 0.790 and would have kept it (0.78-0.90 over ten
+  // seeds, on either side of the floor), and its coherence would have
+  // passed the old floor too.
+  const quiet = gateFixture(
+    noisy(field(512, wall), 4.5, 5),
+    noisy(field(512, wall, 2.4, -1.7), 4.5, 6),
+    512,
+  );
+  // live 0.011, coherence 0.103, plateau 0.853, next 0.790; found (-2.167, -0.027)
+  assert.ok(quiet.next < N_MAX, `next ${quiet.next} - this seed no longer pins the plateau alone`);
+  assert.ok(quiet.plateau > P_MAX, `plateau ${quiet.plateau}`);
+  assert.ok(!isMeasured(quiet));
+});
+
+test('estimate reports a frame the gate refused, and does not clamp it', () => {
+  // The pipeline reads `measured` and puts the frame at the identity; the page
+  // then counts it. `clamped` is a different report - a rotation too large to
+  // be a burst - and a frame that could not be measured at all is not that.
+  const a = window2d(noisy(field(GATE_SIZE, gradient), 17, 5), GATE_SIZE);
+  const b = window2d(noisy(field(GATE_SIZE, gradient), 17, 6), GATE_SIZE);
+
+  const translate = estimate(a, b, GATE_SIZE, 'translate');
+  assert.equal(translate.measured, false);
+  assert.equal(translate.clamped, false);
+
+  // In similarity mode the log-polar peak fails the same gate, which falls
+  // back to translation as an implausible angle does - but without saying the
+  // angle was implausible, because no angle was read at all.
+  const similarity = estimate(a, b, GATE_SIZE, 'similarity');
+  assert.equal(similarity.measured, false);
+  assert.equal(similarity.clamped, false);
+  assert.equal(similarity.angle, 0);
+  assert.equal(similarity.scale, 1);
+
+  // That has to hold whatever the junk argmax happened to read, and it only
+  // does because estimate asks the gate before the bounds. On these seeds
+  // the log-polar surface read an angle of 14.6 degrees and a scale of 0.69
+  // - outside the scale bounds - at a next of 0.994 (coherence 0.073,
+  // plateau 0.310), and the first version, which checked the bounds first,
+  // reported the frame clamped. Over ten seed pairs two of ten landed out
+  // of bounds that way.
+  const wild = estimate(
+    window2d(noisy(field(GATE_SIZE, gradient), 17, 1), GATE_SIZE),
+    window2d(noisy(field(GATE_SIZE, gradient), 17, 101), GATE_SIZE),
+    GATE_SIZE, 'similarity',
+  );
+  // translation: live 0.010, coherence 0.046, plateau 0.649, next 0.958
+  assert.equal(wild.measured, false);
+  assert.equal(wild.clamped, false);
+  assert.equal(wild.angle, 0);
+  assert.equal(wild.scale, 1);
+
+  const real = estimate(
+    window2d(field(GATE_SIZE, scene), GATE_SIZE),
+    window2d(field(GATE_SIZE, scene, 3.3, -2.6), GATE_SIZE),
+    GATE_SIZE, 'translate',
+  );
+  assert.equal(real.measured, true);
+  assert.ok(real.live > 0 && real.coherence > 0, 'the statistics travel with the move');
+  assert.ok(real.plateau >= 0 && real.plateau <= P_MAX, 'and so does the plateau');
+  assert.ok(real.next >= 0 && real.next <= N_MAX, 'and the uniqueness');
+});
+
+test('a real turn the log-polar surface could not measure is not reported as too large', () => {
+  // The log-polar surface runs at about half the coherence of the translation
+  // surface, so a real scene can pass the translation gate and fail the
+  // rotation one. That frame is aligned by translation and the page hears
+  // nothing: "too large to be a burst" would be untrue of it, and that is
+  // the same untruth this gate exists to remove.
+  const turn = (fn, degrees) => {
+    const radians = (degrees * Math.PI) / 180;
+    return (u, v) => fn(
+      u * Math.cos(radians) + v * Math.sin(radians),
+      -u * Math.sin(radians) + v * Math.cos(radians),
+    );
+  };
+
+  // Twenty per cent noise, three degrees: the log-polar peak is a plateau,
+  // 0.722 against 0.7 (next 0.510, coherence 0.140), and its argmax would
+  // have read -5.9 degrees for a turn of three, so refusing it was right;
+  // the translation peak then reads next 0.236 and is kept.
+  const refused = estimate(
+    window2d(noisy(field(GATE_SIZE, lowScene), 18, 2010), GATE_SIZE),
+    window2d(noisy(field(GATE_SIZE, turn(lowScene, 3)), 18, 2011), GATE_SIZE),
+    GATE_SIZE, 'similarity',
+  );
+  assert.equal(refused.measured, true);
+  assert.equal(refused.clamped, false);
+  assert.equal(refused.angle, 0);
+  assert.equal(refused.scale, 1);
+
+  // Fifteen per cent noise, four degrees: the log-polar peak reads plateau
+  // 0.387 and next 0.433 (coherence 0.182), and the turn is read, as -4.11.
+  const measured = estimate(
+    window2d(noisy(field(GATE_SIZE, lowScene), 13.5, 3), GATE_SIZE),
+    window2d(noisy(field(GATE_SIZE, turn(lowScene, 4)), 13.5, 4), GATE_SIZE),
+    GATE_SIZE, 'similarity',
+  );
+  assert.equal(measured.measured, true);
+  assert.equal(measured.clamped, false);
+  close(measured.angle, -4, 1.5, 'the angle, as the correction it is');
+
+  // The seeds this test used to pin the refusal on, now admitted, and
+  // admitted wrongly: the log-polar peak reads plateau 0.565 and next
+  // 0.447, and the angle comes out as -0.15 for a turn of three. That is
+  // the log-polar surface's own junk peak, at zero - the structure every
+  // spectrum shares, its axes and its window, correlates at no shift - and
+  // for a turn under seven degrees the true peak sits inside the box of it,
+  // where neither floor can tell the two apart. The old floor refused this
+  // seed at a coherence of 0.147 against 0.15, and that was luck rather
+  // than discrimination: over twenty seeds of each turn in the N_MAX
+  // comment the wrong angles read 0.12-0.18 and the right ones 0.11-0.21,
+  // and at thirty per cent noise the old floor refused eleven right turns
+  // in fifteen to catch four wrong ones in five, where this gate refuses
+  // none. Pinned as what happens, not as what should: whatever fixes the
+  // zero peak has to change this.
+  const zero = estimate(
+    window2d(noisy(field(GATE_SIZE, lowScene), 18, 1006), GATE_SIZE),
+    window2d(noisy(field(GATE_SIZE, turn(lowScene, 3)), 18, 1007), GATE_SIZE),
+    GATE_SIZE, 'similarity',
+  );
+  assert.equal(zero.measured, true);
+  assert.equal(zero.clamped, false);
+  assert.ok(Math.abs(zero.angle + 3) > 1.5, `the zero peak, read as ${zero.angle}`);
+  assert.ok(Math.abs(zero.angle) < 1, `the zero peak, read as ${zero.angle}`);
 });
 
 test('the window removes the mean and fades the edges to nothing', () => {
@@ -248,7 +1005,10 @@ test('doing nothing is one of the three answers', () => {
   const reference = field(size, scene);
   const frame = circularShift(reference, size, 9, 9);
 
-  assert.deepEqual(estimate(reference, frame, size, 'none'), { ...NO_MOVE, clamped: false });
+  assert.deepEqual(
+    estimate(reference, frame, size, 'none'),
+    { ...NO_MOVE, measured: true, clamped: false },
+  );
   assert.deepEqual(ALIGN_MODES, ['none', 'translate', 'similarity']);
 
   // Translation-only leaves the angle and the scale alone rather than guessing

--- a/tools/stack-images/README.md
+++ b/tools/stack-images/README.md
@@ -220,10 +220,184 @@ window of the reference at output resolution, and the residual corrects the
 coarse answer in place. At output resolution there is nothing to multiply up,
 so a twentieth of a pixel of error stays a twentieth of a pixel. The same
 synthetic bursts land within a quarter of a pixel per frame. The residual is
-gated — a weak peak, or a correction larger than the coarse pass could
-plausibly have been wrong by, leaves the coarse answer alone — and the crop
-gives up a small margin on every side up front, because a frame that moves
-after the crop was decided stops covering ground the crop assumed.
+gated — a peak that is not a peak, or a correction larger than the coarse pass
+could plausibly have been wrong by, leaves the coarse answer alone — and the
+crop gives up a small margin on every side up front, because a frame that
+moves after the crop was decided stops covering ground the crop assumed.
+
+**Whether a peak is a peak is decided by two of four statistics — `plateau`
+and `next`, with `live` as the guard under them and `coherence` reported for
+the record — and one gate, `isMeasured`.** Every correlation returns the four
+beside the shift. `plateau` asks whether the peak has a position at all;
+`next` asks whether it is the answer or merely the tallest of several; the
+two paragraphs after this one take each in turn. `live` is the mean weight
+the whitening gave the bins, the share of the spectrum that stood above the
+noise floor at all, and is there only to catch a square whose spectrum is
+numerically empty. The gate is `plateau` at most 0.7, `next` at most 0.8 and
+`live` at least 0.004, at every window size — both floors are ratios of the
+surface to its own peak, and neither scales with the side — and the same
+function decides the log-polar peak, the translation peak and the
+refinement's residual, so there is one place to calibrate. The measurements
+it was calibrated on — identical frames, a noisy textured shift, a noisy
+low-texture shift, a noisy gradient and the same rounded to 8 bits, two
+unrelated pictures, a dense star field and a sparse one, a wall at output
+resolution, two JPEGs sharing a lattice, and a low-texture scene turned a few
+degrees for the log-polar surface — are the fixtures in
+`tests/js/stack-images-align.test.js`, with what each measured written beside
+its assertion, and the comments on `P_MAX` and `N_MAX` in `align.js` carry
+the ranges over ten seeds at every window size, with what each floor refuses
+knowingly and why.
+
+`coherence` — the peak divided by the height every weighted bin agreeing on
+one offset would have produced, 1 for a perfect match — was the gate for a
+week, at 0.15 on the 256 square scaled by the side, and it is reported now
+and not read. It did the job on every fixture family but the tool's own
+subject. A star field is sparse in the spectrum as well as in the picture: a
+few hundred points put their energy into a few hundred bins, and under the
+whitening floor every one of the thousands of noise bins still carries a
+small weight, so the denominator belongs to the noise and a perfect match of
+a sparse field reads as a poor one. In the browser, on the built refinement
+path, a field of four hundred stars at fifteen per cent noise read 0.042
+against a floor of 0.075 and was refused, its frames left 1–2.7 pixels off
+where the code without the floor refined them to under 0.3 — while two
+unrelated smooth pictures locked on their shared JPEG lattice read 0.088 and
+passed. No floor separates those two, and the z-score does not either; the
+comment on `L_MIN` in `align.js` has the browser's whole table.
+
+**`plateau` is the shape of the peak: junk that correlates perfectly well and
+still has no position.**
+A smooth gradient — a clear sky — is refused although it correlates with
+itself, and it does correlate: what the survey square holds of it is the
+slope's 8-bit banding over a letterbox, and the letterbox's hard edge along
+row 171 is shared by both frames wherever the camera moved, so the correlation
+is pinned vertically by the edge and free along the slope, which matches
+itself at any offset. That is a ridge, not a peak. Its height is real —
+coherence 0.47–0.51 in the browser, three times what was then the floor — but
+its position
+is wherever the noise tipped the argmax along the ridge, and the sub-pixel fit
+is a parabola through the top of a plateau. Before this test, four frames of
+one gradient with twelve per cent noise came back measured and were moved by
+−12.9, +35.6 and −0.4 output pixels from an identity that was the truth: one
+to three alignment pixels, multiplied up, and a heavier crop for a set that
+had not moved at all. So `phaseCorrelate` also reports the highest point of
+the surface eight pixels from the peak, at every window size, in the eight
+compass directions — eight along the axes, eight times root two on the
+diagonals; a true ring at eight reads 0.05–0.15 higher on real peaks and
+would need its own floor — as a fraction of the peak, and the gate refuses
+anything over 0.7. Eight because it is the refinement's own margin: a peak
+still standing eight pixels out cannot place the frame within the margin
+whatever its argmax says, and on the coarse square eight alignment pixels is
+already tens of output pixels. The gradients measured 0.93–0.99 in the
+browser and 0.95–1.00 on the letterboxed fixture at every noise level tried;
+the weakest real match, a low-texture scene at thirty per cent noise, 0.60 in
+the browser and 0.65–0.68 over ten seeds depending on the seeds; a star field
+0.03–0.10, a textured scene 0.1–0.5. The same reading refuses the letterboxed
+gradient's log-polar peak (0.78, at a `next` of 0.39–0.56 that passes and a
+coherence of 0.22 that is no longer asked), which
+similarity mode had been applying as a scale of 0.95–1.01, and the
+refinement's own version of the sky: a low-texture 512 window whose features
+are sixty pixels across measures 0.77–0.96 with its peak one to seven pixels
+off, inside the margin, and is refused on every seed at both noise levels
+tried — nothing else would have refused it, and a radius that followed the
+side, sixteen at 512, read it at 0.59–0.71 and let nine seeds in ten
+through. The comment on `P_MAX` in `align.js` has the browser table and the
+fixture table side by side, the log-polar and other-window readings, and the
+two pairs the gate knowingly lets through on the letterboxed square: two
+unrelated textured pictures (coherence 0.18–0.20, plateau 0.59–0.73, nine
+seeds in ten, moved by one to four alignment pixels) and two unrelated
+low-texture scenes at fifteen per cent noise (0.15–0.17 and 0.59–0.83, about
+half). Both are the letterbox ridge with the unrelated texture's bumps along
+it, both are refused by `next` alone on a full square (0.82–0.99 and
+0.70–0.91, the second passing five seeds in ten), and both are left to
+the consensus check the way the JPEG lattice below is. Note that a
+full-square gradient fixture does *not* reproduce the browser: it measures
+coherence 0.04–0.10 and `next` 0.87–0.99, and is refused by uniqueness
+alone. The letterbox is what the browser case is made of.
+
+**`next` is whether the peak is alone, for the junk `plateau` cannot see.**
+It is the tallest point of the surface outside a box of ten pixels around
+the peak, as a fraction of the peak: the peak-to-sidelobe ratio, the oldest
+test of a correlation peak there is. A genuine match has one peak and the
+rest of the surface is noise; two unrelated pictures have many noise peaks
+of much the same height, and the argmax is whichever happened to be tallest;
+a lattice has a row of equal peaks. The box is ten because the plateau is
+read at eight — inside eight the shape of the peak is the other floor's
+question — and it was measured at 6, 8, 12, 16 and 20 too. A real broad peak's
+skirt is wider than the box, reaching eleven or twelve pixels, so at ten the
+reading is still partly the peak itself: that costs 0.03–0.10 against a reach
+past the skirt, and moves neither the unrelated pairs nor the star fields,
+whose next peak is far away. The browser's table at the 512 window separates
+every right answer (`next` at most 0.69) from every wrong or junk one (at
+least 0.83); on the fixtures every photograph and every dense field is under
+0.65 at every size, and the junk at 0.70–1.00 — gradients 0.76–0.99,
+unrelated pairs 0.75–0.99 at 512, two unrelated JPEGs 0.72–1.00. The floor
+is 0.8, and the case that set it is the noisy sparse sky at the survey
+square: the browser's 400-star field, shrunk twelvefold into the 256×171
+thumbnail with fifteen per cent noise averaged down with it, read 0.76 with
+the right answer in the browser and 0.63–0.89 with the right answer on every
+seed in node; 0.8 admits the browser's and six seeds in ten — about what the
+old floor admitted, at coherence 0.14–0.17 against 0.15 — where 0.75 admits
+two. It sits nearer the junk than the middle for the reason the plateau
+floor does: a coarse move refused is a frame stacked at the identity,
+unaligned by its whole shift, and a junk frame admitted was junk in the
+stack already. It is also the sparse sky and nothing else that spends this
+margin: which draw of the sky a window caught, not how much noise is on it,
+decides how near the floor a real answer lands, and over ten draws a
+twenty-star window at six per cent noise reached 0.72 and a seventeen-star
+one 0.96 — the second refused on one draw in ten although its answer was
+right. What the floor lets through, with the numbers, is in the comment on
+`N_MAX`: a seed here and there of the unrelated pairs, about one seed in ten
+of two unrelated JPEGs (eight of eighty over four qualities, worst at 50 on
+smooth content, where the lattice's nearest aliases sit inside the box and
+the pair sixteen pixels out falls with the scene's own envelope), and the one
+family the old floor caught and
+this does not — two unrelated pictures of which one has little texture,
+whose surface is a few broad bumps rather than many sharp ones (0.67–0.84 at
+512, eight seeds in ten under the floor, at a plateau of 0.43–0.70 the other
+floor does not catch either). The letterbox refuses that pair on the survey
+square (0.82–0.95), so it reaches the refinement only from a square frame.
+The log-polar surface goes through the same floor and is given none of its
+own: real turns read 0.20–0.81 and all but one seed in forty are admitted,
+where the old floor refused fourteen seeds in twenty of a textured
+scene turned nine degrees at thirty per cent noise. The one refused is a
+third of a degree at thirty per cent noise, reading 0.811 — the smaller the
+turn, the nearer its peak sits to the surface's own junk peak at zero shift,
+and the two read as one crowd — and what that costs is the rotation, not the
+frame, which is still aligned by translation. A floor of 0.85 for this
+surface alone would admit it and would also admit the unrelated pairs sitting
+at 0.71–0.86 there, one of which reads a seven-degree turn between two
+pictures that share nothing; that trade was not taken. What neither floor sees
+there is the surface's own junk peak at zero shift — the structure every
+spectrum shares, its axes and its window — which a small turn of a
+low-texture scene lands on one seed in four or five and reads as no turn;
+for a turn under seven degrees the true peak is inside the box of it.
+Coherence did not see it either (the wrong angles read 0.12–0.18, the right
+ones 0.11–0.21), and the test pins one such seed as what happens.
+
+The statistic it replaced was a z-score, the peak over the surface's standard
+deviation, and it did not measure what it seemed to. After whitening every
+live bin has unit magnitude, so a perfect match peaks at *k/n* over a floor of
+about *√k/n* by Parseval, and the score was *√k* — a count of the bins that
+survived the whitening, not a measure of whether the two pictures agreed. It
+read 27 on a featureless gradient and 150 on a textured scene, the gate was set
+at 4, and no frame ever failed it: featureless frames were moved by up to nine
+pixels, with a spurious rotation in similarity mode, while the page reported
+that they had been left where they were.
+
+**A frame the gate refuses is left at the identity.** Not at the shift the
+peak reported — that is the tallest point of a featureless surface, and
+applying it is what the old gate did by never firing. The pipeline discards
+the coarse `dx`, `dy`, angle and scale, records the frame as `measured: false`
+with its four statistics, skips its refinement (a residual measured from the
+identity is not a residual but the whole shift, which was just refused), and
+`commonArea` runs over the final moves with that identity among them. The
+page's "left where they were" is then a description of what happened. The
+reference frame is always `measured: true`: it is what everything else is
+measured against. A log-polar peak the gate refuses is a smaller event: the
+frame is aligned by translation alone and `clamped` stays false, because
+"reported a rotation too large to be a burst" would be untrue of a frame that
+reported no rotation at all — `clamped` is kept for the plausibility bounds
+only.
 
 Rotation and scale come from the same trick applied twice: in log-polar
 coordinates a rotation *is* a shift along one axis and a scale *is* a shift
@@ -279,14 +453,115 @@ applying it is worse than doing nothing.
 
 ## Things that will bite
 
-**The correlation is whitened, so a picture with a narrow spectrum is all
-rounding error.** Dividing by the magnitude of each frequency is what makes
-phase correlation immune to one frame being brighter than another, and it also
-amplifies bins the picture put nothing into. Bins below a millionth of the
-strongest are dropped rather than normalised. This costs nothing on a
-photograph and is the difference between an answer and noise on anything
-smooth — which is also why the test fixtures are value noise over three
-octaves rather than a few sinusoids.
+**The whitening is regularised, and the constant is large on purpose.**
+Dividing each frequency by its magnitude is what makes phase correlation
+immune to one frame being brighter than another, and it also lifts the
+thousands of bins a photograph put nothing into — sensor noise, whose phases
+say nothing about the shift — to the same vote as a real edge. On a
+low-texture scene with fifteen per cent noise that put the coarse answer 1.3
+to 2.8 pixels off. So each bin is divided by its magnitude *plus* a floor of
+`WHITEN` times the median bin: a bin well above the floor is whitened, a bin
+below it fades in proportion to how far below it is, and the noise barely
+votes. The median rather than the mean because the mean belongs to the handful
+of low-frequency bins. The constant is 128, not the 0.1–0.3 a regularisation
+constant usually is, because the median of a noisy square *is* the noise
+floor: a small constant leaves the noise bins at nine-tenths of the weight of
+a real one, which measured as no help at all. The comment on `WHITEN` in
+`align.js` has the table; the exponent |X|^0.75 was tried as the alternative
+and was no better than full whitening. The old millionth-of-the-strongest cut
+survives only as a guard against dividing by nothing on a square whose whole
+spectrum is numerically empty: on a picture no bin is zeroed any more, it is
+faded by the floor instead. This is also why the test fixtures are value noise
+over three octaves rather than a few sinusoids: a fixture that puts nothing
+into most of its bins is all rounding error by the time it reaches the peak.
+
+**A sky correlates with itself and still cannot be aligned, and the
+letterbox is why.** Every 3:2 frame reaches the coarse square as 256 by 171
+of picture over transparent black, so two frames of a smooth gradient share a
+hard edge that did not move with the camera and a slope that matches itself at
+any offset — coherence 0.5, a ridge for a peak, and an argmax that wanders by
+one to three alignment pixels, which the multiply-up turned into tens of
+output pixels of movement on frames that had not moved. `coherence` cannot
+see it, because the content genuinely correlates; the `plateau` reading in
+`phaseCorrelate` — how much of the peak is still standing eight pixels away —
+can, and `isMeasured` refuses anything over `P_MAX`. The same edge also
+biases every real low-texture answer the survey square accepts: letterboxed,
+the low-texture fixture lands 1.3–1.9 alignment pixels off at fifteen per
+cent noise and 1.0–2.0 at thirty, pulled towards the ridge, where the full
+square lands it within 0.1–0.7 and 0.3–1.9; on a 3000-pixel frame that is
+15–22 output pixels, beyond the refinement's 8-pixel margin, so the 512
+residual — itself within half a pixel there — is refused by the margin test
+and the coarse error stands. That is a cost of the survey square, not of the
+gate, and the fix is the same one that would remove the ridge under the
+gradients and the unrelated pairs: taper the picture's own box in
+`lumaSquare` — a window over `fit`'s rectangle, or fill outside it with the
+picture's mean before windowing — so the edge is not a feature both frames
+share. It is a follow-up. Two things follow for anyone extending the gate
+meanwhile. A fixture of the gradient over the whole square measures a tenth
+of the coherence and is refused without the plateau's help, so a fixture that
+does not letterbox does not reproduce the browser; the tests' `letterbox`
+helper exists for that. And the plateau radius is eight at every window size,
+not a fraction of the side: a radius of four at 128 refused the low-texture
+pair with its peak in the right place, and a radius of sixteen at 512 kept
+the wall with its peak five pixels wrong. `plateauRadius` in `align.js` says
+why, and the comment on `P_MAX` has the readings at both.
+
+**The gate mostly catches a JPEG's block lattice, and where it does is not
+where it was designed to.** Every frame of a phone burst is a JPEG, and every
+JPEG carries the same 8-pixel grid, so two frames share a feature that did
+not move with the picture. Two unrelated smooth pictures both compressed
+correlate on nothing else, and `next` reads the row of equal peaks for what
+it is — 0.72–1.00 at 512 over eighty seed pairs at qualities 95, 75, 50 and
+20 — but eight of those eighty are admitted, about one in ten, worst on
+smooth content at quality 50. The leak is where the lattice puts its aliases:
+the nearest sit eight pixels from the peak, inside the ten-pixel box, so what
+is read is the pair sixteen or seventeen pixels out, and those fall away with
+the scene's own smooth envelope where the near ones stand level with the
+peak. It is harmless as the pipeline is arranged — the survey square
+letterboxes the same pairs to 0.91–0.99 and refuses every one, and at 512 an
+argmax on a random lattice peak is outside the refinement's 8-pixel margin
+and discarded there — but the consensus check is what should be catching it.
+
+The refinement's own scenario is the same lattice between two frames of *one*
+smooth scene: the coarse move a third of a pixel short, and the residual
+landing on the lattice's alias at +3 pixels, inside the margin. Uniqueness
+cannot see that one at all, for the same reason — it reads 0.46–0.93 at
+quality 75 and 0.27–0.40 at 20, the noise beyond the lattice rather than the
+lattice. What refuses it is the plateau, by a coincidence nobody chose: its
+radius is eight because that is the refinement's margin, and eight is also
+the block pitch, so the shoulder is read on the lattice's first alias and
+spikes there — 0.71–0.96 at a radius of eight against 0.50–0.69 at six and
+0.47–0.74 at ten. At qualities 95, 75 and 50 that refuses the lock on every
+seed pair tried. Only at quality 20, where the blocking buries the alias,
+does it get through: eight of ten seed pairs, applying the alias. Textured
+content is immune (0.77–0.91, correct to 0.03 pixels), and so is the coarse
+pass — the thumbnail averages the blocks away. This is a peak of the wrong
+thing, not a weak one; full whitening landed on the same alias, so it is
+inherited rather than introduced by the gate. The tests pin both sides, so a
+plateau radius moved off eight cannot quietly hand the lock back, and
+whatever finally catches it has to say so there.
+
+**A sparse sky is refined at 512 again, and the 64 window is not gated at
+all.** Twenty stars in a 512 window at six per cent noise read `next`
+0.40–0.53 and `plateau` 0.05–0.30 and are refined to within 0.2 pixels,
+where the coherence floor refused them at 0.04 — level with junk, for the
+reason above. That range is one draw of the sky over ten noise seeds; over
+ten different draws the same window reads 0.32–0.72, and a seventeen-star
+one 0.37–0.96, so it is which stars the window caught rather than how much
+noise is on them that decides how near the floor a right answer lands. At
+fifteen per cent the same twenty stars are wrong by 10–105
+pixels and `next` refuses every seed at 0.80–0.99; the browser's own field
+keeps twenty-two stars in its window and is right at fifteen per cent, at
+0.36–0.57. Neither floor scales with the side, and at 128 both hold: the
+real pairs read 0.04–0.45 and the junk 0.67–1.00. At 64 the surface has too
+few bins for junk to read as junk — an 8-bit gradient at one per cent noise
+reads 0.41–0.70 and passes eight seeds in ten, an unrelated pair 0.63–0.97 —
+where the old floor at 0.60 refused both, and every noisy real pair with
+them. That is accepted rather than fixed: `plan.js` gives the 64 window only
+to crops under 272 pixels on the short side, where the coarse square is
+within a factor of 1.6 of output resolution, and `refineMargin` caps what an
+applied residual can move a frame that did not move at one pixel. The
+comment on `N_MAX` has the numbers at every size.
 
 **Focus stacking needs its bands to overlap.** Sharpness is measured from a
 pixel's neighbours, so a band edge scored without them draws a seam across the

--- a/tools/stack-images/src/align.js
+++ b/tools/stack-images/src/align.js
@@ -11,13 +11,13 @@
  *
  * Shifting a picture does not change the size of its spectrum, only the phase
  * of it, and the phase changes by an amount proportional to the shift. So
- * multiplying one frame's spectrum by the conjugate of another's, throwing away
- * the magnitudes, and transforming back gives a surface with a single spike at
- * the offset between them. One transform each and one back - about ten
- * milliseconds on the small squares this works over - and it finds a shift of
- * two hundred pixels as cheaply as a shift of two. Searching for the same
- * answer by trying offsets is quadratic in the range and would be the slowest
- * thing in the tool.
+ * multiplying one frame's spectrum by the conjugate of another's, dividing the
+ * magnitudes out as far as the noise allows, and transforming back gives a
+ * surface with a single spike at the offset between them. One transform each
+ * and one back - about ten milliseconds on the small squares this works over -
+ * and it finds a shift of two hundred pixels as cheaply as a shift of two.
+ * Searching for the same answer by trying offsets is quadratic in the range
+ * and would be the slowest thing in the tool.
  *
  * ROTATION AND SCALE, BY THE SAME TRICK APPLIED TWICE
  *
@@ -56,11 +56,440 @@ export const MAX_ROTATION = 30;
 export const MIN_SCALE = 0.8;
 export const MAX_SCALE = 1.25;
 
-/** Below this the correlation peak is not a peak, and the frame is reported. */
-export const WEAK_PEAK = 4;
+/**
+ * How much of the cross-spectrum's magnitude the whitening keeps, as a multiple
+ * of the median bin. See phaseCorrelate for what the number does; this is why
+ * it is 128 and not the 0.1 to 0.3 a regularisation constant usually is.
+ *
+ * The median bin of a noisy square *is* the noise floor - a photograph puts
+ * nothing measurable into most of its high frequencies, so most bins are noise
+ * and the median sits among them. A constant of 0.3 leaves those bins at
+ * nine-tenths of the weight of a real edge, which is no regularisation at all
+ * on a noisy frame: measured on the low-texture fixture in the tests, with
+ * fifteen per cent noise, 0.1 to 0.5 all missed the shift by 1.3 to 2.8 pixels,
+ * exactly as full whitening did. Weighting a bin by how far it stands above
+ * the median is what helps, and the constant sets where "above" begins. Over
+ * five seeds each at 256:
+ *
+ *                       c = 16          64            128           256
+ *   low-texture, error  0.96-1.33 px    0.29-1.08     0.21-1.01     0.23-0.93
+ *   textured, error     0.11-0.25       0.06-0.23     0.06-0.23     0.06-0.22
+ *   junk, coherence     up to 0.043     up to 0.068   up to 0.086   up to 0.105
+ *   low-texture, coh.   0.139-0.151     0.281-0.294   0.376-0.386   0.472-0.481
+ *
+ * Both accuracy and the gap between a real match and an unrelated pair keep
+ * improving as the constant grows, because the limit is plain
+ * cross-correlation, the maximum-likelihood estimate under white noise. What
+ * the limit loses is the sharp peak that made a phase-only correlation immune
+ * to a repeating pattern, and at 256 the plain correlation begins to find the
+ * slope the two gradient frames share - one seed lands within two pixels of
+ * it - where at 128 no seed came nearer than seven. 128 is where the
+ * low-texture scene lands within a pixel on four seeds of five, and 1.01 on
+ * the fifth, while the gradient is still nothing but noise. The exponent
+ * |X|^0.75 was measured as the alternative and landed the low-texture fixture
+ * 1.29-2.74 pixels off, no better than full whitening, so it was not kept.
+ */
+export const WHITEN = 128;
+
+/**
+ * The gate: what a peak has to show before a frame is moved by it.
+ *
+ * Four statistics come back with every peak and two of them decide. `plateau`
+ * asks whether the peak has a position at all - the comment on P_MAX. `next`
+ * asks whether it is the answer or merely the tallest of several - the
+ * comment on N_MAX. `live` is the guard under both, and `coherence` is
+ * reported and not read; the two paragraphs below say why each is what it is.
+ *
+ * `live` is the mean weight, the share of the spectrum that stood above the
+ * noise floor at all. It is not what separates a match from a mismatch - noise
+ * fills every bin, so a noisy featureless frame has as much live spectrum as a
+ * photograph - and is here for the other failure: a square whose spectrum is
+ * numerically empty, where the median is rounding error and every bin above it
+ * "agrees" perfectly. A flat frame measures 0 and a bare slope 0.0014 at 256,
+ * the same slope quantised to 8 bits 0.0032 (its contour lines are a lattice,
+ * and correlate at coherence 0.98 to the wrong answer), and anything with a
+ * picture and any noise in it 0.0097 or more at every size tried. That last
+ * figure is the 8-bit rounding of getImageData, which every square the
+ * pipeline builds has been through: it puts about a 129th of the weight into
+ * every bin. A float square of a clean, very smooth scene has no such floor -
+ * value noise at 80 pixels measured 0.0025 with coherence 0.995 - and would
+ * be refused by `live` alone, which is a fact about the tests and any future
+ * caller, not about the page. Nor does the floor hold at the small windows:
+ * the bare 8-bit slope measures 0.016 at 128 and 0.079 at 64, because the
+ * window's own spectrum is a larger share of so few bins, so a rendered
+ * gradient with no noise on it at all is refined there by its contour lattice,
+ * within the margin. Sensor noise at one per cent is enough for the other
+ * two floors to refuse it instead - at 256 on every seed, at 128 on nine in
+ * ten.
+ *
+ * WHY COHERENCE IS REPORTED AND NOT READ
+ *
+ * `coherence` is the fraction of the weighted spectrum that agreed on the
+ * peak - the peak times n over the sum of the weights, one for a perfect
+ * match. It was the gate, at 0.15 on the coarse square and scaled by the
+ * side, and it did that job on every fixture family but one, which is the
+ * tool's own subject. A star field is sparse in the spectrum as well as in
+ * the picture: a few hundred points put their energy into a few hundred
+ * bins, and under a whitening floor of WHITEN times the median every one of
+ * the thousands of noise bins still carries a small weight, so the sum in
+ * the denominator belongs to the noise and a perfect match of a sparse
+ * field reads as a poor one. That is what the statistic is, not where its
+ * floor was. In the browser, on the built refinement path - 3000x2000
+ * frames, the 512 window cut at full resolution - a field of four hundred
+ * stars at six per cent noise read 0.139 against a floor of 0.075 and was
+ * refined to under 0.3 pixels; at fifteen per cent it read 0.042, was
+ * refused, and its frames stayed 1-2.7 pixels off where the same code
+ * without the floor had refined them to under 0.3. Two unrelated smooth
+ * pictures locked on their shared JPEG lattice read 0.088 and passed. The
+ * browser's whole table at 512, with z the peak over the surface's deviation:
+ *
+ *                                 coherence   plateau   next    z      answer
+ *   star field, 6% noise           0.139       0.08     0.25    36.8   right
+ *   star field, 15% noise          0.042       0.33     0.69    11.7   right, refused
+ *   textured scene                 0.893       0.12     0.10    178    right
+ *   textured scene, 30% noise      0.168       0.52     0.48    36.4   right
+ *   low-texture, 15% noise         0.040       0.36     0.85    11.1   wrong, 23 px
+ *   low-texture, 30% noise         0.036       0.23     0.95    9.9    wrong
+ *   smooth gradient                0.032       0.93     0.95    8.9    junk
+ *   two unrelated smooth JPEGs     0.088       0.32     1.00    11.6   lattice lock
+ *   unrelated low/low              0.030       0.21     0.98    8.3    junk
+ *   unrelated stars/stars          0.048       0.21     0.83    13.1   junk
+ *   unrelated texture/low          0.034       0.33     1.00    6.7    junk
+ *   unrelated texture/stars        0.034       0.60     0.99    6.6    junk
+ *
+ * A right answer at 0.042 and junk at 0.088: no floor on the first column
+ * separates them, and none on the z-score either (11.7 against 11.6). The
+ * last column does. The ten-seed calibration of the old floor is in this
+ * file's history, and what it established that still matters - the
+ * whitening constant, the plateau's radius - is recorded on WHITEN and P_MAX.
+ */
+export const L_MIN = 0.004;
+
+/**
+ * `next`: whether the peak is the answer or merely the tallest of several.
+ *
+ * The tallest point of the surface outside a box of NEXT_REACH pixels around
+ * the peak, as a fraction of the peak - the peak-to-sidelobe ratio, the
+ * oldest test there is of a correlation peak. A genuine match has one peak
+ * and the rest of the surface is noise; two unrelated pictures have many
+ * noise peaks of much the same height, and the argmax is whichever happened
+ * to be tallest; a lattice lock has a row of equal peaks eight pixels apart.
+ * The box keeps the peak's own skirt from being read as a second peak, and
+ * it is ten because the plateau is read at eight: inside eight the shape of
+ * the peak is P_MAX's question, and this one begins where that one stops.
+ *
+ * Measured over ten seeds on the fixtures in tests/js/stack-images-align.test.js.
+ * The four-hundred-star rows are the browser's field as the pipeline sees
+ * it: four hundred stars on a 3000x2000 frame, shrunk twelvefold into 256x171
+ * over the letterbox for the survey - each star a sub-pixel dot, the noise
+ * averaged down by the same factor, then 8-bit - and, for the refinement,
+ * the twenty-two of them that fall in a 512 window cut from the middle of
+ * the frame, at full-resolution noise.
+ *
+ *   at 512, the refinement window            next          plateau     answer
+ *   textured, 15% and 30% noise              0.09-0.24     0.21-0.35   right
+ *   low-texture, 15% and 30%                 0.09-0.30     0.35-0.55   right
+ *   four hundred stars in the square, 6-15%  0.06-0.14     0.03-0.07   right
+ *   twenty-two stars in the window, 6-15%    0.26-0.57     0.01-0.21   right
+ *   twenty stars, 6%                         0.40-0.53     0.05-0.30   right
+ *   twenty stars, 6%, ten other draws        0.32-0.72     0.02-0.49   right
+ *   seventeen stars, 6%, ten other draws     0.37-0.96     0.02-0.51   right, 9 of 10 pass
+ *   twenty stars, 15%                        0.80-0.99     0.18-0.64   wrong, 10-105 px
+ *   wall, 60-pixel features, 5% and 15%      0.78-0.92     0.79-0.90   plateau refuses
+ *   wall, 30-pixel features, 15%             0.64-0.79     0.78-0.85   plateau refuses
+ *   gradient, 15% noise, and 8-bit at 1%     0.84-0.99     0.43-0.94   junk
+ *   two unrelated smooth JPEGs, Q95 to Q20   0.72-1.00     0.03-0.98   junk, 8 of 80 pass
+ *   unrelated texture/texture, low/low, 5%   0.82-0.99     0.31-0.82   junk
+ *   unrelated texture/texture, 15%           0.75-0.98     0.50-0.90   junk, 8 of 40 pass
+ *   unrelated texture/stars, stars/stars     0.89-0.99     0.06-0.68   junk
+ *   unrelated texture/low                    0.67-0.84     0.43-0.70   junk, 8 of 10 pass
+ *
+ *   at 256, the survey square, letterboxed   next          plateau     answer
+ *   textured, 15% and 30%                    0.28-0.50     0.23-0.55   right
+ *   low-texture, 15% and 30%                 0.20-0.41     0.43-0.62   right
+ *   four hundred stars, 6% and 10%           0.45-0.69     0.14-0.31   right
+ *   four hundred stars, 15%                  0.63-0.89     0.31-0.49   right, 6 of 10 pass
+ *   four hundred stars, 20%                  0.70-0.95     0.39-0.81   8 of 10 right, 1 passes
+ *   two hundred stars, 6%                    0.66-0.79     0.17-0.26   right
+ *   two hundred stars, 10%                   0.81-0.98     0.29-0.94   7 of 10 right, none pass
+ *   eight hundred stars, 6-20%               0.33-0.76     0.11-0.46   right
+ *   twenty stars, 6%                         0.26-0.34     0.10-0.19   right
+ *   gradients, 8-bit, 1% to 12% noise        0.92-0.99     0.93-1.00   both refuse
+ *   textured sky                             0.94-0.98     0.96-0.98   both refuse
+ *   unrelated low/low, 5% and 15%            0.72-0.83     0.64-0.80   junk, 4 of 10 pass at 15%
+ *   unrelated texture/texture, 5%            0.78-0.88     0.59-0.73   junk, 3 of 10 pass
+ *   unrelated texture/low                    0.82-0.95     0.75-1.00   junk
+ *   unrelated texture/stars                  0.72-0.98     0.50-0.74   junk, 7 of 10 pass
+ *   unrelated stars/stars                    0.82-1.00     0.22-0.73   junk
+ *
+ * On the full 256 square, without the letterbox, every real family reads
+ * 0.07-0.62 - the textured scene at fifty per cent noise is the 0.62, and is
+ * 0.3-2.4 pixels off - and the junk 0.59-1.00: gradients 0.76-0.99 over forty
+ * seeds with none admitted, the seeds that dip under this floor being refused
+ * by the plateau instead (0.72-0.81 there), unrelated
+ * texture/texture 0.82-0.99, texture/stars and stars/stars 0.79-1.00, low/low
+ * 0.70-0.91 (5 of 10 pass at fifteen per cent), texture/low 0.59-0.83 (8 of
+ * 10). At 128 the real pairs read 0.04-0.45 and the junk 0.67-1.00, with the
+ * gradients passing one seed in ten; at 64 the noisy textured pair reaches
+ * 0.80 on one seed, the 8-bit gradient at one per cent noise reads 0.41-0.70
+ * and passes eight seeds in ten where the old floor refused it, and the
+ * unrelated pairs 0.63-0.97. That window is not gated by this either, then:
+ * plan.js hands it only to crops whose short side is under 272 pixels, and
+ * refineMargin caps what an applied residual can move such a frame at one
+ * pixel for a set that did not move.
+ *
+ * The floor is 0.8. The real side's last case is the noisy sparse sky at the
+ * survey square: the browser read it at 0.76 with the right answer, the
+ * fixture at 0.63-0.89 with the right answer on every seed, and 0.8 admits
+ * the browser's and six seeds of the fixture's ten - about what the old floor
+ * admitted, at coherence 0.14-0.17 against 0.15 - where 0.75 admits two. At
+ * twenty per cent the same field is wrong on two seeds in ten, so past that
+ * refusing is right, and the floor refuses nine. It is the sparse sky and
+ * nothing else that spends this margin. Every photograph, and every dense
+ * field, is under 0.65 at every size on every seed - the highest of them is
+ * the letterboxed textured scene at fifty per cent noise, 0.64 - so the floor
+ * could sit at 0.7 for them. The sparse windows are where it is close: over
+ * ten different draws of a sparse sky the twenty-star window at six per cent
+ * reaches 0.72 and a seventeen-star one 0.96, the second refused on one draw
+ * in ten although its answer was right. Which draw of the sky the window
+ * caught, not how much noise is on it, decides how near the floor a real
+ * answer lands. The log-polar turns below reach 0.81. What 0.8 lets through
+ * that 0.75 would not is a seed here and there of the unrelated pairs - a
+ * sparse sky and an unrelated pair are both one peak among noise peaks, and
+ * they overlap between 0.7 and 0.9 - and about one seed in ten of the two
+ * unrelated JPEGs below. It sits nearer the junk than the middle for the
+ * reason the plateau floor does: a coarse move refused is a frame stacked
+ * at the identity, unaligned by its whole shift, and a junk
+ * frame admitted was junk in the stack already; the consensus check is where
+ * to be strict.
+ *
+ * One family the coherence floor caught and this does not: two unrelated
+ * pictures of which one has little texture. Its surface is the low-texture
+ * picture's own correlation shape with the other picture's noise on it, a
+ * few broad bumps rather than many sharp ones, and the tallest bump's
+ * neighbours read 0.67-0.84 at 512 and 0.59-0.83 at 256 - inside the floor
+ * on eight seeds of ten - at a plateau of 0.43-0.70 that P_MAX does not
+ * catch either. Coherence read it at 0.05-0.06, a quarter of the real
+ * low-texture scene's, and it was the one junk family where coherence had a
+ * margin; the sparse skies sit at 0.04-0.05 in the same place, which is why
+ * that floor could not stay. On the survey square the letterbox refuses the
+ * pair (0.82-0.95), so it reaches the refinement only from a square frame,
+ * and only once the survey has admitted it.
+ *
+ * The two unrelated JPEGs are the widest of the junk families that this
+ * reading is meant to catch and does not always. Over eighty seed pairs -
+ * two unrelated scenes, one smooth and one mid-textured, at qualities 95, 75,
+ * 50 and 20 - next ran 0.72-1.00 and eight were admitted, about one in ten,
+ * worst on the smooth pair at quality 50 where three of ten passed; the
+ * plateau never refused one that this admitted. The leak is where the lattice
+ * puts its aliases. The nearest sit eight pixels from the peak, inside the
+ * box, so what is read is the pair at sixteen or seventeen, and those fall
+ * with the scene's own smooth envelope rather than standing level with the
+ * peak the way the near ones do. It is harmless as the pipeline is arranged:
+ * on the survey square the same pairs are letterboxed and read 0.91-0.99,
+ * refused on all eighteen seeds tried, and at 512 an argmax that landed on a
+ * random lattice peak is outside the refinement's eight-pixel margin and
+ * discarded there. Harmless is not invisible, and the number is recorded
+ * because the consensus check is what should be catching this.
+ *
+ * The reach was measured at 6, 8, 10, 12, 16 and 20. None of them moves the
+ * unrelated pairs or the star fields, whose next peak is far away - a sparse
+ * sky reads the same 0.33 at every reach from 6 to 20. What moves is a real
+ * broad peak's own skirt, and the skirt is wider than the box: on the ring
+ * around the peak the low-texture and textured pairs first fall to the
+ * outside level at eleven or twelve pixels, so at ten the reading is still
+ * partly the peak itself. It costs 0.03 on the low-texture scene at fifteen
+ * per cent noise, 0.10 at thirty and 0.08 on the letterboxed textured scene
+ * at fifty, against a reach past the skirt - not enough to buy anything, and
+ * a wider box would have to be justified against the junk it stops looking
+ * at. At 6, inside the plateau radius, the skirt lifts the low-texture scene
+ * at thirty per cent to 0.61 and the textured at fifty to 0.82, for nothing.
+ * Six does do one thing ten cannot: the refinement's lattice lock on smooth
+ * JPEG content, whose neighbouring peaks sit exactly eight pixels away, reads
+ * 0.50-0.69 there against 0.46-0.93 at ten. That would be a floor of 0.7
+ * refusing the lock outright, bought with the real side's margin, so it was
+ * not taken - and, as the paragraph on plateauRadius says, the plateau
+ * refuses that lock anyway at every quality but the heaviest.
+ *
+ * The same floor decides the log-polar peak, and it needs no floor of its
+ * own. Real turns at 256 over ten seeds: the low-texture scene turned three
+ * degrees reads 0.30-0.46 at fifteen per cent noise, 0.36-0.47 at twenty and
+ * 0.41-0.61 at thirty; turned four degrees, 0.31-0.61; the textured scene
+ * turned four degrees 0.20-0.27, nine degrees at thirty per cent 0.48-0.72,
+ * twenty degrees 0.22-0.34, scaled by 1.12 0.23-0.38; a star field turned
+ * five degrees 0.07-0.22; and the letterboxed textured and low-texture turns
+ * 0.26-0.42. Every seed of every one is admitted, and estimate() reads the
+ * angle on all ten seeds of each. The junk there: the gradient at fifteen
+ * per cent noise 0.83-0.95, unrelated pairs 0.70-1.00 (one to three seeds in
+ * ten pass), and the letterboxed 8-bit gradient 0.39-0.56 - admitted, as it
+ * was under the old floor, and discarded when the translation peak it
+ * leads to is refused.
+ *
+ * The margin there is 0.01, not the 0.08 those rows suggest, and the case
+ * that spends it is a turn too small to matter. Ten further seeds of the
+ * textured scene turned a third of a degree at thirty per cent noise read
+ * 0.35-0.81, right on every one, and the seed at 0.811 is refused: the
+ * smaller the turn, the nearer the log-polar peak sits to the surface's own
+ * junk peak at zero, and the two read as one crowd. What that seed costs is
+ * the rotation and not the frame - a third of a degree is under a pixel over
+ * most of a 24-megapixel frame, and the translation is measured either way.
+ * A floor of 0.85 for this surface alone would admit it, and would also
+ * admit the unrelated pairs that sit at 0.71-0.86 there, one of which reads
+ * a 7.2-degree turn between two pictures that share nothing; the trade is
+ * one refused third of a degree against a wrong turn applied to a frame the
+ * translation gate may well admit, and it was not taken. One floor is also
+ * one floor to calibrate, which is the whole reason isMeasured is a function
+ * rather than three comparisons in two places.
+ */
+export const N_MAX = 0.8;
+const NEXT_REACH = 10;
+
+/**
+ * The shape of the peak: junk that correlates perfectly well and still has no
+ * position - a plateau or a ridge.
+ *
+ * `plateau` is the highest point of the surface eight pixels from the peak
+ * in the eight compass directions - eight along the axes, eight times root
+ * two on the diagonals - as a fraction of the peak. A height statistic -
+ * coherence then, next now - asks how tall the peak is; this asks whether it
+ * has a position at all. A smooth gradient - a clear sky - correlates with
+ * itself perfectly well, because its 8-bit banding survives the survey and
+ * the two frames share every hard edge the survey square gives them, but
+ * the surface it produces is a ridge, and where the argmax lands on that
+ * ridge is decided by the noise. In the browser, four frames of one gradient
+ * with twelve per cent noise came back measured at coherence 0.47-0.51 and
+ * were moved by
+ * -12.9, +35.6 and -0.4 output pixels from an identity that was the truth:
+ * one to three alignment pixels, which the multiply-up turns into tens. The
+ * sub-pixel fit cannot help, because it is fitting a parabola to the top of
+ * a plateau.
+ *
+ * Measured in the browser on the built survey path (3000x2000 frames, JPEG,
+ * resized to 256x171 and drawn into the 256 square), the plateau at r = 8:
+ *
+ *                                   coherence   plateau
+ *   gradient, identical or shifted  0.28-0.52   0.93-0.99
+ *   two unrelated low-texture       0.28        0.81
+ *   low-texture, 30% noise          0.60        0.60
+ *   low-texture, 15% noise          0.71-0.81   0.34-0.40
+ *   star field, 6% noise            0.51-0.66   0.35-0.48
+ *   textured, clean and 30% noise   0.92-0.96   0.11-0.17
+ *
+ * and in node on the fixtures in tests/js/stack-images-align.test.js, ten
+ * seeds each at 256, with the picture letterboxed to 256x171 over black the
+ * way lumaSquare letterboxes a 3:2 frame - which is what reproduces the
+ * browser: a full-square gradient measures coherence 0.04-0.10 and next
+ * 0.87-0.99, and so do the vignette and textured-sky rows below (next
+ * 0.76-0.99), all refused without the plateau's help, and it is the
+ * letterbox's hard edge, shared by both frames, that pins the vertical,
+ * lifts the coherence over what was then its floor, and leaves the ridge:
+ *
+ *                                        coherence    plateau     refused
+ *   gradient, 8-bit, 0.3-3% noise        0.43-0.60    0.95-0.996  all
+ *   gradient, 8-bit, 12% noise           0.20-0.23    0.87-1.00   all
+ *   vignette, 8-bit, 1-3% noise          0.48-0.57    0.96-0.99   all
+ *   textured sky (5% low-frequency)      0.45-0.57    0.94-0.99   all
+ *   vignette over low-texture, moved 3   0.54-0.55    0.67-0.74   5 of 10
+ *   two unrelated low-texture, 5%        0.25-0.26    0.73-0.82   all
+ *   two unrelated low-texture, 15%       0.15-0.17    0.59-0.83   about half
+ *   two unrelated textured, 5%           0.18-0.20    0.59-0.73   1 of 10
+ *   unrelated texture/low, /stars        0.09-0.21    0.42-0.94   all
+ *   low-texture, 30% noise               0.26-0.28    0.47-0.68   none
+ *   low-texture, 15% noise               0.40-0.42    0.44-0.58   none
+ *   textured, 50% noise                  0.11-0.12    0.47-0.72   1 of 10
+ *   textured, 30% noise                  0.19-0.21    0.37-0.54   none
+ *   textured, 15% noise                  0.36-0.38    0.24-0.29   none
+ *   vignette over textured, moved 3      0.69-0.70    0.40-0.42   none
+ *   star field, 6% and 15% noise         0.52-0.79    0.03-0.10   none
+ *   twenty stars, 6% noise               0.20-0.23    0.02-0.12   none
+ *
+ * The floor is 0.7. Against the browser it has 0.1 of margin on both sides;
+ * against the fixtures the real side is thinner, 0.02-0.05, because the
+ * letterbox ridge sits under every real pair too: the low-texture scene at
+ * thirty per cent noise reaches 0.65-0.68 depending on the seeds, and the
+ * scene that straddles the floor is a low-texture one under a lens vignette
+ * that did not move with it, refused on half its seeds although its peak was
+ * within 0.8 pixels of the truth on every one. Raising the floor to 0.75
+ * would take all ten and still refuse every gradient (0.87 at worst) and the
+ * five per cent low/low pair, but admits more of the two pairs below - a
+ * trade, not an improvement, so 0.7 stands. The textured sky is refused
+ * because it cannot be located rather than because it is junk: its peak was
+ * 1.2-6.8 pixels off, and refusing it is right. The textured scene at fifty
+ * per cent noise was refused by the coherence floor of the time, with its
+ * peak 0.6-2.2 pixels off; it now passes nine seeds in ten at a next of
+ * 0.55-0.67, with 0.4-2.4 pixels of error, which is the small blur a
+ * doubtful coarse move on a real scene costs.
+ *
+ * Two pairs the gate knowingly lets through, on the letterboxed square only,
+ * both to be caught by the consensus check the way the JPEG lattice will be:
+ * two unrelated textured pictures pass nine seeds in ten and are moved by one
+ * to four alignment pixels, and two unrelated low-texture pictures at fifteen
+ * per cent noise pass about half. The surface is the letterbox ridge with the
+ * unrelated texture's noise bumps along it, so the argmax sits on a bump and
+ * the ridge reads 0.6-0.7 of it eight pixels away - a noisy ridge measures
+ * lower than the gradient's clean one. On a full square both pairs read next
+ * 0.82-0.99 (texture/texture) and 0.70-0.91 (low/low, admitted on five seeds
+ * in ten) at a coherence of 0.04-0.10. The structural fix is
+ * to taper the picture's own box in lumaSquare rather than the whole square,
+ * so the letterbox edge is not a feature both frames share; that would remove
+ * the ridge under the gradients, the unrelated pairs and the real low-texture
+ * answers at once, and is a follow-up rather than part of this gate. The
+ * browser's own reading of a low/low pair, 0.28 and 0.81, is refused.
+ *
+ * One row the two tables do not agree on: the browser's star field reads
+ * 0.35-0.48, ten times the fixture's, and flat across radii of three, five
+ * and eight, which is the signature of a ridge rather than of star size. Why
+ * that survey square carries a ridge at four tenths of the peak is not
+ * explained; it is well under the floor either way.
+ *
+ * The same floor decides the log-polar peak. Real turns measured 0.02-0.57
+ * there (the low-texture scene turned three degrees at twenty per cent noise
+ * is the 0.57), and the letterboxed gradient 0.78 at a coherence of 0.22 and
+ * a next of 0.39-0.56 - nothing else refuses it, so before this it was
+ * applied as a scale of 0.95-1.01.
+ *
+ * The radius is eight at every size, and plateauRadius says why it does not
+ * follow the side. What it reads at the refinement windows, full square, ten
+ * seeds: at 512 every real fixture is under the floor with margin - the
+ * low-texture scene 0.35-0.40 at fifteen per cent noise and 0.43-0.55 at
+ * thirty, textured 0.20-0.48 at fifteen to fifty, stars 0.04-0.08, the
+ * low-texture scene under a vignette 0.34-0.44 - while the plateaus the
+ * refinement exists to refuse are all over it: a wall with sixty-pixel
+ * features at 0.77-0.96 (fifteen per cent noise) and 0.82-0.90 (five), the
+ * same wall with thirty-pixel features 0.77-0.87, and the textured sky
+ * 0.82-0.91, every one with its peak 0.6-7.5 pixels off, inside the margin,
+ * at a next of 0.64-0.92 that is partly under N_MAX, so this is the floor
+ * that refuses them. At sixteen, the radius the side/32 rule gave
+ * 512, the wall at five per cent read 0.59-0.71 and passed nine seeds in ten
+ * with 0.6-5.1 pixels of error applied. At 128 the low-texture pair at
+ * fifteen per cent reads 0.33-0.47 and is kept, as is the vignette-over-low
+ * pair at 0.35-0.53, where the radius of four the old rule gave 128 refused
+ * the first at 0.76-0.91 with its peak in the right place; every junk family
+ * at 128 is refused by next (0.67-1.00, one gradient seed in ten passing).
+ * At 64 the real pairs read 0.02-0.65 here and the junk 0.11-0.73, and the
+ * comment on N_MAX says why that window is gated by neither floor.
+ */
+export const P_MAX = 0.7;
+
+/**
+ * Whether a correlation peak is one to act on.
+ *
+ * Takes what phaseCorrelate returned, and is the one place the decision is
+ * made: the log-polar peak, the translation peak and the refinement's residual
+ * all come through here, so there is one gate to calibrate and one to explain.
+ * Without a plateau the peak is taken to be a point and without a next it is
+ * taken to be alone, so a statistics object built by hand - the reference
+ * move, a consensus check - is answered rather than silently refused on a
+ * NaN. The size of the square no longer enters: the two floors that decide
+ * are ratios of the surface to its own peak, and the tables on P_MAX and
+ * N_MAX show them holding from 128 to 512 without scaling.
+ */
+export function isMeasured({ live, plateau = 0, next = 0 }) {
+  return live >= L_MIN && plateau <= P_MAX && next <= N_MAX;
+}
 
 /** The identity, for a frame that needs no moving or could not be measured. */
-export const NO_MOVE = Object.freeze({ dx: 0, dy: 0, angle: 0, scale: 1, confidence: 0 });
+export const NO_MOVE = Object.freeze({ dx: 0, dy: 0, angle: 0, scale: 1 });
 
 /* ------------------------------------------------------------- preparation */
 
@@ -106,6 +535,24 @@ export function window2d(values, size) {
  * an integer offset and a burst that drifted by half a pixel a frame stacks
  * slightly soft - the exact softness the alignment was there to prevent.
  *
+ * Beside the shift it returns the four statistics, two of which the gate
+ * reads. `live` is the mean of the weights the whitening gave the bins, the
+ * share of the spectrum that stood above the noise floor. `coherence` is the
+ * peak divided by the height every weighted bin agreeing would have produced:
+ * one for a perfect match, near zero for two pictures that share nothing -
+ * and, the comment on L_MIN says why, near zero for a perfect match of a
+ * sparse field too, which is why it is reported and not read. Neither depends
+ * on how bright the frames were or how much spectrum they had, which is what
+ * the z-score this used to report did depend on - after whitening, every live
+ * bin has the same magnitude, so a perfect match peaks at k/n over a floor of
+ * about sqrt(k)/n, and the score was sqrt(k): a count of the bins that
+ * survived, not a measure of agreement. It read 27 on a featureless gradient.
+ * `plateau` is how much of the peak is still standing a few pixels away from
+ * it, the shape of the peak rather than its height, and `next` is how tall
+ * the rest of the surface gets once the peak's own neighbourhood is left out,
+ * whether the peak is the answer or the tallest of several; the comments on
+ * P_MAX and N_MAX say what each catches that the other cannot.
+ *
  * @param {Float64Array} a  windowed, size*size
  * @param {Float64Array} b  windowed, size*size
  * @param {number} size     a power of two
@@ -120,35 +567,45 @@ export function phaseCorrelate(a, b, size) {
   fft2(aRe, aIm, size);
   fft2(bRe, bIm, size);
 
-  // The cross-power spectrum, normalised to unit magnitude. Throwing the
-  // magnitudes away is what makes this robust to one frame being brighter than
-  // the other: only where the structure is matters, not how strong it is.
+  // The cross-power spectrum, whitened - each bin divided by its own magnitude,
+  // so that only where the structure is counts and not how strong it is, which
+  // is what makes this indifferent to one frame being brighter than the other.
   //
-  // Except where there is no structure. Normalising divides by the magnitude,
-  // so a bin the picture put nothing in gets its rounding error amplified to
-  // the same weight as a real edge - and a picture with a narrow spectrum has
-  // thousands of those. Bins below a millionth of the strongest are dropped
-  // rather than whitened, which costs nothing on a photograph and is the
-  // difference between an answer and noise on anything smooth.
+  // Divided by its magnitude plus a floor, rather than by its magnitude alone,
+  // and the floor is the point. Whitening lifts every bin to the same weight,
+  // including the thousands a photograph put nothing into, which hold nothing
+  // but sensor noise and whose phases say nothing about the shift. Adding a
+  // floor of WHITEN times the median bin to the divisor leaves a bin well
+  // above the floor whitened and lets one below it fade in proportion to how
+  // far below it is: the strong bins vote with one voice each and the noise
+  // barely votes at all. The median rather than the mean because the mean is
+  // owned by the handful of low-frequency bins and says nothing about where
+  // the noise sits.
+  const magnitude = new Float64Array(n);
   let strongest = 0;
   for (let i = 0; i < n; i += 1) {
     const re = aRe[i] * bRe[i] + aIm[i] * bIm[i];
     const im = aIm[i] * bRe[i] - aRe[i] * bIm[i];
     aRe[i] = re;
     aIm[i] = im;
-    const magnitude = Math.hypot(re, im);
-    if (magnitude > strongest) strongest = magnitude;
+    magnitude[i] = Math.hypot(re, im);
+    if (magnitude[i] > strongest) strongest = magnitude[i];
   }
 
+  const eps = WHITEN * median(magnitude);
+  // Only a guard against dividing by nothing, on a square that is genuinely
+  // empty; anything with a picture in it never reaches it.
   const floor = strongest * 1e-6;
+  let weight = 0;
   for (let i = 0; i < n; i += 1) {
-    const magnitude = Math.hypot(aRe[i], aIm[i]);
-    if (magnitude <= floor) {
+    const divisor = magnitude[i] + eps;
+    if (divisor <= floor) {
       aRe[i] = 0;
       aIm[i] = 0;
     } else {
-      aRe[i] /= magnitude;
-      aIm[i] /= magnitude;
+      aRe[i] /= divisor;
+      aIm[i] /= divisor;
+      weight += magnitude[i] / divisor;
     }
   }
 
@@ -156,17 +613,9 @@ export function phaseCorrelate(a, b, size) {
 
   let peak = -Infinity;
   let peakAt = 0;
-  let total = 0;
-  let squares = 0;
   for (let i = 0; i < n; i += 1) {
-    const value = aRe[i];
-    total += value;
-    squares += value * value;
-    if (value > peak) { peak = value; peakAt = i; }
+    if (aRe[i] > peak) { peak = aRe[i]; peakAt = i; }
   }
-
-  const mean = total / n;
-  const deviation = Math.sqrt(Math.max(0, squares / n - mean * mean)) || 1e-12;
 
   const px = peakAt % size;
   const py = (peakAt / size) | 0;
@@ -174,6 +623,54 @@ export function phaseCorrelate(a, b, size) {
 
   const dx = wrap(px + parabola(at(px - 1, py), peak, at(px + 1, py)), size);
   const dy = wrap(py + parabola(at(px, py - 1), peak, at(px, py + 1)), size);
+
+  // How much of the peak is still standing a few pixels out. A peak that is a
+  // point has fallen to the noise by then; one that is a plateau or a ridge
+  // has not, and its argmax is wherever the noise tipped it. Eight compass
+  // directions rather than a ring, because a ridge runs one way and the
+  // question is whether *any* direction is still high - r along the axes and
+  // r * sqrt(2) on the diagonals, which P_MAX was calibrated on: a true ring
+  // at r reads 0.05-0.15 higher on real peaks and would need its own floor.
+  const r = plateauRadius();
+  let shoulder = -Infinity;
+  for (let j = -1; j <= 1; j += 1) {
+    for (let i = -1; i <= 1; i += 1) {
+      if (i === 0 && j === 0) continue;
+      const value = at(px + i * r, py + j * r);
+      if (value > shoulder) shoulder = value;
+    }
+  }
+
+  // The tallest point anywhere else on the surface, outside a box around the
+  // peak wide enough to hold the peak's own skirt: whether the peak is the
+  // answer or merely the tallest of several. A second pass rather than part
+  // of the first, because the box is not known until the peak is; it is one
+  // comparison per bin and the transform above dwarfs it. Wrapping, since the
+  // surface does.
+  const reach = NEXT_REACH;
+  const inside = new Uint8Array(size);
+  for (let x = 0; x < size; x += 1) {
+    const away = Math.abs(x - px);
+    inside[x] = Math.min(away, size - away) <= reach ? 1 : 0;
+  }
+  let next = -Infinity;
+  let outside = false;
+  for (let y = 0; y < size; y += 1) {
+    const away = Math.abs(y - py);
+    const row = y * size;
+    if (Math.min(away, size - away) <= reach) {
+      for (let x = 0; x < size; x += 1) {
+        if (inside[x]) continue;
+        outside = true;
+        if (aRe[row + x] > next) next = aRe[row + x];
+      }
+    } else {
+      outside = true;
+      for (let x = 0; x < size; x += 1) {
+        if (aRe[row + x] > next) next = aRe[row + x];
+      }
+    }
+  }
 
   return {
     // The peak sits where the frame has to be moved to, not where it moved
@@ -183,8 +680,78 @@ export function phaseCorrelate(a, b, size) {
     dx,
     dy,
     peak,
-    confidence: (peak - mean) / deviation,
+    live: weight / n,
+    // The inverse transform divides by n, so every weighted bin agreeing at
+    // one offset stacks to weight / n there.
+    coherence: weight > 0 ? (peak * n) / weight : 0,
+    plateau: peak > 0 ? shoulder / peak : 1,
+    next: peak > 0 && outside ? next / peak : 1,
   };
+}
+
+/**
+ * How far from the peak the plateau is read: eight pixels, at every size.
+ *
+ * Eight is the refinement's margin. A residual is only applied when it is
+ * within eight output pixels of the coarse answer, so a peak still standing
+ * eight pixels out cannot place the frame within the margin whatever its
+ * argmax says; and at the coarse square eight alignment pixels is already
+ * tens of output pixels on any frame the survey shrank. The first version
+ * scaled the radius with the side - a thirty-second of it, sixteen at 512 -
+ * reasoning from the multiply-up, which the refinement window does not have:
+ * at sixteen the wall at output resolution the refinement exists to refuse
+ * passed nine seeds in ten, and at four the low-texture pair at 128 was
+ * refused with its peak in the right place. The comment on P_MAX has the
+ * readings at both.
+ *
+ * Eight is also the pitch of a JPEG's block grid, and that coincidence is
+ * doing work nobody chose. Two frames of one smooth scene compressed at
+ * quality 75 or 50 lock onto the lattice, and the shoulder read at eight
+ * lands on its first alias: the plateau spikes there - 0.71-0.96 at r = 8
+ * against 0.50-0.69 at 6, 0.56-0.81 at 9 and 0.47-0.74 at 10 - and refuses
+ * the lock on every seed at both qualities, where next does not. Only at
+ * quality 20, where the alias is buried in the blocking, does the lock get
+ * through. So a change to this radius, or to the margin it is drawn from,
+ * silently gives that lock back; the lattice test in
+ * tests/js/stack-images-align.test.js pins both sides so it cannot go
+ * quietly.
+ */
+function plateauRadius() {
+  return 8;
+}
+
+/**
+ * The median of an array, by quickselect over a copy.
+ *
+ * A sort would do the same in twenty-five milliseconds at 512 by 512, which
+ * per frame is a quarter of the time the correlation itself takes; this is a
+ * fifth of that, and the array is only read once more anyway.
+ */
+function median(values) {
+  const copy = Float64Array.from(values);
+  const target = copy.length >> 1;
+  let low = 0;
+  let high = copy.length - 1;
+  while (low < high) {
+    const pivot = copy[(low + high) >> 1];
+    let i = low;
+    let j = high;
+    while (i <= j) {
+      while (copy[i] < pivot) i += 1;
+      while (copy[j] > pivot) j -= 1;
+      if (i <= j) {
+        const swap = copy[i];
+        copy[i] = copy[j];
+        copy[j] = swap;
+        i += 1;
+        j -= 1;
+      }
+    }
+    if (j < target) low = i;
+    else if (i > target) high = j;
+    else break;
+  }
+  return copy[target];
 }
 
 /** Sub-pixel offset of a peak, from it and its two neighbours. */
@@ -325,15 +892,25 @@ export function rotateScale(values, size, degrees, scale) {
  * angle and the scale alone because neither depends on how large the square
  * was.
  *
+ * `measured` says whether the translation peak passed the gate. When it did
+ * not, the shift returned beside it is whatever the tallest point of a
+ * featureless surface happened to be, and the caller should not apply it.
+ * `clamped` is a different report and says only one thing: the rotation or
+ * scale read off the log-polar peak was too large to be a burst. A log-polar
+ * peak the gate refused is not that - the frame reported no rotation at all,
+ * and the page must not say it reported too much - so it falls back to
+ * translation silently, with `clamped` left false.
+ *
  * @param {Float64Array} reference
  * @param {Float64Array} frame
  * @param {number} size
  * @param {string} mode  one of ALIGN_MODES
  * @returns {{dx: number, dy: number, angle: number, scale: number,
- *   confidence: number, clamped: boolean}}
+ *   measured: boolean, clamped: boolean, live: number, coherence: number,
+ *   plateau: number, next: number}}
  */
 export function estimate(reference, frame, size, mode) {
-  if (mode === 'none') return { ...NO_MOVE, clamped: false };
+  if (mode === 'none') return { ...NO_MOVE, measured: true, clamped: false };
 
   let angle = 0;
   let scale = 1;
@@ -361,10 +938,20 @@ export function estimate(reference, frame, size, mode) {
     angle = measured > 90 ? measured - 180 : measured;
     scale = 1 / Math.exp(found.dx * b.base);
 
-    if (Math.abs(angle) > MAX_ROTATION || scale < MIN_SCALE || scale > MAX_SCALE
-        || !Number.isFinite(scale) || found.confidence < WEAK_PEAK) {
-      // Not a burst, or not a peak. Fall back to translation, which is the
-      // answer that can only fail to help rather than actively harm.
+    // The gate is asked before the bounds are, and the order is the point. A
+    // peak the gate refuses is where the surface's noise piled up, and the
+    // row that noise chose spans half a turn, so a third of the time it lands
+    // past thirty degrees; asked the other way round, that frame would be
+    // reported as having turned too far to be a burst when it reported no
+    // turn at all.
+    if (!isMeasured(found)) {
+      // Not a peak. Fall back to translation, with nothing to report.
+      angle = 0;
+      scale = 1;
+    } else if (Math.abs(angle) > MAX_ROTATION || scale < MIN_SCALE || scale > MAX_SCALE
+        || !Number.isFinite(scale)) {
+      // Not a burst. The same fall-back, which is the answer that can only
+      // fail to help rather than actively harm, and this one is said.
       angle = 0;
       scale = 1;
       clamped = true;
@@ -379,7 +966,11 @@ export function estimate(reference, frame, size, mode) {
     dy: shift.dy,
     angle,
     scale,
-    confidence: shift.confidence,
+    measured: isMeasured(shift),
     clamped,
+    live: shift.live,
+    coherence: shift.coherence,
+    plateau: shift.plateau,
+    next: shift.next,
   };
 }

--- a/tools/stack-images/src/main.js
+++ b/tools/stack-images/src/main.js
@@ -574,7 +574,9 @@ function finished(result) {
 function movesNote(moves) {
   if (el.align.value === 'none') return phrase('result.moves-none');
   const measurable = moves.slice(1);
-  const weak = measurable.filter((move) => !(move.confidence > 4)).length;
+  // The pipeline decided, and an unmeasured frame is sitting at the identity,
+  // so "left where they were" is a report and not a hope.
+  const weak = measurable.filter((move) => move.measured === false).length;
   const clamped = measurable.filter((move) => move.clamped).length;
 
   if (weak) {

--- a/tools/stack-images/src/pipeline.js
+++ b/tools/stack-images/src/pipeline.js
@@ -36,7 +36,7 @@
  * and neither the fill nor the readback pays for rows nobody is looking at.
  */
 
-import { WEAK_PEAK, estimate, phaseCorrelate, window2d } from './align.js';
+import { NO_MOVE, estimate, isMeasured, phaseCorrelate, window2d } from './align.js';
 import {
   bands, commonArea, outputSize, placement, planRun, refineMargin, refineWindow, workingSize,
 } from './plan.js';
@@ -458,7 +458,7 @@ export async function runStack(request, hooks) {
   for (const [index, frame] of frames.entries()) {
     stop();
     if (align === 'none') {
-      moves.push({ dx: 0, dy: 0, angle: 0, scale: 1, confidence: 0, clamped: false });
+      moves.push({ ...NO_MOVE, measured: true, clamped: false });
       continue;
     }
     report({ stage: 'measure', done: index, total: frames.length, name: frame.name });
@@ -471,16 +471,33 @@ export async function runStack(request, hooks) {
     }, output, fit, frame.turn);
 
     if (!reference) {
+      // Everything else is measured against this frame, so it is the one move
+      // known exactly.
       reference = square;
-      moves.push({ dx: 0, dy: 0, angle: 0, scale: 1, confidence: Infinity, clamped: false });
+      moves.push({
+        ...NO_MOVE, measured: true, clamped: false, live: 1, coherence: 1, plateau: 0, next: 0,
+      });
       continue;
     }
     const found = estimate(reference, square, ALIGN_SIZE, align);
-    moves.push({
+    // A peak the gate refused is the tallest point of a featureless surface,
+    // not a shift, and the page says such a frame was left where it was. The
+    // identity makes that literally true, and it is what the crop and the
+    // stack below see for this frame; the statistics travel with it so the
+    // page can count it.
+    moves.push(found.measured ? {
       ...found,
       // Back out of the alignment square and into the output's own pixels.
       dx: found.dx / fit.scale,
       dy: found.dy / fit.scale,
+    } : {
+      ...NO_MOVE,
+      measured: false,
+      clamped: false,
+      live: found.live,
+      coherence: found.coherence,
+      plateau: found.plateau,
+      next: found.next,
     });
   }
 
@@ -556,19 +573,29 @@ export async function runStack(request, hooks) {
         // Each frame's first full-size appearance settles its final position.
         // Later bands and passes reuse the answer, so a banded run stays
         // consistent with itself. The gates keep a bad peak from undoing a
-        // good coarse answer: a window without enough texture to correlate, or
-        // a residual larger than the coarse pass could plausibly have been
-        // wrong by, leaves the frame where the coarse measurement put it.
+        // good coarse answer: a window without enough texture to correlate, a
+        // window whose peak is a plateau - a wall, a sky - so that its
+        // position is the noise's choice, a window whose peak is one of
+        // several of much the same height - two unrelated pictures, a sky too
+        // sparse for its noise - so that which one the argmax took is the
+        // noise's choice instead, or a residual larger than the coarse pass
+        // could plausibly have been wrong by, leaves the frame where the
+        // coarse measurement put it. A frame the coarse pass could
+        // not measure is not refined at all: it is sitting at the identity,
+        // and a residual measured from there is not a residual but a whole
+        // shift, which is the measurement that was already refused.
         if (refine && !refined[index]) {
           refined[index] = true;
-          const square = refineSquare(
-            bitmap, spot, output, moves[index], refineAt, refine, frame.turn,
-          );
           if (index === 0) {
-            referenceWindow = square;
-          } else if (referenceWindow) {
+            referenceWindow = refineSquare(
+              bitmap, spot, output, moves[index], refineAt, refine, frame.turn,
+            );
+          } else if (referenceWindow && moves[index].measured) {
+            const square = refineSquare(
+              bitmap, spot, output, moves[index], refineAt, refine, frame.turn,
+            );
             const residual = phaseCorrelate(referenceWindow, square, refine);
-            if (residual.confidence >= WEAK_PEAK
+            if (isMeasured(residual)
                 && Math.abs(residual.dx) <= margin && Math.abs(residual.dy) <= margin) {
               moves[index].dx += residual.dx;
               moves[index].dy += residual.dy;


### PR DESCRIPTION
Follows #365, which is merged; this targets `main`.

## What was wrong

The alignment applied every shift the correlation returned, and the number it called `confidence` could not tell a match from noise. After the old whitening every surviving bin has unit magnitude, so for a perfect match the peak is k/n and the surface's deviation about the square root of k over n: the z-score is the square root of k, the count of bins the picture had, not whether the two pictures agree. A featureless sky scored 27, a star field 60, texture 140, and the gate of 4 never fired.

So four frames of one smooth gradient were moved by up to 36 output pixels on the strength of noise, and the result note said every frame had been measured, while the sentence for the other case ("could not be measured confidently and were left where they were", translated in fourteen languages) described code that did not exist.

## What changed

- **The whitening is regularised**: `X / (|X| + eps)` with eps from the median cross-spectrum magnitude, instead of unit magnitude above a hard floor. A bin the picture put nothing into no longer carries the same weight as an edge.
- **Two statistics that decide, and two that report.** `plateau` asks whether the peak has a position at all: how much of it is still there eight pixels away in the flattest direction. `next` asks whether it is alone: the tallest point of the surface outside a ten-pixel box around it. A smooth gradient does correlate with itself, at coherence 0.5, but its peak is a ridge whose argmax is noise, and that is what moved the sky frames. `live` stays as the guard against a numerically empty square, and `coherence` is now reported for the record rather than read.
- **One gate, `isMeasured`**, used by the coarse pass, the log-polar peak and the refinement. A coarse pass it refuses leaves the frame at the identity with `measured: false`, so the note is a report rather than a hope; a log-polar peak it refuses falls back to shift only *without* claiming the rotation was too large, which `clamped` now means and nothing else.
- The page counts unmeasured frames from that flag rather than from a literal 4.

The coherence floor was tried first and removed: it penalises sparse spectra by construction, so it refused a star field the previous code had refined correctly. That history, and every threshold's calibration table, is recorded beside the constants.

Recorded rather than fixed here, in the README: the survey square letterboxes a 3:2 frame over transparent black, and that shared edge biases a low-texture coarse answer by a pixel or two and admits some unrelated pairs; on smooth content a refinement window can lock onto the JPEG block lattice. Both are the next phase's work, where a nine-window consensus check replaces the single centre window.

## Before / after

Four frames of one smooth gradient with independent noise, shift-only alignment, driven through the real page. Before, the frames were moved by noise and the note said every one was measured. After, three of four are reported as unmeasured and left where they were, and the result keeps its full size instead of losing tens of pixels to a crop that was correcting nothing.

| Before | After |
|---|---|
| <img width="700" alt="gate-before" src="https://github.com/user-attachments/assets/dd024ee8-15a0-4599-b658-87c5ed182182" /> | <img width="700" alt="gate-after" src="https://github.com/user-attachments/assets/850bc228-1b66-4c39-a35d-0d1b9312ea30" /> |

Verified in the browser against the built page. Refused: the gradient set in both modes, a horizontal gradient, and a set of three unrelated pictures, all with `clamped` false. Measured and unchanged or better: textured frames with sub-pixel shifts (errors under 0.15 px), shifts of 120 to 190 px (under 0.11 px), 2-degree rotations with scale (angle errors under 0.03 degrees), a star field at 6% noise with a 95 px shift (under 0.09 px, which is the refinement working) and at 15% noise (under 0.45 px).

Tests: `stack-images-align.test.js` gains the gate fixtures on both sides with their measured statistics; 127 stack-images tests pass. No visitor-facing string changed, so no locale is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
