### PR TITLE
Measure a box drag from where the box was, not from where it has got to

### DIFF
--- a/tests/js/redact-image-stage.test.js
+++ b/tests/js/redact-image-stage.test.js
@@ -1,0 +1,166 @@
+/**
+ * tools/redact-image/src/stage.js - the drag, as arithmetic.
+ *
+ * Every step of a drag is measured from where the pointer went down, not from
+ * where the box was a moment ago, and the caller writes each answer straight
+ * into the rectangle it handed over. Those two facts are only safe together
+ * because the stage copies that rectangle once, when the press happens: a
+ * stage that kept the caller's object would re-apply the whole drag on every
+ * pointer report, and the box would sprint away from the pointer - visibly
+ * broken on screen, invisible to every test of the arithmetic underneath.
+ *
+ * So the caller modelled here mutates in place exactly as main.js does, and
+ * the pointer reports its way across the picture in small steps rather than
+ * one jump, because one jump is the single case the broken version got right.
+ *
+ * The DOM is the least that lets the class build itself: elements that
+ * remember a class, a style and their parent, and a window that hands back the
+ * move and up events a drag listens for.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { Stage } from '../../tools/redact-image/src/stage.js';
+
+/** The stage is 500 x 400 on screen and the picture is 1000 x 800: two to one. */
+const STAGE = { left: 0, top: 0, width: 500, height: 400 };
+const SOURCE = { width: 1000, height: 800 };
+
+/** An element that remembers what the stage does to it. */
+function element() {
+  const node = {
+    className: '',
+    textContent: '',
+    style: {},
+    dataset: {},
+    children: [],
+    parent: null,
+    listeners: {},
+    append(...nodes) {
+      for (const child of nodes) {
+        child.parent = node;
+        node.children.push(child);
+      }
+    },
+    setAttribute(name, value) { node[`@${name}`] = value; },
+    addEventListener(type, fn) { (node.listeners[type] ??= []).push(fn); },
+    focus() {},
+    remove() { node.parent = null; },
+    querySelector: (selector) => node.children.find(
+      (child) => child.className.split(' ').includes(selector.slice(1)),
+    ),
+    closest: (selector) => (node.className.split(' ').includes(selector.slice(1))
+      ? node
+      : node.parent?.closest(selector) ?? null),
+    getBoundingClientRect: () => STAGE,
+  };
+  return node;
+}
+
+/** A window that keeps the listeners a drag adds and lets a test fire them. */
+function fakeWindow() {
+  const listeners = {};
+  return {
+    addEventListener(type, fn) { (listeners[type] ??= []).push(fn); },
+    removeEventListener(type, fn) {
+      listeners[type] = (listeners[type] ?? []).filter((other) => other !== fn);
+    },
+    fire(type, event) { for (const fn of [...(listeners[type] ?? [])]) fn(event); },
+  };
+}
+
+/**
+ * A stage wired to a caller that behaves like main.js: it owns the regions and
+ * writes each change into the object it already has.
+ */
+function build(regions) {
+  globalThis.document = { createElement: () => element() };
+  globalThis.window = fakeWindow();
+
+  const stage = element();
+  const gestures = [];
+  const owner = new Stage(stage, {
+    onCreate: (rect) => regions.push({ id: `r${regions.length + 1}`, style: 'fill', ...rect }),
+    onChange: (id, rect) => {
+      Object.assign(regions.find((region) => region.id === id), rect);
+      owner.render(regions, id);
+    },
+    onSelect: () => {},
+    onDelete: () => {},
+    onGestureStart: () => gestures.push(regions.map((region) => ({ ...region }))),
+    regionOf: (id) => regions.find((region) => region.id === id),
+    describe: () => 'a box',
+  });
+
+  owner.setSource(SOURCE.width, SOURCE.height);
+  owner.render(regions, null);
+  const boxes = stage.children.filter((child) => child.className.startsWith('redact-box'));
+  return { stage, boxes, gestures, regions };
+}
+
+/** The stage a node sits on: the press is listened for there, not on the box. */
+const stageOf = (node) => (node.parent ? stageOf(node.parent) : node);
+
+/** Press, report the move in `steps` reports, and let go. */
+function drag(target, from, to, { steps = 8 } = {}) {
+  stageOf(target).listeners.pointerdown[0]({
+    button: 0, pointerId: 1, target, clientX: from.x, clientY: from.y, preventDefault() {},
+  });
+  for (let i = 1; i <= steps; i += 1) {
+    window.fire('pointermove', {
+      clientX: from.x + ((to.x - from.x) * i) / steps,
+      clientY: from.y + ((to.y - from.y) * i) / steps,
+    });
+  }
+  window.fire('pointerup', {});
+}
+
+const grip = (box, handle) => box.children.find((child) => child.dataset.handle === handle);
+
+test('a move lands where the pointer let go, however often the pointer reported', () => {
+  const regions = [{ id: 'r1', x: 100, y: 100, width: 200, height: 100, style: 'fill' }];
+  const { boxes } = build(regions);
+
+  // 50 across and 50 down on a stage drawn at half size: 100 source pixels each way.
+  drag(boxes[0], { x: 100, y: 80 }, { x: 150, y: 130 });
+
+  assert.deepEqual(regions[0], {
+    id: 'r1', x: 200, y: 200, width: 200, height: 100, style: 'fill',
+  });
+});
+
+test('a drag reported in one jump and the same drag reported in fifty agree', () => {
+  const once = [{ id: 'r1', x: 100, y: 100, width: 200, height: 100, style: 'fill' }];
+  const many = [{ id: 'r1', x: 100, y: 100, width: 200, height: 100, style: 'fill' }];
+
+  drag(build(once).boxes[0], { x: 60, y: 60 }, { x: 20, y: 90 }, { steps: 1 });
+  drag(build(many).boxes[0], { x: 60, y: 60 }, { x: 20, y: 90 }, { steps: 50 });
+
+  assert.deepEqual(many[0], once[0]);
+});
+
+test('a resize follows the handle rather than outrunning it', () => {
+  const regions = [{ id: 'r1', x: 100, y: 100, width: 200, height: 100, style: 'fill' }];
+  const { boxes } = build(regions);
+
+  // The bottom right corner is at (150, 100) on screen; take it 20 right and
+  // 10 down, which is 40 and 20 more source pixels of box.
+  drag(grip(boxes[0], 'se'), { x: 150, y: 100 }, { x: 170, y: 110 });
+
+  assert.deepEqual(regions[0], {
+    id: 'r1', x: 100, y: 100, width: 240, height: 120, style: 'fill',
+  });
+});
+
+test('a click that did not move changes nothing and is not undoable', () => {
+  const regions = [{ id: 'r1', x: 100, y: 100, width: 200, height: 100, style: 'fill' }];
+  const { boxes, gestures } = build(regions);
+
+  drag(boxes[0], { x: 100, y: 80 }, { x: 100, y: 80 });
+
+  assert.deepEqual(regions[0], {
+    id: 'r1', x: 100, y: 100, width: 200, height: 100, style: 'fill',
+  });
+  assert.equal(gestures.length, 0);
+});

--- a/tools/redact-image/src/stage.js
+++ b/tools/redact-image/src/stage.js
@@ -146,7 +146,13 @@ export class Stage {
 
   /** An existing box: move it, or drag one of its edges. */
   #dragBox(id, handle, start) {
-    const from = this.#handlers.regionOf(id);
+    // A copy of where the box was when the drag began: every step below
+    // measures from the press, and `onChange` writes the answer into the very
+    // rectangle the caller just handed over. A `from` that was that rectangle
+    // would move with the box, so each pointer report would add the whole drag
+    // again to a box already moved by it - and the box would run away from the
+    // pointer, further the more moves the pointer sent.
+    const from = { ...this.#handlers.regionOf(id) };
     let moved = false;
 
     this.#follow((point) => {


### PR DESCRIPTION
Dragging a black box across the image redactor moved it much further than the pointer went — far enough on a normal drag to slam into the edge of the picture — which reads on screen as a box that jumps somewhere random the moment the mouse moves.

## What was wrong

Every step of a drag is measured from the press: [`stage.js`](https://github.com/A-Box-of-Tools/website/blob/main/tools/redact-image/src/stage.js) asks the caller for the box's rectangle when the pointer goes down, and each `pointermove` adds the whole distance travelled since to it. But `regionOf` hands back the caller's own live object, and `onChange` writes the answer straight into that same object — so `from` moved with the box, and each of the hundred moves a pointer reports in a second added the entire drag again to a box already moved by it.

One `pointermove` was right, which is why the arithmetic in `regions.js` tested clean and a scripted single-jump drag looks fine. Two moves put the box half as far out again; a real drag ran off the picture.

The fix is one copy taken at the press — what `shared/js/cropper.js` has always done for its own drag.

## Before and after

The same gesture in both: a box drawn over the Date column, then dragged 240 pixels right onto the Reference column.

**Before** — the pointer asked for 240 and the box went as far as the picture allowed:

<img width="2560" height="1040" alt="before" src="https://github.com/user-attachments/assets/8df4b9f5-e4db-4e2c-af9b-eec1cf839e1b" />

**After** — it lands where it was put:

<img width="2560" height="1040" alt="after" src="https://github.com/user-attachments/assets/baf4f081-3edd-431f-848b-877c7ed1d4a6" />

## Tests

`tests/js/redact-image-stage.test.js` is new: `stage.js` has never had tests, because it needs a DOM. It follows `cropper.test.js` in stubbing the least DOM the class needs, models the caller the way `main.js` really behaves — mutating the rectangle in place — and reports each drag in many small moves, because one jump is the single case the broken version got right. Three of its four cases fail on the code before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
