### PR TITLE
Put the encoder question to a thread the page can outlive

### DIFF
--- a/buildlib/imports.py
+++ b/buildlib/imports.py
@@ -18,6 +18,10 @@ Two ways that happens, and neither is hypothetical:
     `shared/js/crc32.js` is exactly this shape. The tool builds, the page
     loads, and the ZIP writer is missing its checksum function.
 
+A third shape names a file without importing it: `new URL('./worker.js',
+import.meta.url)`, which is how a Worker's script is found. It fails the same
+way and is read the same way - see `asset_urls` below.
+
 Both are invisible to `python build.py` and to CI, and both break the tool
 completely. So the build reads every module it is about to emit, collects the
 specifiers, and refuses a tool whose imports do not all land on a file that
@@ -65,6 +69,36 @@ def specifiers(source, where='<js>'):
         elif (previous == '(' and index >= 2
                 and tokens[index - 2][1] == 'import'):
             found.append((line, text[1:-1]))
+
+    return found
+
+
+def asset_urls(source, where='<js>'):
+    """Every file `source` names with `new URL('…', import.meta.url)`.
+
+    Not an import, so `specifiers` above does not see it, but the same failure
+    with the same cost: a Worker started from a path nobody shipped is a 404
+    on the visitor's machine, and the feature it was carrying simply never
+    happens. `shared/js/codec-support.js` starting `codec-probe.js` and
+    stack-images starting its own `worker.js` are both this shape, and the
+    first is a shared module whose worker has to be listed in `js_parts`
+    separately - the zip/crc32 trap again, in a place `import` never looks.
+
+    Only relative strings are collected. `new URL(text)` over something a
+    visitor typed and `new URL('https://…')` are the same expression naming no
+    file in this repository, and there is nothing for them to land on.
+    """
+    found = []
+    tokens = minify.tokenize_js(source, where)
+
+    for index, (line, text) in enumerate(tokens):
+        if index < 3 or not text or text[0] not in '\'"':
+            continue
+        if [tokens[index - back][1] for back in (3, 2, 1)] != ['new', 'URL', '(']:
+            continue
+        specifier = text[1:-1]
+        if specifier.startswith('./') or specifier.startswith('../'):
+            found.append((line, specifier))
 
     return found
 
@@ -200,6 +234,19 @@ def check(shipped, read, where):
                 problems.append(
                     f'{name}:{line}: "{specifier}" -> {target}, which this '
                     f'tool does not ship')
+
+        # A file named by `new URL(…, import.meta.url)` rather than imported.
+        # Checked only where it lands inside src/, because that is the whole of
+        # what a tool's asset list covers: a vendored engine sits in vendor/
+        # and is shipped by a path this set knows nothing about.
+        for line, specifier in asset_urls(source, f'{where}/{name}'):
+            target = resolve(name, specifier)
+            if target is None or not target.startswith('src/'):
+                continue
+            if target not in shipped:
+                problems.append(
+                    f'{name}:{line}: new URL("{specifier}") -> {target}, '
+                    f'which this tool does not ship')
 
         # A file that exists can still lack the name asked of it; the browser
         # refuses to link the whole module and the page's code never starts.

--- a/docs/adding-a-tool.md
+++ b/docs/adding-a-tool.md
@@ -123,6 +123,8 @@ A component more than one tool needs, and that no tool should own, lives under
 | `shared/js/parse-xml.js` | `js_parts = ["parse-xml"]` | XML and HTML, one parser with two rulebooks |
 | `shared/js/qr-tables.js` | `js_parts = ["qr-tables"]` | the QR specification's tables and the arithmetic around them, for the writer and the reader alike |
 | `shared/js/pdf-page-writer.js` | `js_parts = ["pdf-page-writer"]` | a PDF writer for putting pictures on pages; not the quartet's rewriter |
+| `shared/js/codec-support.js` | `js_parts = ["codec-support", "codec-probe"]` | whether this browser will encode a configuration, with a deadline on the answer; never listed without `codec-probe` |
+| `shared/js/codec-probe.js` | `js_parts = ["codec-probe"]` | the worker `codec-support` puts that question to, so a browser that blocks on it cannot take the page with it; needs `worker-src 'self'` in the tool's `[csp]` |
 | `shared/js/video-support.js` | `js_parts = ["video-support"]` | what this browser will decode, encode and record; imports `codec-support` |
 | `shared/js/frame-canvas.js` | `js_parts = ["frame-canvas"]` | the canvas a video's frames are drawn into at the output size, turned the way the file asks; `readBack` for a tool that reads the pixels out again |
 | `shared/js/format.js` | `js_parts = ["format"]` | sizes, durations and the m:ss.mmm clock as words, in the tiers and decimals the tool names |
@@ -134,9 +136,13 @@ A component more than one tool needs, and that no tool should own, lives under
 | `shared/js/trust.js` | nothing — every tool gets it | the live network check and the offline line |
 
 `zip` needs `crc32` listed as well — it is a separate part because a PNG writer
-wants the checksum without the archive. The four `pdf-*` parts travel
-together: the reader and the writer both import the grammar and the filters,
-and `buildlib/imports.py` refuses a tool that lists some and not the rest.
+wants the checksum without the archive. `codec-support` needs `codec-probe` the
+same way, and for a reason `import` cannot express: it starts that file as a
+Worker rather than importing it, so the tool that lists one and not the other
+builds cleanly and then says nothing at all when the button is pressed. The
+four `pdf-*` parts travel together: the reader and the writer both import the
+grammar and the filters, and `buildlib/imports.py` refuses a tool that lists
+some and not the rest.
 
 `phrases` and `trust` are the two parts no tool asks for. Every tool page wears
 the frame, the frame has sentences its JavaScript puts on screen, and the
@@ -214,7 +220,9 @@ module a tool is about to ship, with the tokeniser from `minify.py` rather than
 a regular expression, and refuses a tool whose imports do not all land on a
 file that tool ships. The case it exists for: `shared/js/zip.js` imports
 `./crc32.js`, so a tool asking for `"zip"` and not `"crc32"` would build
-cleanly and 404 in the browser.
+cleanly and 404 in the browser. A file named by `new URL(…, import.meta.url)`
+rather than imported — a Worker's script — is read the same way and held to the
+same rule.
 
 Only *choosing* the files is shared. What a tool does with them afterwards — the
 list, the thumbnails, the reordering, the per-row buttons — differs enough per

--- a/shared/js/codec-probe.js
+++ b/shared/js/codec-probe.js
@@ -1,0 +1,62 @@
+/**
+ * The capability question, asked on a thread that is not the page's.
+ *
+ * GENERATED INTO EACH TOOL. This file lives at shared/js/codec-probe.js and
+ * the build copies it to <tool>/src/shared/codec-probe.js for the tools that
+ * ask for it with `js_parts = ["codec-support", "codec-probe", ...]`. It is a
+ * Worker rather than a module: nothing imports it, and codec-support.js beside
+ * it names it with `new URL('./codec-probe.js', import.meta.url)`. The two
+ * always ship together - buildlib/imports.py fails a build that ships one
+ * without the other, the same way it does for zip.js and crc32.js.
+ *
+ * WHY A WHOLE THREAD FOR ONE QUESTION
+ *
+ * `VideoEncoder.isConfigSupported` is specified to return a promise, and every
+ * browser that implements the class is expected to settle it. One does not,
+ * and it does not merely leave the promise pending: it blocks the thread that
+ * asked. Nothing that thread was going to do next happens - not the deadline
+ * codec-support.js sets, not the error handler, not the sentence the tool
+ * meant to show instead. On the WebKit build this site's QA suite runs
+ * against, a click on Create video was still unanswered five minutes later.
+ *
+ * A deadline can only be kept by a thread that is still running, which is the
+ * whole reason this file exists. The question is asked here and the clock is
+ * watched over there. When this thread is the one that stops, the page is
+ * still able to notice the silence, terminate it, and say so.
+ */
+
+/**
+ * Say hello, before any question arrives.
+ *
+ * The page waits for this before trusting a silence. A worker that never
+ * loaded - a Content-Security-Policy with no worker-src, a browser with no
+ * Worker at all, a build that failed to ship this file - says nothing in
+ * exactly the way a wedged one says nothing, and the two need opposite
+ * answers: ask on the page instead, or refuse and tell the visitor. This
+ * message is the only thing that tells them apart.
+ */
+self.postMessage({ ready: true });
+
+self.addEventListener('message', async ({ data }) => {
+  const { id, name, config } = data;
+  const codec = globalThis[name];
+
+  // Not the same as "cannot encode". Every browser that offers WebCodecs to a
+  // window offers it to a worker as well, so this is not expected - but where
+  // it happens the page can still ask on its own thread, and an answer from
+  // there beats a guess from here.
+  if (typeof codec?.isConfigSupported !== 'function') {
+    self.postMessage({ id, absent: true });
+    return;
+  }
+
+  try {
+    const answer = await codec.isConfigSupported(config);
+    self.postMessage({ id, supported: Boolean(answer && answer.supported) });
+  } catch {
+    // A codec string this browser cannot even parse, or a class that threw
+    // rather than rejecting. The browser did answer, in its own way, and the
+    // answer was no.
+    self.postMessage({ id, supported: false });
+  }
+});

--- a/shared/js/codec-support.js
+++ b/shared/js/codec-support.js
@@ -5,10 +5,10 @@
  *
  * `VideoEncoder.isConfigSupported` is specified to return a promise, and every
  * browser that implements the class is expected to settle it. One does not.
- * On the WebKit build this site's QA suite runs against, the promise from
- * `VideoEncoder.isConfigSupported` is still pending two minutes later, while
- * `VideoDecoder.isConfigSupported` on the same build answers immediately -
- * which is how video-to-gif works there and everything that encodes did not.
+ * On the WebKit build this site's QA suite runs against, the question never
+ * comes back, while `VideoDecoder.isConfigSupported` on the same build answers
+ * immediately - which is how video-to-gif works there and everything that
+ * encodes did not.
  *
  * What "did not" looked like was worse than a refusal. `pickH264Codec` awaits
  * that promise inside a loop over nine candidate codec strings, so pressing
@@ -23,6 +23,28 @@
  * when a codec is unavailable, and the visitor is told - which is the whole of
  * what these tools promise to do when they cannot do the work.
  *
+ * WHY THE DEADLINE NEEDED A SECOND THREAD
+ *
+ * The first version of this raced the question against a `setTimeout` on the
+ * same thread, which is sound against a promise that never settles and
+ * useless against what actually happens. That build does not leave the promise
+ * pending - it blocks the thread that asked, so the timer set to rescue it
+ * never gets a turn. The deadline was there, correct, and unreachable; the
+ * page still wedged on the click, and the QA suite went on watching a Create
+ * video button that had not answered five minutes later.
+ *
+ * So the question goes to codec-probe.js, a worker, and the clock stays here.
+ * A thread that is still running can hold a deadline over one that is not.
+ * When the worker goes quiet the page ends the wait, terminates it, and the
+ * tool says what it says when a codec is unavailable.
+ *
+ * Falling back matters as much as the worker does. A page that cannot start
+ * one - a policy without worker-src, a browser with no Worker - must not
+ * conclude from that that it cannot encode; it asks on its own thread
+ * instead, exactly as this file used to. Which is why the worker announces
+ * itself before any question is put to it: silence from a worker that never
+ * started is not evidence about the browser's encoder.
+ *
  * WHY THE THIRD ANSWER
  *
  * `null` means the browser did not reply, and it is worth telling apart from a
@@ -35,22 +57,145 @@
  * How long to wait for a browser to answer a question about itself.
  *
  * Generous. Chrome answers these in single-digit milliseconds, and the point
- * is not to hurry a slow machine - it is to end a wait that has no end.
+ * is not to hurry a slow machine - it is to end a wait that has no end. The
+ * same figure bounds the worker's start, for the same reason.
  */
 const PATIENCE = 2000;
 
 /**
- * Ask a WebCodecs class whether it supports a configuration.
+ * The classes a question can be about.
  *
- * @param {{isConfigSupported?: (config: object) => Promise<{supported?: boolean}>}} codec
- *        `VideoEncoder`, `VideoDecoder`, `AudioEncoder` or `AudioDecoder`.
- * @param {object} config  the configuration to ask about
- * @param {number} [ms]    how long to wait before giving up
- * @returns {Promise<boolean|null>} true, false, or null for no answer in time
+ * A worker cannot be handed a class, so it is handed the name and looks the
+ * class up for itself. Anything not on this list - a double a test passes in,
+ * most usefully - is asked on this thread, because there is nothing the worker
+ * could look up that would be the same object.
  */
-export async function askSupported(codec, config, ms = PATIENCE) {
-  if (typeof codec?.isConfigSupported !== 'function') return false;
+const CLASSES = ['VideoEncoder', 'VideoDecoder', 'AudioEncoder', 'AudioDecoder'];
 
+/** Which of those `codec` is, or null for anything else. */
+function nameOf(codec) {
+  return CLASSES.find((name) => globalThis[name] === codec) ?? null;
+}
+
+/** The worker, once one has started. */
+let probe = null;
+
+/** A promise for that worker, so a page starts at most one at a time. */
+let started = null;
+
+/** The questions outstanding on it, by id, and how many have been asked. */
+const waiting = new Map();
+let asked = 0;
+
+/**
+ * The classes whose question has already stopped a thread.
+ *
+ * Once a browser has failed to answer about H.264 it will fail again, and a
+ * second attempt costs another worker and another deadline to learn what the
+ * first one established. Remembered by class rather than for the whole page,
+ * because a build that blocks on the encoder still answers about the decoder
+ * and there is no reason to stop asking it.
+ */
+const wedged = new Set();
+
+/** Start one, or answer null for a page where no worker can run. */
+function startProbe(ms) {
+  return new Promise((resolve) => {
+    let worker;
+    try {
+      worker = new Worker(new URL('./codec-probe.js', import.meta.url), { type: 'module' });
+    } catch {
+      resolve(null);
+      return;
+    }
+
+    // A worker that cannot load says so here rather than at construction, and
+    // until it does it looks exactly like one that is slow to start - hence
+    // the deadline as well as the handler.
+    let timer;
+    const giveUp = () => {
+      clearTimeout(timer);
+      worker.terminate();
+      resolve(null);
+    };
+    timer = setTimeout(giveUp, ms);
+    worker.addEventListener('error', giveUp);
+
+    worker.addEventListener('message', ({ data }) => {
+      if (data && data.ready) {
+        clearTimeout(timer);
+        probe = worker;
+        resolve(worker);
+        return;
+      }
+      const settle = waiting.get(data && data.id);
+      if (settle) {
+        waiting.delete(data.id);
+        settle(data);
+      }
+    });
+  });
+}
+
+/** The started worker, or null once it is known there will not be one. */
+function theProbe(ms) {
+  if (!started) started = startProbe(ms);
+  return started;
+}
+
+/**
+ * Stop waiting on a thread that has stopped answering.
+ *
+ * Terminated rather than left alone: it is holding a question that will never
+ * come back, and every later question would queue behind that one. The next
+ * caller starts a fresh worker, which is worth doing - the class that wedged
+ * is remembered separately and will not be asked again.
+ */
+function forgetProbe() {
+  if (probe) probe.terminate();
+  probe = null;
+  started = null;
+  waiting.clear();
+}
+
+/**
+ * Start over: no worker, no memory of one, nothing wedged.
+ *
+ * For the tests. A module-level worker is otherwise remembered for the life of
+ * the process, so one case's wedged encoder would decide the next case's
+ * answer.
+ */
+export function forgetTheBrowser() {
+  forgetProbe();
+  wedged.clear();
+}
+
+/** Put one question to the worker, and take silence for an answer. */
+function put(worker, message, ms) {
+  return new Promise((resolve) => {
+    let timer;
+    waiting.set(message.id, (data) => {
+      clearTimeout(timer);
+      resolve(data);
+    });
+    timer = setTimeout(() => {
+      waiting.delete(message.id);
+      resolve(null);
+    }, ms);
+    worker.postMessage(message);
+  });
+}
+
+/**
+ * Ask on this thread, which is what a page does when no worker can answer.
+ *
+ * The deadline is honest here and unenforceable against the one build this was
+ * written for - a `setTimeout` cannot fire on a thread that is blocked. It is
+ * still right to keep: this path is reached on browsers that have no Worker
+ * rather than on the one that wedges, and a promise that merely never settles
+ * is bounded by it.
+ */
+async function askHere(codec, config, ms) {
   let timer;
   const silence = Symbol('no answer');
   try {
@@ -68,4 +213,37 @@ export async function askSupported(codec, config, ms = PATIENCE) {
   } finally {
     clearTimeout(timer);
   }
+}
+
+/**
+ * Ask a WebCodecs class whether it supports a configuration.
+ *
+ * @param {{isConfigSupported?: (config: object) => Promise<{supported?: boolean}>}} codec
+ *        `VideoEncoder`, `VideoDecoder`, `AudioEncoder` or `AudioDecoder`.
+ * @param {object} config  the configuration to ask about
+ * @param {number} [ms]    how long to wait before giving up
+ * @returns {Promise<boolean|null>} true, false, or null for no answer in time
+ */
+export async function askSupported(codec, config, ms = PATIENCE) {
+  if (typeof codec?.isConfigSupported !== 'function') return false;
+
+  const name = nameOf(codec);
+  if (name === null) return askHere(codec, config, ms);
+  if (wedged.has(name)) return null;
+
+  const worker = await theProbe(ms);
+  if (!worker) return askHere(codec, config, ms);
+
+  asked += 1;
+  const reply = await put(worker, { id: asked, name, config }, ms);
+
+  if (reply === null) {
+    wedged.add(name);
+    forgetProbe();
+    return null;
+  }
+  // The worker has the deadline but not the class. Nothing has been learned
+  // about the browser yet, so the page asks with the object it does have.
+  if (reply.absent) return askHere(codec, config, ms);
+  return reply.supported;
 }

--- a/tests/js/codec-support.test.js
+++ b/tests/js/codec-support.test.js
@@ -10,12 +10,18 @@
  * It is also the one behaviour no browser will demonstrate on demand, so it is
  * tested with a promise that simply never resolves - which is exactly what the
  * code has to survive, and can be written down in one line here.
+ *
+ * The cases below the first group are about where the question is asked. That
+ * build does not leave the promise pending, it blocks the thread that asked,
+ * so the deadline above can only be kept by moving the question to a worker -
+ * and a worker brings its own ways to fail. Every one of them has to end with
+ * the page still able to say something.
  */
 
-import test from 'node:test';
+import test, { afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { askSupported } from '../../shared/js/codec-support.js';
+import { askSupported, forgetTheBrowser } from '../../shared/js/codec-support.js';
 
 /** A stand-in for VideoEncoder and friends, answering however the test says. */
 const codec = (answer) => ({ isConfigSupported: () => answer });
@@ -60,4 +66,126 @@ test('a browser without the class at all is a no', async () => {
 test('an answer without a supported field is a no', async () => {
   assert.equal(await askSupported(codec(Promise.resolve({})), {}), false);
   assert.equal(await askSupported(codec(Promise.resolve(null)), {}), false);
+});
+
+/*
+ * Where the question is asked.
+ *
+ * A real class rather than a double from here on: the module hands the worker
+ * a name, not an object, so it only takes that route for something it can find
+ * on globalThis under one of the names the worker knows.
+ */
+
+/**
+ * A page with a Worker of a given temperament and a VideoEncoder to ask about.
+ *
+ * `starts` is whether the worker ever announces itself, `answers` what it
+ * replies to a question (undefined for a worker that never replies at all),
+ * and `onThisThread` what the class itself would say if the page asked it
+ * directly - which is how each case below proves which of the two answered.
+ */
+function pageWith({ starts = true, answers = undefined, onThisThread } = {}) {
+  const workers = [];
+
+  class FakeWorker {
+    constructor(url, options) {
+      this.url = String(url);
+      this.options = options;
+      this.heard = [];
+      this.stopped = false;
+      this.listeners = { message: [], error: [] };
+      workers.push(this);
+      if (starts) queueMicrotask(() => this.say({ ready: true }));
+    }
+
+    addEventListener(kind, fn) { this.listeners[kind].push(fn); }
+    say(data) { this.listeners.message.forEach((fn) => fn({ data })); }
+    terminate() { this.stopped = true; }
+
+    postMessage(message) {
+      this.heard.push(message);
+      if (answers === undefined) return;
+      queueMicrotask(() => this.say({ id: message.id, ...answers }));
+    }
+  }
+
+  globalThis.Worker = FakeWorker;
+  globalThis.VideoEncoder = { isConfigSupported: () => onThisThread };
+  return workers;
+}
+
+afterEach(() => {
+  delete globalThis.Worker;
+  delete globalThis.VideoEncoder;
+  forgetTheBrowser();
+});
+
+test('the question goes to the worker, not to this thread', async () => {
+  // The class on this thread never answers, so a true here can only have come
+  // from the worker.
+  const workers = pageWith({
+    answers: { supported: true },
+    onThisThread: new Promise(() => {}),
+  });
+
+  assert.equal(await askSupported(VideoEncoder, { codec: 'avc1.640028' }, 40), true);
+  assert.equal(workers.length, 1);
+  assert.equal(workers[0].options.type, 'module');
+  assert.match(workers[0].url, /codec-probe\.js$/);
+  assert.deepEqual(workers[0].heard[0].name, 'VideoEncoder');
+});
+
+test('a worker that goes quiet is silence, and is not left running', async () => {
+  const workers = pageWith({ onThisThread: new Promise(() => {}) });
+
+  assert.equal(await askSupported(VideoEncoder, {}, 40), null);
+  // Terminated rather than abandoned: it is holding a question that will
+  // never come back, and the next one would queue behind it for ever.
+  assert.equal(workers[0].stopped, true);
+});
+
+test('a browser that has wedged once is not asked a second time', async () => {
+  const workers = pageWith({ onThisThread: new Promise(() => {}) });
+
+  assert.equal(await askSupported(VideoEncoder, {}, 40), null);
+  const started = Date.now();
+  assert.equal(await askSupported(VideoEncoder, {}, 40), null);
+
+  // Nine candidate codec strings would otherwise cost nine deadlines and nine
+  // workers to learn what the first one established about the browser.
+  assert.equal(workers.length, 1);
+  assert.ok(Date.now() - started < 30, 'the second question paid the deadline again');
+});
+
+test('a worker that never starts sends the question back to this thread', async () => {
+  // A policy with no worker-src, a browser with no Worker, a file that did not
+  // ship: silence from a worker that never ran says nothing about the encoder,
+  // and a page that concluded "cannot encode" from it would refuse to work on
+  // a browser that is perfectly able to.
+  const workers = pageWith({
+    starts: false,
+    onThisThread: Promise.resolve({ supported: true }),
+  });
+
+  assert.equal(await askSupported(VideoEncoder, {}, 40), true);
+  assert.equal(workers[0].stopped, true);
+});
+
+test('a page that cannot make a worker at all still asks', async () => {
+  pageWith({ onThisThread: Promise.resolve({ supported: true }) });
+  globalThis.Worker = undefined;
+
+  assert.equal(await askSupported(VideoEncoder, {}, 40), true);
+});
+
+test('a worker without the class asks this thread instead', async () => {
+  // Every browser that offers WebCodecs to a window offers it to a worker too,
+  // so this is not expected - but where it happens the page still has the
+  // class, and an answer beats a guess.
+  pageWith({
+    answers: { absent: true },
+    onThisThread: Promise.resolve({ supported: true }),
+  });
+
+  assert.equal(await askSupported(VideoEncoder, {}, 40), true);
 });

--- a/tests/python/test_imports.py
+++ b/tests/python/test_imports.py
@@ -91,6 +91,37 @@ class Resolve(unittest.TestCase):
         self.assertIsNone(imports.resolve('src/main.js', 'lodash'))
 
 
+class AssetUrls(unittest.TestCase):
+    """`new URL('./x.js', import.meta.url)` - how a Worker's script is named.
+
+    Not an import, so the reader above never sees it, and the tool that ships
+    the module without shipping its worker builds cleanly and then does
+    nothing at all when the button is pressed.
+    """
+
+    def urls(self, source):
+        return [spec for _, spec in imports.asset_urls(source)]
+
+    def test_a_worker_script(self):
+        self.assertEqual(
+            self.urls("new Worker(new URL('./worker.js', import.meta.url));"),
+            ['./worker.js'])
+
+    def test_a_path_out_of_the_folder(self):
+        self.assertEqual(
+            self.urls("const E = new URL('../vendor/lib.js', import.meta.url);"),
+            ['../vendor/lib.js'])
+
+    def test_an_absolute_url_names_no_file(self):
+        self.assertEqual(self.urls("new URL('https://example.com/x.js');"), [])
+
+    def test_a_url_built_from_something_a_visitor_typed(self):
+        self.assertEqual(self.urls('url = new URL(raw.trim());'), [])
+
+    def test_the_word_in_prose_is_not_one(self):
+        self.assertEqual(self.urls("// new URL('./x.js') in a comment"), [])
+
+
 class Check(unittest.TestCase):
     def test_a_tool_whose_imports_all_land(self):
         files = {'src/main.js': "import { z } from './zip.js';",
@@ -124,6 +155,32 @@ class Check(unittest.TestCase):
         with self.assertRaises(ConfigError) as caught:
             imports.check(set(files), files.get, 'demo')
         self.assertIn('2 import(s)', str(caught.exception))
+
+    def test_a_worker_script_that_was_never_shipped(self):
+        # codec-support.js is in js_parts and codec-probe.js is not: the page
+        # loads, the encoder question is never answered, and nothing says so.
+        files = {'src/main.js': "import { a } from './shared/ask.js';",
+                 'src/shared/ask.js':
+                     "export const a = new Worker("
+                     "new URL('./probe.js', import.meta.url));"}
+        with self.assertRaises(ConfigError) as caught:
+            imports.check(set(files), files.get, 'demo')
+        self.assertIn('src/shared/probe.js', str(caught.exception))
+
+    def test_a_worker_script_that_was_shipped(self):
+        files = {'src/main.js': "import { a } from './shared/ask.js';",
+                 'src/shared/ask.js':
+                     "export const a = new Worker("
+                     "new URL('./probe.js', import.meta.url));",
+                 'src/shared/probe.js': ''}
+        imports.check(set(files), files.get, 'demo')       # does not raise
+
+    def test_a_vendored_engine_is_left_alone(self):
+        # vendor/ is shipped by another path entirely and is not in the asset
+        # list this check is given, so it has nothing to say about it.
+        files = {'src/main.js': "const E = new URL('../vendor/lib.js', "
+                                "import.meta.url);"}
+        imports.check(set(files), files.get, 'demo')       # does not raise
 
     def test_non_javascript_is_not_read(self):
         # A tool's src/ can hold other files; they are copied, not parsed.

--- a/tools/crop-video/tool.toml
+++ b/tools/crop-video/tool.toml
@@ -32,13 +32,13 @@ css_parts = ["progress", "results", "form", "notes", "cropper", "checks", "chips
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.
-js_parts = ["file-picker", "codec-support", "mp4-reader", "video-support", "message-box", "media", "format", "webcodecs", "errors", "mp4-boxes", "cropper"]
+js_parts = ["file-picker", "codec-support", "codec-probe", "mp4-reader", "video-support", "message-box", "media", "format", "webcodecs", "errors", "mp4-boxes", "cropper"]
 # Where a finished result can be carried without being saved first: the row of
 # links shared/handoff.js shows beside the download once there is one. Slugs of
 # tools whose picker takes what this page produces; checked against the tools
 # that exist by the build.
 handoff = ["trim-video", "video-to-gif"]
-lastmod = "2026-09-02"
+lastmod = "2026-09-07"
 
 # --- what search engines and chat apps are told ------------------------------
 
@@ -57,9 +57,11 @@ og_card = "Cut a clip down to the part that matters, without it ever leaving you
 # whatever this tool needs that the rest of the site does not.
 csp_note = """
   media-src needs blob: because both the clip you chose and the cropped result
-  are played from memory on this machine rather than from a URL. That is the
-  only addition: this tool fetches nothing, so connect-src is left exactly as
-  the site sets it."""
+  are played from memory on this machine rather than from a URL. worker-src
+  needs 'self' because the question of what this browser can encode is put to
+  a small script in this folder rather than asked on the page itself. Those
+  are the only additions: this tool fetches nothing, so connect-src is left
+  exactly as the site sets it."""
 
 # --- the pledge block --------------------------------------------------------
 
@@ -299,7 +301,8 @@ features = [
   "Runs offline; no upload, no account, no watermark",
 ]
 
-# This tool needs one thing the rest of the site does not: blob: on media-src,
+# This tool needs two things the rest of the site does not. One is
+# blob: on media-src,
 # because both the clip you chose and the cropped result are played from memory
 # on this machine rather than from a URL. A tool can only ever widen its own
 # page this way - it cannot narrow the site policy, and it cannot touch any
@@ -308,9 +311,17 @@ features = [
 # blob: URL before parking it for the next tool (see shared/handoff.js), and
 # reading a blob: URL is a fetch the policy has to permit. blob: names bytes
 # inside this page; nothing here gains any reach over the network.
+# The other is worker-src 'self', for the worker that asks this browser what it
+# can encode. That question blocks the thread it is asked on in at least one
+# browser, and a deadline cannot be kept by a thread that has stopped - so it
+# goes to a worker the page is able to outlive and give up on. It is 'self', a
+# file in this folder cached by the service worker beside it, and there is no
+# blob: on it, because nothing here ever builds a script at runtime. See
+# shared/js/codec-support.js.
 [csp]
 "connect-src" = ["blob:"]
 "media-src" = ["'self'", "blob:"]
+"worker-src" = ["'self'"]
 
 # The drop zone. Rendered by templates/partials/file-picker.html, which
 # body.html includes, and driven by src/shared/file-picker.js.

--- a/tools/images-to-video/tool.toml
+++ b/tools/images-to-video/tool.toml
@@ -32,8 +32,8 @@ css_parts = ["progress", "results", "form", "notes"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.
-js_parts = ["file-picker", "codec-support", "mp4-muxer", "message-box", "format", "webcodecs", "errors", "mp4-boxes", "image-list"]
-lastmod = "2026-08-27"
+js_parts = ["file-picker", "codec-support", "codec-probe", "mp4-muxer", "message-box", "format", "webcodecs", "errors", "mp4-boxes", "image-list"]
+lastmod = "2026-09-07"
 
 # --- what search engines and chat apps are told ------------------------------
 
@@ -53,8 +53,10 @@ og_card = "Turn a folder of images into an MP4 slideshow, encoded on your own ma
 csp_note = """
   img-src allows http/https so the "add from web address" feature can pull an
   image IN, and because ad creatives come from anywhere. media-src and
-  worker-src need blob: because the finished video and the encoder both live in
-  memory on this machine rather than at a URL."""
+  worker-src need blob: because the finished video and the encoder both live
+  in memory on this machine rather than at a URL. worker-src also carries the
+  small script that asks this browser what it can encode, which is a file in
+  this folder."""
 
 # --- the pledge block --------------------------------------------------------
 

--- a/tools/reverse-video/tool.toml
+++ b/tools/reverse-video/tool.toml
@@ -32,13 +32,13 @@ css_parts = ["progress", "results", "form", "notes", "checks"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.
-js_parts = ["file-picker", "codec-support", "mp4-reader", "mp4-writer", "video-support", "message-box", "media", "format", "webcodecs", "errors", "mp4-boxes", "aac"]
+js_parts = ["file-picker", "codec-support", "codec-probe", "mp4-reader", "mp4-writer", "video-support", "message-box", "media", "format", "webcodecs", "errors", "mp4-boxes", "aac"]
 # Where a finished result can be carried without being saved first: the row of
 # links shared/handoff.js shows beside the download once there is one. Slugs of
 # tools whose picker takes what this page produces; checked against the tools
 # that exist by the build.
 handoff = ["trim-video", "video-to-gif"]
-lastmod = "2026-08-28"
+lastmod = "2026-09-07"
 
 # --- what search engines and chat apps are told ------------------------------
 
@@ -56,10 +56,12 @@ og_card = "Play a clip backwards - the picture and the sound - without it leavin
 # Appended to the Content-Security-Policy comment in the generated page, for
 # whatever this tool needs that the rest of the site does not.
 csp_note = """
-  media-src needs blob: because both the clip you chose and the reversed result
-  are played from memory on this machine rather than from a URL. That is the
-  only addition: this tool fetches nothing, so connect-src is left exactly as
-  the site sets it."""
+  media-src needs blob: because both the clip you chose and the reversed
+  result are played from memory on this machine rather than from a URL.
+  worker-src needs 'self' because the question of what this browser can encode
+  is put to a small script in this folder rather than asked on the page
+  itself. Those are the only additions: this tool fetches nothing, so
+  connect-src is left exactly as the site sets it."""
 
 # --- the pledge block --------------------------------------------------------
 
@@ -304,7 +306,8 @@ features = [
   "Runs offline; no upload, no account, no watermark",
 ]
 
-# This tool needs one thing the rest of the site does not: blob: on media-src,
+# This tool needs two things the rest of the site does not. One is
+# blob: on media-src,
 # because both the clip you chose and the reversed result are played from memory
 # on this machine rather than from a URL. A tool can only ever widen its own
 # page this way - it cannot narrow the site policy, and it cannot touch any
@@ -313,9 +316,17 @@ features = [
 # blob: URL before parking it for the next tool (see shared/handoff.js), and
 # reading a blob: URL is a fetch the policy has to permit. blob: names bytes
 # inside this page; nothing here gains any reach over the network.
+# The other is worker-src 'self', for the worker that asks this browser what it
+# can encode. That question blocks the thread it is asked on in at least one
+# browser, and a deadline cannot be kept by a thread that has stopped - so it
+# goes to a worker the page is able to outlive and give up on. It is 'self', a
+# file in this folder cached by the service worker beside it, and there is no
+# blob: on it, because nothing here ever builds a script at runtime. See
+# shared/js/codec-support.js.
 [csp]
 "connect-src" = ["blob:"]
 "media-src" = ["'self'", "blob:"]
+"worker-src" = ["'self'"]
 
 # The drop zone. Rendered by templates/partials/file-picker.html, which
 # body.html includes, and driven by src/shared/file-picker.js.

--- a/tools/timelapse-video/tool.toml
+++ b/tools/timelapse-video/tool.toml
@@ -32,13 +32,13 @@ css_parts = ["progress", "results", "form", "notes", "chips"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.
-js_parts = ["file-picker", "codec-support", "mp4-reader", "mp4-muxer", "video-support", "message-box", "media", "format", "webcodecs", "errors", "mp4-boxes", "frame-canvas"]
+js_parts = ["file-picker", "codec-support", "codec-probe", "mp4-reader", "mp4-muxer", "video-support", "message-box", "media", "format", "webcodecs", "errors", "mp4-boxes", "frame-canvas"]
 # Where a finished result can be carried without being saved first: the row of
 # links shared/handoff.js shows beside the download once there is one. Slugs of
 # tools whose picker takes what this page produces; checked against the tools
 # that exist by the build.
 handoff = ["video-to-gif"]
-lastmod = "2026-08-28"
+lastmod = "2026-09-07"
 
 # --- what search engines and chat apps are told ------------------------------
 
@@ -57,9 +57,11 @@ og_card = "Turn hours of footage into seconds - without the file leaving your ma
 # whatever this tool needs that the rest of the site does not.
 csp_note = """
   media-src needs blob: because both the clip you chose and the finished
-  time-lapse are played from memory on this machine rather than from a URL. That
-  is the only addition: this tool fetches nothing, so connect-src is left
-  exactly as the site sets it."""
+  time-lapse are played from memory on this machine rather than from a URL.
+  worker-src needs 'self' because the question of what this browser can encode
+  is put to a small script in this folder rather than asked on the page
+  itself. Those are the only additions: this tool fetches nothing, so
+  connect-src is left exactly as the site sets it."""
 
 # --- the pledge block --------------------------------------------------------
 
@@ -316,7 +318,8 @@ features = [
   "Runs offline; no upload, no account, no watermark",
 ]
 
-# This tool needs one thing the rest of the site does not: blob: on media-src,
+# This tool needs two things the rest of the site does not. One is
+# blob: on media-src,
 # because both the clip you chose and the finished time-lapse are played from
 # memory on this machine rather than from a URL. A tool can only ever widen its
 # own page this way - it cannot narrow the site policy, and it cannot touch any
@@ -325,9 +328,17 @@ features = [
 # blob: URL before parking it for the next tool (see shared/handoff.js), and
 # reading a blob: URL is a fetch the policy has to permit. blob: names bytes
 # inside this page; nothing here gains any reach over the network.
+# The other is worker-src 'self', for the worker that asks this browser what it
+# can encode. That question blocks the thread it is asked on in at least one
+# browser, and a deadline cannot be kept by a thread that has stopped - so it
+# goes to a worker the page is able to outlive and give up on. It is 'self', a
+# file in this folder cached by the service worker beside it, and there is no
+# blob: on it, because nothing here ever builds a script at runtime. See
+# shared/js/codec-support.js.
 [csp]
 "connect-src" = ["blob:"]
 "media-src" = ["'self'", "blob:"]
+"worker-src" = ["'self'"]
 
 # The drop zone. Rendered by templates/partials/file-picker.html, which
 # body.html includes, and driven by src/shared/file-picker.js.

--- a/tools/trim-video/tool.toml
+++ b/tools/trim-video/tool.toml
@@ -33,13 +33,13 @@ css_parts = ["progress", "results", "form", "notes", "modes", "checks", "chips"]
 # Shared modules this tool asks for. The same arrangement as css_parts, and for
 # the same reason: a component more than one tool needs and no tool should own.
 # file-picker brings in the drop zone.
-js_parts = ["file-picker", "codec-support", "mp4-reader", "mp4-writer", "video-support", "message-box", "media", "format", "errors", "webcodecs", "mp4-boxes", "segments", "timeline", "aac"]
+js_parts = ["file-picker", "codec-support", "codec-probe", "mp4-reader", "mp4-writer", "video-support", "message-box", "media", "format", "errors", "webcodecs", "mp4-boxes", "segments", "timeline", "aac"]
 # Where a finished result can be carried without being saved first: the row of
 # links shared/handoff.js shows beside the download once there is one. Slugs of
 # tools whose picker takes what this page produces; checked against the tools
 # that exist by the build.
 handoff = ["video-to-gif", "reverse-video"]
-lastmod = "2026-09-02"
+lastmod = "2026-09-07"
 
 # --- what search engines and chat apps are told ------------------------------
 
@@ -57,10 +57,12 @@ og_card = "Mark the parts worth keeping as it plays, and save them as one video.
 # Appended to the Content-Security-Policy comment in the generated page, for
 # whatever this tool needs that the rest of the site does not.
 csp_note = """
-  media-src needs blob: because both the video you chose and the finished result
-  are played from memory on this machine rather than from a URL. That is the
-  only addition: this tool fetches nothing, so connect-src is left exactly as
-  the site sets it."""
+  media-src needs blob: because both the video you chose and the finished
+  result are played from memory on this machine rather than from a URL.
+  worker-src needs 'self' because the question of what this browser can encode
+  is put to a small script in this folder rather than asked on the page
+  itself. Those are the only additions: this tool fetches nothing, so
+  connect-src is left exactly as the site sets it."""
 
 # --- the pledge block --------------------------------------------------------
 
@@ -378,7 +380,8 @@ features = [
   "Runs offline; no upload, no account, no watermark",
 ]
 
-# This tool needs one thing the rest of the site does not: blob: on media-src,
+# This tool needs two things the rest of the site does not. One is
+# blob: on media-src,
 # because both the video you chose and the finished result are played from
 # memory on this machine rather than from a URL. A tool can only ever widen its
 # own page this way - it cannot narrow the site policy, and it cannot touch any
@@ -387,9 +390,17 @@ features = [
 # blob: URL before parking it for the next tool (see shared/handoff.js), and
 # reading a blob: URL is a fetch the policy has to permit. blob: names bytes
 # inside this page; nothing here gains any reach over the network.
+# The other is worker-src 'self', for the worker that asks this browser what it
+# can encode. That question blocks the thread it is asked on in at least one
+# browser, and a deadline cannot be kept by a thread that has stopped - so it
+# goes to a worker the page is able to outlive and give up on. It is 'self', a
+# file in this folder cached by the service worker beside it, and there is no
+# blob: on it, because nothing here ever builds a script at runtime. See
+# shared/js/codec-support.js.
 [csp]
 "connect-src" = ["blob:"]
 "media-src" = ["'self'", "blob:"]
+"worker-src" = ["'self'"]
 
 # The drop zone. Rendered by templates/partials/file-picker.html, which
 # body.html includes, and driven by src/shared/file-picker.js.


### PR DESCRIPTION
`VideoEncoder.isConfigSupported` does not leave its promise pending on the WebKit build the QA suite runs against. It blocks the thread that asked. So the `setTimeout` #295 added to bound it never got a turn, and neither did the error handler or the sentence the tool meant to show. Pressing **Create video** ended the page.

The question now goes to `shared/js/codec-probe.js`, a worker, and the clock stays on the page. When the worker goes quiet the page ends the wait, terminates it, and the tool refuses the way it refuses any missing codec.

**Falling back matters as much as the worker.** A page that cannot start one must not conclude that it cannot encode, so the worker announces itself before any question reaches it. Silence from a worker that never ran sends the question back to the page, exactly as before. Silence from one that did start is remembered per class, so nine candidate codec strings cost one deadline rather than nine.

The five tools that encode ship the worker and allow it with `worker-src 'self'`; `images-to-video` already allowed one. Nothing here builds a script at runtime, so no tool gains `blob:` it did not have.

`buildlib/imports.py` now reads `new URL('./x.js', import.meta.url)` the way it reads an import. A worker is named that way rather than imported, so without it a tool could list `codec-support` and leave out `codec-probe`, build cleanly, and then say nothing when the button was pressed.

## Checked

- `python build.py --out _plain --clean --no-minify` passes. The worker ships into all five tools, carries the same `?v=` hash as its precache entry, and every page emits `worker-src`.
- Removing `codec-probe` from one tool's `js_parts` fails the build naming the file and line. Restored.
- `tests/js/codec-support.test.js`: 13 pass, including a worker that goes quiet (silence, and terminated), one that never starts (asked on the page instead), a page with no `Worker` at all, and a browser already known to wedge (not asked twice).
- `tests/python/test_imports.py`: 35 pass.
- In a browser against the build: `images-to-video` encoded two PNGs to a real MP4 in 1.3s, and `crop-video`'s shared decode and encode questions both answered in 10ms through the worker.

Not reproducible locally: the wedge is a Linux WebKit behaviour and no such browser is installed here. The preview run on this pull request is the check that matters, and the QA test that has been flapping on it is A-Box-of-Tools/qa#92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
