### PR TITLE
Pick a page up anywhere on its tile, and put its own number on it

### DIFF
--- a/locales/ar/tools/merge-pdf.html
+++ b/locales/ar/tools/merge-pdf.html
@@ -42,7 +42,8 @@
       <button type="button" id="range-turn" class="ghost">أدِر هذه</button>
     </div>
     <p id="range-note" class="field-note">
-      بالأرقام أدناه، وهي تُعاد ترقيماً مع عملك. وتعمل كذلك <code>odd</code>
+      بالرقم الصغير في زاوية كل صفحة أدناه، وهو يُعاد ترقيمه مع عملك &mdash; لا
+      بالرقم الكبير، فذاك رقم الصفحة في ملفها. وتعمل كذلك <code>odd</code>
       للفردية و<code>even</code> للزوجية و<code>all</code> للكل
       و<code>last</code> للأخيرة.
     </p>
@@ -208,6 +209,7 @@
     <span data-phrase="page.remove">أزِل الصفحة {n}</span>
     <span data-phrase="page.from">{name}، الصفحة {n}</span>
     <span data-phrase="page.origin">من الصفحة {n}</span>
+    <span data-phrase="page.at">الرقم {n} في الترتيب</span>
     <span data-phrase="page.anticlockwise">أدِر الصفحة {n} عكس عقارب الساعة</span>
     <span data-phrase="page.clockwise">أدِر الصفحة {n} مع عقارب الساعة</span>
     <span data-phrase="page.earlier">قدِّم الصفحة {n}</span>

--- a/locales/ar/tools/merge-pdf.html
+++ b/locales/ar/tools/merge-pdf.html
@@ -17,10 +17,10 @@
 
     <p class="card-lede">
       كل صفحة من كل ملف اخترته، بالترتيب الذي ستخرج به.
-      اسحب واحدة من مقبضها <span class="grip" aria-hidden="true">&#8942;&#8942;</span>
-      لتحريكها، أو أدِرها بالأسهم، أو أخرِجها بعلامة
-      &times;. ولم يُكتَب شيء هنا بعد &mdash; فالمستند يُجمَّع حين تضغط الزر في
-      الخطوة 4.
+      اسحب البطاقة من أي موضع فيها لتحريك تلك الصفحة &mdash; وعلى شاشة لمس من
+      مقبضها <span class="grip" aria-hidden="true">&#8942;&#8942;</span> وحده، حتى تظل القائمة
+      قابلة للتمرير. أدِر الصفحة بالأسهم، أو أخرِجها بعلامة &times;. ولم يُكتَب شيء
+      هنا بعد &mdash; فالمستند يُجمَّع حين تضغط الزر في الخطوة 4.
     </p>
 
     <div class="toolbar">
@@ -207,6 +207,7 @@
     <span data-phrase="page.turned">أدارتها هذه الأداة</span>
     <span data-phrase="page.remove">أزِل الصفحة {n}</span>
     <span data-phrase="page.from">{name}، الصفحة {n}</span>
+    <span data-phrase="page.origin">من الصفحة {n}</span>
     <span data-phrase="page.anticlockwise">أدِر الصفحة {n} عكس عقارب الساعة</span>
     <span data-phrase="page.clockwise">أدِر الصفحة {n} مع عقارب الساعة</span>
     <span data-phrase="page.earlier">قدِّم الصفحة {n}</span>

--- a/locales/de/tools/merge-pdf.html
+++ b/locales/de/tools/merge-pdf.html
@@ -44,9 +44,10 @@
       <button type="button" id="range-turn" class="ghost">Diese drehen</button>
     </div>
     <p id="range-note" class="field-note">
-      Nach den Nummern unten, die sich laufend neu vergeben. <code>odd</code>,
-      <code>even</code>, <code>all</code> und <code>last</code> funktionieren
-      ebenfalls.
+      Nach der kleinen Nummer in der Ecke jeder Seite unten, die sich laufend
+      neu vergibt &mdash; nicht nach der großen, das ist die Seite in ihrer
+      eigenen Datei. <code>odd</code>, <code>even</code>, <code>all</code> und
+      <code>last</code> funktionieren ebenfalls.
     </p>
     <p id="range-error" class="error" role="alert" hidden></p>
 
@@ -214,6 +215,7 @@
     <span data-phrase="page.remove">Seite {n} entfernen</span>
     <span data-phrase="page.from">{name}, Seite {n}</span>
     <span data-phrase="page.origin">Von Seite {n}</span>
+    <span data-phrase="page.at">Nummer {n} in der Reihenfolge</span>
     <span data-phrase="page.anticlockwise">Seite {n} gegen den Uhrzeigersinn drehen</span>
     <span data-phrase="page.clockwise">Seite {n} im Uhrzeigersinn drehen</span>
     <span data-phrase="page.earlier">Seite {n} nach vorn</span>

--- a/locales/de/tools/merge-pdf.html
+++ b/locales/de/tools/merge-pdf.html
@@ -17,11 +17,12 @@
 
     <p class="card-lede">
       Jede Seite jeder ausgewählten Datei, in der Reihenfolge, in der sie
-      herauskommen wird. Ziehen Sie eine am
-      <span class="grip" aria-hidden="true">&#8942;&#8942;</span>-Griff, um sie zu
-      verschieben, drehen Sie sie mit den Pfeilen, oder nehmen Sie sie mit dem
-      &times; heraus. Geschrieben ist hier noch nichts. Das Dokument wird erst
-      zusammengesetzt, wenn Sie in Schritt 4 auf den Knopf drücken.
+      herauskommen wird. Ziehen Sie eine Kachel an einer beliebigen Stelle, um
+      die Seite zu verschieben &mdash; auf einem Touchscreen am
+      <span class="grip" aria-hidden="true">&#8942;&#8942;</span>-Griff, damit die Liste
+      weiter scrollt. Drehen Sie eine Seite mit den Pfeilen, oder nehmen Sie sie
+      mit dem &times; heraus. Geschrieben ist hier noch nichts. Das Dokument wird
+      erst zusammengesetzt, wenn Sie in Schritt 4 auf den Knopf drücken.
     </p>
 
     <div class="toolbar">
@@ -212,6 +213,7 @@
     <span data-phrase="page.turned">Von diesem Werkzeug gedreht</span>
     <span data-phrase="page.remove">Seite {n} entfernen</span>
     <span data-phrase="page.from">{name}, Seite {n}</span>
+    <span data-phrase="page.origin">Von Seite {n}</span>
     <span data-phrase="page.anticlockwise">Seite {n} gegen den Uhrzeigersinn drehen</span>
     <span data-phrase="page.clockwise">Seite {n} im Uhrzeigersinn drehen</span>
     <span data-phrase="page.earlier">Seite {n} nach vorn</span>

--- a/locales/es/tools/merge-pdf.html
+++ b/locales/es/tools/merge-pdf.html
@@ -17,10 +17,12 @@
 
     <p class="card-lede">
       Todas las páginas de todos los archivos que has elegido, en el orden en que
-      van a salir. Arrastra una por su asa
-      <span class="grip" aria-hidden="true">&#8942;&#8942;</span> para moverla,
-      gírala con las flechas o quítala con la &times;. Aquí todavía no se ha
-      escrito nada: el documento se monta cuando pulses el botón del paso 4.
+      van a salir. Arrastra una ficha por cualquier parte para mover esa página
+      &mdash; en una pantalla táctil, por su asa
+      <span class="grip" aria-hidden="true">&#8942;&#8942;</span>, para que la lista siga
+      desplazándose. Gírala con las flechas o quítala con la &times;. Aquí todavía
+      no se ha escrito nada: el documento se monta cuando pulses el botón del
+      paso 4.
     </p>
 
     <div class="toolbar">
@@ -208,6 +210,7 @@
     <span data-phrase="page.turned">Girada por esta herramienta</span>
     <span data-phrase="page.remove">Quitar la página {n}</span>
     <span data-phrase="page.from">{name}, página {n}</span>
+    <span data-phrase="page.origin">De la página {n}</span>
     <span data-phrase="page.anticlockwise">Girar la página {n} a la izquierda</span>
     <span data-phrase="page.clockwise">Girar la página {n} a la derecha</span>
     <span data-phrase="page.earlier">Adelantar la página {n}</span>

--- a/locales/es/tools/merge-pdf.html
+++ b/locales/es/tools/merge-pdf.html
@@ -44,8 +44,10 @@
       <button type="button" id="range-turn" class="ghost">Girar estas</button>
     </div>
     <p id="range-note" class="field-note">
-      Por los números de abajo, que se renumeran sobre la marcha. <code>odd</code>,
-      <code>even</code>, <code>all</code> y <code>last</code> también valen.
+      Por el número pequeño de la esquina de cada página de abajo, que se
+      renumera sobre la marcha &mdash; no por el grande, que es la página que
+      era en su propio archivo. <code>odd</code>, <code>even</code>,
+      <code>all</code> y <code>last</code> también valen.
     </p>
     <p id="range-error" class="error" role="alert" hidden></p>
 
@@ -211,6 +213,7 @@
     <span data-phrase="page.remove">Quitar la página {n}</span>
     <span data-phrase="page.from">{name}, página {n}</span>
     <span data-phrase="page.origin">De la página {n}</span>
+    <span data-phrase="page.at">Número {n} en el orden</span>
     <span data-phrase="page.anticlockwise">Girar la página {n} a la izquierda</span>
     <span data-phrase="page.clockwise">Girar la página {n} a la derecha</span>
     <span data-phrase="page.earlier">Adelantar la página {n}</span>

--- a/locales/fr/tools/merge-pdf.html
+++ b/locales/fr/tools/merge-pdf.html
@@ -44,9 +44,10 @@
       <button type="button" id="range-turn" class="ghost">Tourner celles-ci</button>
     </div>
     <p id="range-note" class="field-note">
-      D'après les numéros ci-dessous, qui se renumérotent au fur et à mesure.
-      <code>odd</code>, <code>even</code>, <code>all</code> et <code>last</code>
-      fonctionnent aussi.
+      D'après le petit numéro dans le coin de chaque page ci-dessous, qui se
+      renumérote au fur et à mesure &mdash; pas d'après le grand, qui est la
+      page qu'elle était dans son propre fichier. <code>odd</code>,
+      <code>even</code>, <code>all</code> et <code>last</code> marchent aussi.
     </p>
     <p id="range-error" class="error" role="alert" hidden></p>
 
@@ -213,6 +214,7 @@
     <span data-phrase="page.remove">Retirer la page {n}</span>
     <span data-phrase="page.from">{name}, page {n}</span>
     <span data-phrase="page.origin">Depuis la page {n}</span>
+    <span data-phrase="page.at">Numéro {n} dans l'ordre</span>
     <span data-phrase="page.anticlockwise">Tourner la page {n} dans le sens inverse des aiguilles d'une montre</span>
     <span data-phrase="page.clockwise">Tourner la page {n} dans le sens des aiguilles d'une montre</span>
     <span data-phrase="page.earlier">Avancer la page {n}</span>

--- a/locales/fr/tools/merge-pdf.html
+++ b/locales/fr/tools/merge-pdf.html
@@ -17,11 +17,12 @@
 
     <p class="card-lede">
       Toutes les pages de tous les fichiers choisis, dans l'ordre où elles
-      ressortiront. Faites-en glisser une par sa poignée
-      <span class="grip" aria-hidden="true">&#8942;&#8942;</span> pour la déplacer,
-      tournez-la avec les flèches, ou retirez-la avec la &times;. Rien n'a encore
-      été écrit ici&nbsp;: le document est assemblé quand vous appuyez sur le
-      bouton de l'étape 4.
+      ressortiront. Faites glisser une vignette par n'importe quel endroit pour
+      déplacer cette page &mdash; sur un écran tactile, par sa poignée
+      <span class="grip" aria-hidden="true">&#8942;&#8942;</span>, pour que la liste continue
+      de défiler. Tournez-la avec les flèches, ou retirez-la avec la &times;. Rien
+      n'a encore été écrit ici&nbsp;: le document est assemblé quand vous appuyez
+      sur le bouton de l'étape 4.
     </p>
 
     <div class="toolbar">
@@ -211,6 +212,7 @@
     <span data-phrase="page.turned">Tournée par cet outil</span>
     <span data-phrase="page.remove">Retirer la page {n}</span>
     <span data-phrase="page.from">{name}, page {n}</span>
+    <span data-phrase="page.origin">Depuis la page {n}</span>
     <span data-phrase="page.anticlockwise">Tourner la page {n} dans le sens inverse des aiguilles d'une montre</span>
     <span data-phrase="page.clockwise">Tourner la page {n} dans le sens des aiguilles d'une montre</span>
     <span data-phrase="page.earlier">Avancer la page {n}</span>

--- a/locales/hi/tools/merge-pdf.html
+++ b/locales/hi/tools/merge-pdf.html
@@ -42,9 +42,10 @@
       <button type="button" id="range-turn" class="ghost">ये घुमाइए</button>
     </div>
     <p id="range-note" class="field-note">
-      नीचे दिखने वाले नंबरों के हिसाब से, जो आपके काम के साथ दोबारा लगते जाते हैं।
-      <code>odd</code>, <code>even</code>, <code>all</code> और <code>last</code>
-      भी चलते हैं।
+      नीचे हर पेज के कोने में दिख रहे छोटे नंबर से, जो चलते-चलते फिर से लगते
+      रहते हैं &mdash; बड़े नंबर से नहीं, वह उसकी अपनी फ़ाइल का पन्ना है।
+      <code>odd</code>, <code>even</code>, <code>all</code> और
+      <code>last</code> भी चलते हैं।
     </p>
     <p id="range-error" class="error" role="alert" hidden></p>
 
@@ -209,6 +210,7 @@
     <span data-phrase="page.remove">पन्ना {n} हटाइए</span>
     <span data-phrase="page.from">{name}, पन्ना {n}</span>
     <span data-phrase="page.origin">पन्ना {n} से</span>
+    <span data-phrase="page.at">क्रम में नंबर {n}</span>
     <span data-phrase="page.anticlockwise">पन्ना {n} वामावर्त घुमाइए</span>
     <span data-phrase="page.clockwise">पन्ना {n} दक्षिणावर्त घुमाइए</span>
     <span data-phrase="page.earlier">पन्ना {n} पहले ले जाइए</span>

--- a/locales/hi/tools/merge-pdf.html
+++ b/locales/hi/tools/merge-pdf.html
@@ -16,9 +16,10 @@
     <h2><span class="step">2</span> पेज लगाइए</h2>
 
     <p class="card-lede">
-      आपकी चुनी हर फ़ाइल का हर पेज, उसी क्रम में जिसमें वे बाहर आएँगे। किसी पेज को
-      उसके <span class="grip" aria-hidden="true">&#8942;&#8942;</span> हैंडल से
-      खींचकर हटाइए, तीरों से घुमाइए, या &times; से निकाल दीजिए। यहाँ अभी कुछ लिखा
+      आपकी चुनी हर फ़ाइल का हर पेज, उसी क्रम में जिसमें वे बाहर आएँगे। किसी टाइल को
+      कहीं से भी खींचकर उस पेज को सरकाइए &mdash; छूने वाली स्क्रीन पर उसके
+      <span class="grip" aria-hidden="true">&#8942;&#8942;</span> हैंडल से, ताकि सूची स्क्रॉल
+      होती रहे। पेज को तीरों से घुमाइए, या &times; से निकाल दीजिए। यहाँ अभी कुछ लिखा
       नहीं गया है, दस्तावेज़ तब बनता है जब आप चरण 4 का बटन दबाते हैं।
     </p>
 
@@ -207,6 +208,7 @@
     <span data-phrase="page.turned">इस टूल ने घुमाया</span>
     <span data-phrase="page.remove">पन्ना {n} हटाइए</span>
     <span data-phrase="page.from">{name}, पन्ना {n}</span>
+    <span data-phrase="page.origin">पन्ना {n} से</span>
     <span data-phrase="page.anticlockwise">पन्ना {n} वामावर्त घुमाइए</span>
     <span data-phrase="page.clockwise">पन्ना {n} दक्षिणावर्त घुमाइए</span>
     <span data-phrase="page.earlier">पन्ना {n} पहले ले जाइए</span>

--- a/locales/id/tools/merge-pdf.html
+++ b/locales/id/tools/merge-pdf.html
@@ -24,9 +24,10 @@
 
     <p class="card-lede">
       Setiap halaman dari setiap file yang Anda pilih, dalam urutan mereka akan
-      keluar. Seret salah satunya lewat pegangan
-      <span class="grip" aria-hidden="true">&#8942;&#8942;</span> untuk
-      memindahkannya, putar dengan panahnya, atau keluarkan dengan &times;.
+      keluar. Seret kartunya dari bagian mana pun untuk memindahkan halaman itu
+      &mdash; di layar sentuh, lewat pegangan
+      <span class="grip" aria-hidden="true">&#8942;&#8942;</span>, supaya daftarnya tetap bisa
+      digulir. Putar dengan panahnya, atau keluarkan dengan &times;.
       Belum ada apa pun di sini yang ditulis &mdash; dokumennya dirakit ketika
       Anda menekan tombol di langkah 4.
     </p>
@@ -216,6 +217,7 @@
     <span data-phrase="page.turned">Diputar oleh alat ini</span>
     <span data-phrase="page.remove">Keluarkan halaman {n}</span>
     <span data-phrase="page.from">{name}, halaman {n}</span>
+    <span data-phrase="page.origin">Dari halaman {n}</span>
     <span data-phrase="page.anticlockwise">Putar halaman {n} berlawanan arah jarum jam</span>
     <span data-phrase="page.clockwise">Putar halaman {n} searah jarum jam</span>
     <span data-phrase="page.earlier">Majukan halaman {n}</span>

--- a/locales/id/tools/merge-pdf.html
+++ b/locales/id/tools/merge-pdf.html
@@ -51,8 +51,10 @@
       <button type="button" id="range-turn" class="ghost">Putar yang ini</button>
     </div>
     <p id="range-note" class="field-note">
-      Menurut nomor di bawah, yang berubah seiring Anda bekerja. <code>odd</code>,
-      <code>even</code>, <code>all</code>, dan <code>last</code> juga berlaku.
+      Pakai nomor kecil di pojok tiap halaman di bawah, yang dinomori ulang
+      sambil jalan &mdash; bukan yang besar, itu halaman keberapa di berkasnya
+      sendiri. <code>odd</code>, <code>even</code>, <code>all</code> dan
+      <code>last</code> juga bisa.
     </p>
     <p id="range-error" class="error" role="alert" hidden></p>
 
@@ -218,6 +220,7 @@
     <span data-phrase="page.remove">Keluarkan halaman {n}</span>
     <span data-phrase="page.from">{name}, halaman {n}</span>
     <span data-phrase="page.origin">Dari halaman {n}</span>
+    <span data-phrase="page.at">Nomor {n} dalam urutan</span>
     <span data-phrase="page.anticlockwise">Putar halaman {n} berlawanan arah jarum jam</span>
     <span data-phrase="page.clockwise">Putar halaman {n} searah jarum jam</span>
     <span data-phrase="page.earlier">Majukan halaman {n}</span>

--- a/locales/it/tools/merge-pdf.html
+++ b/locales/it/tools/merge-pdf.html
@@ -44,8 +44,10 @@
       <button type="button" id="range-turn" class="ghost">Gira queste</button>
     </div>
     <p id="range-note" class="field-note">
-      In base ai numeri qui sotto, che si rinumerano man mano. Funzionano anche
-      <code>odd</code>, <code>even</code>, <code>all</code> e <code>last</code>.
+      Per il numero piccolo nell'angolo di ogni pagina qui sotto, che si
+      rinumera man mano &mdash; non per quello grande, che è la pagina che era
+      nel suo file. Funzionano anche <code>odd</code>, <code>even</code>,
+      <code>all</code> e <code>last</code>.
     </p>
     <p id="range-error" class="error" role="alert" hidden></p>
 
@@ -211,6 +213,7 @@
     <span data-phrase="page.remove">Togli la pagina {n}</span>
     <span data-phrase="page.from">{name}, pagina {n}</span>
     <span data-phrase="page.origin">Dalla pagina {n}</span>
+    <span data-phrase="page.at">Numero {n} nell'ordine</span>
     <span data-phrase="page.anticlockwise">Ruota la pagina {n} in senso antiorario</span>
     <span data-phrase="page.clockwise">Ruota la pagina {n} in senso orario</span>
     <span data-phrase="page.earlier">Sposta la pagina {n} prima</span>

--- a/locales/it/tools/merge-pdf.html
+++ b/locales/it/tools/merge-pdf.html
@@ -17,11 +17,12 @@
 
     <p class="card-lede">
       Ogni pagina di ogni file che hai scelto, nell'ordine in cui usciranno.
-      Trascinane una per la sua maniglia
-      <span class="grip" aria-hidden="true">&#8942;&#8942;</span> per spostarla,
-      giralla con le frecce, oppure toglila con la &times;. Qui non è ancora stato
-      scritto niente: il documento viene messo insieme quando premi il pulsante al
-      passo 4.
+      Trascina una scheda da qualunque punto per spostare quella pagina &mdash; su
+      uno schermo tattile, per la sua maniglia
+      <span class="grip" aria-hidden="true">&#8942;&#8942;</span>, così l'elenco continua a
+      scorrere. Girala con le frecce, oppure toglila con la &times;. Qui non è
+      ancora stato scritto niente: il documento viene messo insieme quando premi
+      il pulsante al passo 4.
     </p>
 
     <div class="toolbar">
@@ -209,6 +210,7 @@
     <span data-phrase="page.turned">Ruotata da questo strumento</span>
     <span data-phrase="page.remove">Togli la pagina {n}</span>
     <span data-phrase="page.from">{name}, pagina {n}</span>
+    <span data-phrase="page.origin">Dalla pagina {n}</span>
     <span data-phrase="page.anticlockwise">Ruota la pagina {n} in senso antiorario</span>
     <span data-phrase="page.clockwise">Ruota la pagina {n} in senso orario</span>
     <span data-phrase="page.earlier">Sposta la pagina {n} prima</span>

--- a/locales/ja/tools/merge-pdf.html
+++ b/locales/ja/tools/merge-pdf.html
@@ -17,7 +17,7 @@
 
     <p class="card-lede">
       選んだすべてのファイルのすべてのページが、出てくる順番で並んでいます。
-      <span class="grip" aria-hidden="true">&#8942;&#8942;</span>のつまみを持ってドラッグすれば移動、矢印で回転、&times;で取り外しです。ここではまだ何も書き出されていません。書類が組み立てられるのは、ステップ4のボタンを押したときです。
+      カードはどこを持ってドラッグしてもそのページを動かせます。タッチ画面では一覧のスクロールを残すため、<span class="grip" aria-hidden="true">&#8942;&#8942;</span>のつまみからだけです。回転は矢印、取り外しは&times;です。ここではまだ何も書き出されていません。書類が組み立てられるのは、ステップ4のボタンを押したときです。
     </p>
 
     <div class="toolbar">
@@ -195,6 +195,7 @@
     <span data-phrase="page.turned">この道具が回しました</span>
     <span data-phrase="page.remove">{n}ページ目を外す</span>
     <span data-phrase="page.from">{name}、{n}ページ目</span>
+    <span data-phrase="page.origin">元の{n}ページ目</span>
     <span data-phrase="page.anticlockwise">{n}ページ目を左に回す</span>
     <span data-phrase="page.clockwise">{n}ページ目を右に回す</span>
     <span data-phrase="page.earlier">{n}ページ目を前へ</span>

--- a/locales/ja/tools/merge-pdf.html
+++ b/locales/ja/tools/merge-pdf.html
@@ -39,7 +39,7 @@
       <button type="button" id="range-turn" class="ghost">これを回す</button>
     </div>
     <p id="range-note" class="field-note">
-      下に表示されている番号で指定します。番号は動かすたびに振り直されます。<code>odd</code>、<code>even</code>、<code>all</code>、<code>last</code>も使えます。
+      下の各ページの角にある小さい番号で指定します。この番号は動かすたびに振り直されます。大きいほうの番号は元のファイルでの何ページ目かなので、そちらではありません。<code>odd</code>、<code>even</code>、<code>all</code>、<code>last</code>も使えます。
     </p>
     <p id="range-error" class="error" role="alert" hidden></p>
 
@@ -196,6 +196,7 @@
     <span data-phrase="page.remove">{n}ページ目を外す</span>
     <span data-phrase="page.from">{name}、{n}ページ目</span>
     <span data-phrase="page.origin">元の{n}ページ目</span>
+    <span data-phrase="page.at">並び順で{n}番目</span>
     <span data-phrase="page.anticlockwise">{n}ページ目を左に回す</span>
     <span data-phrase="page.clockwise">{n}ページ目を右に回す</span>
     <span data-phrase="page.earlier">{n}ページ目を前へ</span>

--- a/locales/ko/tools/merge-pdf.html
+++ b/locales/ko/tools/merge-pdf.html
@@ -42,7 +42,8 @@
       <button type="button" id="range-turn" class="ghost">이것 돌리기</button>
     </div>
     <p id="range-note" class="field-note">
-      아래에 보이는 번호 기준이고, 번호는 움직일 때마다 다시 매겨집니다.
+      아래 각 쪽 모서리의 작은 번호 기준이고, 이 번호는 움직일 때마다 다시
+      매겨집니다. 큰 번호는 원래 파일에서 몇 쪽이었는지라 그쪽이 아닙니다.
       <code>odd</code>, <code>even</code>, <code>all</code>, <code>last</code>도
       됩니다.
     </p>
@@ -206,6 +207,7 @@
     <span data-phrase="page.remove">{n}번째 쪽 빼기</span>
     <span data-phrase="page.from">{name}, {n}쪽</span>
     <span data-phrase="page.origin">원본 {n}쪽</span>
+    <span data-phrase="page.at">순서에서 {n}번째</span>
     <span data-phrase="page.anticlockwise">{n}번째 쪽을 시계 반대 방향으로 돌리기</span>
     <span data-phrase="page.clockwise">{n}번째 쪽을 시계 방향으로 돌리기</span>
     <span data-phrase="page.earlier">{n}번째 쪽을 앞으로</span>

--- a/locales/ko/tools/merge-pdf.html
+++ b/locales/ko/tools/merge-pdf.html
@@ -17,9 +17,10 @@
 
     <p class="card-lede">
       고른 모든 파일의 모든 페이지가, 나올 순서대로 놓여 있습니다.
-      <span class="grip" aria-hidden="true">&#8942;&#8942;</span> 손잡이를 잡고
-      끌면 옮겨지고, 화살표로 돌리고, &times;로 빼냅니다. 여기서는 아직 아무것도
-      쓰이지 않았습니다. 문서는 4단계의 버튼을 누를 때 조립됩니다.
+      타일은 어디를 잡고 끌어도 그 쪽이 옮겨집니다. 터치 화면에서는 목록이 계속
+      스크롤되도록 <span class="grip" aria-hidden="true">&#8942;&#8942;</span> 손잡이에서만
+      끌 수 있습니다. 쪽은 화살표로 돌리고, &times;로 빼냅니다. 여기서는 아직
+      아무것도 쓰이지 않았습니다. 문서는 4단계의 버튼을 누를 때 조립됩니다.
     </p>
 
     <div class="toolbar">
@@ -204,6 +205,7 @@
     <span data-phrase="page.turned">이 도구가 돌렸습니다</span>
     <span data-phrase="page.remove">{n}번째 쪽 빼기</span>
     <span data-phrase="page.from">{name}, {n}쪽</span>
+    <span data-phrase="page.origin">원본 {n}쪽</span>
     <span data-phrase="page.anticlockwise">{n}번째 쪽을 시계 반대 방향으로 돌리기</span>
     <span data-phrase="page.clockwise">{n}번째 쪽을 시계 방향으로 돌리기</span>
     <span data-phrase="page.earlier">{n}번째 쪽을 앞으로</span>

--- a/locales/nl/tools/merge-pdf.html
+++ b/locales/nl/tools/merge-pdf.html
@@ -17,9 +17,10 @@
 
     <p class="card-lede">
       Elke pagina van elk bestand dat je koos, in de volgorde waarin ze eruit
-      komen. Sleep er een aan zijn
-      <span class="grip" aria-hidden="true">&#8942;&#8942;</span>-handvat om hem te
-      verplaatsen, draai hem met de pijltjes, of haal hem weg met de &times;. Er is
+      komen. Sleep een tegel op elke plek om die pagina te verplaatsen &mdash; op
+      een aanraakscherm aan zijn
+      <span class="grip" aria-hidden="true">&#8942;&#8942;</span>-handvat, zodat de lijst blijft
+      scrollen. Draai hem met de pijltjes, of haal hem weg met de &times;. Er is
       hier nog niets geschreven: het document wordt pas in elkaar gezet als je in
       stap 4 op de knop drukt.
     </p>
@@ -211,6 +212,7 @@
     <span data-phrase="page.turned">Door dit gereedschap gedraaid</span>
     <span data-phrase="page.remove">Pagina {n} verwijderen</span>
     <span data-phrase="page.from">{name}, pagina {n}</span>
+    <span data-phrase="page.origin">Van pagina {n}</span>
     <span data-phrase="page.anticlockwise">Pagina {n} linksom draaien</span>
     <span data-phrase="page.clockwise">Pagina {n} rechtsom draaien</span>
     <span data-phrase="page.earlier">Pagina {n} naar voren</span>

--- a/locales/nl/tools/merge-pdf.html
+++ b/locales/nl/tools/merge-pdf.html
@@ -44,9 +44,10 @@
       <button type="button" id="range-turn" class="ghost">Deze draaien</button>
     </div>
     <p id="range-note" class="field-note">
-      Volgens de nummers hieronder, die onderweg hernummerd worden.
-      <code>odd</code>, <code>even</code>, <code>all</code> en <code>last</code>
-      werken ook.
+      Op het kleine nummer in de hoek van elke pagina hieronder, dat gaandeweg
+      opnieuw genummerd wordt &mdash; niet op het grote, dat is de pagina die
+      hij in zijn eigen bestand was. <code>odd</code>, <code>even</code>,
+      <code>all</code> en <code>last</code> werken ook.
     </p>
     <p id="range-error" class="error" role="alert" hidden></p>
 
@@ -213,6 +214,7 @@
     <span data-phrase="page.remove">Pagina {n} verwijderen</span>
     <span data-phrase="page.from">{name}, pagina {n}</span>
     <span data-phrase="page.origin">Van pagina {n}</span>
+    <span data-phrase="page.at">Nummer {n} in de volgorde</span>
     <span data-phrase="page.anticlockwise">Pagina {n} linksom draaien</span>
     <span data-phrase="page.clockwise">Pagina {n} rechtsom draaien</span>
     <span data-phrase="page.earlier">Pagina {n} naar voren</span>

--- a/locales/pt/tools/merge-pdf.html
+++ b/locales/pt/tools/merge-pdf.html
@@ -43,8 +43,10 @@
       <button type="button" id="range-turn" class="ghost">Girar estas</button>
     </div>
     <p id="range-note" class="field-note">
-      Pelos números abaixo, que são renumerados conforme você mexe. <code>odd</code>,
-      <code>even</code>, <code>all</code> e <code>last</code> também funcionam.
+      Pelo número pequeno no canto de cada página abaixo, que é renumerado
+      conforme você mexe &mdash; não pelo grande, que é a página que ela era no
+      arquivo dela. <code>odd</code>, <code>even</code>, <code>all</code> e
+      <code>last</code> também funcionam.
     </p>
     <p id="range-error" class="error" role="alert" hidden></p>
 
@@ -210,6 +212,7 @@
     <span data-phrase="page.remove">Tirar a página {n}</span>
     <span data-phrase="page.from">{name}, página {n}</span>
     <span data-phrase="page.origin">Da página {n}</span>
+    <span data-phrase="page.at">Número {n} na ordem</span>
     <span data-phrase="page.anticlockwise">Girar a página {n} no sentido anti-horário</span>
     <span data-phrase="page.clockwise">Girar a página {n} no sentido horário</span>
     <span data-phrase="page.earlier">Mover a página {n} para antes</span>

--- a/locales/pt/tools/merge-pdf.html
+++ b/locales/pt/tools/merge-pdf.html
@@ -17,10 +17,11 @@
 
     <p class="card-lede">
       Toda página de todo arquivo que você escolheu, na ordem em que elas vão sair.
-      Arraste uma pela alça
-      <span class="grip" aria-hidden="true">&#8942;&#8942;</span> para movê-la, gire
-      com as setas, ou tire com o &times;. Aqui ainda não foi escrito nada: o
-      documento é montado quando você apertar o botão no passo 4.
+      Arraste um cartão por qualquer parte dele para mover aquela página &mdash;
+      numa tela de toque, pela alça
+      <span class="grip" aria-hidden="true">&#8942;&#8942;</span>, para a lista continuar
+      rolando. Gire com as setas, ou tire com o &times;. Aqui ainda não foi escrito
+      nada: o documento é montado quando você apertar o botão no passo 4.
     </p>
 
     <div class="toolbar">
@@ -208,6 +209,7 @@
     <span data-phrase="page.turned">Girada por esta ferramenta</span>
     <span data-phrase="page.remove">Tirar a página {n}</span>
     <span data-phrase="page.from">{name}, página {n}</span>
+    <span data-phrase="page.origin">Da página {n}</span>
     <span data-phrase="page.anticlockwise">Girar a página {n} no sentido anti-horário</span>
     <span data-phrase="page.clockwise">Girar a página {n} no sentido horário</span>
     <span data-phrase="page.earlier">Mover a página {n} para antes</span>

--- a/locales/tr/tools/merge-pdf.html
+++ b/locales/tr/tools/merge-pdf.html
@@ -51,9 +51,10 @@
       <button type="button" id="range-turn" class="ghost">Bunları döndür</button>
     </div>
     <p id="range-note" class="field-note">
-      Aşağıdaki numaralara göre; onlar da siz ilerledikçe yeniden verilir.
-      <code>odd</code>, <code>even</code>, <code>all</code> ve
-      <code>last</code> de çalışır.
+      Aşağıdaki her sayfanın köşesindeki küçük numaraya göre; o numara siz
+      çalıştıkça yeniden verilir &mdash; büyük olana göre değil, o sayfanın
+      kendi dosyasındaki numarasıdır. <code>odd</code>, <code>even</code>,
+      <code>all</code> ve <code>last</code> da çalışır.
     </p>
     <p id="range-error" class="error" role="alert" hidden></p>
 
@@ -220,6 +221,7 @@
     <span data-phrase="page.remove">{n}. sayfayı çıkar</span>
     <span data-phrase="page.from">{name}, sayfa {n}</span>
     <span data-phrase="page.origin">{n}. sayfadan</span>
+    <span data-phrase="page.at">Sıradaki {n}. numara</span>
     <span data-phrase="page.anticlockwise">{n}. sayfayı saat yönünün tersine döndür</span>
     <span data-phrase="page.clockwise">{n}. sayfayı saat yönünde döndür</span>
     <span data-phrase="page.earlier">{n}. sayfayı öne al</span>

--- a/locales/tr/tools/merge-pdf.html
+++ b/locales/tr/tools/merge-pdf.html
@@ -24,9 +24,10 @@
     <h2><span class="step">2</span> Sayfaları düzenleyin</h2>
 
     <p class="card-lede">
-      Seçtiğiniz her dosyanın her sayfası, çıkacakları sırayla. Taşımak için
-      birini <span class="grip" aria-hidden="true">&#8942;&#8942;</span>
-      tutamağından sürükleyin, oklarla döndürün ya da &times; ile çıkarın.
+      Seçtiğiniz her dosyanın her sayfası, çıkacakları sırayla. O sayfayı taşımak
+      için kartı herhangi bir yerinden sürükleyin &mdash; dokunmatik ekranda
+      <span class="grip" aria-hidden="true">&#8942;&#8942;</span> tutamağından, ki liste
+      kaymaya devam etsin. Sayfayı oklarla döndürün ya da &times; ile çıkarın.
       Burada henüz hiçbir şey yazılmadı &mdash; belge, 4. adımda düğmeye
       bastığınızda kurulur.
     </p>
@@ -218,6 +219,7 @@
     <span data-phrase="page.turned">Bu araç tarafından döndürüldü</span>
     <span data-phrase="page.remove">{n}. sayfayı çıkar</span>
     <span data-phrase="page.from">{name}, sayfa {n}</span>
+    <span data-phrase="page.origin">{n}. sayfadan</span>
     <span data-phrase="page.anticlockwise">{n}. sayfayı saat yönünün tersine döndür</span>
     <span data-phrase="page.clockwise">{n}. sayfayı saat yönünde döndür</span>
     <span data-phrase="page.earlier">{n}. sayfayı öne al</span>

--- a/locales/zh-TW/tools/merge-pdf.html
+++ b/locales/zh-TW/tools/merge-pdf.html
@@ -16,8 +16,7 @@
     <h2><span class="step">2</span> 安排頁面</h2>
 
     <p class="card-lede">
-      你選的每個檔案的每一頁，都按出來的順序排在這裡。抓住
-      <span class="grip" aria-hidden="true">&#8942;&#8942;</span> 把手拖動就能挪，用箭頭可以轉，用 &times; 可以刪。這裡還什麼都沒寫出去，文件要等你在第四步按下按鈕才會拼起來。
+      你選的每個檔案的每一頁，都按出來的順序排在這裡。卡片抓哪裡都能拖動這一頁；觸控螢幕上只能抓 <span class="grip" aria-hidden="true">&#8942;&#8942;</span> 把手，這樣列表還能捲動。用箭頭可以轉，用 &times; 可以刪。這裡還什麼都沒寫出去，文件要等你在第四步按下按鈕才會拼起來。
     </p>
 
     <div class="toolbar">
@@ -195,6 +194,7 @@
     <span data-phrase="page.turned">這個工具轉過</span>
     <span data-phrase="page.remove">去掉第 {n} 頁</span>
     <span data-phrase="page.from">{name}，第 {n} 頁</span>
+    <span data-phrase="page.origin">原第 {n} 頁</span>
     <span data-phrase="page.anticlockwise">把第 {n} 頁逆時針轉</span>
     <span data-phrase="page.clockwise">把第 {n} 頁順時針轉</span>
     <span data-phrase="page.earlier">把第 {n} 頁往前挪</span>

--- a/locales/zh-TW/tools/merge-pdf.html
+++ b/locales/zh-TW/tools/merge-pdf.html
@@ -38,7 +38,7 @@
       <button type="button" id="range-turn" class="ghost">旋轉這些</button>
     </div>
     <p id="range-note" class="field-note">
-      按下面顯示的編號來寫，編號會隨著你的操作重新編排。<code>odd</code>、<code>even</code>、<code>all</code> 和 <code>last</code> 也能用。
+      按下面每一頁角上的小編號來寫，這個編號會隨著你的操作重新編排；大的那個不是，那是它在自己檔案裡的頁碼。<code>odd</code>、<code>even</code>、<code>all</code> 和 <code>last</code> 也能用。
     </p>
     <p id="range-error" class="error" role="alert" hidden></p>
 
@@ -195,6 +195,7 @@
     <span data-phrase="page.remove">去掉第 {n} 頁</span>
     <span data-phrase="page.from">{name}，第 {n} 頁</span>
     <span data-phrase="page.origin">原第 {n} 頁</span>
+    <span data-phrase="page.at">排在第 {n} 位</span>
     <span data-phrase="page.anticlockwise">把第 {n} 頁逆時針轉</span>
     <span data-phrase="page.clockwise">把第 {n} 頁順時針轉</span>
     <span data-phrase="page.earlier">把第 {n} 頁往前挪</span>

--- a/locales/zh/tools/merge-pdf.html
+++ b/locales/zh/tools/merge-pdf.html
@@ -38,7 +38,7 @@
       <button type="button" id="range-turn" class="ghost">旋转这些</button>
     </div>
     <p id="range-note" class="field-note">
-      按下面显示的编号来写，编号会随着你的操作重新编排。<code>odd</code>、<code>even</code>、<code>all</code> 和 <code>last</code> 也能用。
+      按下面每一页角上的小编号来写，这个编号会随着你的操作重新编排；大的那个不是，那是它在自己文件里的页码。<code>odd</code>、<code>even</code>、<code>all</code> 和 <code>last</code> 也能用。
     </p>
     <p id="range-error" class="error" role="alert" hidden></p>
 
@@ -195,6 +195,7 @@
     <span data-phrase="page.remove">去掉第 {n} 页</span>
     <span data-phrase="page.from">{name}，第 {n} 页</span>
     <span data-phrase="page.origin">原第 {n} 页</span>
+    <span data-phrase="page.at">排在第 {n} 位</span>
     <span data-phrase="page.anticlockwise">把第 {n} 页逆时针转</span>
     <span data-phrase="page.clockwise">把第 {n} 页顺时针转</span>
     <span data-phrase="page.earlier">把第 {n} 页往前挪</span>

--- a/locales/zh/tools/merge-pdf.html
+++ b/locales/zh/tools/merge-pdf.html
@@ -16,8 +16,7 @@
     <h2><span class="step">2</span> 安排页面</h2>
 
     <p class="card-lede">
-      你选的每个文件的每一页，都按出来的顺序排在这里。抓住
-      <span class="grip" aria-hidden="true">&#8942;&#8942;</span> 把手拖动就能挪，用箭头可以转，用 &times; 可以删。这里还什么都没写出去，文档要等你在第四步按下按钮才会拼起来。
+      你选的每个文件的每一页，都按出来的顺序排在这里。卡片抓哪儿都能拖动这一页；触摸屏上只能抓 <span class="grip" aria-hidden="true">&#8942;&#8942;</span> 把手，这样列表还能滚。用箭头可以转，用 &times; 可以删。这里还什么都没写出去，文档要等你在第四步按下按钮才会拼起来。
     </p>
 
     <div class="toolbar">
@@ -195,6 +194,7 @@
     <span data-phrase="page.turned">这个工具转过</span>
     <span data-phrase="page.remove">去掉第 {n} 页</span>
     <span data-phrase="page.from">{name}，第 {n} 页</span>
+    <span data-phrase="page.origin">原第 {n} 页</span>
     <span data-phrase="page.anticlockwise">把第 {n} 页逆时针转</span>
     <span data-phrase="page.clockwise">把第 {n} 页顺时针转</span>
     <span data-phrase="page.earlier">把第 {n} 页往前挪</span>

--- a/tools/merge-pdf/README.md
+++ b/tools/merge-pdf/README.md
@@ -199,6 +199,16 @@ If that ever changes it will be because a renderer got small enough to vendor
 under the rules in [What can be built here](../../docs/what-can-be-built-here.md),
 not because the thumbnails were worth an upload.
 
+What that argument missed for a while is that one of those facts is not a fact
+about the page at all. The big number on the paper is a **position** — 1, 2, 3
+down the list, renumbered on every change — so with nothing else to tell two
+tiles apart, taking page 3 out of twelve and taking page 12 out leave the same
+screen behind: eleven tiles numbered 1 to 11. It was reported as the × removing
+the wrong page, and it was not; the tool simply could not show which page it had
+removed. Every tile now also carries the page it came from, which is the one
+thing about it that holds still while the numbers move, and is what makes a
+removal or a reorder legible without a picture of the page.
+
 ## Limitations
 
 - **Encrypted documents are refused**, empty password included.

--- a/tools/merge-pdf/README.md
+++ b/tools/merge-pdf/README.md
@@ -199,15 +199,22 @@ If that ever changes it will be because a renderer got small enough to vendor
 under the rules in [What can be built here](../../docs/what-can-be-built-here.md),
 not because the thumbnails were worth an upload.
 
-What that argument missed for a while is that one of those facts is not a fact
-about the page at all. The big number on the paper is a **position** — 1, 2, 3
-down the list, renumbered on every change — so with nothing else to tell two
-tiles apart, taking page 3 out of twelve and taking page 12 out leave the same
-screen behind: eleven tiles numbered 1 to 11. It was reported as the × removing
-the wrong page, and it was not; the tool simply could not show which page it had
-removed. Every tile now also carries the page it came from, which is the one
-thing about it that holds still while the numbers move, and is what makes a
-removal or a reorder legible without a picture of the page.
+What that argument missed for a while is that the number on the paper was not a
+fact about the page at all. It was a **position** — 1, 2, 3 down the list,
+renumbered on every change — and a position cannot move. Drag a page three
+places and it still reads the number of the slot it landed in; take page 3 out
+of twelve and the screen left behind is the one taking page 12 out would leave,
+eleven tiles numbered 1 to 11. Both were reported as bugs, first as the drag not
+working and then as the × removing the wrong page, and neither was: the tool
+could not show what it had done.
+
+So the big number on the paper is now the page's own — the page it was in the
+file it came out of — which moves with the tile and makes a reorder or a removal
+legible at a glance. Where it currently sits is the small pill in the sheet's
+corner, because that is what the range box counts, and it is drawn as a label
+rather than as part of the paper: the two numbers read alike until something is
+moved, and a person has to be able to tell which is which the moment they
+diverge.
 
 ## Limitations
 

--- a/tools/merge-pdf/body.html
+++ b/tools/merge-pdf/body.html
@@ -43,8 +43,10 @@
       <button type="button" id="range-turn" class="ghost">Turn these</button>
     </div>
     <p id="range-note" class="field-note">
-      By the numbers below, which renumber as you go. <code>odd</code>,
-      <code>even</code>, <code>all</code> and <code>last</code> work too.
+      By the small number in the corner of each page below, which renumbers as
+      you go &mdash; not the big one, which is the page it was in its own file.
+      <code>odd</code>, <code>even</code>, <code>all</code> and
+      <code>last</code> work too.
     </p>
     <p id="range-error" class="error" role="alert" hidden></p>
 
@@ -210,6 +212,7 @@
     <span data-phrase="page.remove">Remove page {n}</span>
     <span data-phrase="page.from">{name}, page {n}</span>
     <span data-phrase="page.origin">From page {n}</span>
+    <span data-phrase="page.at">Number {n} in the running order</span>
     <span data-phrase="page.anticlockwise">Turn page {n} anticlockwise</span>
     <span data-phrase="page.clockwise">Turn page {n} clockwise</span>
     <span data-phrase="page.earlier">Move page {n} earlier</span>

--- a/tools/merge-pdf/body.html
+++ b/tools/merge-pdf/body.html
@@ -17,10 +17,11 @@
 
     <p class="card-lede">
       Every page of every file you chose, in the order they will come out.
-      Drag one by its <span class="grip" aria-hidden="true">&#8942;&#8942;</span>
-      handle to move it, turn it with the arrows, or take it out with the
-      &times;. Nothing here has been written yet &mdash; the document is
-      assembled when you press the button in step 4.
+      Drag a tile anywhere on it to move that page &mdash; on a touch screen,
+      by its <span class="grip" aria-hidden="true">&#8942;&#8942;</span> grip,
+      so the list still scrolls. Turn a page with the arrows, or take it out
+      with the &times;. Nothing here has been written yet &mdash; the document
+      is assembled when you press the button in step 4.
     </p>
 
     <div class="toolbar">
@@ -208,6 +209,7 @@
     <span data-phrase="page.turned">Turned by this tool</span>
     <span data-phrase="page.remove">Remove page {n}</span>
     <span data-phrase="page.from">{name}, page {n}</span>
+    <span data-phrase="page.origin">From page {n}</span>
     <span data-phrase="page.anticlockwise">Turn page {n} anticlockwise</span>
     <span data-phrase="page.clockwise">Turn page {n} clockwise</span>
     <span data-phrase="page.earlier">Move page {n} earlier</span>

--- a/tools/merge-pdf/src/main.js
+++ b/tools/merge-pdf/src/main.js
@@ -7,6 +7,7 @@ import { bytes, count as countOf, shortName } from './format.js';
 import { sizeLabel } from './pages.js';
 import { describeRanges, parseRanges } from './plan.js';
 import { produce } from './produce.js';
+import { wireReorder } from './reorder.js';
 import { EncryptedPdfError, NotAPdfError, PdfDocument } from './shared/pdf-reader.js';
 import { wireFilePicker, readingLabel } from './shared/file-picker.js';
 import { makeExample } from './example.js';
@@ -213,16 +214,6 @@ function renderSources() {
 
 /* --------------------------------------------------------------- the pages */
 
-let dragIndex = null;
-/** Where the dragged page would land: { index, after } */
-let dropAt = null;
-
-function clearDropMarkers() {
-  for (const node of el.pageList.querySelectorAll('.insert-before, .insert-after')) {
-    node.classList.remove('insert-before', 'insert-after');
-  }
-}
-
 /**
  * One page, as a tile.
  *
@@ -242,14 +233,12 @@ function buildPageNode(entry, index) {
   const handle = document.createElement('button');
   handle.type = 'button';
   handle.className = 'drag-handle';
-  handle.draggable = true;
   handle.textContent = '⋮⋮';
   handle.title = phrase('page.drag', { n: index + 1 });
   handle.setAttribute('aria-label', handle.title);
 
   const shapeWrap = document.createElement('div');
   shapeWrap.className = 'shape-wrap';
-  shapeWrap.draggable = true;
 
   const turned = entry.rotate % 180 !== 0;
   const width = turned ? page.height : page.width;
@@ -299,6 +288,21 @@ function buildPageNode(entry, index) {
     meta.append(from);
   }
 
+  /*
+    Which page of the original this tile is, which is the one thing about it
+    that does not change as the list is worked on. The big number on the paper
+    is a position: it is 1, 2, 3 down the list whatever is in the list, so with
+    no thumbnail to tell tiles apart, removing page 3 of twelve and removing
+    page 12 leave the screen looking exactly the same - eleven tiles numbered 1
+    to 11 - and the tool cannot show which page it just took out. This line
+    holds still while the numbers renumber, and is the difference between
+    "it removed something" and "it removed that one".
+  */
+  const origin = document.createElement('p');
+  origin.className = 'page-origin';
+  origin.textContent = phrase('page.origin', { n: entry.index + 1 });
+  meta.append(origin);
+
   const dims = document.createElement('p');
   dims.className = 'page-dims';
   dims.textContent = sizeLabel(width, height);
@@ -324,7 +328,6 @@ function buildPageNode(entry, index) {
   meta.append(controls);
 
   li.append(handle, shapeWrap, meta);
-  wireDrag(li, [handle, shapeWrap], index);
   return li;
 }
 
@@ -353,82 +356,17 @@ function move(from, to) {
   render();
 }
 
-function wireDrag(li, handles, index) {
-  const startDrag = (event) => {
-    if (running) { event.preventDefault(); return; }
-    dragIndex = index;
-    li.classList.add('dragging');
-    event.dataTransfer.effectAllowed = 'move';
-    // Firefox refuses to start a drag unless some data is set.
-    event.dataTransfer.setData('text/plain', String(index));
-  };
-
-  const endDrag = () => {
-    dragIndex = null;
-    dropAt = null;
-    li.classList.remove('dragging');
-    clearDropMarkers();
-  };
-
-  for (const source of handles) {
-    source.addEventListener('dragstart', startDrag);
-    source.addEventListener('dragend', endDrag);
-  }
-
-  li.addEventListener('dragover', (event) => {
-    if (dragIndex === null) return;
-    event.preventDefault();
-    event.dataTransfer.dropEffect = 'move';
-
-    // Which side of the tile the pointer is on decides where it lands, so the
-    // marker always reads as "it goes here", not "it swaps with this".
-    const rect = li.getBoundingClientRect();
-    const after = event.clientX > rect.left + rect.width / 2;
-
-    clearDropMarkers();
-    li.classList.add(after ? 'insert-after' : 'insert-before');
-    dropAt = { index, after };
-  });
-
-  li.addEventListener('drop', (event) => {
-    event.preventDefault();
-    event.stopPropagation();
-    applyDrop();
-  });
-}
-
-/** Move the dragged page to wherever the marker currently sits. */
-function applyDrop() {
-  if (dragIndex === null || dropAt === null) {
-    clearDropMarkers();
-    return;
-  }
-
-  let target = dropAt.after ? dropAt.index + 1 : dropAt.index;
-  // Removing the item first shifts everything after it down by one.
-  if (dragIndex < target) target -= 1;
-
-  const from = dragIndex;
-  dragIndex = null;
-  dropAt = null;
-
-  if (from === target) {
-    clearDropMarkers();
-    return;
-  }
-
-  move(from, target);
-}
-
-// Dropping in the gaps between tiles should still land somewhere sensible
-// rather than being swallowed by the window-level handler.
-el.pageList.addEventListener('dragover', (event) => {
-  if (dragIndex !== null) event.preventDefault();
-});
-el.pageList.addEventListener('drop', (event) => {
-  if (dragIndex === null) return;
-  event.preventDefault();
-  applyDrop();
+/*
+  Wired once, to the list rather than to each tile, because render() throws
+  every tile away and builds it again: a listener per node would be reattached
+  a hundred times for a hundred-page document and, worse, would be attached to
+  a node the drag in progress no longer refers to.
+*/
+const cancelReorder = wireReorder(el.pageList, {
+  item: '.page-item',
+  handle: '.drag-handle',
+  blocked: () => Boolean(running),
+  onMove: move,
 });
 
 /* ------------------------------------------------------------ bulk actions */
@@ -578,6 +516,9 @@ function countOutputs(split) {
 /* --------------------------------------------------------------- rendering */
 
 function render() {
+  // Every tile below is about to be replaced, so a drag still holding one is
+  // holding a node that will not be on the page a line from now.
+  cancelReorder();
   renderSources();
 
   const has = entries.length > 0;

--- a/tools/merge-pdf/src/main.js
+++ b/tools/merge-pdf/src/main.js
@@ -248,10 +248,34 @@ function buildPageNode(entry, index) {
   shape.className = 'page-shape';
   shape.style.aspectRatio = `${Math.max(1, width)} / ${Math.max(1, height)}`;
 
+  /*
+    The big number is the page's own - the page it was in the file it came out
+    of - and not where it currently sits, which is the other way round from how
+    this started and is the whole of what was wrong.
+
+    A position cannot move. It is 1, 2, 3 down the list whatever is in the list,
+    so a tile dragged three places to the left still read "1" when it landed
+    and every number on screen was where it had been a moment before. With no
+    thumbnail to go by, the only available reading was that the drag had not
+    worked - which is exactly how it was reported. What a page *is* moves with
+    it, so that is what the paper now says, and dragging visibly rearranges the
+    numbers.
+
+    Where it sits is still worth showing, because the box above takes those
+    numbers, so it is the small pill in the corner: a label on the slot rather
+    than on the page.
+  */
   const number = document.createElement('span');
   number.className = 'page-number';
-  number.textContent = String(index + 1);
+  number.textContent = String(entry.index + 1);
+  number.title = phrase('page.origin', { n: entry.index + 1 });
   shape.append(number);
+
+  const at = document.createElement('span');
+  at.className = 'page-at';
+  at.textContent = String(index + 1);
+  at.title = phrase('page.at', { n: index + 1 });
+  shape.append(at);
 
   if (entry.rotate % 360 !== 0) {
     const turn = document.createElement('span');
@@ -287,21 +311,6 @@ function buildPageNode(entry, index) {
       { name: entry.source.label, n: entry.index + 1 });
     meta.append(from);
   }
-
-  /*
-    Which page of the original this tile is, which is the one thing about it
-    that does not change as the list is worked on. The big number on the paper
-    is a position: it is 1, 2, 3 down the list whatever is in the list, so with
-    no thumbnail to tell tiles apart, removing page 3 of twelve and removing
-    page 12 leave the screen looking exactly the same - eleven tiles numbered 1
-    to 11 - and the tool cannot show which page it just took out. This line
-    holds still while the numbers renumber, and is the difference between
-    "it removed something" and "it removed that one".
-  */
-  const origin = document.createElement('p');
-  origin.className = 'page-origin';
-  origin.textContent = phrase('page.origin', { n: entry.index + 1 });
-  meta.append(origin);
 
   const dims = document.createElement('p');
   dims.className = 'page-dims';

--- a/tools/merge-pdf/src/reorder.js
+++ b/tools/merge-pdf/src/reorder.js
@@ -1,0 +1,214 @@
+/**
+ * Dragging a page tile to a new place in the running order.
+ *
+ * This was written with the HTML drag-and-drop API - `draggable="true"`, a
+ * dataTransfer, dragover and drop - and that API is the wrong one for the job
+ * in two ways that a person meets immediately.
+ *
+ * It does not exist on a touch screen. There is no dragstart from a finger in
+ * any mobile browser, so on a phone or a tablet dragging a tile did nothing at
+ * all, anywhere on it, and the only way to move a page was the two arrows
+ * under it, one position at a time.
+ *
+ * And with a mouse it worked over some of a tile and not the rest: only an
+ * element carrying the attribute can be picked up, so the paper and the little
+ * grip could be dragged and the whole lower band of the tile - the file name,
+ * the paper size, the four buttons - was dead. A tile that answers to the
+ * pointer over two thirds of itself reads as broken, because the part a person
+ * happens to grab is the part that decides.
+ *
+ * Pointer events have neither problem: one code path for mouse, pen and touch,
+ * and the whole tile is the handle. What they do not bring is the two things
+ * the browser used to do for free, so both are here - the tile follows the
+ * pointer, and the page scrolls when the drag reaches its edge.
+ *
+ * A finger is the exception to "the whole tile is the handle". A list of pages
+ * is taller than the screen and has to be scrollable, and a touch that starts
+ * a drag is a touch that cannot scroll - so from a finger the drag starts on
+ * the grip alone, which is the one part of the tile whose `touch-action` says
+ * the page must not pan. Everything else on the tile scrolls the way the rest
+ * of the page does.
+ */
+
+/** How far the pointer must travel before this is a drag and not a click. */
+const SLOP = 5;
+
+/** How close to the edge of the window a drag has to be to scroll it. */
+const EDGE = 70;
+const EDGE_SPEED = 14;
+
+/**
+ * @param {HTMLElement} list      the container the tiles are children of
+ * @param {object} options
+ * @param {string} options.item   selector for one tile
+ * @param {string} options.handle selector for the grip inside it
+ * @param {() => boolean} options.blocked  true while the tool is busy
+ * @param {(from: number, to: number) => void} options.onMove
+ */
+export function wireReorder(list, { item, handle, blocked, onMove }) {
+  /** The drag in progress: null between them. */
+  let drag = null;
+
+  const tileAt = (node) => node?.closest?.(item) ?? null;
+  const indexOf = (tile) => Number(tile.dataset.index);
+
+  const clearMarkers = () => {
+    for (const node of list.querySelectorAll('.insert-before, .insert-after')) {
+      node.classList.remove('insert-before', 'insert-after');
+    }
+  };
+
+  /**
+   * Which tile the pointer is over, and which side of it.
+   *
+   * The tile being dragged is out of the way of the hit test - it carries
+   * `pointer-events: none` while it is lifted - so what comes back is always
+   * something to land beside.
+   */
+  const landing = (x, y) => {
+    const over = tileAt(document.elementFromPoint(x, y));
+    if (!over) return null;
+    const box = over.getBoundingClientRect();
+    // Which side the pointer is on decides where it goes, so the marker reads
+    // as "it lands here" rather than "it swaps with this one". Right of centre
+    // is later in the order in Arabic only if you read from the left, which is
+    // why the answer is turned round there: the fourteenth page of a document
+    // is drawn to the left of the thirteenth, and a bar on the right of a tile
+    // that means "after" would be pointing at the page before it.
+    const past = x > box.left + box.width / 2;
+    return { index: indexOf(over), after: drag?.rtl ? !past : past, tile: over };
+  };
+
+  const showMarker = (spot) => {
+    clearMarkers();
+    if (spot) spot.tile.classList.add(spot.after ? 'insert-after' : 'insert-before');
+  };
+
+  /*
+    The tile, under the pointer. The offset is measured in page coordinates
+    rather than the window's, because the window moves: while the edge scroll
+    below is running the tile's own layout position slides up with the
+    document, and a translation of "how far the pointer has moved on screen"
+    would leave it further behind with every frame.
+  */
+  const follow = () => {
+    const x = drag.x + scrollX - drag.startX;
+    const y = drag.y + scrollY - drag.startY;
+    drag.tile.style.transform = `translate(${x}px, ${y}px)`;
+  };
+
+  /* The window scrolls itself while a drag sits near its edge, which the drag
+     API used to do and pointer events do not. Without it a page cannot be
+     carried past the fold of a long document at all: the pointer reaches the
+     bottom of the screen and there is nowhere further to go. */
+  let scrolling = 0;
+  const edgeScroll = () => {
+    if (!drag?.lifted) { scrolling = 0; return; }
+    const { y } = drag;
+    const push = y < EDGE ? -EDGE_SPEED : (y > innerHeight - EDGE ? EDGE_SPEED : 0);
+    if (push) {
+      scrollBy(0, push);
+      follow();
+      drag.spot = landing(drag.x, drag.y);
+      showMarker(drag.spot);
+    }
+    scrolling = requestAnimationFrame(edgeScroll);
+  };
+
+  const lift = () => {
+    drag.lifted = true;
+    drag.tile.classList.add('dragging');
+    scrolling = requestAnimationFrame(edgeScroll);
+  };
+
+  const finish = (apply) => {
+    if (!drag) return;
+    const { tile, from, spot, lifted } = drag;
+    drag = null;
+    cancelAnimationFrame(scrolling);
+    tile.classList.remove('dragging');
+    tile.style.transform = '';
+    clearMarkers();
+    if (!lifted || !apply || !spot) return;
+
+    let to = spot.after ? spot.index + 1 : spot.index;
+    // Taking the tile out first shifts everything after it down by one.
+    if (from < to) to -= 1;
+    if (to !== from) onMove(from, to);
+  };
+
+  list.addEventListener('pointerdown', (event) => {
+    if (drag || blocked() || event.button !== 0) return;
+
+    const tile = tileAt(event.target);
+    if (!tile) return;
+
+    const grip = event.target.closest(handle);
+    // A press that lands on one of the tile's own buttons is that button's,
+    // not a drag - except the grip, which is a button whose whole job is this.
+    if (!grip && event.target.closest('button, a, input, select')) return;
+    // A finger may only start a drag on the grip; anywhere else on the tile it
+    // is the visitor scrolling the list.
+    if (event.pointerType === 'touch' && !grip) return;
+
+    drag = {
+      tile,
+      pointerId: event.pointerId,
+      // Read once: the answer cannot change during a drag, and reading it on
+      // every move would be a style recalculation per pointer event.
+      rtl: getComputedStyle(list).direction === 'rtl',
+      from: indexOf(tile),
+      // Where the grab happened on the page, not on the screen - see follow().
+      startX: event.clientX + scrollX,
+      startY: event.clientY + scrollY,
+      x: event.clientX,
+      y: event.clientY,
+      lifted: false,
+      spot: null,
+    };
+    // Captured on the list rather than the tile, so the tile is free to take
+    // itself out of the hit test once it is lifted. A pointer that has already
+    // gone cannot be captured and throws saying so, which is not a reason to
+    // leave a drag half-started.
+    try {
+      list.setPointerCapture(event.pointerId);
+    } catch {
+      drag = null;
+    }
+  });
+
+  list.addEventListener('pointermove', (event) => {
+    if (!drag || event.pointerId !== drag.pointerId) return;
+    drag.x = event.clientX;
+    drag.y = event.clientY;
+
+    if (!drag.lifted) {
+      const moved = Math.hypot(
+        drag.x + scrollX - drag.startX, drag.y + scrollY - drag.startY);
+      if (moved < SLOP) return;
+      lift();
+    }
+    // A touch that has become a drag must stop being a scroll as well.
+    event.preventDefault();
+    follow();
+    drag.spot = landing(drag.x, drag.y);
+    showMarker(drag.spot);
+  });
+
+  for (const type of ['pointerup', 'pointercancel']) {
+    list.addEventListener(type, (event) => {
+      if (!drag || event.pointerId !== drag.pointerId) return;
+      finish(type === 'pointerup');
+    });
+  }
+
+  // Somewhere to put a drag down that is not a decision, for a person who has
+  // picked up the wrong tile.
+  addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && drag?.lifted) finish(false);
+  });
+
+  // A tile lifted and then removed under us - the tool cleared the list, or a
+  // file went - would leave the drag pointing at a node no longer on the page.
+  return () => finish(false);
+}

--- a/tools/merge-pdf/styles.css
+++ b/tools/merge-pdf/styles.css
@@ -90,9 +90,25 @@
   background: var(--surface-2);
   display: flex;
   flex-direction: column;
+  /* The whole tile can be picked up, so the whole tile says so. And a surface
+     that is dragged is not a surface whose words are selected: without this a
+     mouse drag across a tile paints "A4 portrait" blue on the way past, which
+     the drag API used to suppress for us. */
+  cursor: grab;
+  user-select: none;
 }
 
-.page-item.dragging { opacity: 0.35; transform: scale(0.97); }
+/* The tile being carried. It follows the pointer on a transform set from
+   src/reorder.js, so nothing here may set one of its own; it lifts off the
+   page instead, and takes itself out of the hit test so the tile underneath
+   is the one the drop lands beside. */
+.page-item.dragging {
+  z-index: 4;
+  cursor: grabbing;
+  pointer-events: none;
+  border-color: var(--accent);
+  box-shadow: 0 10px 24px rgb(16 24 40 / 28%);
+}
 
 /* A bar showing exactly where the dragged page will land, rather than just
    tinting the tile it is over. */
@@ -130,6 +146,11 @@
   letter-spacing: -2px;
   cursor: grab;
   opacity: 0.85;
+  /* The one part of a tile a finger may drag. Everything else on it scrolls
+     the list, which a list taller than the screen has to be able to do, and
+     a touch that has begun a drag can no longer be a scroll - so the grip
+     tells the browser not to pan from here, and only from here. */
+  touch-action: none;
 }
 
 .drag-handle:hover {
@@ -185,26 +206,54 @@
   color: var(--accent-deep);
 }
 
+/*
+  The × in the corner of a tile.
+
+  `padding: 0` is not tidiness. tool-frame.css gives every button on the site
+  0.5rem by 0.9rem, which a 1.5rem box cannot hold: the width floors at the
+  padding it has to fit, so the circle came out 28.8 by 24 - an ellipse, with
+  the glyph sitting off its centre because a 14.4px line box does not fit in
+  what is left of the height either. The three sibling tools that draw the same
+  control all say `padding: 0` and this one had lost it.
+*/
 .remove-btn {
   position: absolute;
   top: 0.35rem;
   inset-inline-end: 0.35rem;
-  width: 1.5rem;
-  height: 1.5rem;
+  display: grid;
+  place-items: center;
+  width: 1.6rem;
+  height: 1.6rem;
+  padding: 0;
   border: none;
   border-radius: 50%;
   background: rgb(0 0 0 / 55%);
   color: #fff;
   cursor: pointer;
-  font-size: 0.9rem;
+  font-size: 1rem;
   line-height: 1;
 }
 
 .remove-btn:hover { background: var(--danger); }
 
+/* A thumb needs a target, and the frame's floor for one is a minimum height of
+   44px on every button. Left alone that stretches these two the other way -
+   a 24px-wide control 44px tall - so where the pointer is coarse they are
+   square about the frame's own number rather than fighting it. The grip has
+   the most to gain: on a touch screen it is the only place a drag can start,
+   and it was 25 pixels across. */
+@media (pointer: coarse) {
+  .remove-btn,
+  .drag-handle {
+    width: 2.75rem;
+    height: 2.75rem;
+  }
+}
+
 .page-meta { padding: 0 0.5rem 0.55rem; min-width: 0; }
 
 .page-from,
+.page-origin,
 .page-dims {
   margin: 0 0 0.25rem;
   font-size: 0.72rem;
@@ -215,6 +264,7 @@
 }
 
 .page-from { color: var(--text); }
+.page-origin { font-variant-numeric: tabular-nums; }
 
 .page-controls { display: flex; align-items: center; gap: 0.2rem; }
 

--- a/tools/merge-pdf/styles.css
+++ b/tools/merge-pdf/styles.css
@@ -190,10 +190,36 @@
   box-shadow: 0 1px 3px rgb(16 24 40 / 25%);
 }
 
+/* The page's own number, which is the page. */
 .page-number {
-  font-size: 1.1rem;
+  font-size: 1.35rem;
   font-weight: 700;
   color: #333;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Where it currently sits, which is the slot rather than the page. Small, and
+   drawn as a label rather than as part of the sheet, because the two numbers
+   on a tile read the same until something is moved and a person has to be able
+   to tell which is which the moment they diverge.
+
+   Inside the paper's top-left corner, not outside it: the grip sits just off
+   that corner on the tile, and a pill hung over the edge lands underneath it.
+   The other three are taken - the x is opposite, the rotation badge is below -
+   and this one is the corner the eye reaches first. */
+.page-at {
+  position: absolute;
+  top: 0.2rem;
+  inset-inline-start: 0.2rem;
+  min-width: 1.05rem;
+  padding: 0 0.2rem;
+  border-radius: 999px;
+  background: var(--text-dim);
+  color: #fff;
+  font-size: 0.62rem;
+  font-weight: 700;
+  line-height: 1.5;
+  text-align: center;
   font-variant-numeric: tabular-nums;
 }
 
@@ -253,7 +279,6 @@
 .page-meta { padding: 0 0.5rem 0.55rem; min-width: 0; }
 
 .page-from,
-.page-origin,
 .page-dims {
   margin: 0 0 0.25rem;
   font-size: 0.72rem;
@@ -264,7 +289,6 @@
 }
 
 .page-from { color: var(--text); }
-.page-origin { font-variant-numeric: tabular-nums; }
 
 .page-controls { display: flex; align-items: center; gap: 0.2rem; }
 


### PR DESCRIPTION
Two things were reported about the merge tool's page list — dragging not working, and the × "strange looking, and it deletes the last one instead of the current one". Both are real. The second is not what it looks like.

## Dragging

It was built on the HTML drag-and-drop API, which is the wrong API for this in two ways a person meets immediately.

**It does not exist on a touch screen.** No mobile browser fires `dragstart` from a finger, so on a phone a tile could not be moved at all, anywhere on it, and the two arrows underneath — one position at a time — were the whole of reordering.

**With a mouse it answered over part of a tile and not the rest**, because only an element carrying `draggable` can be picked up. Measured rather than reasoned about, by driving a headless Edge with `Input.setInterceptDrags` over a grid of points across one tile:

```
   . # # # # # # # #      # = the tile was picked up
   . # # # # # # # #      . = nothing happened
   # # # # # # # # #
   # # # # # # # # #      the paper and the grip
   # # # # # # # # #
   # # # # # # # # #
   # # # # # # # # #
   . T . . . . . . .      the file name, the paper size
   . . . . . . . . .      and the four buttons: dead
   . . . . . . . . .
   . . . . . . . . .      61 of 99 points
```

`src/reorder.js` does it with pointer events instead: one path for mouse, pen and touch, and the whole tile is the handle. The two things the browser used to do for free are done here, because a drag without them is worse than the one it replaces — the tile follows the pointer, and the window scrolls when the drag reaches its edge.

A finger is the exception to "the whole tile". A list of pages has to stay scrollable, and a touch that begins a drag cannot also be a scroll, so from a finger the drag starts on the ⋮⋮ grip — the one part of the tile whose `touch-action` says the page must not pan. Verified both ways: a touch on the grip moves the page, a touch on the paper scrolls the list and moves nothing.

## The ×

Two faults in one missing line. `tool-frame.css` gives every button on the site `0.5rem 0.9rem` of padding, and a `1.5rem` box cannot hold it — the width floors at the padding it has to fit, so the circle came out **28.8 by 24**: an ellipse, with its glyph off centre because a 14.4px line box does not fit in what is left of the height either. The three sibling tools that draw the same control all say `padding: 0`; this one had lost it. Where the pointer is coarse the frame's 44px floor stretched it the other way, so there both it and the grip are square about that number rather than fighting it.

## "It deletes the last one", and the reorder that looked like nothing

Same cause, reported twice. The code was right both times — the entry removed is
the one clicked, checked with a synthetic click, a real CDP mouse press and the
page's own handler. What was wrong is that the tool could not **show** what it
had done, because **the number on the paper was a position, and a position
cannot move**.

It was 1, 2, 3 down the list whatever was in the list. Drag a page three places
and it landed reading the number of the slot it landed in, with every number on
screen exactly where it had been a second before. Take page 3 out of twelve and
the screen left behind is the one taking page 12 out would leave: eleven tiles
numbered 1 to 11.

So the big number is now the page's own — the page it was in the file it came
out of — which moves with the tile. Where it currently sits is a small pill
inside the sheet's corner, because that is what the range box counts, drawn as a
label rather than as part of the paper: the two read alike until something is
moved and a person has to be able to tell which is which the moment they
diverge. It goes *inside* the corner, not over the edge, or the grip covers it;
the other three corners are taken by the × and the rotation badge.

The note under the range box said "By the numbers below", which was unambiguous
when a tile had one number on it. It now names the small one and says what the
big one is instead.

## Also, unreported

Which side of a tile the pointer was on was compared physically, so in Arabic — where page 14 is drawn to the *left* of page 13 — the bar meaning "after" appeared on the side of the tile holding the page before it. Decided logically now, and checked by dragging in the built Arabic page.

## Before and after

One PDF, three pages. On the left the × as it shipped — 28.8 by 24, an ellipse,
its glyph off centre — and three tiles carrying nothing but their position. On
the right the same three: the page's own number on the paper, its place in the
running order in the corner.

| Before | After |
|---|---|
| <img width="1842" alt="before" src="https://github.com/user-attachments/assets/fe03f047-841f-4566-9140-58557c743c65" /> | <img width="1842" alt="after" src="https://github.com/user-attachments/assets/8aa055d7-1bad-4c2b-a245-98ef58f9871a" /> |

The point of it. The last page dragged to the front — the slots stay 1, 2, 3 and
the pages read 3, 1, 2, so the move is on screen. Before this, all three tiles
still read 1, 2, 3 and the drag looked like it had failed:

<img width="1842" alt="a page dragged to the front" src="https://github.com/user-attachments/assets/d229ffbc-a28f-40f0-a236-0d6022cf9670" />

And the × pressed on the middle tile of three. It reads 1, 3 — not the 1, 2 that
removing the *last* page would also have left:

<img width="1842" alt="the middle page removed" src="https://github.com/user-attachments/assets/7c8a1161-82b0-4333-8950-5a34c4f84363" />

Three PDFs in Chinese, where the pages now read 1, 2, 3 then 1, 2, 3, 4 rather
than a run of 1 to 7, and the reworded note sits above them:

| Before | After |
|---|---|
| <img width="1842" alt="before, several files" src="https://github.com/user-attachments/assets/b8245cfd-141b-4097-ac29-6a48a3812d88" /> | <img width="1842" alt="after, in Chinese" src="https://github.com/user-attachments/assets/1d8fdbcd-7c9e-4520-97b1-44787b8d9742" /> |

## Verified

- three mouse drags in a built page, including one grabbed by the file-name band that could not be dragged at all before;
- a touch drag from the grip, and a touch on the paper that scrolls instead;
- the × removing its own tile after all of it;
- two RTL drags in the built Arabic page, and the Arabic tile checked again after the renumbering — the pill mirrors to the sheet's top right;
- a drag and a removal driven again after the numbering changed, reading the two numbers off each tile;
- two full `python build.py --clean --no-minify` runs clean, and `test_phrases` green over all fifteen languages both times.

Fifteen languages carry the new line and the reworded lede.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


