### PR TITLE
Weigh the alignment square by the picture in it, not by the box round it

### DIFF
--- a/tests/js/stack-images-align.test.js
+++ b/tests/js/stack-images-align.test.js
@@ -22,9 +22,10 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
-  ALIGN_MODES, MAX_ROTATION, NO_MOVE, N_MAX, P_MAX,
+  ALIGN_MODES, L_MIN, MAX_ROTATION, NO_MOVE, N_MAX, N_MAX_SURVEY, P_MAX,
   estimate, isMeasured, logPolar, logSpectrum, phaseCorrelate, rotateScale, window2d,
 } from '../../tools/stack-images/src/align.js';
+import { placement } from '../../tools/stack-images/src/plan.js';
 
 const close = (actual, expected, tolerance, what) => assert.ok(
   Math.abs(actual - expected) <= tolerance,
@@ -116,8 +117,11 @@ const otherLow = (u, v) => 90 * octave(u + 1000, v + 777, 11.3);
 const diagonal = (u, v) => 150 + 0.15 * u + 0.09 * v;
 const horizontal = (u, v) => 150 + 0.235 * u;
 
-/** A night sky: small bright spots on a dark ground, a few hundred unless asked. */
-function starField(size, count = 300) {
+/**
+ * The stars themselves, so that a fixture too large to ask every star about
+ * every pixel can walk them instead. `surveyStars` below is the one that does.
+ */
+function starList(size, count = 300) {
   let state = 99;
   const next = () => {
     state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
@@ -130,6 +134,12 @@ function starField(size, count = 300) {
       brightness: 60 + 190 * next(), spread: 0.8 + 1.2 * next(),
     });
   }
+  return stars;
+}
+
+/** A night sky: small bright spots on a dark ground, a few hundred unless asked. */
+function starField(size, count = 300) {
+  const stars = starList(size, count);
   return (u, v) => {
     let out = 8;
     for (const star of stars) {
@@ -311,12 +321,24 @@ function eightBit(values) {
 }
 
 /**
- * What lumaSquare does to every 3:2 frame: the picture fills 256 by 171 of
- * the square and the rest is the canvas's transparent black. The hard edge
- * along row 171 is shared by both frames wherever the camera moved, and it
- * is the difference between a gradient that measures 0.08 coherence and one
- * that measures 0.56 - the edge pins the vertical, and the slope, which
- * matches itself at any offset, leaves a ridge along the other axis.
+ * A 3:2 picture over 256 by 171 of the square with the rest left transparent
+ * black, ANCHORED AT THE TOP - which is not where the pipeline puts it.
+ * `placement` centres the box, so a real 3:2 picture's two horizontal edges
+ * land at row 43 and row 212, where the square's own Hann has already faded to
+ * about a quarter; this one's single edge lands at row 171, at three-quarters
+ * weight. Its letterbox step is therefore about three times the pipeline's,
+ * and every fixture built on it overstates what the letterbox does.
+ *
+ * It is kept because the tables on P_MAX and N_MAX were calibrated on it and
+ * the tests that pin those readings have to be able to reproduce them. Nothing
+ * new should be measured here: `surveyBox` below is the box the pipeline
+ * builds, and the tests that measure the change to `window2d` use that.
+ *
+ * Windowed whole, the edge is left standing, shared by both frames wherever
+ * the camera moved, and is the difference between a gradient that measures
+ * 0.08 coherence and one that measures 0.56: it pins the vertical, and the
+ * slope, which matches itself at any offset, leaves a ridge along the other
+ * axis.
  */
 function letterbox(values, size, rows = 171) {
   for (let y = rows; y < size; y += 1) {
@@ -324,6 +346,54 @@ function letterbox(values, size, rows = 171) {
   }
   return values;
 }
+
+/**
+ * The rectangle `lumaSquare` draws an output of this shape into, and now
+ * windows over: `placement`'s own answer, imported rather than restated so
+ * that a fixture cannot describe a square the pipeline does not build. A 3:2
+ * output is 256 by 170.67 centred at y 42.67; a 2:3 output is the same turned
+ * on its side; a square output fills the square and has no letterbox at all,
+ * which is the control every one of these measurements is read against.
+ */
+const surveyBox = (width, height) => placement(
+  { width, height }, { width: GATE_SIZE, height: GATE_SIZE },
+);
+const WHOLE_SQUARE = { x: 0, y: 0, width: GATE_SIZE, height: GATE_SIZE };
+
+/** Transparent black everywhere the picture is not, which is what the canvas leaves. */
+function clip(values, size, box) {
+  const left = Math.round(box.x);
+  const top = Math.round(box.y);
+  const right = Math.round(box.x + box.width);
+  const bottom = Math.round(box.y + box.height);
+  for (let y = 0; y < size; y += 1) {
+    const inside = y >= top && y < bottom;
+    for (let x = 0; x < size; x += 1) {
+      if (!inside || x < left || x >= right) values[y * size + x] = 0;
+    }
+  }
+  return values;
+}
+
+/**
+ * A photographic black level, added to a scene before it is letterboxed.
+ *
+ * The letterbox step is as tall as the picture's own mean above black, and
+ * these scenes start at zero where a photograph starts at whatever its shadows
+ * are. Without this the fixture has a third of a real ridge and does not
+ * reproduce the browser at all: the low-texture 3:2 pair below reads 0.10-1.42
+ * alignment pixels off with the whole square tapered against 0.08-1.37 with
+ * its box, which is no difference. Lifted, it reads 1.36-1.96 against
+ * 0.08-1.37 and `next` falls from 0.20-0.31 to 0.12-0.20, which is the
+ * direction and roughly the size of what the browser measured on the real
+ * path. It is the same trap as the letterbox's own geometry: a fixture that
+ * gets the surface's proportions wrong measures a different question.
+ */
+const BLACK_LEVEL = 75;
+const lit = (values) => {
+  for (let i = 0; i < values.length; i += 1) values[i] += BLACK_LEVEL;
+  return values;
+};
 
 test('identical textured frames pass the gate', () => {
   const found = gateFixture(field(GATE_SIZE, scene), field(GATE_SIZE, scene));
@@ -387,14 +457,14 @@ test('the noisiest real scenes keep their peaks under the plateau floor', () => 
   close(texture.dx, -3.3, 0.5, 'horizontal correction');
   close(texture.dy, 2.6, 0.5, 'vertical correction');
 
-  // The same two with the survey square's letterbox under them, since its
-  // edge lifts every plateau: the textured pair to 0.488 and the low-texture
-  // pair to 0.589, both still measured. The letterbox is not free on the
-  // low-texture pair - the ridge pulls its vertical towards zero, to 0.41
-  // against 1.7 - which is a cost of the survey square, not of the gate, and
-  // is recorded here rather than asserted away. It lifts the uniqueness
-  // reading too, to 0.46 and 0.37 from 0.29 and 0.27, because the ridge is
-  // a second place the surface stands high.
+  // The same two over the historical top-anchored letterbox with the whole
+  // square tapered, which is the surface P_MAX and N_MAX were calibrated on:
+  // its edge lifts every plateau, the textured pair to 0.488 and the
+  // low-texture pair to 0.589, both still measured. The ridge is not free on
+  // the low-texture pair - it pulls the vertical towards zero, to 0.41 against
+  // 1.7 - and the test below takes that out on the box the pipeline really
+  // builds. It lifts the uniqueness reading too, to 0.46 and 0.37 from 0.29
+  // and 0.27, because a ridge is a second place the surface stands high.
   const boxedTexture = gateFixture(
     letterbox(noisy(field(GATE_SIZE, scene), 56, 1), GATE_SIZE),
     letterbox(noisy(field(GATE_SIZE, scene, 3.3, -2.6), 56, 2), GATE_SIZE),
@@ -410,6 +480,497 @@ test('the noisiest real scenes keep their peaks under the plateau floor', () => 
   // (-2.809, 0.414)
   assert.ok(isMeasured(boxedLow), `plateau ${boxedLow.plateau}, next ${boxedLow.next}`);
   assert.ok(boxedLow.plateau < P_MAX, 'the nearest real fixture to the plateau floor');
+});
+
+test('a letterboxed pair lands nearer the truth when its own box is tapered', () => {
+  // What the letterbox costs a real answer, and what taking it out gives back,
+  // on the box the pipeline builds rather than the historical fixture above.
+  // The pair is the low-texture scene at fifteen per cent noise over a
+  // photographic black level, moved 2.4 left and 1.7 up.
+  //
+  // With the whole square tapered, the letterbox's hard edge is a line both
+  // frames share at every offset along itself, so the surface is a ridge along
+  // that line and the other axis is pulled towards zero. Which axis depends on
+  // which way the picture is letterboxed, and both are here because both are
+  // wrong in the same way: the 3:2 pair reads its vertical as 0.28 against a
+  // truth of 1.7, and the 2:3 pair reads its horizontal as -0.25 against -2.4.
+  //
+  // The third shape is the control and the point of the whole change. A square
+  // output has no letterbox, so this function does nothing to it and it lands
+  // 0.10-0.72 pixels off over the same ten seeds - which is where the boxed
+  // letterboxed pairs land too. The box does not make the coarse pass better
+  // than it was; it stops the letterbox making it worse.
+  const pair = (box, over, seedA, seedB) => phaseCorrelate(
+    window2d(clip(lit(noisy(field(GATE_SIZE, lowScene), 13.5, seedA)), GATE_SIZE, box),
+      GATE_SIZE, over),
+    window2d(clip(lit(noisy(field(GATE_SIZE, lowScene, 2.4, -1.7), 13.5, seedB)), GATE_SIZE, box),
+      GATE_SIZE, over),
+    GATE_SIZE,
+  );
+  const off = (found) => Math.hypot(found.dx + 2.4, found.dy - 1.7);
+  const spread = (box, over) => {
+    let worst = 0;
+    let best = Infinity;
+    for (let seed = 3; seed < 23; seed += 2) {
+      const found = off(pair(box, over, seed, seed + 1));
+      worst = Math.max(worst, found);
+      best = Math.min(best, found);
+    }
+    return { worst, best };
+  };
+
+  const wide = surveyBox(3000, 2000);
+  const wideSquare = pair(wide, null, 3, 4);
+  // plateau 0.446, next 0.212, at (-2.491, 0.276) - 1.43 px off
+  close(wideSquare.dy, 0.28, 0.05, 'the vertical the letterbox pins');
+  const wideBoxed = pair(wide, wide, 3, 4);
+  // plateau 0.370, next 0.122, at (-2.300, 1.169) - 0.54 px off, and the
+  // uniqueness reading has fallen because the ridge is where the surface stood
+  // high away from the peak
+  close(wideBoxed.dy, 1.17, 0.05, 'the vertical, unpinned');
+  assert.ok(wideBoxed.next < wideSquare.next, `next ${wideBoxed.next} against ${wideSquare.next}`);
+
+  const tall = surveyBox(2000, 3000);
+  const tallSquare = pair(tall, null, 3, 4);
+  // plateau 0.539, next 0.267, at (-0.251, 1.735) - 2.15 px off: the whole of
+  // a 2.4-pixel horizontal move lost to a vertical letterbox
+  close(tallSquare.dx, -0.25, 0.05, 'the horizontal the letterbox pins');
+  const tallBoxed = pair(tall, tall, 3, 4);
+  // plateau 0.422, next 0.139, at (-2.709, 1.734) - 0.31 px off
+  close(tallBoxed.dx, -2.71, 0.05, 'the horizontal, unpinned');
+
+  // Over ten seeds every boxed answer is nearer than every whole-square one, at
+  // both shapes: 0.29-1.09 against 1.36-1.96 for the 3:2 pair and 0.13-1.05
+  // against 2.05-2.37 for the 2:3 one.
+  const wideBoxes = spread(wide, wide);
+  const wideWhole = spread(wide, null);
+  assert.ok(wideBoxes.worst < wideWhole.best, `3:2 ${wideBoxes.worst} against ${wideWhole.best}`);
+  const tallBoxes = spread(tall, tall);
+  const tallWhole = spread(tall, null);
+  assert.ok(tallBoxes.worst < tallWhole.best, `2:3 ${tallBoxes.worst} against ${tallWhole.best}`);
+
+  // The control: 0.10-0.72 over the same seeds, whichever window is asked for,
+  // because there is no letterbox to leave a rectangle.
+  const control = spread(WHOLE_SQUARE, null);
+  assert.ok(control.worst < 0.8, `an output that is square: ${control.worst}`);
+});
+
+test('the box hands a letterboxed output the gate a square output already had', () => {
+  // The half of the change that costs something, pinned so it cannot move
+  // quietly. The letterbox's edge stood high away from the peak on every
+  // surface it was in, real and junk alike, and `next` is a reading of exactly
+  // that - so it was refusing junk by accident, and only on outputs that were
+  // not square. Taking it out gives every output shape the leak a square
+  // output has always had, which the comment on N_MAX records and the
+  // consensus check is left to catch. The counts below are that sentence: the
+  // boxed column is the square column, and the whole-square column is the
+  // accident.
+  //
+  // Ten seeds each, admitted by isMeasured. A square output is one column
+  // because this function does nothing to it.
+  //
+  //                        whole square   the box   square output
+  //   8-bit sky, 3:2           0/10         0/10        0/10
+  //   8-bit sky, 2:3           0/10         1/10        0/10
+  //   unrelated tex/low, 3:2   1/10         3/10        7/10
+  //   unrelated tex/low, 2:3   1/10         6/10        7/10
+  //
+  // The sky is the case the whole gate exists for, and the one seed in ten it
+  // now lets through at 2:3 is the rate a square output has always leaked at
+  // over the wider sweep in the N_MAX comment - not a new failure, but a real
+  // one, and the browser check is where a near-clean sky has to be looked at.
+  const admitted = (make, box, over) => {
+    let count = 0;
+    for (let seed = 1; seed < 21; seed += 2) {
+      const found = phaseCorrelate(
+        window2d(clip(make(seed, false), GATE_SIZE, box), GATE_SIZE, over),
+        window2d(clip(make(seed + 1, true), GATE_SIZE, box), GATE_SIZE, over),
+        GATE_SIZE,
+      );
+      if (isMeasured(found)) count += 1;
+    }
+    return count;
+  };
+  const sky = (seed) => eightBit(noisy(field(GATE_SIZE, diagonal), 1.3, seed));
+  const unrelated = (seed, second) => lit(
+    noisy(field(GATE_SIZE, second ? otherLow : scene), 28, seed),
+  );
+
+  const wide = surveyBox(3000, 2000);
+  const tall = surveyBox(2000, 3000);
+
+  assert.equal(admitted(sky, wide, null), 0, 'the 3:2 sky, whole square');
+  assert.equal(admitted(sky, wide, wide), 0, 'the 3:2 sky, its own box');
+  assert.equal(admitted(sky, tall, null), 0, 'the 2:3 sky, whole square');
+  assert.equal(admitted(sky, tall, tall), 1, 'the 2:3 sky, its own box');
+  assert.equal(admitted(sky, WHOLE_SQUARE, null), 0, 'the sky as a square output');
+
+  assert.equal(admitted(unrelated, wide, null), 1, 'the 3:2 junk pair, whole square');
+  assert.equal(admitted(unrelated, wide, wide), 3, 'the 3:2 junk pair, its own box');
+  assert.equal(admitted(unrelated, tall, null), 1, 'the 2:3 junk pair, whole square');
+  assert.equal(admitted(unrelated, tall, tall), 6, 'the 2:3 junk pair, its own box');
+  assert.equal(admitted(unrelated, WHOLE_SQUARE, null), 7, 'the junk pair as a square output');
+});
+/**
+ * The survey square as the pipeline really builds it, the resize included.
+ *
+ * Every fixture above is drawn straight into the 256 square, and that is a
+ * different subject from the one the coarse pass sees. The pipeline shrinks a
+ * whole frame into a 256 long edge first, and the resize averages a
+ * photograph's noise down about twelvefold before anything is correlated: what
+ * reaches the correlation is a scene whose peak is far sharper than the same
+ * scene rendered at 256 with its noise still on it. Reading the coarse gate on
+ * a 256-native fixture therefore reads a real answer much nearer the junk than
+ * the browser ever puts it, which is how this file once concluded that no
+ * floor could sit between the two.
+ *
+ * So these scenes are rendered at SURVEY_SCALE times the picture's rectangle,
+ * given their noise and their 8 bits there, box-averaged down into the
+ * rectangle and drawn into the centred box - the order the pipeline does it
+ * in, with the resize standing in for createImageBitmap's.
+ *
+ * THE RATIO IS DERIVED AND NOT CHOSEN. The rectangle's long edge is GATE_SIZE
+ * whatever shape the output is, so rendering it at SURVEY_SOURCE / GATE_SIZE
+ * puts a SURVEY_SOURCE-pixel frame in front of the same resize the pipeline
+ * performs, and 3072 is a phone's frame to a rounding: the browser's own
+ * measurements were made at 3000 into 256, which is 11.7. Getting this wrong
+ * is not a detail, and the first version of these fixtures got it wrong. At a
+ * scale of 6 the low-texture scene at fifteen per cent reads 0.035-0.037 where
+ * the browser reads 0.07-0.11, a sparse field reads about half what it reads
+ * here, and a floor calibrated on that sits too high to be safe by that much.
+ * The comment on N_MAX_SURVEY has the sweep at 4, 6, 8, 10 and 12 against the
+ * browser column, and the family-by-family comparison at 12.
+ */
+const SURVEY_SOURCE = 3072;
+const SURVEY_SCALE = SURVEY_SOURCE / GATE_SIZE;
+const SURVEY_SEEDS = [1, 3, 5, 7];
+
+/** The picture's rectangle in whole pixels, beside the box `lumaSquare` windows over. */
+function surveyRect(width, height) {
+  const box = surveyBox(width, height);
+  const left = Math.round(box.x);
+  const top = Math.round(box.y);
+  return {
+    box,
+    left,
+    top,
+    width: Math.round(box.x + box.width) - left,
+    height: Math.round(box.y + box.height) - top,
+  };
+}
+
+/** The scene at that size, before the camera has seen it. */
+function surveyScene(rect, fn, { dx = 0, dy = 0, level = 0 } = {}) {
+  const width = rect.width * SURVEY_SCALE;
+  const height = rect.height * SURVEY_SCALE;
+  const out = new Float64Array(width * height);
+  const cx = (width - 1) / 2;
+  const cy = (height - 1) / 2;
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) out[y * width + x] = fn(x - cx - dx, y - cy - dy);
+  }
+  return out;
+}
+
+/**
+ * A star field at the survey scale, drawn star by star rather than pixel by
+ * pixel. `starField` asks every star about every pixel, which is fine over a
+ * 256 square and is six billion questions over a 3072 one; a star reaches
+ * about five pixels, so walking the stars and touching only what each covers
+ * is the same picture for a thousandth of the work. The same picture exactly:
+ * the base and then each star in list order is the order `starField` adds them
+ * in, so the sums are bit for bit identical, measured at a worst difference of
+ * zero over a window of the two.
+ */
+function surveyStars(rect, stars, { dx = 0, dy = 0, level = 0 } = {}) {
+  const width = rect.width * SURVEY_SCALE;
+  const height = rect.height * SURVEY_SCALE;
+  const out = new Float64Array(width * height).fill(8 + level);
+  const cx = (width - 1) / 2;
+  const cy = (height - 1) / 2;
+  const reach = Math.ceil(Math.sqrt(30));
+  for (const star of stars) {
+    const px = star.x + cx + dx;
+    const py = star.y + cy + dy;
+    const x0 = Math.max(0, Math.floor(px - reach));
+    const x1 = Math.min(width - 1, Math.ceil(px + reach));
+    const y0 = Math.max(0, Math.floor(py - reach));
+    const y1 = Math.min(height - 1, Math.ceil(py + reach));
+    const spread = 2 * star.spread ** 2;
+    for (let y = y0; y <= y1; y += 1) {
+      const down = (y - py) ** 2;
+      for (let x = x0; x <= x1; x += 1) {
+        const d2 = (x - px) ** 2 + down;
+        if (d2 < 30) out[y * width + x] += star.brightness * Math.exp(-d2 / spread);
+      }
+    }
+  }
+  for (let i = 0; i < out.length; i += 1) if (out[i] > 255) out[i] = 255;
+  return out;
+}
+
+/** One frame of it: noise and 8 bits at full size, averaged down, drawn into the square. */
+function surveyFrame(scene, rect, sigma, seed) {
+  const width = rect.width * SURVEY_SCALE;
+  const shot = eightBit(noisy(Float64Array.from(scene), sigma, seed));
+  const out = new Float64Array(GATE_SIZE * GATE_SIZE);
+  for (let y = 0; y < rect.height; y += 1) {
+    for (let x = 0; x < rect.width; x += 1) {
+      let sum = 0;
+      for (let j = 0; j < SURVEY_SCALE; j += 1) {
+        const row = (y * SURVEY_SCALE + j) * width + x * SURVEY_SCALE;
+        for (let i = 0; i < SURVEY_SCALE; i += 1) sum += shot[row + i];
+      }
+      out[(rect.top + y) * GATE_SIZE + rect.left + x] = sum / (SURVEY_SCALE * SURVEY_SCALE);
+    }
+  }
+  return eightBit(out);
+}
+
+/** The pair of them, windowed over the picture's box the way `lumaSquare` does. */
+function surveySquares(rect, first, second, sigma, seed) {
+  return [
+    window2d(surveyFrame(first, rect, sigma, seed), GATE_SIZE, rect.box),
+    window2d(surveyFrame(second, rect, sigma, seed + 500), GATE_SIZE, rect.box),
+  ];
+}
+
+function surveyPair(rect, first, second, sigma, seed) {
+  const [a, b] = surveySquares(rect, first, second, sigma, seed);
+  return phaseCorrelate(a, b, GATE_SIZE);
+}
+
+/** The same pair over SURVEY_SEEDS, which is what every reading below is a range of. */
+function surveySeeds(rect, first, second, sigma) {
+  return SURVEY_SEEDS.map((seed) => surveyPair(rect, first, second, sigma, seed));
+}
+
+test('a clear sky is refused at the survey square, where the whole square let it through', () => {
+  // The regression this floor exists to stop, reproduced. Over the whole
+  // square the letterbox's edge stood high away from the peak and lifted this
+  // reading to 0.96, so N_MAX refused a sky on every seed of every shape.
+  // Over the picture's box the ridge is gone, the sky reads under 0.8, and the
+  // seeds the old gate admits below are moved 1.77 to 2.07 alignment pixels
+  // from an identity that was the truth - which the multiply-up from a 256
+  // square to a 3000-pixel frame turns into about twenty-five output ones. In
+  // the browser the same thing happened at 3:2, on eleven seeds in twelve at
+  // 0.62-0.74 and up to 38 output pixels.
+  const wide = surveyRect(3000, 2000);
+  const tall = surveyRect(2000, 3000);
+  const slope = (rect) => surveyScene(rect, diagonal);
+
+  // A sky with five per cent noise is the junk family that comes nearest this
+  // floor, and the one where the floor does the work rather than watching the
+  // other two do it: live is 0.0120, well over L_MIN, and the plateau runs
+  // 0.650-0.736 at 3:2 and 0.671-0.750 at 2:3, so P_MAX lets some of these
+  // through and this floor has to catch them. 3:2 reads next 0.578-0.674 and
+  // N_MAX admits two seeds of the four, moved 0.72-2.07 alignment pixels from
+  // an identity that was the truth; 2:3 reads 0.647-0.708 and N_MAX admits
+  // one, moved 1.00-2.43.
+  for (const [rect, what, leaks] of [[wide, '3:2', 2], [tall, '2:3', 1]]) {
+    const noisySky = slope(rect);
+    let admitted = 0;
+    let reached = 0;
+    for (const found of surveySeeds(rect, noisySky, noisySky, 12.75)) {
+      assert.ok(!isMeasured(found, N_MAX_SURVEY), `${what} noisy sky at ${found.next}`);
+      if (found.live >= L_MIN && found.plateau <= P_MAX) reached += 1;
+      if (isMeasured(found)) admitted += 1;
+    }
+    assert.ok(reached > 0, `${what}: no seed reaches this floor, so it decides nothing here`);
+    assert.equal(admitted, leaks, `${what}: the seeds the floor this replaced would have moved`);
+  }
+
+  // And the clean sky the browser measured: 3:2 next 0.672-0.674 at a plateau
+  // of 0.566-0.571, 2:3 next 0.637-0.644 at 0.543-0.549. Both are refused by
+  // live as well in this fixture - a slope with 0.4% noise on it leaves 0.0038
+  // against L_MIN's 0.004, where the browser's JPEG leaves enough for it to
+  // pass - so what is pinned here is the uniqueness reading itself.
+  for (const [rect, what] of [[wide, '3:2'], [tall, '2:3']]) {
+    const clean = slope(rect);
+    for (const found of surveySeeds(rect, clean, clean, 1)) {
+      assert.ok(found.next > N_MAX_SURVEY, `${what} clear sky at ${found.next}`);
+      assert.ok(!isMeasured(found, N_MAX_SURVEY), `${what} clear sky: plateau ${found.plateau}`);
+    }
+  }
+
+  // And the junk family the coarse square has always leaked, for which this
+  // floor changes nothing: two unrelated low-texture pictures read 0.939-0.962
+  // at a plateau of 0.351-0.427 and are refused either way, with 18.2
+  // alignment pixels of movement behind them. This is here because a floor
+  // that refuses a sky and stops refusing junk would be no gate at all.
+  const unrelated = surveySeeds(
+    wide, surveyScene(wide, lowScene, { level: BLACK_LEVEL }),
+    surveyScene(wide, otherLow, { level: BLACK_LEVEL }), 13.5,
+  );
+  for (const found of unrelated) {
+    assert.ok(found.next > N_MAX, `the unrelated pair at ${found.next}`);
+    assert.ok(!isMeasured(found, N_MAX_SURVEY));
+  }
+});
+
+test('the survey floor is the one estimate asks for the translation peak', () => {
+  // The floor above is only worth having if it is passed where it belongs, and
+  // a defaulted argument is exactly the kind of thing a refactor drops without
+  // any test noticing. So this drives the whole of estimate() rather than
+  // phaseCorrelate and isMeasured separately: a five per cent sky is refused
+  // at both shapes, and it is refused by nothing but this floor, because with
+  // the argument dropped N_MAX admits three of these eight squares.
+  for (const [width, height, what] of [[3000, 2000, '3:2'], [2000, 3000, '2:3']]) {
+    const rect = surveyRect(width, height);
+    const sky = surveyScene(rect, diagonal);
+    for (const seed of SURVEY_SEEDS) {
+      const [a, b] = surveySquares(rect, sky, sky, 12.75, seed);
+      const found = estimate(a, b, GATE_SIZE, 'translate');
+      assert.equal(found.measured, false, `${what} sky through estimate: next ${found.next}`);
+    }
+  }
+});
+
+test('the real families are measured at the survey square', () => {
+  // The other side of the floor, on the same path: what a photograph reads
+  // once the resize has averaged its noise down. Every one of these is right
+  // to a fifth of a pixel and every one is admitted, and the widest of them
+  // is what decides how low the floor can go.
+  const wide = surveyRect(3000, 2000);
+  const tall = surveyRect(2000, 3000);
+  const moved = { dx: 2.4 * SURVEY_SCALE, dy: -1.7 * SURVEY_SCALE };
+  const off = (found) => Math.hypot(found.dx + 2.4, found.dy - 1.7);
+
+  const admits = (rect, first, second, sigma, worst, what) => {
+    for (const found of surveySeeds(rect, first, second, sigma)) {
+      assert.ok(isMeasured(found, N_MAX_SURVEY), `${what}: next ${found.next}`);
+      assert.ok(off(found) < worst, `${what}: ${off(found)} pixels off`);
+    }
+  };
+
+  // The textured scene at fifty per cent noise - the family a 256-native
+  // fixture reads at 0.71, and the reason this file used to say no floor
+  // could sit under 0.8. Through the resize it reads 0.057-0.067, right to
+  // 0.115-0.139 of a pixel.
+  admits(wide, surveyScene(wide, scene, { level: BLACK_LEVEL }),
+    surveyScene(wide, scene, { ...moved, level: BLACK_LEVEL }), 92, 0.3, 'textured, 50% noise');
+
+  // A low-texture scene at fifteen per cent, letterboxed the other way:
+  // next 0.080-0.084, right to 0.106-0.108 of a pixel.
+  admits(tall, surveyScene(tall, lowScene, { level: BLACK_LEVEL }),
+    surveyScene(tall, lowScene, { ...moved, level: BLACK_LEVEL }), 13.5, 0.3, 'low texture 15%');
+
+  // A night sky as the survey square really sees one: four hundred stars over
+  // a 3000-pixel frame, each of them a sub-pixel dot by the time the resize is
+  // done. next 0.157-0.180 against a floor of 0.45, right to 0.199-0.215 of a
+  // pixel. This is the real family that comes nearest the floor, and the
+  // browser reads the same field at 0.12-0.29.
+  const dense = starList(wide.width * SURVEY_SCALE, 400);
+  admits(wide, surveyStars(wide, dense), surveyStars(wide, dense, moved), 15, 0.3, 'four hundred stars');
+
+  // And a pair eight times apart in brightness, which is a bracket rather than
+  // a burst but is the same alignment question. The dim frame is quantised to
+  // 8 bits at an eighth of the level and carries the same read noise as the
+  // bright one, which is the harsher of the two ways to model it: next
+  // 0.073-0.087, right to 0.115-0.135 of a pixel. Eight *stops* apart - 256 to
+  // one - is a different case and not a real family: it reads 0.77-1.00 with
+  // its answer anywhere between a fifth of a pixel and fifty-eight, and both
+  // floors refuse it, correctly.
+  admits(wide, surveyScene(wide, scene, { level: BLACK_LEVEL }),
+    surveyScene(wide, (u, v) => (scene(u, v) + BLACK_LEVEL) / 8, moved), 28, 0.3,
+    'textured, frame eight times dimmer');
+});
+
+test('a sparse star field is refused at the survey square, and its answer was right', () => {
+  // What the floor costs, pinned rather than argued away. Thirty-four stars
+  // over a 3:2 output read next 0.497-0.587 - inside the band where a clear
+  // sky lives, and above the floor - with their answer 0.45-0.61 of a pixel
+  // from the truth. So these frames stack at the identity, and are not
+  // refined either, because a frame the coarse pass refused is not refined.
+  //
+  // There is no floor that avoids this. Over five draws each of twenty,
+  // thirty-four and fifty stars at three shapes and seven seeds - 315 pairs,
+  // 296 of them right to within a pixel - a floor of 0.45 admits 151 of the
+  // right ones, 0.5 admits 199 and 0.8 admits 274, and the family reads
+  // 0.223-0.999 across the whole of that. It overlaps every junk family
+  // measured, because a sparse field's peak genuinely is one of several and at
+  // the survey square that is what a clear sky looks like too. The comment on
+  // N_MAX_SURVEY has the counts and why the line sits where it does.
+  const wide = surveyRect(3000, 2000);
+  const moved = { dx: 2.4 * SURVEY_SCALE, dy: -1.7 * SURVEY_SCALE };
+  const sparse = starList(wide.width * SURVEY_SCALE, 34);
+  for (const found of surveySeeds(wide, surveyStars(wide, sparse), surveyStars(wide, sparse, moved), 15)) {
+    const off = Math.hypot(found.dx + 2.4, found.dy - 1.7);
+    assert.ok(off < 1, `thirty-four stars: ${off} pixels off, so the answer is right`);
+    assert.ok(!isMeasured(found, N_MAX_SURVEY), `thirty-four stars at ${found.next}`);
+    assert.ok(isMeasured(found), `thirty-four stars: N_MAX admits it at ${found.next}`);
+  }
+});
+
+test('the refinement keeps the peak the survey floor would refuse', () => {
+  // The two floors are one statistic read on two surfaces, and this is the
+  // window that proves they cannot be swapped. Seventeen stars in a 512
+  // refinement window at six per cent noise - a full square of picture at the
+  // resolution the frame was shot at, no box and no resize - read 0.578 with
+  // their answer 0.20 of a pixel from the truth. N_MAX admits it, which is
+  // what the refinement needs; the survey floor refuses it, which is what the
+  // coarse square needs. Neither is wrong about its own surface: a sparse
+  // window's peak is genuinely one of several, and at the survey square that
+  // is what a clear sky looks like too.
+  const sky = starField(512, 17);
+  const found = gateFixture(
+    noisy(field(512, sky), 15, 7),
+    noisy(field(512, sky, 5.4, -3.2), 15, 8),
+    512,
+  );
+  // live 0.010, coherence 0.036, plateau 0.135, next 0.578; found
+  // (-5.22, 3.12), 0.20 px off
+  assert.ok(isMeasured(found), `live ${found.live}, plateau ${found.plateau}, next ${found.next}`);
+  assert.ok(!isMeasured(found, N_MAX_SURVEY), `next ${found.next} against ${N_MAX_SURVEY}`);
+  close(found.dx, -5.4, 0.3, 'horizontal correction');
+  close(found.dy, 3.2, 0.3, 'vertical correction');
+
+  // And the function's own default, which is what every caller but one gets.
+  // Which caller is which is not asserted here - a hand-built statistics
+  // object cannot tell - and the two tests that do assert it are the estimate
+  // one above and the log-polar one below.
+  assert.equal(isMeasured({ live: L_MIN, plateau: 0, next: 0.6 }), true);
+  assert.equal(isMeasured({ live: L_MIN, plateau: 0, next: 0.6 }, N_MAX_SURVEY), false);
+});
+
+test('the log-polar peak keeps N_MAX, and a real turn needs it to', () => {
+  // The other half of "only the coarse translation peak is judged there". The
+  // log-polar surface is a whole square of spectrum whatever shape the output
+  // has, its readings sit where the table on N_MAX puts them, and giving it
+  // the survey floor would stop similarity mode reading real turns - quietly,
+  // because a refused log-polar peak falls back to translation and reports no
+  // rotation rather than a wrong one.
+  const turn = (fn, degrees) => {
+    const radians = (degrees * Math.PI) / 180;
+    return (u, v) => fn(
+      u * Math.cos(radians) + v * Math.sin(radians),
+      -u * Math.sin(radians) + v * Math.cos(radians),
+    );
+  };
+  // The textured scene at thirty per cent noise turned twelve degrees.
+  // estimate() is handed squares that are already windowed - lumaSquare does
+  // that - and takes the spectrum of those, so the surface has to be built the
+  // same way here or it is not the one the gate sees.
+  const reference = window2d(noisy(field(GATE_SIZE, scene), 55.5, 7), GATE_SIZE);
+  const turned = window2d(noisy(field(GATE_SIZE, turn(scene, 12)), 55.5, 8), GATE_SIZE);
+
+  // Its log-polar peak reads live 0.0852, plateau 0.403, next 0.625 - between
+  // the two floors, which is the whole point of the fixture - and the angle
+  // comes back as -12.00 for a turn of twelve.
+  const surface = phaseCorrelate(
+    window2d(logPolar(logSpectrum(reference, GATE_SIZE), GATE_SIZE).values, GATE_SIZE),
+    window2d(logPolar(logSpectrum(turned, GATE_SIZE), GATE_SIZE).values, GATE_SIZE),
+    GATE_SIZE,
+  );
+  assert.ok(surface.next > N_MAX_SURVEY, `the turn's log-polar peak at ${surface.next}`);
+  assert.ok(isMeasured(surface), `the turn's log-polar peak: plateau ${surface.plateau}`);
+  assert.ok(!isMeasured(surface, N_MAX_SURVEY), 'the survey floor would refuse this turn');
+
+  const found = estimate(
+    Float64Array.from(reference), Float64Array.from(turned), GATE_SIZE, 'similarity',
+  );
+  assert.equal(found.clamped, false);
+  close(found.angle, -12, 1, 'the angle, as the correction it is');
 });
 
 test('a featureless frame fails the gate', () => {
@@ -916,6 +1477,85 @@ test('the window removes the mean and fades the edges to nothing', () => {
     close(values[x], 0, 1e-9, `top edge at ${x}`);
     close(values[(size - 1) * size + x], 0, 1e-9, `bottom edge at ${x}`);
     close(values[x * size], 0, 1e-9, `left edge at ${x}`);
+  }
+});
+
+test('the boxed window over the whole square is the window it always was', () => {
+  // The control the browser survey used: an output that is square has no
+  // letterbox, so there is no rectangle to speak of and every variant must be
+  // the same window. Asserted exactly rather than closely - it is the same
+  // arithmetic in the same order, not an approximation of it.
+  const size = 32;
+  const whole = window2d(field(size, scene), size);
+  const boxed = window2d(field(size, scene), size, { x: 0, y: 0, width: size, height: size });
+  for (let i = 0; i < whole.length; i += 1) assert.equal(boxed[i], whole[i], `at ${i}`);
+});
+
+test("the boxed window fades to nothing at the picture's own edges", () => {
+  const size = 32;
+  const box = { x: 4, y: 6, width: 20, height: 14 };
+  const values = window2d(field(size, scene), size, box);
+
+  let inside = 0;
+  for (let y = 0; y < size; y += 1) {
+    for (let x = 0; x < size; x += 1) {
+      const value = values[y * size + x];
+      const edge = x === box.x || y === box.y
+        || x === box.x + box.width - 1 || y === box.y + box.height - 1;
+      const within = x >= box.x && x < box.x + box.width && y >= box.y && y < box.y + box.height;
+      if (!within) assert.equal(value, 0, `outside the picture at ${x},${y}`);
+      else if (edge) close(value, 0, 1e-9, `the picture's own edge at ${x},${y}`);
+      else if (value !== 0) inside += 1;
+    }
+  }
+  // The taper is the picture's, so what is left standing is its middle: the
+  // whole of the rectangle bar its border ring, 18 by 12.
+  assert.equal(inside, 18 * 12, 'the picture inside the taper');
+});
+
+test('the boxed window takes the mean out of the picture and not of the ground', () => {
+  // The half of this that matters as much as the taper. A picture of one
+  // constant value has nothing in it, and must come back as nothing - even
+  // though the ground it sits on is a whole picture darker, which is what the
+  // mean of the square would be dragged down by, leaving the flat rectangle
+  // standing as a bright block with an edge all round it.
+  const size = 32;
+  const box = { x: 8, y: 8, width: 16, height: 16 };
+  const flat = () => {
+    const out = field(size, scene);
+    for (let y = box.y; y < box.y + box.height; y += 1) {
+      for (let x = box.x; x < box.x + box.width; x += 1) out[y * size + x] = 200;
+    }
+    return out;
+  };
+
+  for (const value of window2d(flat(), size, box)) close(value, 0, 1e-9, 'a flat picture');
+
+  const square = window2d(flat(), size);
+  let standing = 0;
+  for (let y = box.y + 1; y < box.y + box.height - 1; y += 1) {
+    for (let x = box.x + 1; x < box.x + box.width - 1; x += 1) {
+      if (Math.abs(square[y * size + x]) > 1) standing += 1;
+    }
+  }
+  assert.ok(standing > 100, `the square's mean leaves the block standing: ${standing}`);
+});
+
+test('a rectangle too small to taper comes back empty rather than NaN', () => {
+  // The Hann divides by one less than the side, so a rectangle a pixel across
+  // would be a square full of NaN, and NaN spreads through the transform into
+  // every bin. A rectangle that thin has nothing to correlate in any case.
+  const size = 32;
+  const boxes = [
+    { x: 5, y: 5, width: 1, height: 20 },
+    { x: 5, y: 5, width: 20, height: 1 },
+    { x: 5, y: 5, width: 0, height: 0 },
+    { x: 40, y: 40, width: 10, height: 10 },
+  ];
+  for (const box of boxes) {
+    for (const value of window2d(field(size, scene), size, box)) {
+      assert.equal(value, 0, `${box.width}x${box.height} at ${box.x},${box.y}`);
+    }
   }
 });
 

--- a/tools/stack-images/README.md
+++ b/tools/stack-images/README.md
@@ -354,11 +354,10 @@ comment on `L_MIN` in `align.js` has the browser's whole table.
 still has no position.**
 A smooth gradient — a clear sky — is refused although it correlates with
 itself, and it does correlate: what the survey square holds of it is the
-slope's 8-bit banding over a letterbox, and the letterbox's hard edge along
-row 171 is shared by both frames wherever the camera moved, so the correlation
-is pinned vertically by the edge and free along the slope, which matches
-itself at any offset. That is a ridge, not a peak. Its height is real —
-coherence 0.47–0.51 in the browser, three times what was then the floor — but
+slope's 8-bit banding, which matches itself at any offset along the slope.
+That is a ridge, not a peak. Its height was real — coherence 0.47–0.51 in the
+browser, three times what was then the floor, the letterbox's own edge
+pinning the other axis and lifting it — but
 its position
 is wherever the noise tipped the argmax along the ridge, and the sub-pixel fit
 is a parabola through the top of a plateau. Before this test, four frames of
@@ -376,13 +375,17 @@ peak still standing eight pixels out cannot say which of nine pixels the
 frame belongs at whatever its argmax says, and on the coarse square eight
 alignment pixels is already tens of output pixels. The gradients measured
 0.93–0.99 in the browser and 0.95–1.00 on the letterboxed fixture at every
-noise level tried;
+noise level tried, when the whole square was still what got tapered;
 the weakest real match, a low-texture scene at thirty per cent noise, 0.60 in
 the browser and 0.65–0.68 over ten seeds depending on the seeds; a star field
-0.03–0.10, a textured scene 0.1–0.5. The same reading refuses the letterboxed
-gradient's log-polar peak (0.78, at a `next` of 0.39–0.56 that passes and a
+0.03–0.10, a textured scene 0.1–0.5. The same reading refused the letterboxed
+gradient's log-polar peak (0.78, at a `next` of 0.39–0.56 that passed and a
 coherence of 0.22 that is no longer asked), which
-similarity mode had been applying as a scale of 0.95–1.01, and the
+similarity mode had been applying as a scale of 0.95–1.01 — and that is the
+one reading the picture's box improves: on the box the pipeline builds, the
+same peak reads a plateau of 0.07–0.85 at a `next` of 0.74–1.00 and is
+refused on eighteen seeds in twenty rather than admitted on all of them — and
+the
 refinement's own version of the sky: a low-texture 512 window whose features
 are sixty pixels across measures 0.77–0.96 with its peak one to seven pixels
 off — close enough to pass for a residual — and is refused on every seed at
@@ -390,18 +393,26 @@ both noise levels tried — nothing else would have refused it, and a radius
 that followed the
 side, sixteen at 512, read it at 0.59–0.71 and let nine seeds in ten
 through. The comment on `P_MAX` in `align.js` has the browser table and the
-fixture table side by side, the log-polar and other-window readings, and the
-two pairs the gate knowingly lets through on the letterboxed square: two
-unrelated textured pictures (coherence 0.18–0.20, plateau 0.59–0.73, nine
-seeds in ten, moved by one to four alignment pixels) and two unrelated
-low-texture scenes at fifteen per cent noise (0.15–0.17 and 0.59–0.83, about
-half). Both are the letterbox ridge with the unrelated texture's bumps along
-it, both are refused by `next` alone on a full square (0.82–0.99 and
-0.70–0.91, the second passing five seeds in ten), and both are left to
-the consensus check the way the JPEG lattice below is. Note that a
-full-square gradient fixture does *not* reproduce the browser: it measures
-coherence 0.04–0.10 and `next` 0.87–0.99, and is refused by uniqueness
-alone. The letterbox is what the browser case is made of.
+fixture table side by side, and the log-polar and other-window readings. The
+fixture table is of the square as it was built before `lumaSquare` handed
+`window2d` the picture's box, and over a letterbox anchored at the top of the
+square where the pipeline centres it — a stronger edge than the real one, and
+the reason a gradient fixture over a full square measured a tenth of the
+coherence and did not reproduce the browser at all.
+
+Over the box the pipeline really builds, every one of those plateau readings
+falls, junk with real: the 8-bit gradients and skies read 0.56–0.93 where the
+whole-square taper read 0.96–1.00, the two unrelated textured pictures
+0.23–0.87 and the two unrelated low-texture ones 0.37–0.81. So this floor
+alone would now admit a sky on some seeds and `next` is what refuses it — at
+exactly the numbers the same sky reads as a *square* output, which has never
+had a letterbox and which this floor has always read that way. In the browser,
+where the sky is a photograph of one rather than a fixture, both readings fall
+under their floors at once, and that is what the coarse square's own
+uniqueness floor is for — the paragraph after next. What this floor still
+catches is what it was calibrated for: a scene that correlates and has no
+position, which at the refinement windows is the wall and the textured sky
+below.
 
 **`next` is whether the peak is alone, for the junk `plateau` cannot see.**
 It is the tallest point of the surface outside a box of ten pixels around
@@ -443,10 +454,65 @@ family the old floor caught and
 this does not — two unrelated pictures of which one has little texture,
 whose surface is a few broad bumps rather than many sharp ones (0.67–0.84 at
 512, eight seeds in ten under the floor, at a plateau of 0.43–0.70 the other
-floor does not catch either). The letterbox refuses that pair on the survey
-square (0.82–0.95), so it reaches the refinement only from a square frame.
-The log-polar surface goes through the same floor and is given none of its
-own: real turns read 0.20–0.81 and all but one seed in forty are admitted,
+floor does not catch either). The survey square used to refuse that pair on
+every seed of a letterboxed output, and no longer does: over the picture's box
+it reads 0.78–1.00 at 3:2 and 0.68–0.92 at 2:3, admitted on three seeds in
+twenty and fifteen, against a square output's own 0.68–0.94 and eleven. It
+now reaches the refinement from a frame of any shape, which is one family of
+the leak the window paragraph below is about.
+
+**The coarse survey square is judged against a second floor, and needs one.**
+`next` is a ratio of a surface to its own peak, so it does not scale with the
+window — but it does depend on what the window holds, and the coarse square
+holds a thumbnail. The whole frame is resized into a 256 long edge before it is
+correlated, so a photograph's noise is averaged down about twelvefold on the way
+in and its peak comes back sharper than anything the refinement sees; and since
+`lumaSquare` hands `window2d` the picture's box, the ridge that used to stand
+high away from every peak on a letterboxed output is gone. Both push this
+square's whole distribution below 0.8. In the browser, on the built survey path
+over twelve seeds a family, the real families read 0.03–0.29 over the box where
+they read 0.06–0.51 over the whole square, and the junk 0.62–1.00 where it read
+0.82–1.00 — a wider separation than the letterbox ever gave, and in the wrong
+place for a floor of 0.8: a clear 3:2 sky walked under it on eleven seeds in
+twelve and was moved by up to 38 output pixels, which is the failure this gate
+exists to prevent. So the coarse translation peak is judged against
+`N_MAX_SURVEY`, which is 0.45, and everything else keeps 0.8 — the refinement's
+windows, which are full squares at the resolution the frame was shot at, and
+the log-polar surface, which is a whole square whatever shape the output has.
+A test drives each of those through the code that decides it, because a floor
+passed as an argument is exactly the kind of thing a refactor drops.
+
+0.45 is the middle of the band the browser measured: every real family it read
+sits under 0.29 and every junk family over 0.62. Node fixtures that reproduce
+the survey path — the scene rendered twelve times the size of the picture's
+rectangle in the square, which is the ratio the pipeline's own resize has, its
+noise and its 8 bits taken there and then averaged down — narrow that band
+rather than widening it, to 0.20 against 0.577 over twenty-one seeds a family
+at three output shapes. They read the real side within about two hundredths of
+the browser and the skies *below* it, which is the conservative direction: a
+line that clears the fixtures' junk clears the browser's by more.
+
+What it costs is a sparse night sky, and no floor avoids that. Twenty to fifty
+stars left in a 256 thumbnail is the one family that spans the whole band,
+0.223–0.999 over five draws each at three shapes; the browser never measured
+one on this path, and it overlaps every junk family there is, because a sparse
+field's peak genuinely is one of several and at the survey square that is what
+a clear sky looks like too. Of 296 such pairs whose answer is right to within a
+pixel, 0.45 admits 151, 0.5 admits 199 and 0.8 admits 274 — so raising the
+floor buys them back a few at a time and never all of them, and a frame this
+floor refuses stacks at the identity and is not refined either, because a frame
+the coarse pass refused is not refined. A *dense* field, the four hundred stars
+a real night sky leaves in that thumbnail, is admitted on every seed of every
+shape with 0.16 to spare. That is a trade rather than a fix, and it leans the
+opposite way to `N_MAX` on purpose: the junk 0.8 admits is two pictures that
+share nothing, in a set that was never going to stack, where the junk 0.45
+refuses is a clear sky in a set that was perfectly good until the alignment
+invented a move for it. The comment on `N_MAX_SURVEY` in `align.js` has both
+tables, the fixture-to-browser comparison family by family, and the sweep of
+render scales the twelve came from.
+
+The log-polar surface goes through `N_MAX` and is given none of its own:
+real turns read 0.20–0.81 and all but one seed in forty are admitted,
 where the old floor refused fourteen seeds in twenty of a textured
 scene turned nine degrees at thirty per cent noise. The one refused is a
 third of a degree at thirty per cent noise, reading 0.811 — the smaller the
@@ -603,38 +669,89 @@ faded by the floor instead. This is also why the test fixtures are value noise
 over three octaves rather than a few sinusoids: a fixture that puts nothing
 into most of its bins is all rounding error by the time it reaches the peak.
 
-**A sky correlates with itself and still cannot be aligned, and the
-letterbox is why.** Every 3:2 frame reaches the coarse square as 256 by 171
-of picture over transparent black, so two frames of a smooth gradient share a
-hard edge that did not move with the camera and a slope that matches itself at
-any offset — coherence 0.5, a ridge for a peak, and an argmax that wanders by
-one to three alignment pixels, which the multiply-up turned into tens of
-output pixels of movement on frames that had not moved. `coherence` cannot
-see it, because the content genuinely correlates; the `plateau` reading in
-`phaseCorrelate` — how much of the peak is still standing eight pixels away —
-can, and `isMeasured` refuses anything over `P_MAX`. The same edge also
-biases every real low-texture answer the survey square accepts: letterboxed,
-the low-texture fixture lands 1.3–1.9 alignment pixels off at fifteen per
-cent noise and 1.0–2.0 at thirty, pulled towards the ridge, where the full
-square lands it within 0.1–0.7 and 0.3–1.9; on a 3000-pixel frame that is
-15–22 output pixels — a coarse error the refinement now does correct, because
-its windows all see the same one and agree on it and it is well inside the
-two coarse pixels a correction is allowed, where the old single-window
-version refused any residual over eight output pixels and left it standing.
-That is a cost of the survey square, not of the gate, and the fix is the same
-one that would remove the ridge under the
-gradients and the unrelated pairs: taper the picture's own box in
-`lumaSquare` — a window over `fit`'s rectangle, or fill outside it with the
-picture's mean before windowing — so the edge is not a feature both frames
-share. It is a follow-up. Two things follow for anyone extending the gate
-meanwhile. A fixture of the gradient over the whole square measures a tenth
-of the coherence and is refused without the plateau's help, so a fixture that
-does not letterbox does not reproduce the browser; the tests' `letterbox`
-helper exists for that. And the plateau radius is eight at every window size,
-not a fraction of the side: a radius of four at 128 refused the low-texture
-pair with its peak in the right place, and a radius of sixteen at 512 kept
-the wall with its peak five pixels wrong. `plateauRadius` in `align.js` says
-why, and the comment on `P_MAX` has the readings at both.
+**A sky correlates with itself and still cannot be aligned.** A smooth
+gradient matches itself at any offset, so what comes back is a ridge rather
+than a peak and the argmax is wherever the noise tipped it — one to three
+alignment pixels, which the multiply-up turns into tens of output pixels of
+movement on frames that had not moved. `coherence` cannot see it, because the
+content genuinely correlates; the `plateau` reading in `phaseCorrelate` — how
+much of the peak is still standing eight pixels away — can, and `isMeasured`
+refuses anything over `P_MAX`.
+
+**The letterbox used to make that worse, and hid how much.** Every 3:2 frame
+reaches the coarse square as a 256 by 171 band of picture centred over
+transparent black, and until `lumaSquare` gave `window2d` the picture's own
+box the taper faded the square's four edges and left those two inner ones
+standing: a
+hard step from picture values straight down to nothing, in the same place in
+every frame, and so the strongest thing any two frames shared however the
+camera moved. It pinned the sky's ridge across the other axis and lifted its
+coherence to 0.5, and it pulled every real low-texture answer the survey
+accepted towards itself.
+
+In the browser, on the built survey path, the coarse error fell from 1.98
+output pixels to 1.48 on a low-texture 3:2 pair, 2.64 to 1.46 on a 2:3 one and
+1.81 to 0.76 on a noisier 3:2 one, while a square output — which has no
+letterbox and therefore no rectangle — measured 0.77 either way. That is one
+pair per scene rather than a distribution, and the fixtures give the
+distribution: over ten seeds the low-texture pair lands 1.36–1.96 alignment
+pixels off at 3:2 with the whole square tapered against 0.29–1.09 with its own
+box, and 2.05–2.37 against 0.13–1.05 at 2:3, where the whole of a 2.4-pixel
+horizontal move was being read as 0.25. The fixture's ridge is stronger than a
+photograph's, so those are the shape of the effect and the browser's are its
+size.
+
+The control is the row that explains both. The same pair as a *square* output
+— nothing letterboxed, this function unchanged — lands 0.10–0.72 off, which is
+where the boxed letterboxed pairs land. The box does not make the coarse pass
+better than it was; it stops the letterbox making it worse. The comment on
+`window2d` in `align.js` has both tables and the two alternatives that were
+measured and not taken: cropping the output's middle square to fill the
+alignment square, and filling outside the box with the box's mean before
+tapering the whole square.
+
+**Taking the ridge out costs the gate, and costs it exactly what a square
+output was already paying.** The ridge was doing gate work by accident: it
+stood high away from the peak on every surface, real and junk alike, and
+`next` is a reading of exactly that — so a letterboxed output was refusing junk
+that the same scene as a square output was admitting. Over eleven junk
+families at twenty seeds each, admitted by `isMeasured` **at 0.8**, which is
+the floor the coarse square was still being judged against at that point: a 3:2
+output went from 5 in 220 to 31, a 2:3 output from 1 to 39, and a square output
+read 36 either way. The featureless sky went the same way — refused on every
+seed of every letterboxed shape before, and leaking a seed here and there at
+the rate a square output had always leaked at. Those are the counts that made
+a second floor necessary, not the counts the shipped gate has: every one of
+those eleven families is refused on every seed of every shape at 0.45.
+
+So this change does not open a hole; it gives every output shape the hole a
+square output has always had, which is the one already recorded above: the
+unrelated texture/low and low/low pairs whose surfaces are a few broad bumps
+rather than many sharp ones, left to the consensus check. Two things are worth
+being plain about. That leak is now on the shapes almost every photograph has,
+not on the rare square one. And the consensus check cannot veto a coarse move
+at all — `refineMove` can only decline to improve one — so a junk coarse peak
+that passes is applied, and what the consensus catches is the refinement's own
+nine windows. What was left of that leak is what `N_MAX_SURVEY` closed: over
+fixtures that reproduce the survey path resize and all, the unrelated pairs
+read 0.74–1.00 and the floor of 0.45 refuses every seed of every shape. The
+reason this passage once said no such floor could exist was a fixture without
+the resize in it, which leaves a real scene carrying twelve times the noise the
+pipeline has already thrown away and reads it at 0.71 — level with the junk.
+What the second floor costs instead is a sparse sky, and the comment on
+`N_MAX_SURVEY` counts it.
+
+Two things follow for anyone extending the gate. The fixtures that record how
+the floors were calibrated still window the whole square over a letterbox
+anchored at the top of it, because that is the surface those numbers were read
+from — and it is a *stronger* letterbox than the pipeline's, whose box is
+centred so that its edges sit where the square's own taper has already faded
+them. Anything measured afresh belongs on `surveyBox`, which is `placement`'s
+own rectangle imported into the tests. And the plateau radius is eight at every
+window size, not a fraction of the side: a radius of four at 128 refused the
+low-texture pair with its peak in the right place, and a radius of sixteen at
+512 kept the wall with its peak five pixels wrong. `plateauRadius` in
+`align.js` says why, and the comment on `P_MAX` has the readings at both.
 
 **The gate mostly catches a JPEG's block lattice, and where it does is not
 where it was designed to.** Every frame of a phone burst is a JPEG, and every
@@ -647,10 +764,13 @@ smooth content at quality 50. The leak is where the lattice puts its aliases:
 the nearest sit eight pixels from the peak, inside the ten-pixel box, so what
 is read is the pair sixteen or seventeen pixels out, and those fall away with
 the scene's own smooth envelope where the near ones stand level with the
-peak. It is harmless as the pipeline is arranged — the survey square
-letterboxes the same pairs to 0.91–0.99 and refuses every one, and at the
-refinement an argmax on a random lattice peak is one window disagreeing with
-the other eight — but it is the consensus that catches it, not either floor.
+peak. At the survey square the letterbox used to refuse the same pairs on every
+seed — `next` 0.97–0.98 at a plateau of 0.99 — and over the picture's box they
+read 0.69–0.99 at a plateau of 0.16–0.79 and pass on two seeds in ten at 3:2
+and three at 2:3, where the same pair as a square output passes none. That is
+the widest the box's cost gets on any family measured. What is left to catch it
+is the consensus rather than either floor: at the refinement an argmax on a
+random lattice peak is one window disagreeing with the other eight.
 
 The refinement's own scenario is the same lattice between two frames of *one*
 smooth scene: the coarse move a third of a pixel short, and the residual
@@ -705,7 +825,14 @@ returns the read window separately from the written one.
 frame.** Every frame is drawn into it the same way — the output box,
 letterboxed into 256 — so that one number converts a shift there into a shift
 in the output. Fitting each frame to the square separately makes that number
-different per frame, and different per axis for any frame of a different shape.
+different per frame, and different per axis for any frame of a different
+shape. The rectangle the window tapers is that same box — `fit` describes the
+draw and the taper, so the two cannot drift apart — and not each frame's own
+spot in it, for the same reason: it has to be identical in every frame or one
+number no longer converts a shift here into a shift there. So a frame of a
+different shape from the output keeps a hard edge of its own where its picture
+stops, which is the mixed-set cost `commonArea` is about rather than something
+every set pays.
 
 **A minimum over no frames is not white.** The accumulator starts at 255 so the
 first frame can only lower it, and reporting that starting point as an answer

--- a/tools/stack-images/src/align.js
+++ b/tools/stack-images/src/align.js
@@ -204,7 +204,7 @@ export const L_MIN = 0.004;
  *   unrelated texture/stars, stars/stars     0.89-0.99     0.06-0.68   junk
  *   unrelated texture/low                    0.67-0.84     0.43-0.70   junk, 8 of 10 pass
  *
- *   at 256, the survey square, letterboxed   next          plateau     answer
+ *   at 256, top-anchored, tapered whole      next          plateau     answer
  *   textured, 15% and 30%                    0.28-0.50     0.23-0.55   right
  *   low-texture, 15% and 30%                 0.20-0.41     0.43-0.62   right
  *   four hundred stars, 6% and 10%           0.45-0.69     0.14-0.31   right
@@ -222,7 +222,84 @@ export const L_MIN = 0.004;
  *   unrelated texture/stars                  0.72-0.98     0.50-0.74   junk, 7 of 10 pass
  *   unrelated stars/stars                    0.82-1.00     0.22-0.73   junk
  *
- * On the full 256 square, without the letterbox, every real family reads
+ * That table, and every reading in it, is the top-anchored letterbox with the
+ * whole square tapered - the fixture, not the square the pipeline builds. It
+ * is kept because these constants were chosen on it and it is what reproduces
+ * them. `placement` centres the box, so a real letterbox's edges sit where the
+ * square's own taper has already faded them to a quarter and the fixture's sit
+ * at three-quarters; the fixture's ridge is about three times the pipeline's,
+ * and anything measured on it overstates what the letterbox does.
+ *
+ * SINCE lumaSquare HANDS window2d THE PICTURE'S BOX
+ *
+ * Re-measured on the CENTRED box, twenty seeds a family, 3:2 and 2:3 together,
+ * the scenes lifted to a photographic black level so that the letterbox step
+ * is the height a photograph's is. The third column is the same family as a
+ * SQUARE output, which has no letterbox and which this function has never
+ * treated any differently:
+ *
+ *                                     whole square   the box    square output
+ *   textured, 15% / 30% / 50% noise    0.18-0.64     0.13-0.71    0.13-0.60
+ *   low-texture, 15% and 30%           0.20-0.44     0.12-0.44    0.11-0.36
+ *   four hundred stars, 6% and 15%     0.07-0.15     0.08-0.20    0.07-0.14
+ *   8-bit gradient and skies, 1%-1.3%  0.94-1.00     0.76-1.00    0.79-1.00
+ *   unrelated texture/texture, 5%      0.80-0.95     0.80-0.99    0.78-1.00
+ *   unrelated texture/texture, 15%     0.74-1.00     0.71-1.00    0.81-0.99
+ *   unrelated low/low, 5%              0.88-1.00     0.71-1.00    0.88-1.00
+ *   unrelated low/low, 15%             0.80-1.00     0.71-1.00    0.72-0.96
+ *   unrelated texture/low, 5%          0.84-1.00     0.68-1.00    0.68-0.94
+ *   unrelated texture/low, 15%         0.74-0.99     0.60-0.97    0.64-0.90
+ *   unrelated texture against stars    0.78-1.00     0.74-1.00    0.84-0.99
+ *
+ * and the same eleven junk families counted rather than ranged, admitted by
+ * isMeasured AT THIS FLOOR over twenty seeds each - which is the floor the
+ * coarse square asked while the ridge was doing its gating, and not the floor
+ * it asks now:
+ *
+ *                       whole square   the box   square output
+ *   3:2 output             5/220        31/220      36/220
+ *   2:3 output             1/220        39/220      36/220
+ *
+ * The third column is the answer to both of the other two. The letterbox's
+ * edge stood high away from the peak on every surface it was in, and this
+ * statistic reads how high the surface stands away from the peak - so the
+ * letterbox was refusing junk, by accident, on exactly the outputs that were
+ * not square. Taking it out does not open a hole; it gives every output shape
+ * the hole a square output has always had, and it is the same hole: the
+ * unrelated texture/low and low/low pairs whose surfaces are a few broad bumps
+ * rather than many sharp ones. The paragraph on the JPEG lattice below is
+ * where that leak is already recorded, and the consensus check is what is left
+ * to catch it. Nothing downstream can veto a coarse peak that passed - the
+ * refinement can only decline to improve it - so what the consensus catches is
+ * the refinement's own windows, and a junk coarse move that got through is
+ * applied.
+ *
+ * Those counts are what this floor lets through, and they are the reason the
+ * coarse square stopped asking it. N_MAX_SURVEY judges that square now, and
+ * refuses every one of these eleven families on every seed of every shape;
+ * what it costs instead is on its own comment.
+ *
+ * There is no room to lower THIS floor for it, and the coarse-only floor that
+ * answers it is N_MAX_SURVEY. This paragraph used to say there was no such
+ * floor to split off, and what it was reading when it said so was a fixture
+ * rather than the pipeline: at 256 with nothing resized on the way in, the
+ * real side reached 0.71 on the textured scene at fifty per cent noise against
+ * a junk side starting at 0.60, and no line separated them. A fixture that
+ * resizes the way the survey does - the scene drawn several times larger, its
+ * noise averaged down with the picture - reads that same scene at 0.04-0.13,
+ * and the browser reads it at 0.04-0.06. The noise a 256-native fixture leaves
+ * on a real scene is noise the pipeline has already thrown away, and it was
+ * the whole of what hid the gap. What decides 0.8 meanwhile is
+ * unchanged and is nothing to do with the coarse square: the sparse sky at the
+ * refinement window, 0.72-0.96 over ten draws, and the log-polar turn too
+ * small to separate from the surface's own junk peak, 0.81 - both full
+ * squares, windowed with no box at all.
+ *
+ * On the full 256 square, without the letterbox - the square-output column
+ * above, and nothing else: the box column beside it is a different reading of
+ * the same scene, 0.13-0.71 against 0.13-0.60 on the row that decides this
+ * range, and what the coarse square reads is on N_MAX_SURVEY's own comment
+ * rather than here. Every real family reads
  * 0.07-0.62 - the textured scene at fifty per cent noise is the 0.62, and is
  * 0.3-2.4 pixels off - and the junk 0.59-1.00: gradients 0.76-0.99 over forty
  * seeds with none admitted, the seeds that dip under this floor being refused
@@ -249,9 +326,11 @@ export const L_MIN = 0.004;
  * twenty per cent the same field is wrong on two seeds in ten, so past that
  * refusing is right, and the floor refuses nine. It is the sparse sky and
  * nothing else that spends this margin. Every photograph, and every dense
- * field, is under 0.65 at every size on every seed - the highest of them is
- * the letterboxed textured scene at fifty per cent noise, 0.64 - so the floor
- * could sit at 0.7 for them. The sparse windows are where it is close: over
+ * field, is under 0.65 at every size on every seed but one: the textured scene
+ * at fifty per cent noise, which read 0.64 over the letterbox and reads 0.71
+ * over the picture's box, aligned correctly on every seed at both. That one
+ * row is why the floor could not simply be dropped to 0.7 for the coarse
+ * square once the ridge went. The sparse windows are where it is close: over
  * ten different draws of a sparse sky the twenty-star window at six per cent
  * reaches 0.72 and a seventeen-star one 0.96, the second refused on one draw
  * in ten although its answer was right. Which draw of the sky the window
@@ -275,9 +354,12 @@ export const L_MIN = 0.004;
  * catch either. Coherence read it at 0.05-0.06, a quarter of the real
  * low-texture scene's, and it was the one junk family where coherence had a
  * margin; the sparse skies sit at 0.04-0.05 in the same place, which is why
- * that floor could not stay. On the survey square the letterbox refuses the
- * pair (0.82-0.95), so it reaches the refinement only from a square frame,
- * and only once the survey has admitted it.
+ * that floor could not stay. The survey square used to refuse the pair on
+ * every seed of a letterboxed output and no longer does: over the picture's
+ * box it reads 0.78-1.00 at 3:2 and 0.68-0.92 at 2:3, admitted on three seeds
+ * of twenty and fifteen, against a square output's own 0.68-0.94 and eleven.
+ * So this pair now reaches the refinement from a frame of any shape, which is
+ * the leak the table above is about and this is one family of it.
  *
  * The two unrelated JPEGs are the widest of the junk families that this
  * reading is meant to catch and does not always. Over eighty seed pairs -
@@ -288,13 +370,16 @@ export const L_MIN = 0.004;
  * puts its aliases. The nearest sit eight pixels from the peak, inside the
  * box, so what is read is the pair at sixteen or seventeen, and those fall
  * with the scene's own smooth envelope rather than standing level with the
- * peak the way the near ones do. It is harmless as the pipeline is arranged:
- * on the survey square the same pairs are letterboxed and read 0.91-0.99,
- * refused on all eighteen seeds tried, and at the refinement an argmax that
- * landed on a random lattice peak is one window disagreeing with the other
- * eight, which the consensus drops. Harmless is not invisible, and the number
- * is recorded because the consensus is what catches this rather than either
- * floor.
+ * peak the way the near ones do. At the survey square the same pairs used to
+ * be refused on every seed by the letterbox rather than by anything here -
+ * next 0.97-0.98 at a plateau of 0.99 - and over the picture's box they read
+ * next 0.69-0.99 at a plateau of 0.16-0.79 and pass on two seeds in ten at
+ * 3:2 and three at 2:3, where the same pair as a square output passes none.
+ * That is the widest the box's cost gets on any family measured, and it is
+ * left standing rather than gated because the frame it admits is one window
+ * disagreeing with the other eight at the refinement, which the consensus
+ * drops. The consensus is what catches this rather than either floor, which is
+ * why the number is recorded.
  *
  * The reach was measured at 6, 8, 10, 12, 16 and 20. None of them moves the
  * unrelated pairs or the star fields, whose next peak is far away - a sparse
@@ -321,13 +406,24 @@ export const L_MIN = 0.004;
  * 0.41-0.61 at thirty; turned four degrees, 0.31-0.61; the textured scene
  * turned four degrees 0.20-0.27, nine degrees at thirty per cent 0.48-0.72,
  * twenty degrees 0.22-0.34, scaled by 1.12 0.23-0.38; a star field turned
- * five degrees 0.07-0.22; and the letterboxed textured and low-texture turns
- * 0.26-0.42. Every seed of every one is admitted, and estimate() reads the
- * angle on all ten seeds of each. The junk there: the gradient at fifteen
- * per cent noise 0.83-0.95, unrelated pairs 0.70-1.00 (one to three seeds in
- * ten pass), and the letterboxed 8-bit gradient 0.39-0.56 - admitted, as it
- * was under the old floor, and discarded when the translation peak it
- * leads to is refused.
+ * five degrees 0.07-0.22. Every seed of every one is admitted here, and
+ * estimate() reads the angle on all ten seeds of each. The junk there: the
+ * gradient at fifteen per cent noise 0.83-0.95 and unrelated pairs 0.70-1.00,
+ * one to three seeds in ten passing.
+ *
+ * The letterbox is the one place this reading moved when lumaSquare began
+ * handing window2d the picture's box, and it moved the right way. On the
+ * centred 3:2 box over twenty seeds, the 8-bit gradient's log-polar peak read
+ * 0.20-0.54 with the whole square tapered and was admitted on every seed -
+ * nothing refused it, and similarity mode was applying it as a scale of
+ * 0.95-1.01 - where over the picture's box it reads 0.74-1.00 and is refused
+ * on eighteen. Two seeds still pass, so this is a rate and not a rule, and
+ * what they buy is discarded when the translation peak they lead to is
+ * refused. Real turns are a wash or better: the textured scene turned nine
+ * degrees at thirty per cent goes from fifteen seeds in twenty admitted to
+ * twenty, the low-texture scene turned three degrees at twenty per cent from
+ * twenty to nineteen, and estimate() reads both angles to within a degree or
+ * two either way.
  *
  * The margin there is 0.01, not the 0.08 those rows suggest, and the case
  * that spends it is a turn too small to matter. Ten further seeds of the
@@ -341,11 +437,172 @@ export const L_MIN = 0.004;
  * admit the unrelated pairs that sit at 0.71-0.86 there, one of which reads
  * a 7.2-degree turn between two pictures that share nothing; the trade is
  * one refused third of a degree against a wrong turn applied to a frame the
- * translation gate may well admit, and it was not taken. One floor is also
- * one floor to calibrate, which is the whole reason isMeasured is a function
- * rather than three comparisons in two places.
+ * translation gate may well admit, and it was not taken.
+ *
+ * This floor decides every surface but one, and N_MAX_SURVEY says which one
+ * and why. The two are the same reading of two different surfaces, not two
+ * opinions about one: everything gated here is a full square of picture at the
+ * resolution it was shot at, and the exception is a thumbnail of the whole
+ * frame with a taper cut to the picture's own box.
  */
 export const N_MAX = 0.8;
+
+/**
+ * The same reading at the coarse survey square, where it lands elsewhere.
+ *
+ * `next` is a ratio of a surface to its own peak and so does not scale with
+ * the side - the tables above hold from 128 to 512 - but it does depend on
+ * what is in the square, and the coarse square holds something no refinement
+ * window does. Two things separate the regimes, and both arrived together.
+ *
+ * The survey square is a thumbnail. The whole frame is resized to a 256 long
+ * edge before it is correlated, so a photograph's noise is averaged down about
+ * twelvefold on the way in and the peak that comes back is sharper than the
+ * same scene's at a full-resolution window: the textured scene at fifty per
+ * cent noise reads 0.04-0.06 here in the browser, where a sparse sky at the
+ * 512 window - the family that set N_MAX - reads 0.32-0.96 with its answer
+ * right. And since lumaSquare hands window2d the picture's box, the letterbox
+ * ridge is gone from this square. That ridge stood high away from the peak on
+ * every surface it was in, junk and real alike, which is exactly what this
+ * statistic reads, so removing it moved the whole distribution down - the junk
+ * with it, which is the point. A clear sky at 3:2 that read 0.96 over the
+ * whole square reads 0.62-0.74 over the box, and 0.8 no longer refuses it.
+ *
+ * WHAT THE BROWSER MEASURED, on the built survey path - a scene rendered at
+ * 3000x2000 or 2000x3000, JPEG at quality 0.92, createImageBitmap resized to
+ * the 256-long-edge thumbnail, drawn into the square through the fit
+ * transform, then this reading - twelve seeds a family, as the peak-uniqueness
+ * reading and as the count isMeasured admitted at 0.8:
+ *
+ *                                   whole square   the box    admitted
+ *   textured 3:2                     0.06-0.09     0.03-0.04   12 -> 12
+ *   textured, 50% noise, 3:2         0.13-0.16     0.04-0.06   12 -> 12
+ *   low texture 15%, 2:3             0.24-0.27     0.05-0.07   12 -> 12
+ *   low texture 15%, 3:2             0.36-0.39     0.07-0.11   12 -> 12
+ *   four hundred stars, 6%, 3:2      0.41-0.51     0.12-0.29   12 -> 12
+ *   clear sky, 3:2                   0.96          0.62-0.74    0 -> 11
+ *   clear sky, 2:3                   0.96          0.75-0.91    0 -> 0
+ *   noisy sky, 3:2                   0.94-0.97     0.73-0.99    0 -> 1
+ *   unrelated low/low, 3:2           0.89-1.00     0.71-0.99    0 -> 2
+ *   unrelated texture/texture, 3:2   0.82-0.99     0.80-1.00    0 -> 0
+ *
+ * The separation is wider than the letterbox ever gave - a real answer at
+ * worst 0.29 against junk at best 0.62, where the letterbox had 0.51 against
+ * 0.82 - and it is in the wrong place for a floor of 0.8, which a clear sky at
+ * 3:2 now walks under on eleven seeds in twelve, moved by up to 38 output
+ * pixels from an identity that was the truth. That is the failure the plateau
+ * and this reading exist to prevent, so the box needed a floor of its own.
+ *
+ * WHERE THE LINE IS, measured in node on fixtures that reproduce that path -
+ * the scene rendered large, given its noise and its 8 bits there,
+ * box-averaged down into the picture's rectangle and drawn into the centred
+ * box - at 3:2, 2:3 and square outputs, twenty-one seeds a family.
+ *
+ * THE RESIZE RATIO IS THE FIXTURE. The pipeline shrinks a whole frame into a
+ * 256 long edge, so a 3000-pixel frame is averaged 11.7 to one before anything
+ * is correlated, and a fixture that renders smaller leaves noise on a real
+ * scene that the pipeline has already thrown away. The scenes below are
+ * therefore rendered at twelve times the rectangle inside the square - 3072
+ * into 256, the browser's own ratio to a rounding - and the tests derive that
+ * multiplier from the two sizes rather than stating it. The scale is not a
+ * detail: swept at 4, 6, 8, 10 and 12 against the browser column above, only
+ * the last reproduces it. At 6, which is what the first version of this floor
+ * was measured on, the low-texture scene at fifteen per cent reads 0.035-0.037
+ * where the browser reads 0.07-0.11 and the fixture at twelve reads
+ * 0.073-0.077; the sparse fields read about half what they read at twelve, and
+ * the floor that came out of it was too high to be safe by that much.
+ *
+ * How the fixtures then compare with the browser, family by family, box
+ * column, the browser's number second:
+ *
+ *   textured, 3:2                  0.057-0.063   0.03-0.04   fixture high
+ *   textured 50% noise, 3:2        0.057-0.073   0.04-0.06   fixture high
+ *   low texture 15%, 2:3           0.080-0.085   0.05-0.07   fixture high
+ *   low texture 15%, 3:2           0.073-0.077   0.07-0.11   inside
+ *   four hundred stars 6%, 3:2     0.151-0.201   0.12-0.29   inside
+ *   clear sky, 3:2                 0.671-0.674   0.62-0.74   inside
+ *   clear sky, 2:3                 0.637-0.645   0.75-0.91   fixture LOW
+ *   noisy sky, 3:2                 0.577-0.716   0.73-0.99   fixture LOW
+ *   unrelated low/low, 3:2         0.906-1.000   0.71-0.99   fixture high
+ *   unrelated texture/texture      0.875-0.999   0.80-1.00   inside
+ *
+ * So the real side agrees to about two hundredths and the junk side reads LOW
+ * on the skies - by a tenth at 2:3 and by fifteen hundredths on the noisy one.
+ * That is the conservative direction and the reason the fixtures are worth
+ * trusting for a floor: they put the junk nearer the real side than the
+ * browser does, so a line that clears the fixtures' junk clears the browser's
+ * by more. It is not licence to trust them upward. Where a fixture family
+ * reads higher than the browser on the real side, the browser is the number
+ * this floor is calibrated against, and any family the browser never measured
+ * is marked below as what it is.
+ *
+ *                                          next        answer
+ *   textured, clean to 50% noise          0.053-0.084  right, 0.11-0.14 px
+ *   textured, frame eight times dimmer    0.073-0.087  right, 0.11-0.14 px
+ *   low texture, 15% and 30%              0.066-0.087  right, 0.10-0.12 px
+ *   four hundred stars, 6%                0.127-0.201  right, 0.15-0.24 px
+ *   twenty to fifty stars, five draws     0.223-0.999  FIXTURE ONLY, below
+ *   skies: three slopes, 0.4% to 5%       0.577-0.998  junk, moved 0.0-2.7 px
+ *   unrelated low/low                     0.869-1.000  junk, moved 18 px
+ *   unrelated texture/texture             0.813-0.999  junk
+ *   texture against stars                 0.737-0.999  junk
+ *   two unrelated JPEGs, Q95 to Q20       0.840-0.999  junk
+ *
+ * The brightness row is eight TIMES - three stops - with the dim frame
+ * quantised to 8 bits at an eighth of the level and carrying the bright
+ * frame's read noise, which is the harsher of the two ways to model a bracket;
+ * scale its noise down with it and the same pair reads 0.054-0.079. Eight
+ * STOPS, 256 to one, is not that family and is not a real one: it reads
+ * 0.77-1.00 with its answer between a fifth of a pixel and fifty-eight, and
+ * both floors refuse it, which is right.
+ *
+ * THE FLOOR IS 0.45, and it is the middle of the band the browser measured:
+ * every real family it read is under 0.29 and every junk family over 0.62. The
+ * fixtures narrow that band rather than widen it - real to 0.20, junk to 0.577
+ * - and 0.45 sits inside both, 0.16 above the highest real reading either path
+ * gives and 0.13 below the lowest junk one. The two closest families are the
+ * four-hundred-star field, which the browser reads at 0.12-0.29 and the
+ * fixtures at 0.127-0.201 over three shapes, and a sky at five per cent noise,
+ * which the fixtures read at 0.577-0.716 with live and plateau both passing
+ * and which moves a frame 0.7-2.7 alignment pixels; the browser's own nearest
+ * junk is the clear 3:2 sky at 0.62-0.74.
+ *
+ * WHAT IT COSTS IS SPARSE STAR FIELDS, and there is no floor that does not.
+ * A field of twenty to fifty stars in the thumbnail is the one family that
+ * spans the whole band: over five draws each at three shapes and seven seeds,
+ * 315 pairs, it reads 0.223-0.999. The browser never measured one on this
+ * path, so this row is the fixtures' alone, and it overlaps every junk family
+ * in the table - a sparse field's peak genuinely is one of several, which at
+ * the survey square is also what a clear sky looks like. Of the 296 of those
+ * pairs whose answer is right to within a pixel, 0.45 admits 151, 0.5 admits
+ * 199 and 0.8 admits 274; of the 19 that are wrong, 0.45 admits one and 0.8
+ * admits two. So the trade is stated rather than claimed away: raising the
+ * floor towards the junk buys sparse fields back a few at a time and never all
+ * of them, and a field this floor refuses stacks at the identity and is not
+ * refined either, because a frame the coarse pass refused is not refined at
+ * all; the comment in the stack says why. A dense field - the four hundred
+ * stars a real night sky leaves in a 256 thumbnail - is admitted on every seed
+ * of every shape, with 0.16 to spare against the browser's own reading of it
+ * and 0.25 against the fixtures'.
+ *
+ * It leans the opposite way to N_MAX, and deliberately. A junk pair N_MAX
+ * admits is two pictures that share nothing, in a set that was never going to
+ * stack; a sky this floor admits is a set that was perfectly good until the
+ * alignment invented a move for it. Admitting costs more here than there, so
+ * this floor sits at the middle of its band where N_MAX sits nearer the junk,
+ * and the sparse fields are what pays for that.
+ *
+ * Only the coarse translation peak is judged here. The refinement's windows
+ * are full squares of picture with no box, at the resolution the frame was
+ * shot at, and the table on N_MAX is theirs; so is the log-polar surface,
+ * which logPolar builds as a whole square and window2d tapers whole whatever
+ * shape the output has. Both halves of that are pinned by tests that fail if
+ * the floor is passed where it should not be or dropped where it should: a
+ * real twelve-degree turn's log-polar peak reads 0.625 and has to be admitted,
+ * and a five per cent sky at the survey square reads 0.578-0.708 through
+ * estimate() and has to be refused.
+ */
+export const N_MAX_SURVEY = 0.45;
 const NEXT_REACH = 10;
 
 /**
@@ -380,13 +637,14 @@ const NEXT_REACH = 10;
  *   textured, clean and 30% noise   0.92-0.96   0.11-0.17
  *
  * and in node on the fixtures in tests/js/stack-images-align.test.js, ten
- * seeds each at 256, with the picture letterboxed to 256x171 over black the
- * way lumaSquare letterboxes a 3:2 frame - which is what reproduces the
- * browser: a full-square gradient measures coherence 0.04-0.10 and next
- * 0.87-0.99, and so do the vignette and textured-sky rows below (next
- * 0.76-0.99), all refused without the plateau's help, and it is the
- * letterbox's hard edge, shared by both frames, that pins the vertical,
- * lifts the coherence over what was then its floor, and leaves the ridge:
+ * seeds each at 256, over the tests' TOP-ANCHORED letterbox with the whole
+ * square tapered. That is a stronger letterbox than `placement` builds and it
+ * is what these readings were taken on; it is also what reproduces the browser
+ * rows above, where a full-square gradient measures coherence 0.04-0.10 and
+ * next 0.87-0.99, and so do the vignette and textured-sky rows below (next
+ * 0.76-0.99), all refused without the plateau's help. It is the letterbox's
+ * hard edge, shared by both frames, that pins the vertical, lifts the
+ * coherence over what was then its floor, and leaves the ridge:
  *
  *                                        coherence    plateau     refused
  *   gradient, 8-bit, 0.3-3% noise        0.43-0.60    0.95-0.996  all
@@ -408,8 +666,8 @@ const NEXT_REACH = 10;
  *   twenty stars, 6% noise               0.20-0.23    0.02-0.12   none
  *
  * The floor is 0.7. Against the browser it has 0.1 of margin on both sides;
- * against the fixtures the real side is thinner, 0.02-0.05, because the
- * letterbox ridge sits under every real pair too: the low-texture scene at
+ * against those fixtures the real side is thinner, 0.02-0.05, because the
+ * ridge sat under every real pair too: the low-texture scene at
  * thirty per cent noise reaches 0.65-0.68 depending on the seeds, and the
  * scene that straddles the floor is a low-texture one under a lens vignette
  * that did not move with it, refused on half its seeds although its peak was
@@ -424,21 +682,34 @@ const NEXT_REACH = 10;
  * 0.55-0.67, with 0.4-2.4 pixels of error, which is the small blur a
  * doubtful coarse move on a real scene costs.
  *
- * Two pairs the gate knowingly lets through, on the letterboxed square only,
- * both to be caught by the consensus check the way the JPEG lattice will be:
- * two unrelated textured pictures pass nine seeds in ten and are moved by one
- * to four alignment pixels, and two unrelated low-texture pictures at fifteen
- * per cent noise pass about half. The surface is the letterbox ridge with the
- * unrelated texture's noise bumps along it, so the argmax sits on a bump and
- * the ridge reads 0.6-0.7 of it eight pixels away - a noisy ridge measures
- * lower than the gradient's clean one. On a full square both pairs read next
- * 0.82-0.99 (texture/texture) and 0.70-0.91 (low/low, admitted on five seeds
- * in ten) at a coherence of 0.04-0.10. The structural fix is
- * to taper the picture's own box in lumaSquare rather than the whole square,
- * so the letterbox edge is not a feature both frames share; that would remove
- * the ridge under the gradients, the unrelated pairs and the real low-texture
- * answers at once, and is a follow-up rather than part of this gate. The
+ * That table is a surface the coarse pass no longer builds, because
+ * lumaSquare now hands window2d the output box and the taper follows the
+ * picture's own edge. Re-measured on the CENTRED box, twenty seeds a family
+ * over 3:2 and 2:3, this floor's readings all fall and so do the answers'
+ * distance from it: the 8-bit gradients and skies read 0.56-0.93 here where
+ * the whole-square taper read 0.96-1.00, the two unrelated textured pictures
+ * 0.23-0.87, the two unrelated low-texture ones 0.37-0.81, the low-texture
+ * scene at thirty per cent 0.39-0.58 and the textured at fifty 0.28-0.52.
+ *
+ * What that means for the gradient is the point, and it is not that this floor
+ * catches it. Over the whole square it was refused by plateau AND by next,
+ * with a wide margin on both; over the box its plateau alone would admit it on
+ * some seeds and only next still refuses, at 0.81-1.00 - the same numbers the
+ * gradient reads as a square output (plateau 0.61-0.85, next 0.80-1.00, one
+ * seed in twenty admitted), because the box is what a square output has always
+ * been. The two junk pairs this floor knowingly let through go the same way:
+ * they read 0.23-0.87 and 0.37-0.81 here, under the floor, and it is next that
+ * decides them. The comment on N_MAX has that whole trade counted, and the
  * browser's own reading of a low/low pair, 0.28 and 0.81, is refused.
+ *
+ * Which `next` decides them is N_MAX_SURVEY rather than N_MAX, and the
+ * difference is not academic: in the browser, where the sky is a photograph of
+ * one rather than a fixture, the plateau over the box reads under this floor
+ * AND the uniqueness reads 0.62-0.74, so 0.8 admitted a clear sky on eleven
+ * seeds in twelve. Neither floor catches that alone. What this one still
+ * catches, and was calibrated for, is the plateau of a scene that cannot be
+ * located: the wall and the textured sky at the refinement windows, in the
+ * paragraph below, which are full squares and untouched.
  *
  * One row the two tables do not agree on: the browser's star field reads
  * 0.35-0.48, ten times the fixture's, and flat across radii of three, five
@@ -449,8 +720,22 @@ const NEXT_REACH = 10;
  * The same floor decides the log-polar peak. Real turns measured 0.02-0.57
  * there (the low-texture scene turned three degrees at twenty per cent noise
  * is the 0.57), and the letterboxed gradient 0.78 at a coherence of 0.22 and
- * a next of 0.39-0.56 - nothing else refuses it, so before this it was
+ * a next of 0.39-0.56 - nothing else refused it, so before this it was
  * applied as a scale of 0.95-1.01.
+ *
+ * On the centred box the pipeline builds, twenty seeds, that gradient's
+ * log-polar peak is the one place the change helps the gate rather than
+ * costing it: over the whole square it reads plateau 0.19-0.57 at a next of
+ * 0.19-0.54 and is admitted on every seed, and over the picture's box it
+ * reads plateau 0.07-0.85 at a next of 0.74-1.00 and is refused on eighteen,
+ * mostly by next. Real turns are unharmed and slightly better: the textured
+ * scene turned nine degrees at thirty per cent noise reads plateau 0.13-0.59
+ * here against 0.13-0.87 over the whole square, which is one seed in twenty
+ * that this floor used to refuse and no longer does, and the low-texture
+ * scene turned three degrees reads 0.18-0.69 against 0.10-0.62, under the
+ * floor either way. A refused log-polar peak is a frame reporting no
+ * rotation, not a frame refused, which is why either direction is
+ * affordable.
  *
  * The radius is eight at every size, and plateauRadius says why it does not
  * follow the side. What it reads at the refinement windows, full square, ten
@@ -480,16 +765,25 @@ export const P_MAX = 0.7;
  *
  * Takes what phaseCorrelate returned, and is the one place the decision is
  * made: the log-polar peak, the translation peak and the refinement's residual
- * all come through here, so there is one gate to calibrate and one to explain.
+ * all come through here, so there is one gate to explain and one place to
+ * change how any of them is decided.
  * Without a plateau the peak is taken to be a point and without a next it is
  * taken to be alone, so a statistics object built by hand - the reference
  * move, a consensus check - is answered rather than silently refused on a
- * NaN. The size of the square no longer enters: the two floors that decide
- * are ratios of the surface to its own peak, and the tables on P_MAX and
- * N_MAX show them holding from 128 to 512 without scaling.
+ * NaN. The size of the square does not enter: the floors that decide are
+ * ratios of the surface to its own peak, and the tables on P_MAX and N_MAX
+ * show them holding from 128 to 512 without scaling.
+ *
+ * What the square holds does enter, in one place, which is what `floor` is
+ * for. Every caller but one is judging a full square of picture at the
+ * resolution the frame was shot at and wants N_MAX; the coarse survey square
+ * is a thumbnail with a taper cut to the picture's box, its whole distribution
+ * sits lower, and it passes N_MAX_SURVEY. The floor travels as an argument
+ * rather than as a second function so that the two cannot drift apart, and
+ * because a caller that says nothing gets the floor the tables above describe.
  */
-export function isMeasured({ live, plateau = 0, next = 0 }) {
-  return live >= L_MIN && plateau <= P_MAX && next <= N_MAX;
+export function isMeasured({ live, plateau = 0, next = 0 }, floor = N_MAX) {
+  return live >= L_MIN && plateau <= P_MAX && next <= floor;
 }
 
 /** The identity, for a frame that needs no moving or could not be measured. */
@@ -498,7 +792,8 @@ export const NO_MOVE = Object.freeze({ dx: 0, dy: 0, angle: 0, scale: 1 });
 /* ------------------------------------------------------------- preparation */
 
 /**
- * A Hann window over the square, with the mean taken out first.
+ * A Hann window over the square, or over a rectangle inside it, with the mean
+ * taken out first.
  *
  * Both halves matter and both are about the edges. A Fourier transform treats
  * the square as one tile of an infinite repeating pattern, so the right-hand
@@ -507,20 +802,171 @@ export const NO_MOVE = Object.freeze({ dx: 0, dy: 0, angle: 0, scale: 1 });
  * feature that both frames share regardless of how they moved. The window fades
  * the edges to nothing so there is no seam, and subtracting the mean first
  * stops the fade itself becoming the brightest structure in the frame.
+ *
+ * WHY A RECTANGLE, AND WHEN
+ *
+ * The coarse square is the output box letterboxed into 256, so unless the
+ * output is square the picture fills a sub-rectangle of it and the rest is the
+ * canvas's transparent black, which reads back as a luma of zero. Fading the
+ * square's own edges leaves that inner edge untouched: a hard step from picture
+ * values straight down to nothing, in exactly the same place in every frame,
+ * and therefore the strongest thing the two frames share however the camera
+ * moved. It matches itself at every offset along its own direction, which is a
+ * ridge in the correlation surface rather than a peak. Given the picture's
+ * rectangle, the mean and the taper are taken over that rectangle alone and
+ * everything outside it is left at zero, so the picture's own edge fades out
+ * the way the square's edges do and the step is gone. `box` is in pixels of
+ * the square and is rounded to whole ones; the whole square is the same window
+ * as before, to the last bit.
+ *
+ * WHAT THE STEP WAS DOING, WHICH IS TWO THINGS
+ *
+ * It pulled the answer along the letterboxed axis, and it stood high away from
+ * the peak on every surface it was in - which is what `next` reads, so it was
+ * also gating. Both are the same feature and neither can be had without the
+ * other; everything below is that trade, measured.
+ *
+ * In the browser, on the built survey path - JPEG at quality 0.92,
+ * createImageBitmap resized to the 256-long-edge thumbnail, drawn into the
+ * square through the same fit transform - as the error of the coarse move in
+ * output pixels. One pair per scene, so these are single readings rather than
+ * ranges. "Centre square" is the alternative of cropping the output's middle
+ * square to fill the alignment square and letterboxing nothing, measured and
+ * not taken because it is inconsistent across the real scenes.
+ *
+ *                            square window   this   centre square
+ *   texture 3:2                   0.84       0.78      1.03
+ *   texture 2:3                   1.17       0.94      1.00
+ *   low texture 15%, 3:2          1.98       1.48      2.18
+ *   low texture 15%, 2:3          2.64       1.46      1.49
+ *   low texture 30%, 3:2          1.81       0.76      1.29
+ *   stars 6%, 3:2                 2.03       2.04      1.71
+ *   low texture 15%, square       0.77       0.77      0.77
+ *
+ * The last row is the control: with no letterbox there is no rectangle and all
+ * three are the same window.
+ *
+ * THE SAME THING OVER SEEDS, AND THE REST OF IT
+ *
+ * On the fixtures in tests/js/stack-images-align.test.js, at the box
+ * `placement` actually builds - CENTRED in the square, rows 43 to 212 for a
+ * 3:2 output and columns 43 to 212 for a 2:3 one - twenty seeds a family, the
+ * error of the coarse move in alignment pixels. The right-hand column is the
+ * same scene as a SQUARE output, where there is no letterbox and this function
+ * is unchanged, and it is the column that explains the other two:
+ *
+ *                          whole square   the box     square output
+ *   low texture 15%, 3:2    1.36-1.96     0.08-1.37     0.10-1.10
+ *   low texture 15%, 2:3    2.03-2.37     0.13-1.21     0.10-1.10
+ *   low texture 30%, 3:2    0.65-2.14     0.12-2.24     0.22-1.56
+ *   low texture 30%, 2:3    0.44-2.54     0.26-1.63     0.22-1.56
+ *   textured 15%, 3:2       0.03-0.43     0.07-0.44     0.03-0.39
+ *   textured 50%, 3:2       0.37-2.51     0.38-3.57     0.39-1.54
+ *   four hundred stars 6%   0.00-0.06     0.01-0.07     0.00-0.06
+ *
+ * A letterboxed low-texture pair was landing a pixel and a half to two and a
+ * half out where the same scene as a square output lands inside one, and with
+ * the box it lands where the square output does. That is the whole of the
+ * accuracy claim: the box does not make the coarse pass better than it was, it
+ * stops the letterbox making it worse. The test in the align suite pins the
+ * first ten of those seeds, where the boxed rows read 0.29-1.09 and 0.13-1.05.
+ * The stars have a black ground, so their step is the size of a night sky's
+ * mean and there was nothing there to remove. The textured scene at fifty per
+ * cent noise is the one row where the box is worse than either neighbour, and
+ * the reason is that it is the picture and not the square that is being
+ * correlated now - 256 by 170 rather than 256 by 256 - so the noisiest scene
+ * has a third less to average over.
+ *
+ * The junk side moves the same way and for the same reason. Over eleven junk
+ * families - the 8-bit gradient and two skies at three noise levels, unrelated
+ * texture/texture, low/low and texture/low at two each, and texture against
+ * stars - twenty seeds each, admitted by isMeasured AT N_MAX, which is the
+ * floor the coarse square was being judged against when the ridge came out and
+ * is no longer the floor it is judged against at all:
+ *
+ *                       whole square   the box   square output
+ *   3:2 output             5/220        31/220      36/220
+ *   2:3 output             1/220        39/220      36/220
+ *
+ * So the ridge was a gate that only letterboxed outputs had, and taking it out
+ * leaves every output shape with the leak a square output has always had and
+ * the README already records - the unrelated texture/low and low/low pairs,
+ * left to the consensus check. That is a real cost and it is the reason this
+ * change is a trade rather than a fix; what it is not is a new failure, and the
+ * right-hand column is how to tell the difference.
+ *
+ * THE TWO FIXTURE TRAPS UNDER THOSE NUMBERS
+ *
+ * The height of the step is the picture's own mean above black, so a fixture
+ * whose scene starts at zero has a third of a photograph's ridge and does not
+ * reproduce the browser at all: at the fixtures' own levels the low-texture
+ * 3:2 pair reads 0.10-1.42 with the whole square against 0.08-1.37 with the
+ * box, which is no difference. Lifted to a photographic black level it reads
+ * 1.36-1.96 against 0.08-1.37, and `next` falls from 0.20-0.31 to 0.12-0.20
+ * against the browser's own 0.26 to 0.08. The tests lift it, and say so.
+ *
+ * The other is the geometry. `placement` centres the box, so a 3:2 picture's
+ * two horizontal edges land where the square's own taper has already faded to
+ * a quarter; a fixture that anchors the letterbox at the top instead puts its
+ * one edge at three-quarters weight and shows an effect three times the size.
+ * The tests' `letterbox` helper is the top-anchored one and is kept only
+ * because the tables on P_MAX and N_MAX were read on it.
+ *
+ * Filling outside the box with the box's mean and tapering the whole square -
+ * the alternative this file used to name as the fix - was measured on the same
+ * families and is the same trade, not a way round it: 39/220 and 35/220 of the
+ * junk against the box's 31 and 39, with the low-texture pair at 0.16-1.09.
+ * It is the step that was doing the gating, not the size of the picture under
+ * it, and nothing that removes the step keeps it.
+ *
+ * So the gate work the step was doing by accident is done on purpose instead,
+ * by a floor calibrated on the surface that is left. Taking the ridge out
+ * lowered every reading on this square, real and junk together, and the junk
+ * further than the real: N_MAX_SURVEY is where the two now separate, and its
+ * comment carries the distribution both sides of it. That is the shape of this
+ * whole change - the letterbox was buying accuracy away to pay for a gate, and
+ * the accuracy is bought back with a number that can be looked at.
+ *
+ * @param {Float64Array} values     size*size, modified in place
+ * @param {number} size             the side of the square
+ * @param {?{x: number, y: number, width: number, height: number}} box
+ *   the picture's rectangle inside the square, or nothing for all of it
  */
-export function window2d(values, size) {
-  let total = 0;
-  for (let i = 0; i < values.length; i += 1) total += values[i];
-  const mean = total / values.length;
+export function window2d(values, size, box = null) {
+  const left = box ? Math.min(size, Math.max(0, Math.round(box.x))) : 0;
+  const top = box ? Math.min(size, Math.max(0, Math.round(box.y))) : 0;
+  const right = box ? Math.min(size, Math.max(left, Math.round(box.x + box.width))) : size;
+  const bottom = box ? Math.min(size, Math.max(top, Math.round(box.y + box.height))) : size;
+  const width = right - left;
+  const height = bottom - top;
 
-  const taper = new Float64Array(size);
-  for (let i = 0; i < size; i += 1) {
-    taper[i] = 0.5 - 0.5 * Math.cos((2 * Math.PI * i) / (size - 1));
+  // A rectangle a pixel or less on a side has no taper to speak of - the Hann
+  // divides by one less than the side - and nothing in it to correlate either.
+  if (width < 2 || height < 2) {
+    values.fill(0);
+    return values;
   }
 
+  let total = 0;
+  for (let y = top; y < bottom; y += 1) {
+    for (let x = left; x < right; x += 1) total += values[y * size + x];
+  }
+  const mean = total / (width * height);
+
+  const taper = (span) => {
+    const out = new Float64Array(span);
+    for (let i = 0; i < span; i += 1) out[i] = 0.5 - 0.5 * Math.cos((2 * Math.PI * i) / (span - 1));
+    return out;
+  };
+  const across = taper(width);
+  const down = taper(height);
+
   for (let y = 0; y < size; y += 1) {
+    const inside = y >= top && y < bottom;
     for (let x = 0; x < size; x += 1) {
-      values[y * size + x] = (values[y * size + x] - mean) * taper[y] * taper[x];
+      values[y * size + x] = inside && x >= left && x < right
+        ? (values[y * size + x] - mean) * down[y - top] * across[x - left]
+        : 0;
     }
   }
   return values;
@@ -899,7 +1345,10 @@ export function rotateScale(values, size, degrees, scale) {
  *
  * `measured` says whether the translation peak passed the gate. When it did
  * not, the shift returned beside it is whatever the tallest point of a
- * featureless surface happened to be, and the caller should not apply it.
+ * featureless surface happened to be, and the caller should not apply it. This
+ * is the pipeline's coarse survey and nothing else calls it, so that gate is
+ * the survey's: N_MAX_SURVEY for the translation peak, and N_MAX for the
+ * log-polar one, which is a full square whatever shape the output is.
  * `clamped` is a different report and says only one thing: the rotation or
  * scale read off the log-polar peak was too large to be a burst. A log-polar
  * peak the gate refused is not that - the frame reported no rotation at all,
@@ -971,7 +1420,11 @@ export function estimate(reference, frame, size, mode) {
     dy: shift.dy,
     angle,
     scale,
-    measured: isMeasured(shift),
+    // A thumbnail of the whole frame, tapered to the picture rather than to
+    // the square: a different surface from anything the refinement correlates,
+    // and N_MAX_SURVEY is where this statistic separates on it. The log-polar
+    // peak above is a whole square of spectrum and keeps N_MAX.
+    measured: isMeasured(shift, N_MAX_SURVEY),
     clamped,
     live: shift.live,
     coherence: shift.coherence,

--- a/tools/stack-images/src/pipeline.js
+++ b/tools/stack-images/src/pipeline.js
@@ -373,8 +373,22 @@ export async function inspect(files, hooks) {
  * everywhere, divided by one number. Fitting each frame to the square
  * separately would make that number different per frame, and different in each
  * axis for any frame of a different shape.
+ *
+ * The window is told that same box - `fit` describes both the draw and the
+ * taper, so the two cannot drift apart - and it is the output's box rather
+ * than this frame's spot in it for the same reason the draw is: the rectangle
+ * has to be identical in every frame or one number no longer converts a shift
+ * here into a shift in the output. So a frame of a different shape from the
+ * output, letterboxed inside the box, keeps a hard edge of its own where its
+ * picture stops. That is the edge `commonArea` is about, and it is a mixed
+ * set's cost rather than every set's; tapering it per frame would buy it back
+ * at the price of the constant.
+ *
+ * What the box removes is the edge every frame of every set had, the output
+ * box's own. window2d says what that edge did to the answer and what taking it
+ * out costs the gate.
  */
-function lumaSquare(bitmap, spot, output, fit, turn) {
+function lumaSquare(bitmap, spot, fit, turn) {
   const { canvas, context } = surface(ALIGN_SIZE, ALIGN_SIZE);
   context.setTransform(1, 0, 0, 1, fit.x, fit.y);
   context.scale(fit.scale, fit.scale);
@@ -386,7 +400,7 @@ function lumaSquare(bitmap, spot, output, fit, turn) {
     out[i] = pixels[at] * 0.299 + pixels[at + 1] * 0.587 + pixels[at + 2] * 0.114;
   }
   canvas.width = 0;
-  return window2d(out, ALIGN_SIZE);
+  return window2d(out, ALIGN_SIZE, fit);
 }
 
 /**
@@ -813,7 +827,7 @@ export async function runStack(request, hooks) {
     // copy of. Its own size never enters the arithmetic.
     const square = lumaSquare(frame.thumb, {
       x: spot.x, y: spot.y, width: spot.width, height: spot.height,
-    }, output, fit, frame.turn);
+    }, fit, frame.turn);
 
     if (!reference) {
       // Everything else is measured against this frame, so it is the one move
@@ -945,8 +959,15 @@ export async function runStack(request, hooks) {
         // the finished moves: every one of them is final by the end of the
         // first band's first pass.
         //
-        // Every window goes through the same gate the coarse pass does, and
-        // for the same reasons: a window without enough texture to correlate,
+        // Every window goes through the same gate the coarse pass does, for
+        // the same reasons but on its own floor: these are full squares of
+        // picture at the resolution the frame was shot at, so `isMeasured`
+        // below is asked with no floor and gets N_MAX, where the coarse peak
+        // is asked with N_MAX_SURVEY because a thumbnail tapered to the
+        // picture's box is a different surface and the same statistic reads on
+        // a different scale there. The comment on N_MAX_SURVEY has both
+        // distributions; do not make the two "consistent". The reasons
+        // themselves are shared: a window without enough texture to correlate,
         // one whose peak is a plateau - a wall, a sky - so that its position
         // is the noise's choice, or one whose peak is merely the tallest of
         // several, so that which one the argmax took is the noise's choice


### PR DESCRIPTION
Follows #367, which is merged; this targets `main`.

## What was wrong

The coarse alignment square is 256 pixels on a side, and the whole output box is letterboxed into it. For any picture that is not square, the picture occupies a sub-rectangle and everything outside it is transparent, which reads back as black. So each frame arrived at the correlation with a hard step at its own edge, from picture straight down to zero, and every frame had the same step in the same place.

That step is the strongest thing in a smooth picture. It pinned the answer along the letterboxed axis and put a ridge in the correlation surface, which cost a pixel or two on any scene without much texture. The README has carried it as a known limitation since the audit.

## What changed, and what it turned out to cost

The window is now taken over the picture's own rectangle: the mean of that rectangle, a Hann taper across its own width and height, and zero outside. The rectangle is the **output** box under the fit transform, not each frame's own spot, because every frame has to be weighted the same way for one number to convert a shift in the square into a shift in the output.

That alone would have been a bad change, and measuring it is how I found out. **The letterbox edge was doing gate work by accident.** It is what made a featureless sky's correlation surface a ridge, and a ridge is what the peak-shape and peak-uniqueness readings detect. Take the edge away and a clear sky produces a clean-looking peak: measured in the browser over twelve seeds, a clear sky at 3:2 went from refused on every seed to **admitted on eleven of twelve**, moved by up to 38 pixels. That is precisely the failure #366 exists to prevent.

The taper is still right, and the measurement says why: it compresses a real answer while leaving junk where it was, so the two separate *further* apart than the letterbox ever put them.

| on the survey square | real scenes | junk |
|---|---|---|
| letterboxed (before) | 0.06 – 0.51 | 0.82 – 1.00 |
| tapered (after) | 0.03 – 0.29 | 0.62 – 1.00 |

What the change needed was not the old floor but a floor of its own. `N_MAX_SURVEY` is 0.45, and it applies to the coarse translation peak alone: the refinement windows and the log-polar surface are full squares with no letterbox in them, and they keep the floor they were calibrated on. Both call sites are pinned by tests that fail if the argument is dropped, which is the trap the previous change in this series had.

## What it buys, and what it costs

Measured end to end through the whole pipeline on one seeded set of scenes:

| scene | before | after |
|---|---|---|
| low texture, portrait 2:3 | 2.65 px | 1.43 px |
| low texture, 15% noise | 3.21 px | 2.85 px |
| texture, sub-pixel shifts | 0.10 px | 0.09 px |
| texture, 0.3-degree turns | 0.06 px | 0.05 px |
| star field | 0.14 px | 0.15 px |

The same run, as the page's own readout, before and after:

| | |
|---|---|
| before | <img width="820" alt="ab-before" src="https://github.com/user-attachments/assets/3d900076-e90c-4421-8936-b5c1959e2717" /> |
| after | <img width="820" alt="ab-after" src="https://github.com/user-attachments/assets/43628cab-50b9-4bfa-a785-e07accf2b29e" /> |

Verified in the browser against the built page: clear and noisy skies refused at 3:2 and 2:3 and left uncropped; textured frames, a textured scene at fifty per cent noise, low-texture frames at both shapes, star fields of four hundred, one hundred and fifty and sixty stars, and a 0.3-degree rotated burst all still measured and unchanged or better.

**The cost, stated because it is real.** A very sparse night sky sits closest to the floor. A field of thirty stars over a six-megapixel frame now has a frame reported as unmeasured and left where it was; sixty stars and up are unaffected. The sentence the page shows for that case already says exactly what happened and needed no change. The numbers the floor was chosen against are recorded beside the constant, so moving it is a decision somebody can make on evidence.

No visitor-facing sentence changed, so no locale is touched. 166 stack-images tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
