### PR TITLE
Ask nine windows where a frame went, and believe them only if they agree

### DIFF
--- a/tests/js/stack-images-align.test.js
+++ b/tests/js/stack-images-align.test.js
@@ -612,10 +612,10 @@ test('the gate holds at the refinement windows', () => {
   // floor refused it there. But the window is too small for the junk to
   // read as junk: this unrelated pair is refused at 0.896, and the same
   // pair on seeds 11 and 12 reads 0.788 and passes. The comment on N_MAX
-  // says why that is accepted - plan.js gives the 64 window only to crops
-  // under 272 pixels on the short side, and refineMargin caps what a
-  // residual can move a frame that did not move at one pixel. What is
-  // pinned is the pair the fixture table has.
+  // says why that is accepted - the refinement measures nine windows and
+  // applies nothing four of them do not agree on, so one small square
+  // passing this floor is a window dropped rather than a frame moved. What
+  // is pinned is the pair the fixture table has.
   const small64 = gateFixture(
     noisy(field(64, lowScene), 13.5, 3), noisy(field(64, lowScene, 2.4, -1.7), 13.5, 4), 64,
   );
@@ -720,9 +720,9 @@ test('two unrelated pictures locked on a JPEG lattice are refused by uniqueness'
   // apart, inside the ten-pixel box, so what next reads is the noise beyond
   // them (0.46-0.93 at quality 75, 0.27-0.40 at 20) and not the lattice.
   // What refuses it at most qualities is the plateau, by a coincidence
-  // rather than by design: its radius is eight because that is the
-  // refinement's margin, and eight is also the block pitch, so the shoulder
-  // is read on the lattice's first alias and spikes there. At quality 75
+  // rather than by design: its radius is eight because that is where a peak
+  // has stopped placing anything, and eight is also the block pitch, so the
+  // shoulder is read on the lattice's first alias and spikes there. At quality 75
   // that reads 0.71-0.98 over ten seed pairs and the lock is refused on
   // every one; the same at 95 and 50. plateauRadius in align.js records the
   // coincidence, and this is the assertion that would fail if the radius
@@ -760,7 +760,8 @@ test('a wall at output resolution is a plateau the refinement refuses', () => {
   // light is at output resolution. Its peak is sixty pixels wide too, so
   // eight pixels out the surface is still at three quarters of the peak or
   // more, and the argmax is one to seven pixels off a shift of (2.4, -1.7)
-  // - inside the eight-pixel margin, so nothing else would have refused it.
+  // - small enough that nothing else would have refused it, and consistent
+  // enough across the grid that the consensus would not have either.
   // Over ten seeds the plateau ran 0.77-0.96 at fifteen per cent noise and
   // 0.82-0.90 at five, every seed refused; at the sixteen-pixel radius the
   // first version read at 512, the five per cent wall stood at 0.59-0.71 and

--- a/tests/js/stack-images-pipeline.test.js
+++ b/tests/js/stack-images-pipeline.test.js
@@ -3,7 +3,17 @@
  *
  * The pipeline is written for a worker and touches no DOM at module scope, so
  * it loads here; what it does with a decoder and a surface is exercised in a
- * browser and not in this file. Two things are worth pinning without either.
+ * browser and not in this file. What it works out BEFORE it touches either is
+ * pinned here, and there is more of that than the shape of the module
+ * suggests: the whole refinement ladder is arithmetic over nine measured
+ * shifts, and the crop is arithmetic over the moves it ends with.
+ *
+ * `compose` earns its place at the top of that list. It is the one step that
+ * has to be right for a rotated burst rather than merely for a shifted one,
+ * and a negated sine in it does not throw and does not look wrong in review -
+ * it turns every frame the wrong way and doubles the blur the refinement was
+ * added to remove. So it is checked against the composition it claims to be,
+ * by pushing points through the two transforms in turn.
  *
  * `declaredSize`, because every later stage plans from the number it returns
  * and the number has to be the size the decode will actually have. That is
@@ -27,7 +37,12 @@ import {
   EXIF_ID, IHDR, PNG_SIGNATURE, TIFF_LE, TIFF_TYPE, ascii, concat, segment, tiffEntry, tiffOf,
   u16be, u32be,
 } from './helpers.js';
-import { declaredSize, openFrame } from '../../tools/stack-images/src/pipeline.js';
+import { NO_MOVE } from '../../tools/stack-images/src/align.js';
+import { REFINE_GRID, REFINE_INSET, refineWindow } from '../../tools/stack-images/src/plan.js';
+import { apply } from '../../tools/stack-images/src/similarity.js';
+import {
+  REFINED, compose, declaredSize, fellBack, finalCrop, openFrame, refineGrid, refineMove,
+} from '../../tools/stack-images/src/pipeline.js';
 
 const sof = (width, height) => concat(
   [0xff, 0xc0], u16be(17), [8], u16be(height), u16be(width),
@@ -174,4 +189,233 @@ test('a preview whose frame header lay past the head declares no size, not a siz
   assert.equal(frame.height, null);
   assert.equal(frame.decoded, null);
   assert.equal(frame.turn, 1, 'the RAF preview\'s own Exif, read off the head, does the turning');
+});
+
+/* ------------------------------------------------------- the refinement */
+
+const OUTPUT = { width: 3000, height: 2000 };
+const CENTRE = { x: 1500, y: 1000 };
+const BOX = { x: 0, y: 0, width: OUTPUT.width, height: OUTPUT.height };
+/** Two coarse pixels of a 256 square laid over a 3000-pixel output. */
+const LIMIT = 2 / (256 / 3000);
+
+/** The nine window centres of a 3x3 grid, near enough for the arithmetic. */
+const GRID = [];
+for (const y of [500, 1000, 1500]) for (const x of [750, 1500, 2250]) GRID.push({ x, y });
+
+/**
+ * The shifts nine windows would measure of a frame that arrived transformed.
+ *
+ * Forwards, as in the similarity tests: the transform is what happened to the
+ * frame and the shift is what it takes to undo it, so nothing here assumes the
+ * sign the module uses.
+ */
+function fieldFrom({ angle = 0, scale = 1, dx = 0, dy = 0 }) {
+  const radians = (angle * Math.PI) / 180;
+  const cos = Math.cos(radians) * scale;
+  const sin = Math.sin(radians) * scale;
+  return GRID.map(({ x, y }) => {
+    const at = {
+      x: CENTRE.x + (x - CENTRE.x) * cos - (y - CENTRE.y) * sin + dx,
+      y: CENTRE.y + (x - CENTRE.x) * sin + (y - CENTRE.y) * cos + dy,
+    };
+    return { x, y, dx: x - at.x, dy: y - at.y };
+  });
+}
+
+const coarse = (over = {}) => ({ ...NO_MOVE, measured: true, clamped: false, ...over });
+
+test('a refinement laid on a coarse move is the two of them in order', () => {
+  // The composition rule written out, checked against doing it the long way.
+  // A negated sine here is a stack blurred by twice the shake, and nothing
+  // else in the repository would notice.
+  const move = { ...NO_MOVE, angle: 1.7, scale: 1.02, dx: -14, dy: 9 };
+  const fit = { angle: -0.31, scale: 0.9985, dx: 2.4, dy: -1.1 };
+  const both = compose(move, fit, true);
+
+  for (const point of [{ x: 0, y: 0 }, { x: 3000, y: 0 }, { x: 2250, y: 1500 }, CENTRE]) {
+    const first = apply(move, point.x, point.y, CENTRE);
+    const long = apply(fit, first.x, first.y, CENTRE);
+    const short = apply(both, point.x, point.y, CENTRE);
+    assert.ok(
+      Math.hypot(long.x - short.x, long.y - short.y) < 1e-9,
+      `at ${point.x},${point.y}: ${JSON.stringify(long)} against ${JSON.stringify(short)}`,
+    );
+  }
+});
+
+test('in translate mode a refinement contributes its shift and nothing else', () => {
+  const move = { ...NO_MOVE, angle: 1.7, scale: 1.02, dx: -14, dy: 9 };
+  const both = compose(move, { angle: -0.31, scale: 0.9985, dx: 2.4, dy: -1.1 }, false);
+  assert.equal(both.angle, 1.7);
+  assert.equal(both.scale, 1.02);
+  assert.ok(Math.abs(both.dx - (-14 + 2.4)) < 1e-12);
+  assert.ok(Math.abs(both.dy - (9 - 1.1)) < 1e-12);
+});
+
+test('nine windows that agree are applied, and land the frame where they say', () => {
+  // The coarse pass left the frame a third of a degree out and two pixels
+  // adrift; the grid sees exactly that and the composed move has to undo it.
+  const move = coarse({ dx: 5, dy: -3, angle: 0.4 });
+  const refined = refineMove(move, fieldFrom({ angle: 0.3, dx: 2, dy: -1 }), true, CENTRE, LIMIT);
+  assert.equal(refined.refine, REFINED.fit);
+
+  const wrong = { angle: 0.3, scale: 1, dx: 2, dy: -1 };
+  for (const { x, y } of GRID) {
+    const arrived = apply(wrong, x, y, CENTRE);
+    const put = apply(refined, arrived.x, arrived.y, CENTRE);
+    // The coarse move is in the fixture too: what is checked is that the
+    // refinement finished it, not that it threw it away.
+    const meant = apply(move, x, y, CENTRE);
+    assert.ok(Math.hypot(put.x - meant.x, put.y - meant.y) < 0.05, `at ${x},${y}`);
+  }
+});
+
+test('nine windows that disagree leave the coarse move alone', () => {
+  // The moving-subject frame with every window surviving the gate. Two of them
+  // agree exactly, which is what the mean-of-the-agreeing rung would seize on;
+  // with four windows in hand the consensus has already reported that the
+  // frame cannot be described, and the coarse answer is the honest one.
+  const move = coarse({ dx: 5, dy: -3 });
+  const scattered = GRID.map(({ x, y }, index) => ({
+    x,
+    y,
+    dx: [9, 9, -23, 14, -31, 26, -12, 33, -18][index],
+    dy: [-7, -7, 18, -25, 11, -34, 29, 6, -21][index],
+  }));
+
+  const refined = refineMove(move, scattered, true, CENTRE, LIMIT);
+  assert.equal(refined.refine, REFINED.coarse);
+  assert.equal(refined.dx, 5);
+  assert.equal(refined.dy, -3);
+  assert.equal(refined.partial, undefined);
+});
+
+test('below the floor, two windows agreeing are a shift and nothing more', () => {
+  const move = coarse({ dx: 5, dy: -3, angle: 0.4 });
+  const points = [
+    { x: 750, y: 500, dx: 3, dy: -2 },
+    { x: 2250, y: 1500, dx: 3.4, dy: -1.7 },
+    { x: 1500, y: 1000, dx: -20, dy: 15 },
+  ];
+  const refined = refineMove(move, points, true, CENTRE, LIMIT);
+  assert.equal(refined.refine, REFINED.partial);
+  assert.equal(refined.partial, true);
+  assert.equal(refined.angle, 0.4, 'a pair of windows says nothing about rotation');
+  assert.ok(Math.abs(refined.dx - (5 + 3.2)) < 1e-9);
+  assert.ok(Math.abs(refined.dy - (-3 - 1.85)) < 1e-9);
+});
+
+test('below the floor with nothing agreeing, the coarse move stands', () => {
+  const move = coarse({ dx: 5, dy: -3 });
+  const points = [
+    { x: 750, y: 500, dx: 3, dy: -2 },
+    { x: 2250, y: 1500, dx: -19, dy: 24 },
+  ];
+  assert.equal(refineMove(move, points, true, CENTRE, LIMIT).refine, REFINED.coarse);
+  assert.equal(refineMove(move, [], true, CENTRE, LIMIT).refine, REFINED.coarse);
+});
+
+test('a shift too large to be a residual is refused however many windows agree', () => {
+  // A globally periodic texture: every window's argmax lands on the same wrong
+  // lattice period, the consensus is unanimous, and the answer is a hundred
+  // pixels of nonsense. Nothing about the fit itself can see that.
+  const move = coarse({ dx: 5, dy: -3 });
+  const unanimous = fieldFrom({ dx: -100 });
+  assert.equal(refineMove(move, unanimous, true, CENTRE, LIMIT).refine, REFINED.coarse);
+  assert.equal(
+    refineMove(move, unanimous, true, CENTRE, 200).refine, REFINED.fit,
+    'the same field inside a wider bound is applied, so it is the bound refusing it',
+  );
+
+  const pair = [
+    { x: 750, y: 500, dx: 60, dy: 0 },
+    { x: 2250, y: 1500, dx: 60, dy: 0 },
+  ];
+  assert.equal(refineMove(move, pair, true, CENTRE, LIMIT).refine, REFINED.coarse);
+});
+
+test('a frame reported as shifted alone stops being one when a turn is applied to it', () => {
+  // The page says of a clamped frame that it was corrected by shifting alone.
+  // In similarity mode the fit's angle reaches it, so the flag has to come off
+  // with the movement that makes it untrue - and stay on in translate mode,
+  // where nothing turned.
+  const move = coarse({ clamped: true });
+  const field = fieldFrom({ angle: 0.3 });
+  assert.equal(refineMove(move, field, true, CENTRE, LIMIT).clamped, false);
+  assert.equal(refineMove(move, field, false, CENTRE, LIMIT).clamped, true);
+  assert.equal(refineMove(move, [], true, CENTRE, LIMIT).clamped, true);
+});
+
+test('the grid is nine windows and every one of them is inside the crop', () => {
+  for (const crop of [
+    { x: 100, y: 50, width: 4000, height: 3000 },
+    { x: 0, y: 0, width: REFINE_GRID * 64 + REFINE_INSET * 2, height: 900 },
+    { x: 7, y: 11, width: 1575, height: 1179 },
+  ]) {
+    const windows = refineWindow(crop);
+    const grid = refineGrid(crop, windows);
+    assert.equal(grid.length, REFINE_GRID * REFINE_GRID);
+    for (const at of grid) {
+      assert.ok(at.x >= crop.x, `${at.x} left of ${crop.x}`);
+      assert.ok(at.y >= crop.y, `${at.y} above ${crop.y}`);
+      assert.ok(at.x + windows.cover <= crop.x + crop.width, `${at.x} plus cover past the crop`);
+      assert.ok(at.y + windows.cover <= crop.y + crop.height, `${at.y} plus cover past the crop`);
+      assert.equal(at.centre.x, at.x + windows.cover / 2);
+      assert.equal(at.centre.y, at.y + windows.cover / 2);
+    }
+  }
+});
+
+/* ------------------------------------------------------------- the crop */
+
+test('a whole box that nobody covered is told apart from one everybody did', () => {
+  const still = [{ ...NO_MOVE, spot: BOX }, { ...NO_MOVE, spot: BOX }];
+  assert.equal(fellBack(BOX, still, OUTPUT), false);
+  const apart = [{ ...NO_MOVE, spot: BOX }, { ...NO_MOVE, dx: 2400, spot: BOX }];
+  assert.equal(fellBack(BOX, apart, OUTPUT), true);
+  assert.equal(
+    fellBack({ x: 0, y: 0, width: 2000, height: 2000 }, apart, OUTPUT), false,
+    'an answer smaller than the box is an answer, not a fallback',
+  );
+});
+
+test('the crop never leaves the box the accumulator holds', () => {
+  const covered = { x: 20, y: 10, width: 2900, height: 1900 };
+  const crop = finalCrop([{ ...NO_MOVE, spot: BOX }], OUTPUT, covered, false, 'mean');
+  assert.deepEqual(crop, covered);
+});
+
+test('focus stacking gives up the radius, and only beside an edge that has ground', () => {
+  const covered = { ...BOX };
+  const moves = [{ ...NO_MOVE, spot: BOX }, { ...NO_MOVE, dy: 8, spot: BOX }];
+  const inset = 3 + 2;
+
+  assert.deepEqual(
+    finalCrop(moves, OUTPUT, covered, false, 'focus', 3),
+    { x: 0, y: 8 + inset, width: 3000, height: 1992 - inset * 2 },
+    'a burst that drifted downwards keeps its full width',
+  );
+  assert.deepEqual(
+    finalCrop(moves, OUTPUT, covered, false, 'mean', 3),
+    { x: 0, y: 8, width: 3000, height: 1992 },
+    'no other mode measures a pixel from its neighbours, so none of them pays for this',
+  );
+
+  const sideways = [{ ...NO_MOVE, spot: BOX }, { ...NO_MOVE, dx: 8, dy: 8, spot: BOX }];
+  const both = finalCrop(sideways, OUTPUT, covered, false, 'focus', 3);
+  assert.equal(both.x, 8 + inset);
+  assert.equal(both.y, 8 + inset);
+});
+
+test('a set that never moved is not inset, and a set nobody covered is inset on both sides', () => {
+  const still = [{ ...NO_MOVE, spot: BOX }, { ...NO_MOVE, spot: BOX }];
+  assert.deepEqual(finalCrop(still, OUTPUT, { ...BOX }, false, 'focus', 3), BOX);
+  // The sliver fallback: the box came back whole and the frames overlap in
+  // almost none of it, which is the case with the most transparent ground of
+  // all and the one a width test alone would wave through.
+  const apart = [{ ...NO_MOVE, spot: BOX }, { ...NO_MOVE, dx: 2400, spot: BOX }];
+  assert.deepEqual(finalCrop(apart, OUTPUT, { ...BOX }, true, 'focus', 3), {
+    x: 5, y: 5, width: 2990, height: 1990,
+  });
 });

--- a/tests/js/stack-images-plan.test.js
+++ b/tests/js/stack-images-plan.test.js
@@ -18,8 +18,8 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
-  DEFAULT_BUDGET, MIN_BAND_ROWS, MODES, MODE_IDS, SCALES,
-  bands, bytesPerPixel, commonArea, isMode, outputSize, placement, planRun, refineMargin,
+  DEFAULT_BUDGET, MIN_BAND_ROWS, MODES, MODE_IDS, REFINE_GRID, REFINE_INSET, SCALES,
+  bands, bytesPerPixel, commonArea, isMode, outputSize, placement, planRun,
   refineWindow, scaleThatFits, workingSize,
 } from '../../tools/stack-images/src/plan.js';
 
@@ -281,6 +281,30 @@ test('a rotated frame crops on every side', () => {
   assert.ok(area.width > 80, `cropped harder than a five degree turn warrants: ${area.width}`);
 });
 
+test('a frame of another shape is cropped to the box it was letterboxed into', () => {
+  // A 4:3 frame in a 3:2 output never covered the columns either side of it,
+  // whether or not it moved. Cropping to the whole output would leave those
+  // columns in the answer with nothing behind them, which is the dark border
+  // the crop exists to prevent, arriving by a different route.
+  const output = { width: 600, height: 400 };
+  const spot = placement({ width: 400, height: 300 }, output);
+  const still = { dx: 0, dy: 0, angle: 0, scale: 1, spot };
+
+  assert.deepEqual(commonArea([still], output), { x: 34, y: 0, width: 532, height: 400 });
+  // And it composes with the movement rather than replacing it: a frame that
+  // also went ten pixels right gives up ten more on the left.
+  assert.deepEqual(
+    commonArea([still, { ...still, dx: 10 }], output),
+    { x: 44, y: 0, width: 522, height: 400 },
+  );
+  // A move with no spot on it is still the whole output, which is what a set
+  // of frames all one shape means.
+  assert.deepEqual(
+    commonArea([{ dx: 0, dy: 0, angle: 0, scale: 1 }], output),
+    { x: 0, y: 0, width: 600, height: 400 },
+  );
+});
+
 test('frames that barely overlap are not cropped to a sliver', () => {
   // Better to hand back a stack with visible edges, which somebody can look at
   // and understand, than a postage stamp with no explanation.
@@ -307,30 +331,44 @@ test('the crop never leaves the output, whatever it is handed', () => {
   }
 });
 
-test('the refinement window is the largest power of two the crop leaves room for', () => {
-  // The 16 held back is the two margins the crop gives up so that a refined
-  // frame still covers what the crop assumed; a window that ignored them would
-  // be measuring rows the run is about to throw away.
-  assert.equal(refineWindow({ width: 1575, height: 1179 }), 512);
-  assert.equal(refineWindow({ width: 4000, height: 3000 }), 512);
-  assert.equal(refineWindow({ width: 300, height: 528 }), 256);
-  assert.equal(refineWindow({ width: 100, height: 90 }), 64);
+test('the refinement grid is the widest cover three of them fit across', () => {
+  // A 24-megapixel burst, cropped: three 512-pixel covers and the inset fit
+  // the short side comfortably, so the grid is the one the browser was
+  // measured on - nine windows of 512 output pixels drawn into 256 squares.
+  assert.deepEqual(refineWindow({ width: 4000, height: 3000 }), { cover: 512, size: 256, grid: 3 });
+
+  // 1179 short: 1536 of cover will not fit inside it, 768 will.
+  assert.deepEqual(refineWindow({ width: 1575, height: 1179 }), { cover: 256, size: 128, grid: 3 });
+  assert.deepEqual(refineWindow({ width: 900, height: 900 }), { cover: 256, size: 128, grid: 3 });
+  assert.deepEqual(refineWindow({ width: 300, height: 528 }), { cover: 64, size: 64, grid: 3 });
+  assert.equal(refineWindow({ width: 4000, height: 3000 }).grid, REFINE_GRID);
 });
 
-test('a crop too small to refine gets no window rather than a tiny one', () => {
-  // 64 minus the margins is the floor: below it the correlation peak is noise
-  // with a coordinate, and applying that is worse than keeping the coarse
-  // answer.
-  assert.equal(refineWindow({ width: 79, height: 200 }), 0);
-  assert.equal(refineWindow({ width: 16, height: 16 }), 0);
+test('a crop too small for a grid gets none rather than a useless one', () => {
+  // Three 64-pixel covers and the inset is the floor: below it the correlation
+  // peak is noise with a coordinate, and applying that is worse than keeping
+  // the coarse answer.
+  const floor = 64 * REFINE_GRID + REFINE_INSET * 2;
+  assert.equal(refineWindow({ width: floor - 1, height: 4000 }), null);
+  assert.deepEqual(refineWindow({ width: floor, height: 4000 }), { cover: 64, size: 64, grid: 3 });
+  assert.equal(refineWindow({ width: 100, height: 90 }), null);
+  assert.equal(refineWindow({ width: 16, height: 16 }), null);
 });
 
-test('the margin matches how wrong the coarse answer can be', () => {
-  // The coarse error lives in the sub-pixel fraction of the shift, so a set
-  // that barely moved cannot have been mismeasured by much: it keeps a
-  // one-pixel allowance instead of being charged sixteen rows for nothing.
-  assert.equal(refineMargin([{ dx: 0, dy: 0 }, { dx: 0.2, dy: -0.3 }]), 1);
-  assert.equal(refineMargin([{ dx: 0, dy: 0 }, { dx: 7.3, dy: -4.6 }]), 8);
-  assert.equal(refineMargin([{ dx: 0, dy: 0 }, { dx: 0, dy: 0.6 }]), 8);
-  assert.equal(refineMargin([{}]), 1);
+test('a window is drawn at half the ground it covers, and never below 64', () => {
+  // The residual being looked for is a pixel or two and the correlation
+  // resolves a fraction of its own square, so half scale costs nothing and
+  // saves a quarter of every readback. The one exception is the smallest
+  // grid, where halving would take the square under what a peak needs.
+  for (const crop of [{ width: 4000, height: 3000 }, { width: 900, height: 900 },
+    { width: 300, height: 528 }]) {
+    const grid = refineWindow(crop);
+    assert.ok(grid.size >= 64 && grid.size <= 256, `a square of ${grid.size}`);
+    assert.equal(grid.size, Math.min(256, Math.max(64, grid.cover / 2)));
+    assert.ok(Number.isInteger(Math.log2(grid.size)), 'the transform needs a power of two');
+    assert.ok(
+      grid.cover * REFINE_GRID + REFINE_INSET * 2 <= Math.min(crop.width, crop.height),
+      'a grid that does not fit the crop it was asked about',
+    );
+  }
 });

--- a/tests/js/stack-images-similarity.test.js
+++ b/tests/js/stack-images-similarity.test.js
@@ -1,0 +1,249 @@
+/**
+ * tools/stack-images/src/similarity.js - nine measured shifts into one turn.
+ *
+ * Two things are worth pinning hard here and they are both about direction.
+ *
+ * The SIGN. A point carries the shift to apply to the frame at that place, so
+ * the transform that comes back is a correction: a frame that arrived turned
+ * by a third of a degree is described by an angle of minus a third. Every
+ * field below is therefore built forwards - a frame is turned by a known
+ * amount, the shift each window would measure is worked out from that turn,
+ * and the fit is asked to give the turn back with the opposite sign. Nothing
+ * here assumes a convention; the fixtures create one.
+ *
+ * The AGREEMENT. The consensus exists so that a window on a moving branch does
+ * not drag the whole frame with it, and the way that fails silently is by
+ * quietly including the outlier and reporting a fit that is a little bit
+ * wrong. So the tests check which points were kept, not only what came out.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  MIN_INLIERS, apply, consensus, fitSimilarity,
+} from '../../tools/stack-images/src/similarity.js';
+
+const CENTRE = { x: 1500, y: 1000 };
+
+/** The nine window centres of a 3x3 grid over a 3000x2000 output. */
+const GRID = [];
+for (const y of [500, 1000, 1500]) for (const x of [750, 1500, 2250]) GRID.push({ x, y });
+
+/**
+ * The shifts nine windows would measure of a frame that arrived turned by
+ * `angle`, scaled by `scale` and moved by (`dx`, `dy`) about the centre.
+ *
+ * Forwards: the transform is what happened TO the frame, and the shift at a
+ * place is what it would take to undo it there. So a fit of this field has to
+ * come back as the inverse of what went in.
+ */
+function fieldFrom({ angle = 0, scale = 1, dx = 0, dy = 0 }, points = GRID) {
+  const radians = (angle * Math.PI) / 180;
+  const cos = Math.cos(radians) * scale;
+  const sin = Math.sin(radians) * scale;
+  return points.map(({ x, y }) => {
+    const at = {
+      x: CENTRE.x + (x - CENTRE.x) * cos - (y - CENTRE.y) * sin + dx,
+      y: CENTRE.y + (x - CENTRE.x) * sin + (y - CENTRE.y) * cos + dy,
+    };
+    return { x, y, dx: x - at.x, dy: y - at.y };
+  });
+}
+
+/**
+ * The largest distance between where a fit puts a point and where it belongs.
+ *
+ * Entered where the frame's content is - the place the window measured, less
+ * the shift measured there - and expected to come out at the place itself.
+ */
+function worst(fit, points, centre = CENTRE) {
+  let most = 0;
+  for (const point of points) {
+    const at = apply(fit, point.x - point.dx, point.y - point.dy, centre);
+    most = Math.max(most, Math.hypot(at.x - point.x, at.y - point.y));
+  }
+  return most;
+}
+
+test('a third of a degree of turn is read back, with the sign it has to have', () => {
+  // The case the whole grid exists for. A frame turned by 0.3 degrees is
+  // eight pixels out at the corners of a 3000-pixel picture and nothing at all
+  // at the middle, so one window in the middle sees nothing to correct - and
+  // the coarse log-polar pass, whose square resolves 0.7 degrees a row, sees
+  // about a third of it.
+  const field = fieldFrom({ angle: 0.3 });
+  const fit = fitSimilarity(field, CENTRE);
+
+  assert.ok(Math.abs(fit.angle + 0.3) < 0.02, `turned back by ${fit.angle}, not -0.3`);
+  assert.ok(Math.abs(fit.scale - 1) < 1e-4, `invented a scale of ${fit.scale}`);
+  assert.ok(fit.rms < 0.01, `fitted an exact field to ${fit.rms} px`);
+  // And the transform composed out of it puts every window where its own
+  // measurement said it should go. The half-pixel scale of the whole exercise
+  // is what makes 0.05 the interesting number here.
+  assert.ok(worst(fit, field) < 0.05, `left ${worst(fit, field)} px on the table`);
+
+  // Read the other way round, which is how the pipeline uses it: the frame is
+  // drawn through this transform, so the content standing at a window's own
+  // centre has to end up that window's measured shift away from where it was.
+  // The two readings differ by the square of the turn - a hundredth of a pixel
+  // at a third of a degree - and are the same statement at this size.
+  for (const point of field) {
+    const at = apply(fit, point.x, point.y, CENTRE);
+    assert.ok(
+      Math.hypot(at.x - point.x - point.dx, at.y - point.y - point.dy) < 0.05,
+      `the window at ${point.x},${point.y} was not moved by what it measured`,
+    );
+  }
+});
+
+test('a turn, a stretch and a shift together come back as all three', () => {
+  // Asymmetric on purpose: a grid symmetric about the centre can hide a sign
+  // error in the translation, because the two halves cancel.
+  const points = [
+    { x: 400, y: 300 }, { x: 1200, y: 350 }, { x: 2600, y: 500 },
+    { x: 500, y: 1100 }, { x: 1700, y: 1250 }, { x: 2400, y: 900 },
+    { x: 700, y: 1800 }, { x: 1500, y: 1700 }, { x: 2800, y: 1900 },
+  ];
+  const truth = { angle: -0.25, scale: 1.01, dx: 6.5, dy: -3.25 };
+  const field = fieldFrom(truth, points);
+  const fit = fitSimilarity(field, CENTRE);
+
+  assert.ok(Math.abs(fit.angle - 0.25) < 0.02, `angle ${fit.angle}`);
+  assert.ok(Math.abs(fit.scale - 1 / 1.01) < 1e-4, `scale ${fit.scale}`);
+  // The translation is the inverse's, about the same centre: undoing a move of
+  // (6.5, -3.25) means moving back by it, once the turn has been taken out.
+  const undone = apply({ angle: 0.25, scale: 1 / 1.01, dx: 0, dy: 0 }, 6.5, -3.25, { x: 0, y: 0 });
+  assert.ok(Math.abs(fit.dx + undone.x) < 0.05, `dx ${fit.dx}`);
+  assert.ok(Math.abs(fit.dy + undone.y) < 0.05, `dy ${fit.dy}`);
+  assert.ok(worst(fit, field) < 0.05);
+});
+
+test('a field that is all one shift is a shift, and no turn at all', () => {
+  // The translate case, and the one where a rotation invented out of rounding
+  // would be worst: it is applied to every frame of the burst.
+  const fit = fitSimilarity(fieldFrom({ dx: 12, dy: -5 }), CENTRE);
+  assert.equal(fit.angle, 0);
+  assert.equal(fit.scale, 1);
+  assert.ok(Math.abs(fit.dx + 12) < 1e-9, `dx ${fit.dx}`);
+  assert.ok(Math.abs(fit.dy - 5) < 1e-9, `dy ${fit.dy}`);
+});
+
+test('the centre the fit is quoted about is the centre it is asked for', () => {
+  // The angle and the scale do not depend on it and the translation entirely
+  // does, because the translation is what is left over after turning about
+  // that point. drawAligned turns about the uncropped output centre, so a fit
+  // quoted about anything else composes into the wrong place.
+  const field = fieldFrom({ angle: 0.4 });
+  const middle = fitSimilarity(field, CENTRE);
+  const corner = fitSimilarity(field, { x: 0, y: 0 });
+
+  assert.ok(Math.abs(middle.angle - corner.angle) < 1e-9);
+  assert.ok(Math.abs(middle.scale - corner.scale) < 1e-12);
+  assert.ok(Math.hypot(middle.dx - corner.dx, middle.dy - corner.dy) > 1);
+  // Both still put the points in the same place, which is the whole claim.
+  assert.ok(worst(corner, field, { x: 0, y: 0 }) < 0.05);
+});
+
+test('two points determine one exactly, and one point determines nothing', () => {
+  const field = fieldFrom({ angle: 0.3, dx: 4 });
+  const pair = fitSimilarity([field[0], field[8]], CENTRE);
+  assert.ok(Math.abs(pair.angle + 0.3) < 0.02);
+  assert.equal(fitSimilarity([field[0]], CENTRE), null);
+  assert.equal(fitSimilarity([], CENTRE), null);
+  // Two windows in the same place fix no angle, whatever they say about it.
+  assert.equal(fitSimilarity([field[4], { ...field[4], dx: 3 }], CENTRE), null);
+});
+
+test('four windows that agree outvote five that do not', () => {
+  // The moving-subject case, at its worst: more of the picture disagrees than
+  // agrees, and the four that do are the ones that saw the ground.
+  const truth = fieldFrom({ angle: 0.3, dx: 2, dy: -1 });
+  const points = truth.map((point, index) => (
+    [0, 2, 6, 8].includes(index)
+      ? point
+      : { ...point, dx: point.dx + 9 + index, dy: point.dy - 7 - index }
+  ));
+
+  const found = consensus(points, 2, CENTRE);
+  assert.deepEqual(found.inliers, [0, 2, 6, 8], 'kept a window that saw the subject');
+  assert.ok(Math.abs(found.fit.angle + 0.3) < 0.02, `angle ${found.fit.angle}`);
+  assert.ok(found.rms < 0.05, `rms ${found.rms}`);
+  assert.ok(worst(found.fit, truth) < 0.05, 'the fit does not explain the windows it kept');
+});
+
+test('nine windows that all agree keep all nine', () => {
+  const field = fieldFrom({ angle: -0.15, scale: 0.999, dx: -3 });
+  const found = consensus(field, 2, CENTRE);
+  assert.deepEqual(found.inliers, [0, 1, 2, 3, 4, 5, 6, 7, 8]);
+  assert.ok(Math.abs(found.fit.angle - 0.15) < 0.02);
+  assert.ok(Math.abs(found.fit.scale - 1 / 0.999) < 1e-4);
+});
+
+test('a consensus is the same consensus every time it is asked', () => {
+  // No sampling anywhere in it, which is the reason a test may pin the inlier
+  // list above rather than a property of it.
+  const field = fieldFrom({ angle: 0.2 });
+  const points = field.map((point, index) => (
+    index % 2 ? { ...point, dx: point.dx + 30 } : point
+  ));
+  const first = consensus(points, 2, CENTRE);
+  for (let again = 0; again < 5; again += 1) {
+    assert.deepEqual(consensus(points, 2, CENTRE), first);
+  }
+});
+
+test('windows that agree on nothing produce nothing, not a plausible fit', () => {
+  // Two unrelated pictures, or a featureless one: the shifts are noise with
+  // coordinates. Least squares would hand back an angle and a scale for this
+  // set without complaining, which is exactly the failure the gate is for.
+  const scattered = GRID.map(({ x, y }, index) => ({
+    x, y, dx: [17, -23, 9, -31, 40, -12, 26, -38, 5][index], dy: [-29, 14, 33, 7, -19, 36, -8, 21, -27][index],
+  }));
+  assert.equal(consensus(scattered, 2, CENTRE), null);
+});
+
+test('two stories the same size is no story, and the order they are in cannot decide', () => {
+  // A subject moving across the top-left block of the grid and the background
+  // holding the other four, with the ninth window junk. Both sets fit
+  // themselves exactly, so both score a zero error, and whichever the loops
+  // reach first would otherwise win and drag the whole frame by the subject's
+  // own movement - reported as a full-confidence fit.
+  const truth = fieldFrom({ angle: 0.3 });
+  const subject = [0, 1, 3, 4];
+  const points = truth.map((point, index) => {
+    if (subject.includes(index)) return { ...point, dx: point.dx - 14, dy: point.dy + 9 };
+    if (index === 8) return { ...point, dx: point.dx + 31, dy: point.dy - 22 };
+    return point;
+  });
+
+  assert.equal(consensus(points, 2, CENTRE), null);
+  // And the same set with the subject on one window fewer is not ambiguous at
+  // all, so the refusal is about the tie and not about the disagreement.
+  const outvoted = truth.map((point, index) => (
+    [0, 1, 3].includes(index) ? { ...point, dx: point.dx - 14, dy: point.dy + 9 } : point
+  ));
+  assert.deepEqual(consensus(outvoted, 2, CENTRE).inliers, [2, 4, 5, 6, 7, 8]);
+});
+
+test('fewer windows than the floor is nothing, however well they agree', () => {
+  // Three windows on a wall agreeing perfectly is three windows on a wall.
+  const field = fieldFrom({ angle: 0.3 });
+  assert.equal(MIN_INLIERS, 4);
+  assert.equal(consensus(field.slice(0, 3), 2, CENTRE), null);
+  assert.equal(consensus(field.slice(0, 1), 2, CENTRE), null);
+  assert.equal(consensus([], 2, CENTRE), null);
+  assert.ok(consensus(field.slice(0, 4), 2, CENTRE), 'four is the floor, not the wall');
+});
+
+test('the tolerance is what decides, and it is the caller who sets it', () => {
+  const field = fieldFrom({ angle: 0.3 });
+  const points = field.map((point, index) => (
+    index === 4 ? { ...point, dx: point.dx + 3 } : point
+  ));
+  assert.deepEqual(consensus(points, 2, CENTRE).inliers, [0, 1, 2, 3, 5, 6, 7, 8]);
+  assert.deepEqual(
+    consensus(points, 5, CENTRE).inliers, [0, 1, 2, 3, 4, 5, 6, 7, 8],
+    'a tolerance wide enough to swallow it does',
+  );
+});

--- a/tests/js/stack-images-stack.test.js
+++ b/tests/js/stack-images-stack.test.js
@@ -236,6 +236,59 @@ test('focus stacking takes each pixel from the frame it was sharp in', () => {
   assert.notEqual(at(26, 16), 128, 'the right half came from the blurred frame');
 });
 
+test('transparent ground reads as an edge, and wins the pixels around it', () => {
+  // Why the pipeline insets the crop by the radius and two more before it cuts
+  // a focus stack. The accumulator covers the whole output and a frame that
+  // was moved does not reach all of it, so what the run hands this mode along
+  // that boundary is transparent - which arrives here as a luma of zero, is
+  // the strongest edge in the picture, and is spread inward by the blur.
+  //
+  // Two frames, both flat, so neither has any real sharpness to offer. One of
+  // them stops at x = 4 and is transparent to the left of it. If the boundary
+  // meant nothing, every pixel would come from the frame that was added first.
+  const width = 20;
+  const height = 5;
+  const radius = 2;
+  const boundary = 4;
+
+  const even = new Uint8ClampedArray(width * height * 4);
+  const stopping = new Uint8ClampedArray(width * height * 4);
+  for (let i = 0; i < width * height; i += 1) {
+    const at = i * 4;
+    even[at] = 100;
+    even[at + 1] = 100;
+    even[at + 2] = 100;
+    even[at + 3] = 255;
+    if (i % width >= boundary) {
+      stopping[at] = 200;
+      stopping[at + 1] = 200;
+      stopping[at + 2] = 200;
+      stopping[at + 3] = 255;
+    }
+  }
+
+  const stack = createStack('focus', { width, height, frames: 2, radius });
+  stack.beginPass(0);
+  stack.add(even, 0, 0);
+  stack.add(stopping, 1, 0);
+  stack.endPass(0);
+  const out = stack.result();
+  const at = (x) => out[((2 * width) + x) * 4];
+
+  // The frame that stops wins everything the blur reached, which is its own
+  // boundary give or take the radius - so the answer is black where that frame
+  // had nothing at all, which is the fringe with a plausible explanation.
+  assert.equal(at(boundary - 1), 0, 'the transparent side did not win, so the inset is unneeded');
+  assert.equal(at(boundary + radius), 200, 'the false edge did not reach as far as expected');
+
+  // And it reaches exactly that far: radius and one more for the Laplacian's
+  // own step past the boundary is what the pipeline gives up, plus one so that
+  // the number is not the edge of the thing it is measuring.
+  for (let x = boundary + radius + 1; x < width; x += 1) {
+    assert.equal(at(x), 100, `x=${x} was still contaminated by the transparent ground`);
+  }
+});
+
 test('the laplacian is large on an edge and zero on flat ground', () => {
   const width = 5;
   const height = 5;

--- a/tools/stack-images/README.md
+++ b/tools/stack-images/README.md
@@ -214,16 +214,102 @@ the coarse answer alone was off by one to two output pixels per frame and the
 stack came out *worse* than a single input frame.
 
 So the answer is finished during the stack itself: when each frame's full-size
-decode is first in hand — a decode the stack was going to pay for anyway — a
-512-pixel window from the middle of the crop is correlated against the same
-window of the reference at output resolution, and the residual corrects the
-coarse answer in place. At output resolution there is nothing to multiply up,
-so a twentieth of a pixel of error stays a twentieth of a pixel. The same
-synthetic bursts land within a quarter of a pixel per frame. The residual is
-gated — a peak that is not a peak, or a correction larger than the coarse pass
-could plausibly have been wrong by, leaves the coarse answer alone — and the
-crop gives up a small margin on every side up front, because a frame that
-moves after the crop was decided stops covering ground the crop assumed.
+decode is first in hand — a decode the stack was going to pay for anyway — the
+frame is correlated against the reference at output resolution and the residual
+corrects the coarse answer in place. At output resolution there is nothing to
+multiply up, so a twentieth of a pixel of error stays a twentieth of a pixel.
+The same synthetic bursts land within a quarter of a pixel per frame.
+
+**The refinement is a grid of nine windows, a gate on each of them, one
+consensus fit, and a ladder to fall down.** It was one window in the middle
+for a week, and one window measures a shift. Nine measure a *field*, and a
+field is what a rotation is: a frame turned a third of a degree moves the
+middle of a 6000×4000 picture by nothing at all and each of its corners by
+nineteen pixels, so the middle window reports honestly that the frame did not
+move while the corners stay as soft as no alignment would have left them.
+Measured in the browser on a synthetic burst rotated by 0.3°, shift-only
+refinement left the corners at a sharpness ratio of 0.47 against 0.48 for no
+alignment at all, where the middle reached 0.64.
+
+The grid is three windows by three over the region the frames covered under
+their coarse moves, inset from its edge. Each covers 512 output pixels and is
+drawn at half scale into a 256 square — `plan.js`'s `refineWindow` decides
+both, halving the cover on a crop too small for three of them and giving up
+below a grid of 64s, where the coarse answer simply stands. Half scale costs
+nothing in accuracy, because the residual being looked for is a pixel or two
+of output and a correlation resolves a fraction of a pixel of its own square
+either way, and it costs a quarter of the readback. Each window is drawn with
+one `drawImage` carrying a **source rectangle**, worked out by inverting the
+transform already on the context: in the browser, on a real 6000×4000 bitmap,
+the whole grid cost 12 ms a frame that way (16 ms with a sub-pixel transform)
+against 21 ms drawing the bitmap nine times over and 100 ms reading nine
+squares out of one full-size draw. The single 512 window it replaces cost 6 ms.
+The whole grid is cheaper than one decode.
+
+Every window goes through `isMeasured`, the same gate as everything else here,
+and one that reports a shift larger than a quarter of what it covers is
+dropped as well — a correlation surface wraps, and no residual of a coarse
+move is that large. What survives goes to `similarity.js`: every pair of
+surviving windows is taken as a proposal, scored by how many of the others it
+explains within two output pixels, and the largest agreeing set is refitted by
+least squares. Exhaustive rather than sampled, because nine points have
+thirty-six pairs and a test can then pin the answer exactly. The browser's
+table, on 3000×2000 frames with the transform known:
+
+| scene | fitted angle | fitted scale | fit RMS | per-window `next` |
+|---|---|---|---|---|
+| texture, 0.3° | 0.2972 | 1.00005 | 0.14 px | 0.06–0.09 |
+| texture, −0.25°, scale 1.01 | −0.2504 | 1.00994 | 0.22 px | 0.06–0.09 |
+| stars 6%, 0.15° | 0.1457 | 0.99981 | 0.34 px | 0.26–0.63 |
+| low texture 15%, 0° | −0.0211 | 0.99749 | 17.6 px | 0.27–0.98 |
+| featureless gradient | 0.47–0.73 | 0.99–1.01 | 35–42 px | 0.85–0.96 |
+| two unrelated pictures | — | — | — | 0.78–0.99 |
+
+The first three are right to about five thousandths of a degree. The last three
+are not right at all, and the per-window gate is what separates them: on the
+low-texture scene exactly one window read 0.27 and the other eight 0.83–0.98,
+and on the two junk families every window failed. That is the whole design —
+gate every window, fit from the survivors, and fall back rather than guess.
+
+**The ladder, in order.** Four or more windows agreeing on one similarity is
+the answer, composed onto the coarse move about the uncropped output centre —
+the angles add, the scales multiply, and the coarse shift is turned and scaled
+by the refinement before the refinement's own shift is added. Below that, two
+windows agreeing on one shift within the same tolerance give their mean
+translation and nothing about rotation, and the move is marked `partial` —
+but only where fewer than four windows survived the gate at all, because with
+four or more in hand a consensus that came back empty has already said they
+disagree, and the two that happen to coincide are the two that sat on the same
+moving subject. Nothing is applied from either rung that would move the frame
+further than the coarse pass could plausibly have been wrong, which is a
+bound quoted in the coarse square's own pixels: nine windows unanimously
+reporting a hundred pixels is a periodic texture whose every window found the
+same wrong lattice period, not a residual. Below that the coarse move stands.
+Below *that* — a frame the coarse pass
+could not measure — the identity stands and the frame is not refined at all,
+because a residual measured from the identity is not a residual but the whole
+shift, which was just refused. Which rung a frame came off is recorded on its
+move as `refine`, so a test and the page can both see it.
+
+In **translate** mode the same consensus runs and only its translation is
+applied. Not a median of the nine windows, which is the obvious
+generalisation: a rotated burst makes the windows disagree *by design*, and
+the median of nine disagreeing shifts describes no part of the frame.
+
+What this cannot do is the honest half of it. A moving subject or a parallax
+makes the windows disagree because they are each right about a different
+thing, no single transform describes that, and the frame drops to a
+translation or to its coarse answer rather than being dragged by whichever
+window shouted loudest. The size at which that holds is the tolerance: a
+depth split that moves one column of windows two pixels or more relative to
+another drops that column, and a smaller one is absorbed into the fit as a
+fraction of a pixel of invented scale — which is inside the error the
+refinement is there to remove, so it is a limit to state rather than a
+failure to catch. And where two disjoint sets of windows are the same size —
+a subject on four of them and the background on the other four — there is no
+majority to find and the frame drops to its coarse answer rather than to a
+coin toss. The reference frame supplies the reference windows and is never
+itself refined.
 
 **Whether a peak is a peak is decided by two of four statistics — `plateau`
 and `next`, with `live` as the guard under them and `coherence` reported for
@@ -284,11 +370,13 @@ the surface eight pixels from the peak, at every window size, in the eight
 compass directions — eight along the axes, eight times root two on the
 diagonals; a true ring at eight reads 0.05–0.15 higher on real peaks and
 would need its own floor — as a fraction of the peak, and the gate refuses
-anything over 0.7. Eight because it is the refinement's own margin: a peak
-still standing eight pixels out cannot place the frame within the margin
-whatever its argmax says, and on the coarse square eight alignment pixels is
-already tens of output pixels. The gradients measured 0.93–0.99 in the
-browser and 0.95–1.00 on the letterboxed fixture at every noise level tried;
+anything over 0.7. Eight because that is where a peak has stopped placing
+anything: the refinement is looking for a residual of a pixel or two, so a
+peak still standing eight pixels out cannot say which of nine pixels the
+frame belongs at whatever its argmax says, and on the coarse square eight
+alignment pixels is already tens of output pixels. The gradients measured
+0.93–0.99 in the browser and 0.95–1.00 on the letterboxed fixture at every
+noise level tried;
 the weakest real match, a low-texture scene at thirty per cent noise, 0.60 in
 the browser and 0.65–0.68 over ten seeds depending on the seeds; a star field
 0.03–0.10, a textured scene 0.1–0.5. The same reading refuses the letterboxed
@@ -297,8 +385,9 @@ coherence of 0.22 that is no longer asked), which
 similarity mode had been applying as a scale of 0.95–1.01, and the
 refinement's own version of the sky: a low-texture 512 window whose features
 are sixty pixels across measures 0.77–0.96 with its peak one to seven pixels
-off, inside the margin, and is refused on every seed at both noise levels
-tried — nothing else would have refused it, and a radius that followed the
+off — close enough to pass for a residual — and is refused on every seed at
+both noise levels tried — nothing else would have refused it, and a radius
+that followed the
 side, sixteen at 512, read it at 0.59–0.71 and let nine seeds in ten
 through. The comment on `P_MAX` in `align.js` has the browser table and the
 fixture table side by side, the log-polar and other-window readings, and the
@@ -423,28 +512,67 @@ Two limits, both on the page:
 - rotation is only ever recovered within half a turn, because the magnitude
   spectrum of a real picture is symmetric and 175° looks exactly like −5°.
 
-The refinement corrects translation only. The angle and the scale keep the
-coarse pass's answer — good to roughly a tenth of a degree — and a tenth of a
-degree is a pixel and a half at the corner of a 24-megapixel frame, so a
-similarity stack keeps a corner softness its middle does not have. Refining
-them too would mean correlating the window at a spread of candidate angles,
-which is a different cost class, and the translation-only refinement already
-removes the error that affected every pixel equally.
+The coarse log-polar step stays, and it is what finds a *large* turn. Its
+square resolves about 0.7° a row, so two or three degrees comes back within
+0.03° and a third of a degree comes back as a tenth — which is why the
+refinement exists and why the coarse step is still worth its transform. The
+two answer different questions: the log-polar pass finds the turn nothing else
+could search for, and the grid measures what is left of it at output
+resolution.
 
-**Aligning means cropping, and the crop is not cosmetic.** A frame moved twenty
-pixels left stops covering the right-hand edge, whatever is not covered is
-transparent, and transparent reads as zero to an accumulator — so without the
-crop an averaged hand-held burst comes back with a dark border, which somebody
-would reasonably blame on the stacking. `commonArea` in `plan.js` returns the
-largest rectangle every frame still covers, taking the inner of each pair of
-corners so a rotated quad is handled conservatively. When the refinement is
-running, the crop then gives up `refineMargin`'s allowance on every side —
-eight pixels for a set that really moved, one for a set that did not — which is
-the room the refined corrections spend. With no alignment every transform is
-the identity, nothing is refined and nothing is cropped. A set that overlaps in almost
-nothing falls back to the whole frame rather than a sliver: a stack with visible
-edges is something a person can look at and understand, and a postage stamp is
-not.
+**Aligning means cropping, and the crop happens at the end.** A frame moved
+twenty pixels left stops covering the right-hand edge, whatever is not covered
+is transparent, and transparent reads as zero to an accumulator — so without
+the crop an averaged hand-held burst comes back with a dark border, which
+somebody would reasonably blame on the stacking. `commonArea` in `plan.js`
+returns the largest rectangle every frame still covers, taking the inner of
+each pair of corners so a rotated quad is handled conservatively, and using
+each frame's own placement box rather than the whole output so that a frame of
+another shape, letterboxed into the middle, is not credited with columns it
+never had.
+
+It is decided **after** the moves are final rather than before, which is what
+lets the refinement move a frame freely: the accumulator covers everything the
+frames covered under their *coarse* moves, every frame is refined on its first
+full-size decode — so the moves are settled by the end of the first band's
+first pass — and the output canvas is allocated at the crop's size the moment
+the crop is known, with each band's rows cut on their way out of the
+accumulator. No second canvas and no copy. The cost is that `plan.peak`'s
+canvas term is now an over-estimate of the canvas actually allocated, by the
+pixel or two a side the refinement moved things, which is the safe direction
+for a figure whose job is to keep a tab alive — and the slack pays for the
+nine reference windows, which are the one thing a run allocates that the
+figure does not count. The accumulator is that box rather than the whole
+output box because the band arithmetic is not indifferent to the difference: a
+run planned on the full box can gain a whole band over a run planned on the
+crop, and a band is a re-read of every frame, so a five-frame stack that read
+each frame once would have read each of them twice. The old arrangement
+decided the crop first and then gave up a fixed margin on every side for the
+refinement to spend, which meant the refinement could not correct more than
+the margin allowed and the margin had to be guessed before anything was
+measured.
+
+Focus stacking gives up a little more: the accumulator has transparent ground
+inside it wherever a refined frame no longer reaches its own coarse boundary,
+`stack.js` reads transparent as a luma of zero, the Laplacian scores that as
+the strongest edge in the picture and the blur spreads it inward by its own
+radius — so the crop is inset by the radius and two more before it is cut, or
+the pixels along its edge take their colour from whichever frame happened to
+end there. That is a black fringe with a plausible explanation, which is the
+worst kind. The inset is per axis and only where there is ground beside that
+axis to catch, so a burst that drifted only downwards keeps its full width.
+`tests/js/stack-images-stack.test.js` pins how far the false edge reaches.
+
+With no alignment every transform is the identity, nothing is refined, and the
+run reports itself cropped only if frames of two shapes were letterboxed into
+one box — which is not a movement, so the page does not call it one. A set
+that overlaps in almost nothing falls back to the whole frame rather than a
+sliver: a stack with visible edges is something a person can look at and
+understand, and a postage stamp is not. That one answer is the only rectangle
+`commonArea` returns that nobody covered, so the refinement is skipped for
+such a run — a grid laid over it would put windows where a frame has nothing,
+and a half-empty window correlates confidently against a full one — and a
+focus stack of it is inset on both axes rather than neither.
 
 A rotation past 30° or a scale outside 0.8–1.25 is refused and the frame falls
 back to translation alone. That is not tidiness: two unrelated pictures still
@@ -489,10 +617,12 @@ biases every real low-texture answer the survey square accepts: letterboxed,
 the low-texture fixture lands 1.3–1.9 alignment pixels off at fifteen per
 cent noise and 1.0–2.0 at thirty, pulled towards the ridge, where the full
 square lands it within 0.1–0.7 and 0.3–1.9; on a 3000-pixel frame that is
-15–22 output pixels, beyond the refinement's 8-pixel margin, so the 512
-residual — itself within half a pixel there — is refused by the margin test
-and the coarse error stands. That is a cost of the survey square, not of the
-gate, and the fix is the same one that would remove the ridge under the
+15–22 output pixels — a coarse error the refinement now does correct, because
+its windows all see the same one and agree on it and it is well inside the
+two coarse pixels a correction is allowed, where the old single-window
+version refused any residual over eight output pixels and left it standing.
+That is a cost of the survey square, not of the gate, and the fix is the same
+one that would remove the ridge under the
 gradients and the unrelated pairs: taper the picture's own box in
 `lumaSquare` — a window over `fit`'s rectangle, or fill outside it with the
 picture's mean before windowing — so the edge is not a feature both frames
@@ -518,18 +648,19 @@ the nearest sit eight pixels from the peak, inside the ten-pixel box, so what
 is read is the pair sixteen or seventeen pixels out, and those fall away with
 the scene's own smooth envelope where the near ones stand level with the
 peak. It is harmless as the pipeline is arranged — the survey square
-letterboxes the same pairs to 0.91–0.99 and refuses every one, and at 512 an
-argmax on a random lattice peak is outside the refinement's 8-pixel margin
-and discarded there — but the consensus check is what should be catching it.
+letterboxes the same pairs to 0.91–0.99 and refuses every one, and at the
+refinement an argmax on a random lattice peak is one window disagreeing with
+the other eight — but it is the consensus that catches it, not either floor.
 
 The refinement's own scenario is the same lattice between two frames of *one*
 smooth scene: the coarse move a third of a pixel short, and the residual
-landing on the lattice's alias at +3 pixels, inside the margin. Uniqueness
+landing on the lattice's alias at +3 pixels, which is small enough to look
+like a residual. Uniqueness
 cannot see that one at all, for the same reason — it reads 0.46–0.93 at
 quality 75 and 0.27–0.40 at 20, the noise beyond the lattice rather than the
 lattice. What refuses it is the plateau, by a coincidence nobody chose: its
-radius is eight because that is the refinement's margin, and eight is also
-the block pitch, so the shoulder is read on the lattice's first alias and
+radius is eight because that is where a peak has stopped placing anything,
+and eight is also the block pitch, so the shoulder is read on the alias and
 spikes there — 0.71–0.96 at a radius of eight against 0.50–0.69 at six and
 0.47–0.74 at ten. At qualities 95, 75 and 50 that refuses the lock on every
 seed pair tried. Only at quality 20, where the blocking buries the alias,
@@ -557,11 +688,12 @@ real pairs read 0.04–0.45 and the junk 0.67–1.00. At 64 the surface has too
 few bins for junk to read as junk — an 8-bit gradient at one per cent noise
 reads 0.41–0.70 and passes eight seeds in ten, an unrelated pair 0.63–0.97 —
 where the old floor at 0.60 refused both, and every noisy real pair with
-them. That is accepted rather than fixed: `plan.js` gives the 64 window only
-to crops under 272 pixels on the short side, where the coarse square is
-within a factor of 1.6 of output resolution, and `refineMargin` caps what an
-applied residual can move a frame that did not move at one pixel. The
-comment on `N_MAX` has the numbers at every size.
+them. That is accepted rather than fixed, and what carries it is the
+consensus rather than a cap on any one window's correction: the refinement
+measures nine windows and applies nothing that four of them do not agree on,
+so a 64-pixel square that read junk has to be joined by three more reading the
+same junk in the same direction before any of it reaches a frame. The comment
+on `N_MAX` has the numbers at every size.
 
 **Focus stacking needs its bands to overlap.** Sharpness is measured from a
 pixel's neighbours, so a band edge scored without them draws a seam across the

--- a/tools/stack-images/src/align.js
+++ b/tools/stack-images/src/align.js
@@ -118,9 +118,9 @@ export const WHITEN = 128;
  * the bare 8-bit slope measures 0.016 at 128 and 0.079 at 64, because the
  * window's own spectrum is a larger share of so few bins, so a rendered
  * gradient with no noise on it at all is refined there by its contour lattice,
- * within the margin. Sensor noise at one per cent is enough for the other
- * two floors to refuse it instead - at 256 on every seed, at 128 on nine in
- * ten.
+ * by a shift small enough to pass for a residual. Sensor noise at one per cent
+ * is enough for the other two floors to refuse it instead - at 256 on every
+ * seed, at 128 on nine in ten.
  *
  * WHY COHERENCE IS REPORTED AND NOT READ
  *
@@ -233,10 +233,13 @@ export const L_MIN = 0.004;
  * gradients passing one seed in ten; at 64 the noisy textured pair reaches
  * 0.80 on one seed, the 8-bit gradient at one per cent noise reads 0.41-0.70
  * and passes eight seeds in ten where the old floor refused it, and the
- * unrelated pairs 0.63-0.97. That window is not gated by this either, then:
- * plan.js hands it only to crops whose short side is under 272 pixels, and
- * refineMargin caps what an applied residual can move such a frame at one
- * pixel for a set that did not move.
+ * unrelated pairs 0.63-0.97. That window is not gated by this either, then,
+ * and what carries it is no longer a cap on the correction: the refinement
+ * measures nine windows and applies nothing that four of them do not agree
+ * on, so a 64-pixel square that read junk has to be joined by three more
+ * reading the same junk in the same direction before any of it reaches a
+ * frame. One window passing this floor when it should not is now a window
+ * dropped by the consensus rather than a frame moved.
  *
  * The floor is 0.8. The real side's last case is the noisy sparse sky at the
  * survey square: the browser read it at 0.76 with the right answer, the
@@ -287,10 +290,11 @@ export const L_MIN = 0.004;
  * with the scene's own smooth envelope rather than standing level with the
  * peak the way the near ones do. It is harmless as the pipeline is arranged:
  * on the survey square the same pairs are letterboxed and read 0.91-0.99,
- * refused on all eighteen seeds tried, and at 512 an argmax that landed on a
- * random lattice peak is outside the refinement's eight-pixel margin and
- * discarded there. Harmless is not invisible, and the number is recorded
- * because the consensus check is what should be catching this.
+ * refused on all eighteen seeds tried, and at the refinement an argmax that
+ * landed on a random lattice peak is one window disagreeing with the other
+ * eight, which the consensus drops. Harmless is not invisible, and the number
+ * is recorded because the consensus is what catches this rather than either
+ * floor.
  *
  * The reach was measured at 6, 8, 10, 12, 16 and 20. None of them moves the
  * unrelated pairs or the star fields, whose next peak is far away - a sparse
@@ -457,9 +461,9 @@ const NEXT_REACH = 10;
  * refinement exists to refuse are all over it: a wall with sixty-pixel
  * features at 0.77-0.96 (fifteen per cent noise) and 0.82-0.90 (five), the
  * same wall with thirty-pixel features 0.77-0.87, and the textured sky
- * 0.82-0.91, every one with its peak 0.6-7.5 pixels off, inside the margin,
- * at a next of 0.64-0.92 that is partly under N_MAX, so this is the floor
- * that refuses them. At sixteen, the radius the side/32 rule gave
+ * 0.82-0.91, every one with its peak 0.6-7.5 pixels off - close enough to pass
+ * for a residual - at a next of 0.64-0.92 that is partly under N_MAX, so this
+ * is the floor that refuses them. At sixteen, the radius the side/32 rule gave
  * 512, the wall at five per cent read 0.59-0.71 and passed nine seeds in ten
  * with 0.6-5.1 pixels of error applied. At 128 the low-texture pair at
  * fifteen per cent reads 0.33-0.47 and is kept, as is the vignette-over-low
@@ -692,17 +696,17 @@ export function phaseCorrelate(a, b, size) {
 /**
  * How far from the peak the plateau is read: eight pixels, at every size.
  *
- * Eight is the refinement's margin. A residual is only applied when it is
- * within eight output pixels of the coarse answer, so a peak still standing
- * eight pixels out cannot place the frame within the margin whatever its
- * argmax says; and at the coarse square eight alignment pixels is already
- * tens of output pixels on any frame the survey shrank. The first version
- * scaled the radius with the side - a thirty-second of it, sixteen at 512 -
- * reasoning from the multiply-up, which the refinement window does not have:
- * at sixteen the wall at output resolution the refinement exists to refuse
- * passed nine seeds in ten, and at four the low-texture pair at 128 was
- * refused with its peak in the right place. The comment on P_MAX has the
- * readings at both.
+ * Eight is the scale at which a peak has stopped placing anything. The
+ * refinement is looking for a residual of a pixel or two, so a peak still
+ * standing at eight cannot say which of nine pixels the frame belongs at,
+ * whatever its argmax reports; and at the coarse square eight alignment
+ * pixels is already tens of output pixels on any frame the survey shrank.
+ * The first version scaled the radius with the side - a thirty-second of it,
+ * sixteen at 512 - reasoning from the multiply-up, which the refinement
+ * window does not have: at sixteen the wall at output resolution the
+ * refinement exists to refuse passed nine seeds in ten, and at four the
+ * low-texture pair at 128 was refused with its peak in the right place. The
+ * comment on P_MAX has the readings at both.
  *
  * Eight is also the pitch of a JPEG's block grid, and that coincidence is
  * doing work nobody chose. Two frames of one smooth scene compressed at
@@ -711,9 +715,10 @@ export function phaseCorrelate(a, b, size) {
  * against 0.50-0.69 at 6, 0.56-0.81 at 9 and 0.47-0.74 at 10 - and refuses
  * the lock on every seed at both qualities, where next does not. Only at
  * quality 20, where the alias is buried in the blocking, does the lock get
- * through. So a change to this radius, or to the margin it is drawn from,
- * silently gives that lock back; the lattice test in
- * tests/js/stack-images-align.test.js pins both sides so it cannot go
+ * through. So a change to this radius silently gives that lock back, and what
+ * must not be broken is the pair of numbers - a reach of eight, read at eight
+ * - rather than any reasoning about where either came from; the lattice test
+ * in tests/js/stack-images-align.test.js pins both sides so it cannot go
  * quietly.
  */
 function plateauRadius() {

--- a/tools/stack-images/src/pipeline.js
+++ b/tools/stack-images/src/pipeline.js
@@ -38,11 +38,12 @@
 
 import { NO_MOVE, estimate, isMeasured, phaseCorrelate, window2d } from './align.js';
 import {
-  bands, commonArea, outputSize, placement, planRun, refineMargin, refineWindow, workingSize,
+  REFINE_INSET, bands, commonArea, outputSize, placement, planRun, refineWindow, workingSize,
 } from './plan.js';
 import { jpegOrientation, orientationMatrix, orientedSize } from './orient.js';
 import { findPreview, jpegSize, looksRaw } from './raw.js';
-import { createStack } from './stack.js';
+import { MIN_INLIERS, consensus } from './similarity.js';
+import { DEFAULT_RADIUS, createStack } from './stack.js';
 
 /**
  * The square the alignment works in. A power of two because the transform needs
@@ -217,7 +218,8 @@ function surface(width, height) {
 }
 
 /**
- * Draw one frame's bitmap into a box, the right way up.
+ * The transform that maps one frame's own pixels into a box the right way up,
+ * and the plain draw through it.
  *
  * Every drawImage of a frame in this file goes through here, because a frame
  * the browser did not orient - a RAW preview whose orientation lives in the
@@ -231,18 +233,32 @@ function surface(width, height) {
  * already on the context - the alignment, in drawAligned - as the innermost
  * step, which is what makes it a property of the frame rather than of the
  * output.
+ *
+ * It is in two halves because the refinement needs the transform without the
+ * draw. Knowing where a destination sits in the frame's own pixels is what
+ * lets it ask the browser for that rectangle and no more, rather than handing
+ * over a 24-megapixel bitmap and a 256-pixel canvas to clip it against, nine
+ * times a frame. Written as a transform and a draw at the natural size, the
+ * two are the same arithmetic as the scaled draw they replace.
  */
-function drawFrame(context, bitmap, spot, turn) {
+function frameTransform(context, bitmap, spot, turn) {
   if (turn === 1) {
-    context.drawImage(bitmap, spot.x, spot.y, spot.width, spot.height);
+    context.translate(spot.x, spot.y);
+    context.scale(spot.width / bitmap.width, spot.height / bitmap.height);
     return;
   }
   const stored = orientedSize(spot.width, spot.height, turn);
   const [a, b, c, d] = orientationMatrix(turn);
-  context.save();
   context.translate(spot.x + spot.width / 2, spot.y + spot.height / 2);
   context.transform(a, b, c, d, 0, 0);
-  context.drawImage(bitmap, -stored.width / 2, -stored.height / 2, stored.width, stored.height);
+  context.translate(-stored.width / 2, -stored.height / 2);
+  context.scale(stored.width / bitmap.width, stored.height / bitmap.height);
+}
+
+function drawFrame(context, bitmap, spot, turn) {
+  context.save();
+  frameTransform(context, bitmap, spot, turn);
+  context.drawImage(bitmap, 0, 0);
   context.restore();
 }
 
@@ -374,25 +390,345 @@ function lumaSquare(bitmap, spot, output, fit, turn) {
 }
 
 /**
- * The luma window the refinement correlates, cut from the middle of the crop
- * at output resolution, with the frame's coarse correction already applied.
+ * How far apart two windows' answers may be and still be counted as one
+ * answer, in output pixels.
  *
- * Drawn through drawAligned exactly as the stack will draw it - the window's
- * corner standing in for the crop - so what the correlation sees is what the
- * accumulator would have seen, and the residual it reports is in output pixels
- * with nothing to multiply back up. That is the whole point of measuring
- * twice: here, an error of a twentieth of a pixel is a twentieth of a pixel.
+ * The refinement exists to remove errors of a pixel or two, so a tolerance of
+ * two is as wide as it can be and still mean anything: a window that disagrees
+ * by more than the whole error being corrected is not measuring the same
+ * movement as its neighbours. It is also comfortably above what a correct
+ * window is off by - the browser's fit RMS over nine correct windows was 0.14
+ * to 0.34 pixels on every scene that worked at all, and 17 to 42 pixels on
+ * every scene that did not, so nothing measured sits near this number.
  */
-function refineSquare(bitmap, spot, output, move, at, size, turn) {
-  const { canvas, context } = surface(size, size);
-  drawAligned(context, bitmap, spot, output, move, at, 0, turn);
-  const pixels = context.getImageData(0, 0, size, size).data;
-  const out = new Float64Array(size * size);
+const REFINE_TOLERANCE = 2;
+
+/**
+ * How far the refinement may move a frame, in the COARSE pass's own pixels.
+ *
+ * The refinement exists to finish a measurement, not to make another one, and
+ * the measurement it is finishing was located to a fraction of a pixel of the
+ * 256 square it was read in. So a residual worth applying is under a pixel of
+ * that square - which is why it is quoted in them rather than in output
+ * pixels, where the same error is one number on a 3000-pixel picture and
+ * another on a 6000-pixel one. Two is a factor of two of slack over what the
+ * peak's own interpolation can be wrong by, and anything past it means the
+ * coarse pass locked onto a DIFFERENT peak, which is not a thing to correct by
+ * a couple of pixels but a thing to refuse.
+ *
+ * A bound of some kind has to be here. The windows have their own wrap check -
+ * a quarter of what one covers - but that is a question about one window's
+ * reading and it is 128 output pixels wide; nine windows agreeing on a shift
+ * of a hundred pixels pass it unanimously, which is exactly the shape a
+ * globally periodic texture gives when every window's argmax lands on the same
+ * wrong lattice period. The single-window refinement this replaced refused any
+ * residual over eight output pixels and so refused that outright.
+ */
+const REFINE_LIMIT = 2;
+
+/** Which rung of the refinement's ladder a frame's answer came off. */
+export const REFINED = Object.freeze({
+  reference: 'reference',
+  fit: 'fit',
+  partial: 'partial',
+  coarse: 'coarse',
+  none: 'none',
+});
+
+/**
+ * A few pixels of the frame beyond what a window can see, so that the edge of
+ * the source rectangle is never the edge of what gets resampled.
+ */
+const SOURCE_SLACK = 4;
+
+/**
+ * Where the refinement's windows sit inside the crop.
+ *
+ * The crop is divided into a grid of equal cells, inset from its edge, and a
+ * window of `cover` output pixels is centred in each. Equal cells rather than
+ * the corners and the middle, because a window's job is to sample the movement
+ * field and an evenly spread sample is what a least-squares fit wants; and
+ * inset, because the crop's own edge is where the frames stop covering, and a
+ * window flush against it can see the transparent ground outside.
+ */
+export function refineGrid(crop, windows) {
+  const width = crop.width - REFINE_INSET * 2;
+  const height = crop.height - REFINE_INSET * 2;
+  const out = [];
+  for (let row = 0; row < windows.grid; row += 1) {
+    for (let column = 0; column < windows.grid; column += 1) {
+      const x = Math.round(
+        crop.x + REFINE_INSET + (width * (column + 0.5)) / windows.grid - windows.cover / 2,
+      );
+      const y = Math.round(
+        crop.y + REFINE_INSET + (height * (row + 0.5)) / windows.grid - windows.cover / 2,
+      );
+      // The corner is rounded because a window is cut at whole pixels, and the
+      // centre is taken from the corner rather than the other way about, so
+      // that the place the fit is told about is the place that was measured.
+      out.push({ x, y, centre: { x: x + windows.cover / 2, y: y + windows.cover / 2 } });
+    }
+  }
+  return out;
+}
+
+/**
+ * Draw only as much of the bitmap as the destination can possibly show.
+ *
+ * The transform on the context already maps the frame's own pixels onto the
+ * canvas, so inverting it and putting the canvas's four corners through it
+ * gives the rectangle of the frame the canvas is looking at. Everything
+ * outside that rectangle would be drawn and immediately clipped away, and at
+ * nine windows a frame over a 24-megapixel bitmap that is most of the work:
+ * the whole grid measured 12 ms a frame this way, against 21 ms drawing the
+ * bitmap nine times over and 100 ms reading nine squares out of one full-size
+ * draw. Drawing a source rectangle into the same rectangle under the same
+ * transform is the same picture as drawing all of it, save at the rectangle's
+ * own edge - which is why it is taken a few pixels larger than it needs to be,
+ * and why the correlation's Hann window fading the square's edges to nothing
+ * makes even that moot.
+ */
+function drawSource(context, bitmap, size) {
+  const inverse = context.getTransform().inverse();
+  let left = Infinity;
+  let top = Infinity;
+  let right = -Infinity;
+  let bottom = -Infinity;
+  for (const [x, y] of [[0, 0], [size, 0], [size, size], [0, size]]) {
+    const at = inverse.transformPoint({ x, y });
+    left = Math.min(left, at.x);
+    right = Math.max(right, at.x);
+    top = Math.min(top, at.y);
+    bottom = Math.max(bottom, at.y);
+  }
+  const x = Math.max(0, Math.floor(left) - SOURCE_SLACK);
+  const y = Math.max(0, Math.floor(top) - SOURCE_SLACK);
+  const width = Math.min(bitmap.width, Math.ceil(right) + SOURCE_SLACK) - x;
+  const height = Math.min(bitmap.height, Math.ceil(bottom) + SOURCE_SLACK) - y;
+  // A window that lands entirely off the frame - a badly mismeasured coarse
+  // move, or a frame letterboxed into a corner of a much larger output - draws
+  // nothing, and the empty square it leaves fails the gate rather than
+  // reporting the shift between two pieces of nothing.
+  if (width <= 0 || height <= 0) return;
+  context.drawImage(bitmap, x, y, width, height, x, y, width, height);
+}
+
+/**
+ * The luma of one refinement window, with the frame's coarse correction
+ * already applied.
+ *
+ * Drawn through the same transform the stack will draw it through - the
+ * window's corner standing in for the crop - so what the correlation sees is
+ * what the accumulator would have seen, and the residual it reports is in
+ * output pixels with nothing to multiply back up. That is the whole point of
+ * measuring twice: here, an error of a twentieth of a pixel is a twentieth of
+ * a pixel.
+ *
+ * The one difference from the stack's draw is the zoom, which puts `cover`
+ * output pixels into a `size` square. Half scale costs a quarter of the
+ * readback and of the transform behind it, and costs nothing in accuracy: the
+ * residual being looked for is a pixel or two of output, and a correlation
+ * resolves a fraction of a pixel of its own square either way. The caller
+ * multiplies the answer back up by the same number.
+ */
+function windowSquare(bitmap, spot, output, move, at, windows, turn) {
+  const { canvas, context } = surface(windows.size, windows.size);
+  const zoom = windows.size / windows.cover;
+  const cx = output.width / 2;
+  const cy = output.height / 2;
+
+  context.setTransform(zoom, 0, 0, zoom, -at.x * zoom, -at.y * zoom);
+  context.translate(cx + move.dx, cy + move.dy);
+  context.rotate((move.angle * Math.PI) / 180);
+  context.scale(move.scale, move.scale);
+  context.translate(-cx, -cy);
+  frameTransform(context, bitmap, spot, turn);
+  drawSource(context, bitmap, windows.size);
+
+  const pixels = context.getImageData(0, 0, windows.size, windows.size).data;
+  const out = new Float64Array(windows.size * windows.size);
   for (let i = 0, p = 0; i < out.length; i += 1, p += 4) {
     out[i] = pixels[p] * 0.299 + pixels[p + 1] * 0.587 + pixels[p + 2] * 0.114;
   }
   canvas.width = 0;
-  return window2d(out, size);
+  return window2d(out, windows.size);
+}
+
+/**
+ * One refinement laid on top of a coarse move, about the uncropped output
+ * centre.
+ *
+ * Both are scale, then rotation, then shift about that centre, and applying
+ * one after the other gives another of the same shape: the angles add, the
+ * scales multiply, and the coarse shift is itself turned and scaled by the
+ * refinement before the refinement's own shift is added. Writing that out is
+ * cheaper than carrying a matrix through the drawing code, and it is the only
+ * arithmetic here that has to be right for a rotated burst rather than merely
+ * for a shifted one.
+ */
+export function compose(move, fit, turning) {
+  const angle = turning ? fit.angle : 0;
+  const scale = turning ? fit.scale : 1;
+  const radians = (angle * Math.PI) / 180;
+  const cos = Math.cos(radians) * scale;
+  const sin = Math.sin(radians) * scale;
+  return {
+    ...move,
+    angle: move.angle + angle,
+    scale: move.scale * scale,
+    dx: cos * move.dx - sin * move.dy + fit.dx,
+    dy: sin * move.dx + cos * move.dy + fit.dy,
+  };
+}
+
+/**
+ * The largest group of windows reporting much the same shift as one of them.
+ *
+ * The fallback for a frame whose windows will not support a similarity: two
+ * that agree are still two independent measurements of one translation, and
+ * their mean is better than the coarse answer, which was read in a 256-pixel
+ * square and multiplied up. Agreement with a member rather than with every
+ * member, which is a cheaper question and the same answer whenever the group
+ * is a real one.
+ */
+function agreeing(points) {
+  let best = [];
+  for (const seed of points) {
+    const near = points.filter(
+      (point) => Math.hypot(point.dx - seed.dx, point.dy - seed.dy) <= REFINE_TOLERANCE,
+    );
+    if (near.length > best.length) best = near;
+  }
+  return best;
+}
+
+/**
+ * Whether a `commonArea` answer is its own sliver fallback rather than a
+ * region every frame really covered.
+ *
+ * `commonArea` hands back the whole box when the true overlap is under a
+ * quarter of either side, because a stack with visible edges is something
+ * somebody can look at and a postage stamp is not. That answer is the only one
+ * it gives that nobody covers, so everything downstream that reasons from "the
+ * area is the whole box, therefore every frame reached every pixel" has to ask
+ * this first. The test is that the box came back whole although something
+ * moved or was letterboxed: any real shift, turn or scale gives up at least
+ * one row or column to the rounding, so the two cannot be confused.
+ */
+export function fellBack(area, moves, output) {
+  if (area.width !== output.width || area.height !== output.height) return false;
+  return moves.some((move) => {
+    // The same default commonArea takes, so the two read one set of moves the
+    // same way.
+    const box = move.spot ?? { x: 0, y: 0, width: output.width, height: output.height };
+    return move.dx !== 0 || move.dy !== 0 || move.angle !== 0 || move.scale !== 1
+      || box.x !== 0 || box.y !== 0
+      || box.width !== output.width || box.height !== output.height;
+  });
+}
+
+/**
+ * The rectangle the answer is cut to, once every frame has been refined.
+ *
+ * `commonArea` on the final moves, held inside the box the accumulator covers
+ * - which is what the frames covered under their COARSE moves, and the
+ * refinement only ever moves them a pixel or two off that - and for focus
+ * stacking a little less again. The accumulator has transparent ground inside
+ * it wherever a frame did not reach, and stack.js reads transparent as a luma
+ * of zero, which the Laplacian scores as the strongest edge in the picture and
+ * the blur then spreads inward by its own radius. The pixels along the crop's
+ * edge would take their colour from whichever frame happened to have its own
+ * boundary there, which is a black fringe with a plausible explanation. So the
+ * crop gives up the radius and two more: one for the Laplacian's own reach
+ * past the boundary, one because a fringe is a fringe and a couple of pixels
+ * of a 24-megapixel picture is nothing.
+ *
+ * Per axis, and only on an axis that has ground beside it. A crop already
+ * spanning the whole accumulator on one axis has nothing outside it on that
+ * axis to be transparent, so a burst that drifted only downwards keeps its
+ * full width - fourteen columns at the radius slider's top. The exception is
+ * the sliver fallback, where the box is whole and nobody covered it, and that
+ * is the case with the most transparent ground of all.
+ */
+export function finalCrop(moves, output, covered, slivered, mode, radius) {
+  const found = commonArea(moves, output);
+  const x = Math.max(found.x, covered.x);
+  const y = Math.max(found.y, covered.y);
+  const width = Math.min(found.x + found.width, covered.x + covered.width) - x;
+  const height = Math.min(found.y + found.height, covered.y + covered.height) - y;
+  const area = width > 0 && height > 0 ? { x, y, width, height } : { ...covered };
+  if (mode !== 'focus') return area;
+
+  const inset = (radius ?? DEFAULT_RADIUS) + 2;
+  const insetX = slivered || area.width < covered.width ? inset : 0;
+  const insetY = slivered || area.height < covered.height ? inset : 0;
+  if (area.width <= insetX * 2 || area.height <= insetY * 2) return area;
+  return {
+    x: area.x + insetX,
+    y: area.y + insetY,
+    width: area.width - insetX * 2,
+    height: area.height - insetY * 2,
+  };
+}
+
+/**
+ * What a frame's surviving windows add up to: the ladder, in order.
+ *
+ * Four or more windows agreeing on one similarity is the answer the grid was
+ * built for, and it is good to about five thousandths of a degree wherever it
+ * is available. Below that - and only below it, counted in windows that
+ * SURVIVED the gate - two of them agreeing on a shift is a shift worth
+ * applying and nothing worth saying about rotation, and the move is marked
+ * `partial` so that which happened is not a guess. That count is the whole
+ * distinction between a frame nobody could measure much of and a frame
+ * everybody measured differently: with four or more windows in hand, a
+ * consensus that came back empty has already reported that they disagree, and
+ * the two of them that happen to coincide are the two that sat on the same
+ * moving subject. Below that the coarse move stands, which is the honest
+ * outcome for such a frame: no single transform describes a walking figure and
+ * the ground behind it, and leaving the frame where the first measurement put
+ * it beats taking the loudest window's word for the whole picture.
+ *
+ * Nothing is applied that moves the frame further than `limit`, whichever rung
+ * proposed it, and the rung below is tried instead. REFINE_LIMIT says why a
+ * bound has to be here at all.
+ *
+ * A frame the coarse pass clamped was reported to the visitor as one corrected
+ * by shifting alone, and in similarity mode the fit's angle and scale are
+ * about to be applied to it, so the flag comes off with the same movement that
+ * makes it untrue.
+ *
+ * In translate mode the same consensus runs and only its translation is
+ * applied. Not a median of the windows, which is what the single-window
+ * refinement's obvious generalisation would have been: a rotated burst makes
+ * the windows disagree BY DESIGN, and the median of nine disagreeing shifts is
+ * a number that describes no part of the frame.
+ */
+export function refineMove(move, points, turning, centre, limit) {
+  const found = consensus(points, REFINE_TOLERANCE, centre);
+  if (found && Math.hypot(found.fit.dx, found.fit.dy) <= limit) {
+    return {
+      ...compose(move, found.fit, turning),
+      refine: REFINED.fit,
+      clamped: turning ? false : move.clamped,
+    };
+  }
+
+  const together = points.length < MIN_INLIERS ? agreeing(points) : [];
+  if (together.length >= 2) {
+    let dx = 0;
+    let dy = 0;
+    for (const point of together) {
+      dx += point.dx;
+      dy += point.dy;
+    }
+    const shift = { angle: 0, scale: 1, dx: dx / together.length, dy: dy / together.length };
+    if (Math.hypot(shift.dx, shift.dy) <= limit) {
+      return { ...compose(move, shift, false), refine: REFINED.partial, partial: true };
+    }
+  }
+
+  return { ...move, refine: REFINED.coarse };
 }
 
 /* -------------------------------------------------------------------- run */
@@ -452,7 +788,16 @@ export async function runStack(request, hooks) {
   // The square every frame is correlated in, sized so that one number converts
   // a shift in it back to a shift in the output.
   const fit = placement(output, { width: ALIGN_SIZE, height: ALIGN_SIZE });
+  // Where each frame sits in the output box. Constant for the whole run and
+  // wanted by every stage after this one, so it is worked out once: the crop
+  // needs it to know what a letterboxed frame ever covered, and the stack and
+  // the refinement need it on every draw.
+  const spots = frames.map((frame) => placement(frame, output));
+  const centre = { x: output.width / 2, y: output.height / 2 };
   const moves = [];
+  // The moves as commonArea wants them: each one carrying the box its frame
+  // filled before it was moved.
+  const placed = () => moves.map((move, index) => ({ ...move, spot: spots[index] }));
   let reference = null;
 
   for (const [index, frame] of frames.entries()) {
@@ -463,7 +808,7 @@ export async function runStack(request, hooks) {
     }
     report({ stage: 'measure', done: index, total: frames.length, name: frame.name });
 
-    const spot = placement(frame, output);
+    const spot = spots[index];
     // The thumbnail is drawn as if it were the full frame, which it is a scaled
     // copy of. Its own size never enters the arithmetic.
     const square = lumaSquare(frame.thumb, {
@@ -476,6 +821,7 @@ export async function runStack(request, hooks) {
       reference = square;
       moves.push({
         ...NO_MOVE, measured: true, clamped: false, live: 1, coherence: 1, plateau: 0, next: 0,
+        refine: REFINED.reference,
       });
       continue;
     }
@@ -490,6 +836,10 @@ export async function runStack(request, hooks) {
       // Back out of the alignment square and into the output's own pixels.
       dx: found.dx / fit.scale,
       dy: found.dy / fit.scale,
+      // Overwritten during the stack, when the frame is refined. A frame that
+      // never reaches a full-size decode - a run cancelled part way - keeps
+      // this, which is what actually happened to it.
+      refine: REFINED.coarse,
     } : {
       ...NO_MOVE,
       measured: false,
@@ -498,6 +848,7 @@ export async function runStack(request, hooks) {
       coherence: found.coherence,
       plateau: found.plateau,
       next: found.next,
+      refine: REFINED.none,
     });
   }
 
@@ -506,55 +857,73 @@ export async function runStack(request, hooks) {
 
   /* --- stack ----------------------------------------------------------- */
 
-  // What every frame covers once moved. With no alignment this is the whole
-  // output; with alignment it is the output less however far the frames went.
-  const crop = commonArea(moves, output);
-
   // The refinement the measure stage promised. The moves above were read in a
   // small square and multiplied back up to output pixels, and the multiply-up
   // scales their sub-pixel error with them - enough to blur the stack by more
   // than it blurs a frame. So during the stack, when each frame's full-size
-  // decode is in hand anyway, a window of it is correlated against the same
-  // window of the reference at output resolution and the answer is corrected in
-  // place. It costs no extra decode, which is why it happens there and not
-  // here. The margin is the room those corrections need: a frame moved after
-  // the crop was decided stops covering ground the crop assumed, so the crop
-  // gives up that much on every side up front.
-  const refine = align === 'none' ? 0 : refineWindow(crop);
-  const margin = refine ? refineMargin(moves) : 0;
-  crop.x += margin;
-  crop.y += margin;
-  crop.width -= margin * 2;
-  crop.height -= margin * 2;
-  const refineAt = refine ? {
-    x: Math.round(crop.x + (crop.width - refine) / 2),
-    y: Math.round(crop.y + (crop.height - refine) / 2),
-  } : null;
-  let referenceWindow = null;
+  // decode is in hand anyway, windows of it are correlated against the same
+  // windows of the reference at output resolution and the answer is corrected
+  // in place. It costs no extra decode, which is why it happens there and not
+  // here.
+  //
+  // The grid is laid out over what the frames covered under their COARSE
+  // moves, which is also the box everything below accumulates into. That is
+  // not the crop the run finishes with - the refinement is about to move them
+  // again, and the crop is settled afterwards from where they ended up - but
+  // it is the right region to sample: the part of the output every frame has
+  // something in.
+  const covered = commonArea(placed(), output);
+  // Except when it is not, because `commonArea` gave up and handed back the
+  // whole box for a set that overlaps in almost nothing. A grid laid over that
+  // puts windows where a frame has nothing, and a half-empty window correlates
+  // confidently against a full one and reports a shift that is neither frame's;
+  // the coarse move standing is the honest answer for such a set.
+  const slivered = fellBack(covered, placed(), output);
+  const windows = align === 'none' || slivered ? null : refineWindow(covered);
+  const grid = windows ? refineGrid(covered, windows) : [];
+  let referenceWindows = null;
   const refined = frames.map(() => false);
+  // How far the refinement may move a frame, out of the coarse pass's square
+  // and into the output's own pixels.
+  const limit = REFINE_LIMIT / fit.scale;
 
+  // The accumulator covers `covered` and the crop is taken at the end, out of
+  // the finished rows. It has to be that way round now: the moves are not
+  // final until every frame has been refined, which happens on each one's
+  // first full-size decode, which is inside this loop. It is `covered` rather
+  // than the whole output box because the band arithmetic is not free of the
+  // difference - a run planned on the box instead of on what the frames cover
+  // can gain a whole band, and a band is a re-read of every frame, so a
+  // five-frame run that read each frame once would read each of them twice.
+  // The refinement's corrections are a pixel or two, so the crop settled below
+  // is inside this box in any case.
   const plan = planRun({
-    width: crop.width, height: crop.height, frames: frames.length, mode,
+    width: covered.width, height: covered.height, frames: frames.length, mode,
     budget: request.budget,
   });
-  report({ stage: 'planned', plan, output: crop, frames: frames.map(describe) });
+  report({ stage: 'planned', plan, output, frames: frames.map(describe) });
 
-  const { canvas: out, context: outContext } = surface(crop.width, crop.height);
-  const list = bands(crop.height, plan.rows, plan.context);
+  // Allocated at the crop's size the moment the crop is known, which is when
+  // the first band has been stacked. No second canvas and no copy: the rows
+  // are cut on their way out of the accumulator.
+  let crop = null;
+  let out = null;
+  let outContext = null;
+  const list = bands(covered.height, plan.rows, plan.context);
   const totalSteps = plan.decodes;
   let step = 0;
 
   for (const [bandIndex, band] of list.entries()) {
     stop();
     const stack = createStack(mode, {
-      width: crop.width,
+      width: covered.width,
       height: band.readRows,
       frames: frames.length,
       kappa: request.kappa,
       gain: request.gain,
       radius: request.radius,
     });
-    const { canvas: scratch, context } = surface(crop.width, band.readRows);
+    const { canvas: scratch, context } = surface(covered.width, band.readRows);
 
     for (let pass = 0; pass < stack.passes; pass += 1) {
       stack.beginPass(pass);
@@ -566,67 +935,113 @@ export async function runStack(request, hooks) {
           band: bandIndex + 1, bands: list.length, pass: pass + 1, passes: stack.passes,
         });
 
-        const spot = placement(frame, output);
+        const spot = spots[index];
         const working = workingSize(frame.decoded.width, frame.decoded.height, 1);
         const bitmap = await decodeAt(frame.blob, working, spot, frame.turn);
 
         // Each frame's first full-size appearance settles its final position.
         // Later bands and passes reuse the answer, so a banded run stays
-        // consistent with itself. The gates keep a bad peak from undoing a
-        // good coarse answer: a window without enough texture to correlate, a
-        // window whose peak is a plateau - a wall, a sky - so that its
-        // position is the noise's choice, a window whose peak is one of
-        // several of much the same height - two unrelated pictures, a sky too
-        // sparse for its noise - so that which one the argmax took is the
-        // noise's choice instead, or a residual larger than the coarse pass
-        // could plausibly have been wrong by, leaves the frame where the
-        // coarse measurement put it. A frame the coarse pass could
-        // not measure is not refined at all: it is sitting at the identity,
-        // and a residual measured from there is not a residual but a whole
-        // shift, which is the measurement that was already refused.
-        if (refine && !refined[index]) {
+        // consistent with itself, and it is what lets the crop be taken from
+        // the finished moves: every one of them is final by the end of the
+        // first band's first pass.
+        //
+        // Every window goes through the same gate the coarse pass does, and
+        // for the same reasons: a window without enough texture to correlate,
+        // one whose peak is a plateau - a wall, a sky - so that its position
+        // is the noise's choice, or one whose peak is merely the tallest of
+        // several, so that which one the argmax took is the noise's choice
+        // instead. A window that reports a shift larger than a quarter of what
+        // it covers is refused as well, and that one is arithmetic rather than
+        // judgement: a correlation surface wraps, so a shift approaching half
+        // the square is as likely to be the same feature coming round the
+        // other side as a real residual, and no residual of a coarse move is
+        // that large. What survives goes to the consensus. A frame the coarse
+        // pass could not measure is not refined at all: it is sitting at the
+        // identity, and a residual measured from there is not a residual but a
+        // whole shift, which is the measurement that was already refused.
+        if (windows && !refined[index]) {
           refined[index] = true;
           if (index === 0) {
-            referenceWindow = refineSquare(
-              bitmap, spot, output, moves[index], refineAt, refine, frame.turn,
-            );
-          } else if (referenceWindow && moves[index].measured) {
-            const square = refineSquare(
-              bitmap, spot, output, moves[index], refineAt, refine, frame.turn,
-            );
-            const residual = phaseCorrelate(referenceWindow, square, refine);
-            if (isMeasured(residual)
-                && Math.abs(residual.dx) <= margin && Math.abs(residual.dy) <= margin) {
-              moves[index].dx += residual.dx;
-              moves[index].dy += residual.dy;
+            referenceWindows = grid.map((at) => windowSquare(
+              bitmap, spot, output, moves[index], at, windows, frame.turn,
+            ));
+          } else if (referenceWindows && moves[index].measured) {
+            const points = [];
+            for (const [which, at] of grid.entries()) {
+              const square = windowSquare(
+                bitmap, spot, output, moves[index], at, windows, frame.turn,
+              );
+              const residual = phaseCorrelate(referenceWindows[which], square, windows.size);
+              if (!isMeasured(residual)) continue;
+              // Out of the window's own square and back into output pixels,
+              // which is the one number the half-scale draw costs.
+              const back = windows.cover / windows.size;
+              const dx = residual.dx * back;
+              const dy = residual.dy * back;
+              if (Math.hypot(dx, dy) > windows.cover / 4) continue;
+              points.push({ x: at.centre.x, y: at.centre.y, dx, dy });
             }
+            moves[index] = refineMove(
+              moves[index], points, align === 'similarity', centre, limit,
+            );
           }
         }
 
         context.setTransform(1, 0, 0, 1, 0, 0);
-        context.clearRect(0, 0, crop.width, band.readRows);
-        drawAligned(context, bitmap, spot, output, moves[index], crop, band.readY, frame.turn);
+        context.clearRect(0, 0, covered.width, band.readRows);
+        drawAligned(context, bitmap, spot, output, moves[index], covered, band.readY, frame.turn);
         bitmap.close();
 
-        stack.add(context.getImageData(0, 0, crop.width, band.readRows).data, index, pass);
+        stack.add(context.getImageData(0, 0, covered.width, band.readRows).data, index, pass);
       }
       stack.endPass(pass);
     }
 
-    // Only the rows this band owns are written. The overlap above and below was
-    // read so that focus stacking could measure across the seam, and it belongs
-    // to the neighbouring bands.
+    // The crop, the first time there is anything to crop. Every frame was
+    // refined during the pass just finished, so this is the earliest moment it
+    // can be asked for and the last one at which it is needed.
+    if (!crop) {
+      crop = finalCrop(placed(), output, covered, slivered, mode, request.radius);
+      ({ canvas: out, context: outContext } = surface(crop.width, crop.height));
+      // The reference windows can never be read again - every frame was
+      // refined during the pass that just finished - and at the 512/256 grid
+      // they are nine 256-squares of doubles, which is more memory than the
+      // single window they replaced and more than plan.peak counts.
+      referenceWindows = null;
+    }
+
+    // Only the rows this band owns are written, and only the columns the crop
+    // kept. The overlap above and below was read so that focus stacking could
+    // measure across the seam, and it belongs to the neighbouring bands; the
+    // rows outside the crop were stacked because the accumulator covers
+    // everything the frames covered, and they are thrown away here rather than
+    // in a second canvas. The bands are cut from that box, so the crop has to
+    // come into its coordinates to be compared with them.
     const finished = stack.result();
-    const keep = new ImageData(crop.width, band.rows);
-    keep.data.set(finished.subarray(
-      band.offset * crop.width * 4,
-      (band.offset + band.rows) * crop.width * 4,
-    ));
-    outContext.putImageData(keep, 0, band.y);
+    const top = crop.y - covered.y;
+    const from = Math.max(band.y, top);
+    const to = Math.min(band.y + band.rows, top + crop.height);
+    if (to > from) {
+      const keep = new ImageData(crop.width, to - from);
+      for (let row = 0; row < to - from; row += 1) {
+        const at = (band.offset + from - band.y + row) * covered.width + (crop.x - covered.x);
+        keep.data.set(
+          finished.subarray(at * 4, (at + crop.width) * 4),
+          row * crop.width * 4,
+        );
+      }
+      outContext.putImageData(keep, 0, from - top);
+    }
     scratch.width = 0;
   }
 
   /* --- encode ---------------------------------------------------------- */
+
+  // What the frames covered before any of them was moved. Measuring the crop
+  // against the output box instead would call a set of two shapes cropped for
+  // the letterboxing alone, and the page's note for that run says the frames
+  // were stacked exactly as given - two sentences that cannot both be true.
+  const base = commonArea(spots.map((spot) => ({ ...NO_MOVE, spot })), output);
 
   stop();
   report({ stage: 'encode', done: totalSteps, total: totalSteps });
@@ -641,9 +1056,9 @@ export async function runStack(request, hooks) {
     blob,
     width: crop.width,
     height: crop.height,
-    // How much the alignment cost at the edges, so the page can say so when it
-    // is more than a trim.
-    cropped: crop.width !== output.width || crop.height !== output.height,
+    // Whether MOVING the frames cost anything at the edges, so the page can
+    // say so when it is more than a trim.
+    cropped: crop.width !== base.width || crop.height !== base.height,
     plan,
     frames: frames.map(describe),
     moves,

--- a/tools/stack-images/src/plan.js
+++ b/tools/stack-images/src/plan.js
@@ -146,6 +146,16 @@ export function planRun({ width, height, frames, mode, budget = DEFAULT_BUDGET }
   // is a fifth of the budget and would be a fifth missing from the figure the
   // page shows. So it comes off the top, and the bands are sized in what is
   // left rather than in the whole.
+  //
+  // The pipeline is handed the box the frames covered and crops at the end, so
+  // the canvas it really allocates is the crop and this term is an
+  // over-estimate of it - by the pixel or two a side the refinement moved
+  // them, and by the radius a focus stack gives up. Over is the safe direction
+  // for a figure whose job is to keep a tab alive, and quoting the crop would
+  // mean knowing the crop, which is not known until every frame has been
+  // refined. The slack pays for the one thing the run allocates that is not
+  // counted here: the refinement's nine reference windows, which are held
+  // while the first band is stacked and dropped when it is done.
   const canvas = width * height * 4;
   const forBands = Math.max(0, budget - canvas);
 
@@ -244,17 +254,26 @@ export function outputSize(frames, scale = 1) {
  * what somebody would blame the stacking for. Cropping to what they all cover
  * is what every stacker does and is the only answer that invents nothing.
  *
- * Each frame's content filled the output box before it was moved, so the region
- * it covers afterwards is that box under its own transform. The rectangle
- * returned is the largest axis-aligned one inside all of them: for a rotated
- * quad, that means taking the inner of each pair of corners on every side,
- * which is conservative rather than exact and errs towards cropping slightly
- * too much.
+ * Each frame's content filled its own placement box before it was moved, so
+ * the region it covers afterwards is that box under its own transform. The
+ * box is the whole output for the ordinary set of frames that are all one
+ * size and shape, and is smaller for a frame of another shape, which
+ * `placement` letterboxes: a 4:3 frame in a 3:2 output never covered the
+ * columns either side of it, whether or not it moved, and a crop that assumed
+ * the whole output would leave those columns in with nothing behind them. A
+ * move that names no spot is taken to have filled the output, which is what
+ * every caller before the letterboxing was noticed meant.
  *
- * With no alignment every transform is the identity and this returns the whole
- * output, so nothing is cropped and nothing is lost.
+ * The rectangle returned is the largest axis-aligned one inside all of them:
+ * for a rotated quad, that means taking the inner of each pair of corners on
+ * every side, which is conservative rather than exact and errs towards
+ * cropping slightly too much.
  *
- * @param {{dx: number, dy: number, angle: number, scale: number}[]} moves
+ * With no alignment every transform is the identity and this returns whatever
+ * the frames covered, so a set of one shape is not cropped and nothing is lost.
+ *
+ * @param {{dx: number, dy: number, angle: number, scale: number,
+ *   spot?: {x: number, y: number, width: number, height: number}}[]} moves
  * @param {{width: number, height: number}} output
  * @returns {{x: number, y: number, width: number, height: number}}
  */
@@ -276,10 +295,11 @@ export function commonArea(moves, output) {
       y: cy + (x - cx) * sin + (y - cy) * cos + (move.dy ?? 0),
     });
 
-    const topLeft = at(0, 0);
-    const topRight = at(output.width, 0);
-    const bottomRight = at(output.width, output.height);
-    const bottomLeft = at(0, output.height);
+    const box = move.spot ?? { x: 0, y: 0, width: output.width, height: output.height };
+    const topLeft = at(box.x, box.y);
+    const topRight = at(box.x + box.width, box.y);
+    const bottomRight = at(box.x + box.width, box.y + box.height);
+    const bottomLeft = at(box.x, box.y + box.height);
 
     left = Math.max(left, topLeft.x, bottomLeft.x);
     right = Math.min(right, topRight.x, bottomRight.x);
@@ -301,50 +321,64 @@ export function commonArea(moves, output) {
   return { x, y, width, height };
 }
 
+/** How many windows across the refinement lays its grid. */
+export const REFINE_GRID = 3;
+
 /**
- * The square the alignment's refinement pass measures in, or 0 when the crop
- * has no room for one worth trusting.
+ * How far the grid stays off the edge of the crop, in output pixels.
+ *
+ * Not because the frames move afterwards - they do, but the windows are drawn
+ * through the coarse moves the crop was worked out from, so every one of them
+ * is inside every frame's coverage at the moment it is measured. It is because
+ * that edge is only NEARLY the edge of the coverage: `commonArea` approximates
+ * each rotated quad by the inner of each pair of corners and then rounds, and
+ * a resample at the boundary takes its samples from just outside it either
+ * way. A window flush against the edge can catch the transparent ground there,
+ * which correlates as an edge both frames share wherever they went and pins
+ * the window to a shift that is not the frame's. Eight pixels of margin keeps
+ * it off, and eight pixels of a crop that has room for this grid at all is
+ * nothing given up.
+ */
+export const REFINE_INSET = 8;
+
+/**
+ * The grid of squares the alignment's refinement measures in, or null when the
+ * crop has no room for one worth trusting.
  *
  * The coarse measurement happens in a small square and is multiplied back up,
  * which multiplies its sub-pixel error with it - at 6000 pixels across, a
  * twentieth of a pixel of estimation error comes back as more than one whole
- * pixel of blur. The refinement corrects that by correlating a window cut from
+ * pixel of blur. The refinement corrects that by correlating windows cut from
  * the frames at output resolution, where an error of a twentieth of a pixel is
- * an error of a twentieth of a pixel. 512 is plenty of texture to lock onto;
- * below 64 there is too little for the peak to mean anything, and no window is
- * the honest answer.
+ * an error of a twentieth of a pixel.
  *
- * The 16 the window keeps back from the crop is the two margins the caller
- * shrinks the crop by; asking for a window the margin then makes impossible
- * would be answering a different question than the one asked.
+ * Nine of them rather than one, because one window measures a shift and nine
+ * measure a field, and a field is what a rotation is. A frame turned a third
+ * of a degree moves the middle of a 6000 by 4000 picture by nothing and each
+ * of its corners by nineteen pixels, so a single window at the middle finds
+ * nothing to correct and reports honestly that the frame did not move.
+ *
+ * `cover` is how much of the output one window spans and `size` is the square
+ * it is drawn into, which is half of it: the residual being looked for is a
+ * pixel or two, the correlation resolves a fraction of a pixel of ITS OWN
+ * square, and drawing at half scale halves the reading and the cost of every
+ * transform in the run behind it. 512 is plenty of texture to lock onto and is
+ * the first size tried; the grid falls to 256 and then 128 on a crop that
+ * cannot fit three of them, and below a 3x3 grid of 64-pixel covers there is
+ * too little in each window for a peak to mean anything and no grid is the
+ * honest answer - the coarse move then stands.
  */
 export function refineWindow({ width, height }) {
-  const room = Math.min(width, height) - 16;
-  if (room < 64) return 0;
-  let size = 64;
-  while (size * 2 <= Math.min(room, 512)) size *= 2;
-  return size;
-}
-
-/**
- * How far the refinement may move a frame beyond its coarse answer, in output
- * pixels. Also how much the crop must shrink on every side, because a frame
- * moved after the crop was decided stops covering ground the crop assumed.
- *
- * The bound is the coarse pass's own error budget: its sub-pixel mistake is a
- * fraction of one alignment-square pixel, which the multiply-up turns into a
- * handful of output pixels. Eight covers that with room to spare. A set whose
- * frames barely moved cannot have been mismeasured by much - the error lives
- * in the sub-pixel fraction of the shift - so it keeps a one-pixel allowance
- * and a tripod burst is not charged sixteen rows for a correction it does not
- * need.
- */
-export function refineMargin(moves) {
-  let most = 0;
-  for (const move of moves) {
-    most = Math.max(most, Math.abs(move.dx ?? 0), Math.abs(move.dy ?? 0));
-  }
-  return most < 0.5 ? 1 : 8;
+  const room = Math.min(width, height) - REFINE_INSET * 2;
+  let cover = 512;
+  while (cover > 64 && REFINE_GRID * cover > room) cover /= 2;
+  if (REFINE_GRID * cover > room) return null;
+  // Half the cover, held inside what a correlation square may usefully be:
+  // 256 is where the transform stops being cheap and 64 is where the surface
+  // stops having a peak on it. A cover of 64 is drawn at 1:1 rather than at
+  // half, which is the floor doing its job rather than an exception to it.
+  const size = Math.min(256, Math.max(64, cover / 2));
+  return { cover, size, grid: REFINE_GRID };
 }
 
 /**

--- a/tools/stack-images/src/similarity.js
+++ b/tools/stack-images/src/similarity.js
@@ -1,0 +1,251 @@
+/**
+ * The one transform a field of measured shifts agrees on, and which of them
+ * agree at all.
+ *
+ * The refinement measures the residual shift between a frame and the reference
+ * in nine windows spread over the picture, and nine shifts are more than a
+ * shift: they are nine samples of a field, and a field that varies across the
+ * frame is exactly what a rotation looks like. A frame turned a third of a
+ * degree moves the middle of a 6000 by 4000 picture by nothing and each of
+ * its corners by nineteen pixels, in four different directions - so a single
+ * window at the middle finds nothing to correct and the corners stay as soft
+ * as they were.
+ * Nine windows see the turn; this module is what reads it back out of them.
+ *
+ * WHY THE FIT IS CLOSED-FORM AND NOT ITERATED
+ *
+ * A similarity has four degrees of freedom - one angle, one scale, two of
+ * translation - and the least-squares similarity through a set of matched
+ * points is a formula, not a search. Two sums over the points give the pair of
+ * numbers the rotation and the scale are the polar form of, and the
+ * translation is whatever moves one centroid onto the other afterwards. It
+ * costs one pass over nine points and it is the exact minimiser, which an
+ * iteration would only ever approach.
+ *
+ * WHY THE CONSENSUS IS EXHAUSTIVE AND NOT RANDOM
+ *
+ * Some of the nine windows will be wrong. A window on a cloudless sky has no
+ * position to report, one on a walking figure reports the figure's movement
+ * rather than the camera's, and least squares has no defence against either:
+ * one window twenty pixels out drags the angle by a tenth of a degree and puts
+ * the error back where it was. So the fit is made from the windows that agree
+ * with each other and the rest are dropped, which is what RANSAC does - except
+ * that RANSAC samples its pairs at random because its point sets run to
+ * thousands, and nine points have thirty-six pairs. Every one is tried, the
+ * largest agreeing set wins, and the answer is the same answer every time the
+ * same nine windows are measured. A test can pin it exactly, which is not true
+ * of a sampler.
+ *
+ * THE SIGN, WHICH IS THE THING TO GET RIGHT
+ *
+ * A point carries the shift to APPLY to the frame there - the same convention
+ * as everything align.js returns, a correction and never a measurement. So the
+ * transform handed back is the one that puts the frame straight, and a frame
+ * that arrived turned by a third of a degree is described by an angle of minus
+ * a third. Getting this backwards does not throw and does not look wrong in
+ * review; it turns the frame the wrong way and doubles the blur the refinement
+ * was there to remove.
+ */
+
+/**
+ * How many windows have to agree before their fit is worth applying.
+ *
+ * Four of nine. Two determine a similarity exactly and so can never disagree
+ * with themselves, and three is one measurement of agreement, which a pair of
+ * windows that happened to catch the same moving branch would pass. Four is
+ * two independent confirmations, and it is more than one cell's worth of the
+ * grid, so no single wrong region of the picture can produce it alone.
+ */
+export const MIN_INLIERS = 4;
+
+const DEGREES = 180 / Math.PI;
+
+/** The centre a fit is expressed about, when the caller does not name one. */
+const ORIGIN = Object.freeze({ x: 0, y: 0 });
+
+/**
+ * Where a similarity puts one point.
+ *
+ * Scale, then rotation, then the shift, all about `centre` - the same order
+ * and the same centre as the pipeline's drawAligned, which is what makes a fit
+ * from here something the drawing transform can be handed without any further
+ * arithmetic.
+ */
+export function apply(fit, x, y, centre = ORIGIN) {
+  const radians = fit.angle / DEGREES;
+  const cos = Math.cos(radians) * fit.scale;
+  const sin = Math.sin(radians) * fit.scale;
+  const dx = x - centre.x;
+  const dy = y - centre.y;
+  return {
+    x: centre.x + dx * cos - dy * sin + fit.dx,
+    y: centre.y + dx * sin + dy * cos + fit.dy,
+  };
+}
+
+/**
+ * How far one point sits from where a fit says it should be, in pixels.
+ *
+ * The fit maps where the frame's content is now onto where it has to end up,
+ * so the point goes in at `(x - dx, y - dy)` and is expected to come out at
+ * `(x, y)`. That is the quantity the least-squares fit minimises, so the
+ * consensus below and the `rms` a fit reports are measuring one thing.
+ */
+function distance(fit, point, centre) {
+  const at = apply(fit, point.x - point.dx, point.y - point.dy, centre);
+  return Math.hypot(at.x - point.x, at.y - point.y);
+}
+
+function rmsOf(fit, points, centre) {
+  if (!points.length) return 0;
+  let total = 0;
+  for (const point of points) {
+    const off = distance(fit, point, centre);
+    total += off * off;
+  }
+  return Math.sqrt(total / points.length);
+}
+
+/**
+ * The similarity that best explains a field of shifts.
+ *
+ * @param {{x: number, y: number, dx: number, dy: number}[]} points  each a
+ *   place in the output and the shift to apply to the frame there
+ * @param {{x: number, y: number}} [centre]  the point the returned angle and
+ *   scale turn about, and the point the returned shift is expressed at
+ * @returns {{angle: number, scale: number, dx: number, dy: number,
+ *   rms: number} | null}  null when the points cannot determine one: fewer
+ *   than two of them, or two in the same place, which fixes no angle.
+ */
+export function fitSimilarity(points, centre = ORIGIN) {
+  const count = points.length;
+  if (count < 2) return null;
+
+  // The two centroids: where the content is now, and where it has to end up.
+  // Taking them out first is what separates the rotation and the scale from
+  // the translation - about their own centroids the two clouds differ by
+  // nothing except a turn and a stretch.
+  let sourceX = 0;
+  let sourceY = 0;
+  let targetX = 0;
+  let targetY = 0;
+  for (const point of points) {
+    sourceX += point.x - point.dx;
+    sourceY += point.y - point.dy;
+    targetX += point.x;
+    targetY += point.y;
+  }
+  sourceX /= count;
+  sourceY /= count;
+  targetX /= count;
+  targetY /= count;
+
+  // `a` and `b` are the rotation and the scale in one: the matrix that best
+  // maps the centred source onto the centred target is [[a, -b], [b, a]],
+  // whose polar form is a turn of atan2(b, a) by a factor of hypot(a, b).
+  let alongside = 0;
+  let across = 0;
+  let spread = 0;
+  let reach = 0;
+  for (const point of points) {
+    const x = point.x - point.dx - sourceX;
+    const y = point.y - point.dy - sourceY;
+    const u = point.x - targetX;
+    const v = point.y - targetY;
+    alongside += x * u + y * v;
+    across += x * v - y * u;
+    spread += x * x + y * y;
+    reach += u * u + v * v;
+  }
+  // Both clouds have to have a size. Points all in one place fix no angle, and
+  // it is the two windows measured at the same spot that reach this: their
+  // targets coincide, the formula's numerators both come out zero, and what
+  // would be handed back is a scale of nothing - a transform that collapses
+  // the frame to a point rather than an admission that it could not be found.
+  if (!(spread > 0) || !(reach > 0)) return null;
+
+  const a = alongside / spread;
+  const b = across / spread;
+  const offX = sourceX - centre.x;
+  const offY = sourceY - centre.y;
+  const fit = {
+    angle: Math.atan2(b, a) * DEGREES,
+    scale: Math.hypot(a, b),
+    // Whatever is left over once the turn has been applied about the caller's
+    // centre: the shift that carries the source centroid onto the target one.
+    dx: targetX - centre.x - (a * offX - b * offY),
+    dy: targetY - centre.y - (b * offX + a * offY),
+    rms: 0,
+  };
+  fit.rms = rmsOf(fit, points, centre);
+  return fit;
+}
+
+/**
+ * The largest set of points that agree on one similarity, and that similarity.
+ *
+ * Every pair is taken as a proposal - two points determine a similarity
+ * exactly - and scored by how many of the others it explains within
+ * `tolerance` pixels. The largest agreeing set wins, ties going to the lower
+ * error, and the answer is refitted by least squares over that whole set, so
+ * that the pair which proposed it has no more say than the rest.
+ *
+ * Null rather than a poor answer when nothing agrees, and that is the point of
+ * the arrangement: a frame whose windows disagree has a moving subject or a
+ * parallax in it, no similarity describes either, and the honest outcome is to
+ * say nothing and leave the caller with the answer it already had.
+ *
+ * Null as well when two sets of the same size share no window between them,
+ * which is the same refusal wearing a disguise. Each of the two fits its own
+ * windows exactly, so both score a zero error and the tie falls to whichever
+ * pair the loops reach first - and on a burst with a subject moving across
+ * four windows and the background holding the other four, "first" means the
+ * top left of the grid. Winning a coin toss is not evidence, and the answer
+ * that came back would be a full-confidence fit indistinguishable from nine
+ * windows agreeing. So a picture with two stories in it gets the same answer
+ * as a picture with none.
+ *
+ * @param {{x: number, y: number, dx: number, dy: number}[]} points
+ * @param {number} tolerance  how far a point may sit from a fit and still count
+ * @param {{x: number, y: number}} [centre]
+ * @returns {{fit: object, inliers: number[], rms: number} | null}
+ */
+export function consensus(points, tolerance, centre = ORIGIN) {
+  // Every proposal is kept rather than only the leader, because the question
+  // asked at the end - is there a rival nobody can choose between? - is about
+  // the field of proposals and cannot be answered from the winner alone.
+  const found = [];
+  for (let i = 0; i < points.length; i += 1) {
+    for (let j = i + 1; j < points.length; j += 1) {
+      const proposal = fitSimilarity([points[i], points[j]], centre);
+      if (!proposal) continue;
+
+      const inliers = [];
+      for (let k = 0; k < points.length; k += 1) {
+        if (distance(proposal, points[k], centre) <= tolerance) inliers.push(k);
+      }
+      found.push({ inliers, rms: rmsOf(proposal, inliers.map((k) => points[k]), centre) });
+    }
+  }
+
+  let best = null;
+  for (const candidate of found) {
+    // Strictly better, so that the first proposal to reach a given size and
+    // error keeps it. The pairs are walked in index order, which is what
+    // makes the whole thing repeatable rather than merely usually right.
+    const better = !best
+      || candidate.inliers.length > best.inliers.length
+      || (candidate.inliers.length === best.inliers.length && candidate.rms < best.rms);
+    if (better) best = candidate;
+  }
+
+  if (!best || best.inliers.length < MIN_INLIERS) return null;
+  const kept = new Set(best.inliers);
+  const rival = found.some((candidate) => candidate.inliers.length === best.inliers.length
+    && candidate.inliers.every((k) => !kept.has(k)));
+  if (rival) return null;
+
+  const fit = fitSimilarity(best.inliers.map((k) => points[k]), centre);
+  if (!fit) return null;
+  return { fit, inliers: best.inliers, rms: fit.rms };
+}

--- a/tools/stack-images/src/stack.js
+++ b/tools/stack-images/src/stack.js
@@ -55,6 +55,17 @@ const SORT_DIRECTLY_UP_TO = 512;
  */
 
 /**
+ * How far around a pixel focus stacking looks, when the caller does not say.
+ *
+ * Exported because the pipeline has to know it too, and for a reason that is
+ * not obvious: the blur below spreads a false edge inward from the frame's own
+ * boundary by exactly this much, so the crop is inset by it before the answer
+ * is cut. Two copies of the number would be two chances for the inset to stop
+ * matching the blur it is there to outrun.
+ */
+export const DEFAULT_RADIUS = 3;
+
+/**
  * @param {string} mode
  * @param {object} options
  * @param {number} options.width    the band's width in pixels
@@ -82,7 +93,7 @@ export function createStack(mode, options) {
   for (const [key, value] of Object.entries(options)) {
     if (value !== undefined) given[key] = value;
   }
-  return build({ kappa: 2, gain: 1, radius: 3, ...given, pixels: width * height });
+  return build({ kappa: 2, gain: 1, radius: DEFAULT_RADIUS, ...given, pixels: width * height });
 }
 
 /**


### PR DESCRIPTION
The last of three, after #365 and #366, which are merged; this targets `main`.

## What was wrong

A hand-held burst turns a few tenths of a degree between frames, and that was not corrected. Shift-only alignment cannot, and the "shift, rotation and scale" setting recovered about a third of a small angle, because the log-polar square it reads resolves 0.7 degrees per row. Large turns of two or three degrees were fine; the small ones every real burst has were not. The refinement that finishes the answer corrected translation only, from a single window at the middle of the picture, so a stack kept a corner softness its centre did not have.

## What changed

The single centre window becomes a **three-by-three grid**. Each window covers 512 output pixels and is drawn into a 256 square by one `drawImage` with a source rectangle, from the full-size decode the stack was going to pay for anyway. All nine cost 12 ms a frame at 24 megapixels, against 6 ms for the one window they replace.

Every window is put through the gate #366 built, and a window whose answer is not a residual at all is dropped. What survives goes to a **new leaf, `src/similarity.js`**: an exhaustive pair consensus over the surviving windows, then a least-squares similarity fit on the largest set that agrees, refusing outright when two equally large sets tell different stories. The result composes onto the coarse move about the output centre.

Then a **ladder**, because the honest answer is often not a transform: the consensus fit; failing that, and only when fewer than four windows survived, the mean translation of two or more that agree; failing that, the coarse move; failing that, the identity. Which rung a frame took is recorded on its move.

The **crop moved to the end**. The accumulator covers the area the coarse pass says every frame reaches, the output canvas is allocated at the final crop size just before the first band is written, and the rows are cut on their way out. No second canvas and no copy. The margin the old refinement had to reserve is gone, so an aligned stack now keeps a few more pixels than it did.

Focus stacking insets its crop by the blur radius, per axis, because the accumulator now has transparent ground beside it and a Laplacian reads that as an edge.

## Before / after

Six frames of one photograph, turned by 0.22 to 0.34 degrees and shifted a few pixels each, stacked with rotation and scale. The same seeded picture both sides; the crop is the top-left corner, where a turn does the most damage.

| Before | After |
|---|---|
| <img width="700" alt="rotation-before" src="https://github.com/user-attachments/assets/a2ee84c6-e994-4235-b89e-99c8b5922e3e" /> | <img width="700" alt="rotation-after" src="https://github.com/user-attachments/assets/6569d58b-25c9-4039-815b-68dbba86f954" /> |

Measured on one seeded set of scenes through both builds:

| scene | worst angle error, before → after | worst shift error, before → after |
|---|---|---|
| texture, 0.3-degree turns | 0.225 deg → 0.001 deg | 0.02 px → 0.06 px |
| texture, sub-pixel shifts | — | 0.04 px → 0.10 px |
| low texture, 15% noise | — | 3.21 px → 3.21 px |
| star field, 6% noise | — | 0.14 px → 0.14 px |

Sub-pixel translation on a textured set is a few hundredths of a pixel worse, which is the fit spending nine windows on four unknowns instead of one window on two. Corner sharpness on the rotated set goes from 0.47 of an input frame to 0.756, level with the centre's 0.757; the detail retained in that corner goes from 36% to 63%.

Also checked in the browser and unchanged: a featureless sky still refused and left uncropped, shifts of 120 to 190 pixels, two-degree turns with scale, median, sigma, focus and no-alignment runs, half working resolution, and a set of two aspect ratios, which now crops to the letterbox without claiming the frames moved.

## What it still cannot do

A moving subject, parallax, or a scene too smooth to place makes the windows disagree, and the frame falls down the ladder rather than being moved by whichever window shouted loudest. That is the design, and the README says so along with the two known holes the audit found and did not close: the coarse square letterboxes a frame over transparent ground, which biases a low-texture answer by a pixel or two, and a refinement window on smooth content can lock onto the JPEG block lattice.

Tests: `stack-images-similarity.test.js` and `stack-images-pipeline.test.js` are new, and the plan and stack suites gain the new rules; 154 stack-images tests pass. No visitor-facing sentence changed, so no locale is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
