### PR TITLE
Put the example button where it belongs, and show the reader what it was given

### DIFF
--- a/locales/ar/tools/qr-barcode-reader.html
+++ b/locales/ar/tools/qr-barcode-reader.html
@@ -11,6 +11,16 @@
 
     {% include "partials/file-picker.html" %}
 
+    <!--
+      ما دخل، معروضًا من جديد. وليس الملف نفسه، بل الصورة التي عمل عليها
+      القارئ: عن الفكّ نفسه، وبالقياس نفسه، وعلى الأرضية البيضاء نفسها. فصورة
+      مصغّرة تبدو خاطئة هي سبب أن يكون الجواب خاطئًا.
+    -->
+    <div id="preview" class="preview" hidden>
+      <p id="preview-caption" class="preview-caption" role="status"></p>
+      <ul id="preview-list" class="preview-list"></ul>
+    </div>
+
     <div class="run-row">
       <button type="button" id="start-camera" class="primary">استعمل الكاميرا</button>
       <button type="button" id="stop-camera" class="ghost" hidden>أوقِف الكاميرا</button>
@@ -129,6 +139,18 @@
   </template>
 
   <!--
+    صورة واحدة في ذلك المعرض. تُنسخ لكل ملف، وكل كلمة فيها هنا في الترميز،
+    لأن هذا الملف يُترجم لكل لغة بينما src/*.js ملف واحد يخدمها جميعًا.
+  -->
+  <template id="preview-template">
+    <li class="preview-item">
+      <span class="preview-shot"></span>
+      <span class="preview-name"></span>
+      <span class="preview-state"></span>
+    </li>
+  </template>
+
+  <!--
     The words script needs, sitting in the markup so that a translator meets
     them where they meet the rest of the page. A `{host}` in one of these is
     filled in with the host that was read; nothing else is substituted.
@@ -214,6 +236,11 @@
     <span data-phrase="how.global">عتبة واحدة للصورة كلها</span>
     <span data-phrase="how.softened">تليين الصورة أولاً</span>
     <span data-phrase="how.dense">، مع فحص كل صف</span>
+
+    <span data-phrase="preview.one">الصورة التي نظر فيها</span>
+    <span data-phrase="preview.many">الصور التي نظر فيها، وعددها {n}</span>
+    <span data-phrase="preview.nothing">لم يُوجَد رمز</span>
+    <span data-phrase="preview.broken">تعذّر فتح الملف</span>
 
     <span data-phrase="status.reading">تجري قراءة الصورة&hellip;</span>
     <span data-phrase="status.nothing">لم يُوجَد رمز في تلك الصورة. فهي تحتاج

--- a/locales/de/tools/qr-barcode-reader.html
+++ b/locales/de/tools/qr-barcode-reader.html
@@ -12,6 +12,17 @@
 
     {% include "partials/file-picker.html" %}
 
+    <!--
+      Was hineinging, wieder herausgezeichnet. Nicht die Datei, sondern das
+      Bild, mit dem der Leser gearbeitet hat: aus derselben Dekodierung, gleich
+      skaliert, auf demselben weißen Grund. Ein Vorschaubild, das falsch
+      aussieht, ist der Grund, warum die Antwort es ist.
+    -->
+    <div id="preview" class="preview" hidden>
+      <p id="preview-caption" class="preview-caption" role="status"></p>
+      <ul id="preview-list" class="preview-list"></ul>
+    </div>
+
     <div class="run-row">
       <button type="button" id="start-camera" class="primary">Kamera verwenden</button>
       <button type="button" id="stop-camera" class="ghost" hidden>Kamera stoppen</button>
@@ -133,6 +144,19 @@
   </template>
 
   <!--
+    Ein Bild in dieser Vorschau. Pro Datei geklont, und jedes Wort darin
+    steht hier im Markup, weil diese Datei je Sprache übersetzt wird und
+    src/*.js eine einzige Datei für alle ist.
+  -->
+  <template id="preview-template">
+    <li class="preview-item">
+      <span class="preview-shot"></span>
+      <span class="preview-name"></span>
+      <span class="preview-state"></span>
+    </li>
+  </template>
+
+  <!--
     Die Wörter, die das Skript braucht, hier im Markup, damit eine Übersetzerin
     sie dort antrifft, wo sie auch dem Rest der Seite begegnet. Ein {host} darin
     wird durch den gelesenen Host ersetzt; sonst wird nichts eingesetzt.
@@ -224,6 +248,11 @@
     <span data-phrase="how.global">einen Schwellwert fürs ganze Bild</span>
     <span data-phrase="how.softened">vorheriges Weichzeichnen des Bildes</span>
     <span data-phrase="how.dense">, mit Prüfung jeder Zeile</span>
+
+    <span data-phrase="preview.one">Das Bild, das geprüft wurde</span>
+    <span data-phrase="preview.many">Die {n} Bilder, die geprüft wurden</span>
+    <span data-phrase="preview.nothing">Kein Code gefunden</span>
+    <span data-phrase="preview.broken">Ließ sich nicht öffnen</span>
 
     <span data-phrase="status.reading">Bild wird gelesen&hellip;</span>
     <span data-phrase="status.nothing">In diesem Bild wurde kein Code gefunden. Es

--- a/locales/es/tools/qr-barcode-reader.html
+++ b/locales/es/tools/qr-barcode-reader.html
@@ -11,6 +11,17 @@
 
     {% include "partials/file-picker.html" %}
 
+    <!--
+      Lo que entró, dibujado de vuelta. No el archivo, sino la imagen con la
+      que trabajó el lector: de la misma descodificación, a la misma escala y
+      sobre el mismo fondo blanco. Así, una miniatura que se ve mal es la razón
+      de que la respuesta lo esté.
+    -->
+    <div id="preview" class="preview" hidden>
+      <p id="preview-caption" class="preview-caption" role="status"></p>
+      <ul id="preview-list" class="preview-list"></ul>
+    </div>
+
     <div class="run-row">
       <button type="button" id="start-camera" class="primary">Usar la cámara</button>
       <button type="button" id="stop-camera" class="ghost" hidden>Parar la cámara</button>
@@ -131,6 +142,19 @@
   </template>
 
   <!--
+    Una imagen de esa vista previa. Se clona por archivo, y cada palabra
+    está aquí en el marcado, porque este archivo se traduce por idioma y
+    src/*.js es uno solo para todos.
+  -->
+  <template id="preview-template">
+    <li class="preview-item">
+      <span class="preview-shot"></span>
+      <span class="preview-name"></span>
+      <span class="preview-state"></span>
+    </li>
+  </template>
+
+  <!--
     Las palabras que necesita el script, aquí en el marcado para que quien
     traduzca se las encuentre donde se encuentra el resto de la página. Un
     {host} se rellena con el host leído; no se sustituye nada más.
@@ -222,6 +246,11 @@
     <span data-phrase="how.global">un solo umbral para toda la imagen</span>
     <span data-phrase="how.softened">suavizar antes la imagen</span>
     <span data-phrase="how.dense">, revisando cada fila</span>
+
+    <span data-phrase="preview.one">La imagen que se examinó</span>
+    <span data-phrase="preview.many">Las {n} imágenes que se examinaron</span>
+    <span data-phrase="preview.nothing">No se encontró ningún código</span>
+    <span data-phrase="preview.broken">No se pudo abrir</span>
 
     <span data-phrase="status.reading">Leyendo la imagen&hellip;</span>
     <span data-phrase="status.nothing">No se encontró ningún código en esa

--- a/locales/fr/tools/qr-barcode-reader.html
+++ b/locales/fr/tools/qr-barcode-reader.html
@@ -11,6 +11,17 @@
 
     {% include "partials/file-picker.html" %}
 
+    <!--
+      Ce qui est entré, redessiné. Pas le fichier, mais l'image sur laquelle
+      le lecteur a travaillé : le même décodage, la même mise à l'échelle, le
+      même fond blanc. Une vignette qui paraît fausse est donc la raison pour
+      laquelle la réponse l'est.
+    -->
+    <div id="preview" class="preview" hidden>
+      <p id="preview-caption" class="preview-caption" role="status"></p>
+      <ul id="preview-list" class="preview-list"></ul>
+    </div>
+
     <div class="run-row">
       <button type="button" id="start-camera" class="primary">Utiliser la caméra</button>
       <button type="button" id="stop-camera" class="ghost" hidden>Arrêter la caméra</button>
@@ -133,6 +144,19 @@
   </template>
 
   <!--
+    Une image de cet aperçu. Clonée par fichier, et chaque mot est ici
+    dans le balisage, parce que ce fichier est traduit par langue alors que
+    src/*.js est un seul fichier pour toutes.
+  -->
+  <template id="preview-template">
+    <li class="preview-item">
+      <span class="preview-shot"></span>
+      <span class="preview-name"></span>
+      <span class="preview-state"></span>
+    </li>
+  </template>
+
+  <!--
     Les mots dont le script a besoin, placés dans le balisage pour qu'un
     traducteur les rencontre là où il rencontre le reste de la page. Un {host}
     est remplacé par l'hôte qui a été lu ; rien d'autre n'est substitué.
@@ -225,6 +249,11 @@
     <span data-phrase="how.global">un seul seuil pour toute l'image</span>
     <span data-phrase="how.softened">un adoucissement préalable de l'image</span>
     <span data-phrase="how.dense">, en examinant chaque ligne</span>
+
+    <span data-phrase="preview.one">L'image qui a été examinée</span>
+    <span data-phrase="preview.many">Les {n} images qui ont été examinées</span>
+    <span data-phrase="preview.nothing">Aucun code trouvé</span>
+    <span data-phrase="preview.broken">Impossible à ouvrir</span>
 
     <span data-phrase="status.reading">Lecture de l'image&hellip;</span>
     <span data-phrase="status.nothing">Aucun code trouvé dans cette image. Il faut

--- a/locales/hi/tools/qr-barcode-reader.html
+++ b/locales/hi/tools/qr-barcode-reader.html
@@ -11,6 +11,16 @@
 
     {% include "partials/file-picker.html" %}
 
+    <!--
+      जो अंदर गया, वही वापस खींचकर। फ़ाइल नहीं &mdash; वह तस्वीर जिस पर पढ़ने
+      वाला काम कर रहा था: वही डिकोड, वही पैमाना, वही सफ़ेद पृष्ठभूमि। इसलिए जो
+      थंबनेल गलत दिखे, वही जवाब के गलत होने की वजह है।
+    -->
+    <div id="preview" class="preview" hidden>
+      <p id="preview-caption" class="preview-caption" role="status"></p>
+      <ul id="preview-list" class="preview-list"></ul>
+    </div>
+
     <div class="run-row">
       <button type="button" id="start-camera" class="primary">कैमरा इस्तेमाल कीजिए</button>
       <button type="button" id="stop-camera" class="ghost" hidden>कैमरा रोकिए</button>
@@ -132,6 +142,19 @@
   </template>
 
   <!--
+    उस झलक की एक तस्वीर। हर फ़ाइल के लिए क्लोन होती है, और इसका हर शब्द
+    यहीं मार्कअप में है, क्योंकि यह फ़ाइल हर भाषा में अनूदित होती है और
+    src/*.js सबके लिए एक ही है।
+  -->
+  <template id="preview-template">
+    <li class="preview-item">
+      <span class="preview-shot"></span>
+      <span class="preview-name"></span>
+      <span class="preview-state"></span>
+    </li>
+  </template>
+
+  <!--
     स्क्रिप्ट को जिन शब्दों की ज़रूरत है, वे मार्कअप में रखे हैं ताकि अनुवाद
     करने वाले को वे वहीं मिलें जहाँ बाकी पन्ना मिलता है। इनमें आया {host} पढ़े
     गए होस्ट से भरा जाता है; और कुछ नहीं बदला जाता।
@@ -220,6 +243,11 @@
     <span data-phrase="how.global">पूरी तस्वीर के लिए एक ही थ्रेशोल्ड</span>
     <span data-phrase="how.softened">तस्वीर को पहले हल्का धुँधला करना</span>
     <span data-phrase="how.dense">, हर पंक्ति जाँचते हुए</span>
+
+    <span data-phrase="preview.one">जिस तस्वीर को देखा गया</span>
+    <span data-phrase="preview.many">जिन {n} तस्वीरों को देखा गया</span>
+    <span data-phrase="preview.nothing">कोई कोड नहीं मिला</span>
+    <span data-phrase="preview.broken">खुल नहीं सकी</span>
 
     <span data-phrase="status.reading">तस्वीर पढ़ी जा रही है&hellip;</span>
     <span data-phrase="status.nothing">उस तस्वीर में कोई कोड नहीं मिला। पूरा

--- a/locales/id/tools/qr-barcode-reader.html
+++ b/locales/id/tools/qr-barcode-reader.html
@@ -19,6 +19,17 @@
 
     {% include "partials/file-picker.html" %}
 
+    <!--
+      Apa yang masuk, digambar kembali. Bukan filenya, melainkan gambar yang
+      dipakai pembacanya: dari dekode yang sama, skala yang sama, di atas dasar
+      putih yang sama. Jadi gambar kecil yang terlihat salah adalah alasan
+      jawabannya juga salah.
+    -->
+    <div id="preview" class="preview" hidden>
+      <p id="preview-caption" class="preview-caption" role="status"></p>
+      <ul id="preview-list" class="preview-list"></ul>
+    </div>
+
     <div class="run-row">
       <button type="button" id="start-camera" class="primary">Pakai kameranya</button>
       <button type="button" id="stop-camera" class="ghost" hidden>Hentikan kameranya</button>
@@ -141,6 +152,19 @@
   </template>
 
   <!--
+    Satu gambar di pratinjau itu. Diklon per file, dan setiap katanya ada
+    di sini dalam markup, karena file ini diterjemahkan per bahasa sedangkan
+    src/*.js satu file untuk semuanya.
+  -->
+  <template id="preview-template">
+    <li class="preview-item">
+      <span class="preview-shot"></span>
+      <span class="preview-name"></span>
+      <span class="preview-state"></span>
+    </li>
+  </template>
+
+  <!--
     The words script needs, sitting in the markup so that a translator meets
     them where they meet the rest of the page. A `{host}` in one of these is
     filled in with the host that was read; nothing else is substituted.
@@ -232,6 +256,11 @@
     <span data-phrase="how.global">satu ambang untuk seluruh gambar</span>
     <span data-phrase="how.softened">melembutkan gambarnya lebih dulu</span>
     <span data-phrase="how.dense">, memeriksa setiap baris</span>
+
+    <span data-phrase="preview.one">Gambar yang diperiksa</span>
+    <span data-phrase="preview.many">{n} gambar yang diperiksa</span>
+    <span data-phrase="preview.nothing">Tidak ditemukan kode</span>
+    <span data-phrase="preview.broken">Tidak bisa dibuka</span>
 
     <span data-phrase="status.reading">Membaca gambarnya&hellip;</span>
     <span data-phrase="status.nothing">Tidak ada kode yang ditemukan di gambar

--- a/locales/it/tools/qr-barcode-reader.html
+++ b/locales/it/tools/qr-barcode-reader.html
@@ -12,6 +12,17 @@
 
     {% include "partials/file-picker.html" %}
 
+    <!--
+      Quel che è entrato, ridisegnato. Non il file, ma l'immagine su cui ha
+      lavorato il lettore: la stessa decodifica, la stessa scala, lo stesso
+      fondo bianco. Perciò una miniatura che sembra sbagliata è il motivo per
+      cui lo è la risposta.
+    -->
+    <div id="preview" class="preview" hidden>
+      <p id="preview-caption" class="preview-caption" role="status"></p>
+      <ul id="preview-list" class="preview-list"></ul>
+    </div>
+
     <div class="run-row">
       <button type="button" id="start-camera" class="primary">Usa la fotocamera</button>
       <button type="button" id="stop-camera" class="ghost" hidden>Ferma la fotocamera</button>
@@ -132,6 +143,19 @@
   </template>
 
   <!--
+    Un'immagine di quell'anteprima. Clonata per file, e ogni parola sta
+    qui nel markup, perché questo file è tradotto per lingua mentre src/*.js è
+    uno solo per tutte.
+  -->
+  <template id="preview-template">
+    <li class="preview-item">
+      <span class="preview-shot"></span>
+      <span class="preview-name"></span>
+      <span class="preview-state"></span>
+    </li>
+  </template>
+
+  <!--
     Le parole che servono allo script, messe nel markup perché chi traduce le
     incontri dove incontra il resto della pagina. Un {host} viene riempito con
     l'host che è stato letto; nient'altro viene sostituito.
@@ -223,6 +247,11 @@
     <span data-phrase="how.global">una soglia sola per tutta l'immagine</span>
     <span data-phrase="how.softened">un ammorbidimento dell'immagine prima</span>
     <span data-phrase="how.dense">, controllando ogni riga</span>
+
+    <span data-phrase="preview.one">L'immagine esaminata</span>
+    <span data-phrase="preview.many">Le {n} immagini esaminate</span>
+    <span data-phrase="preview.nothing">Nessun codice trovato</span>
+    <span data-phrase="preview.broken">Non si è potuto aprire</span>
 
     <span data-phrase="status.reading">Sto leggendo l'immagine&hellip;</span>
     <span data-phrase="status.nothing">In quell'immagine non è stato trovato

--- a/locales/ja/tools/qr-barcode-reader.html
+++ b/locales/ja/tools/qr-barcode-reader.html
@@ -16,6 +16,16 @@
 
     {% include "partials/file-picker.html" %}
 
+    <!--
+      入ってきたものを、そのまま描き戻したもの。ファイルではなく、読み取りが実際に使った画像です。
+      同じデコード、同じ縮尺、同じ白い下地。だから、ここのサムネイルがおかしければ、
+      それが答えのおかしい理由です。
+    -->
+    <div id="preview" class="preview" hidden>
+      <p id="preview-caption" class="preview-caption" role="status"></p>
+      <ul id="preview-list" class="preview-list"></ul>
+    </div>
+
     <div class="run-row">
       <button type="button" id="start-camera" class="primary">カメラを使う</button>
       <button type="button" id="stop-camera" class="ghost" hidden>カメラを止める</button>
@@ -124,6 +134,18 @@
   </template>
 
   <!--
+    その一覧の画像ひとつ分。ファイルごとに複製し、ここにある語がすべて記述されているのは、
+    このファイルが言語ごとに翻訳される一方で、src/*.js は共通の一つのファイルだからです。
+  -->
+  <template id="preview-template">
+    <li class="preview-item">
+      <span class="preview-shot"></span>
+      <span class="preview-name"></span>
+      <span class="preview-state"></span>
+    </li>
+  </template>
+
+  <!--
     スクリプトが必要とする語です。翻訳する人がページの他の部分と同じ場所で
     出会えるように記述の中に置いてあります。中の {host} は読み取ったホストで
     埋められます。それ以外は置き換わりません。
@@ -146,6 +168,11 @@
     <span data-phrase="mode.numeric">数字のみ</span><span data-phrase="mode.alphanumeric">英大文字と数字</span><span data-phrase="mode.byte">バイト</span><span data-phrase="mode.kanji">漢字</span>
 
     <span data-phrase="how.local">区画ごとに求めたしきい値</span><span data-phrase="how.inverted">濃淡の入れ替え</span><span data-phrase="how.global">画像全体で一つのしきい値</span><span data-phrase="how.softened">先に画像をなめらかにする方法</span><span data-phrase="how.dense">（全行を調べたうえで）</span>
+
+    <span data-phrase="preview.one">調べた画像</span>
+    <span data-phrase="preview.many">調べた画像{n}枚</span>
+    <span data-phrase="preview.nothing">コードは見つかりませんでした</span>
+    <span data-phrase="preview.broken">開けませんでした</span>
 
     <span data-phrase="status.reading">画像を読んでいます&hellip;</span>
     <span data-phrase="status.nothing">この画像にコードは見つかりませんでした。白い余白まで含めてシンボル全体が画面に入っていること、そして濃い四角がきちんと濃く写る明るさが必要です。</span><span data-phrase="status.broken">このファイルは画像として開けませんでした。</span><span data-phrase="status.looking">探しています&hellip;コードを動かさず、画面の半分ほどを埋めてください。</span><span data-phrase="status.on">カメラが動いています。記録はされていません。</span>

--- a/locales/ko/tools/qr-barcode-reader.html
+++ b/locales/ko/tools/qr-barcode-reader.html
@@ -11,6 +11,16 @@
 
     {% include "partials/file-picker.html" %}
 
+    <!--
+      들어간 것을 그대로 다시 그린 것. 파일이 아니라 판독기가 실제로 다룬
+      이미지입니다: 같은 디코드, 같은 배율, 같은 흰 바탕. 그래서 여기 썸네일이
+      이상해 보이면, 그것이 답이 이상한 이유입니다.
+    -->
+    <div id="preview" class="preview" hidden>
+      <p id="preview-caption" class="preview-caption" role="status"></p>
+      <ul id="preview-list" class="preview-list"></ul>
+    </div>
+
     <div class="run-row">
       <button type="button" id="start-camera" class="primary">카메라 쓰기</button>
       <button type="button" id="stop-camera" class="ghost" hidden>카메라 멈추기</button>
@@ -130,6 +140,19 @@
   </template>
 
   <!--
+    그 미리보기의 이미지 하나. 파일마다 복제되며, 그 안의 모든 낱말이 여기
+    마크업에 있는 것은 이 파일은 언어마다 번역되지만 src/*.js는 모두가 함께 쓰는
+    한 파일이기 때문입니다.
+  -->
+  <template id="preview-template">
+    <li class="preview-item">
+      <span class="preview-shot"></span>
+      <span class="preview-name"></span>
+      <span class="preview-state"></span>
+    </li>
+  </template>
+
+  <!--
     스크립트가 쓰는 낱말들입니다. 번역하는 사람이 페이지의 나머지를 만나는 곳에서
     함께 만나도록 마크업 안에 두었습니다. 안의 {host}는 읽어 낸 호스트로
     채워지고, 그 밖에는 아무것도 치환되지 않습니다.
@@ -218,6 +241,11 @@
     <span data-phrase="how.global">이미지 전체에 하나의 임계값</span>
     <span data-phrase="how.softened">이미지를 먼저 부드럽게 하는 방법</span>
     <span data-phrase="how.dense">, 모든 행을 살피면서</span>
+
+    <span data-phrase="preview.one">살펴본 이미지</span>
+    <span data-phrase="preview.many">살펴본 이미지 {n}개</span>
+    <span data-phrase="preview.nothing">코드를 찾지 못했습니다</span>
+    <span data-phrase="preview.broken">열 수 없었습니다</span>
 
     <span data-phrase="status.reading">이미지를 읽는 중&hellip;</span>
     <span data-phrase="status.nothing">그 이미지에서 코드를 찾지 못했습니다. 흰

--- a/locales/nl/tools/qr-barcode-reader.html
+++ b/locales/nl/tools/qr-barcode-reader.html
@@ -12,6 +12,17 @@
 
     {% include "partials/file-picker.html" %}
 
+    <!--
+      Wat erin ging, teruggetekend. Niet het bestand, maar de afbeelding
+      waar de lezer mee werkte: dezelfde decodering, dezelfde schaal, dezelfde
+      witte ondergrond. Een miniatuur die er verkeerd uitziet, is dus de reden
+      dat het antwoord dat ook is.
+    -->
+    <div id="preview" class="preview" hidden>
+      <p id="preview-caption" class="preview-caption" role="status"></p>
+      <ul id="preview-list" class="preview-list"></ul>
+    </div>
+
     <div class="run-row">
       <button type="button" id="start-camera" class="primary">Camera gebruiken</button>
       <button type="button" id="stop-camera" class="ghost" hidden>Camera stoppen</button>
@@ -134,6 +145,19 @@
   </template>
 
   <!--
+    Eén afbeelding in dat voorbeeld. Per bestand gekloond, en elk woord
+    erin staat hier in de markup, omdat dit bestand per taal vertaald wordt en
+    src/*.js één bestand voor alle talen is.
+  -->
+  <template id="preview-template">
+    <li class="preview-item">
+      <span class="preview-shot"></span>
+      <span class="preview-name"></span>
+      <span class="preview-state"></span>
+    </li>
+  </template>
+
+  <!--
     De woorden die het script nodig heeft, hier in de markup zodat een vertaler
     ze tegenkomt waar hij de rest van de pagina tegenkomt. Een {host} hierin
     wordt ingevuld met de host die gelezen is; verder wordt er niets vervangen.
@@ -224,6 +248,11 @@
     <span data-phrase="how.global">één drempelwaarde voor de hele afbeelding</span>
     <span data-phrase="how.softened">de afbeelding eerst verzachten</span>
     <span data-phrase="how.dense">, met controle van elke rij</span>
+
+    <span data-phrase="preview.one">De afbeelding die bekeken is</span>
+    <span data-phrase="preview.many">De {n} afbeeldingen die bekeken zijn</span>
+    <span data-phrase="preview.nothing">Geen code gevonden</span>
+    <span data-phrase="preview.broken">Kon niet geopend worden</span>
 
     <span data-phrase="status.reading">Bezig met lezen&hellip;</span>
     <span data-phrase="status.nothing">In die afbeelding is geen code gevonden. Er

--- a/locales/pt/tools/qr-barcode-reader.html
+++ b/locales/pt/tools/qr-barcode-reader.html
@@ -11,6 +11,17 @@
 
     {% include "partials/file-picker.html" %}
 
+    <!--
+      O que entrou, desenhado de volta. Não o arquivo, e sim a imagem com que
+      o leitor trabalhou: a mesma decodificação, a mesma escala, o mesmo fundo
+      branco. Então uma miniatura que parece errada é a razão de a resposta
+      estar.
+    -->
+    <div id="preview" class="preview" hidden>
+      <p id="preview-caption" class="preview-caption" role="status"></p>
+      <ul id="preview-list" class="preview-list"></ul>
+    </div>
+
     <div class="run-row">
       <button type="button" id="start-camera" class="primary">Usar a câmera</button>
       <button type="button" id="stop-camera" class="ghost" hidden>Parar a câmera</button>
@@ -131,6 +142,19 @@
   </template>
 
   <!--
+    Uma imagem dessa prévia. Clonada por arquivo, e cada palavra está aqui
+    na marcação, porque este arquivo é traduzido por idioma e src/*.js é um só
+    para todos.
+  -->
+  <template id="preview-template">
+    <li class="preview-item">
+      <span class="preview-shot"></span>
+      <span class="preview-name"></span>
+      <span class="preview-state"></span>
+    </li>
+  </template>
+
+  <!--
     As palavras de que o script precisa, postas na marcação para quem traduz
     encontrá-las onde encontra o resto da página. Um {host} é preenchido com o
     host que foi lido; nada mais é substituído.
@@ -222,6 +246,11 @@
     <span data-phrase="how.global">um limiar só para a imagem inteira</span>
     <span data-phrase="how.softened">suavizar a imagem antes</span>
     <span data-phrase="how.dense">, conferindo cada linha</span>
+
+    <span data-phrase="preview.one">A imagem que foi examinada</span>
+    <span data-phrase="preview.many">As {n} imagens que foram examinadas</span>
+    <span data-phrase="preview.nothing">Nenhum código encontrado</span>
+    <span data-phrase="preview.broken">Não deu para abrir</span>
 
     <span data-phrase="status.reading">Lendo a imagem&hellip;</span>
     <span data-phrase="status.nothing">Nenhum código encontrado nessa imagem.

--- a/locales/tr/tools/qr-barcode-reader.html
+++ b/locales/tr/tools/qr-barcode-reader.html
@@ -18,6 +18,16 @@
 
     {% include "partials/file-picker.html" %}
 
+    <!--
+      İçeri gireni geri çizmek. Dosyanın kendisi değil, okuyucunun üzerinde
+      çalıştığı resim: aynı çözme, aynı ölçek, aynı beyaz zemin. Yani burada
+      yanlış görünen bir küçük resim, cevabın da neden yanlış olduğudur.
+    -->
+    <div id="preview" class="preview" hidden>
+      <p id="preview-caption" class="preview-caption" role="status"></p>
+      <ul id="preview-list" class="preview-list"></ul>
+    </div>
+
     <div class="run-row">
       <button type="button" id="start-camera" class="primary">Kamerayı kullan</button>
       <button type="button" id="stop-camera" class="ghost" hidden>Kamerayı durdur</button>
@@ -138,6 +148,19 @@
   </template>
 
   <!--
+    O önizlemedeki bir resim. Dosya başına klonlanır ve içindeki her söz
+    burada, biçimlemede durur; çünkü bu dosya her dile çevrilir, src/*.js ise
+    hepsine hizmet eden tek dosyadır.
+  -->
+  <template id="preview-template">
+    <li class="preview-item">
+      <span class="preview-shot"></span>
+      <span class="preview-name"></span>
+      <span class="preview-state"></span>
+    </li>
+  </template>
+
+  <!--
     The words script needs, sitting in the markup so that a translator meets
     them where they meet the rest of the page. A `{host}` in one of these is
     filled in with the host that was read; nothing else is substituted.
@@ -228,6 +251,11 @@
     <span data-phrase="how.global">resmin tamamı için tek bir eşik</span>
     <span data-phrase="how.softened">resmin önce yumuşatılması</span>
     <span data-phrase="how.dense">, her satır denetlenerek</span>
+
+    <span data-phrase="preview.one">Baktığı resim</span>
+    <span data-phrase="preview.many">Baktığı {n} resim</span>
+    <span data-phrase="preview.nothing">Kod bulunamadı</span>
+    <span data-phrase="preview.broken">Açılamadı</span>
 
     <span data-phrase="status.reading">Resim okunuyor&hellip;</span>
     <span data-phrase="status.nothing">O resimde kod bulunamadı. Simgenin

--- a/locales/zh-TW/tools/qr-barcode-reader.html
+++ b/locales/zh-TW/tools/qr-barcode-reader.html
@@ -16,6 +16,15 @@
 
     {% include "partials/file-picker.html" %}
 
+    <!--
+      進去的東西，再畫出來。不是那個檔案，而是讀碼時真正用的那張圖：同一次解碼、
+      同樣的縮放、同樣的白底。所以這裡的縮圖看起來不對，就是答案不對的原因。
+    -->
+    <div id="preview" class="preview" hidden>
+      <p id="preview-caption" class="preview-caption" role="status"></p>
+      <ul id="preview-list" class="preview-list"></ul>
+    </div>
+
     <div class="run-row">
       <button type="button" id="start-camera" class="primary">用鏡頭</button>
       <button type="button" id="stop-camera" class="ghost" hidden>停止鏡頭</button>
@@ -123,6 +132,18 @@
   </template>
 
   <!--
+    預覽裡的一張圖。按檔案複製，裡面每一個字都寫在這份標記裡，因為這份檔案
+    按語言翻譯，而 src/*.js 是所有語言共用的一份。
+  -->
+  <template id="preview-template">
+    <li class="preview-item">
+      <span class="preview-shot"></span>
+      <span class="preview-name"></span>
+      <span class="preview-state"></span>
+    </li>
+  </template>
+
+  <!--
     指令碼要用的那些詞，放在標記裡，讓翻譯的人在遇到這一頁其餘部分的地方就能
     遇到它們。裡面的 {host} 會被讀到的主機填上，別的都不替換。
   -->
@@ -140,6 +161,11 @@
     <span data-phrase="mode.numeric">只有數字</span><span data-phrase="mode.alphanumeric">大寫字母和數字</span><span data-phrase="mode.byte">位元組</span><span data-phrase="mode.kanji">漢字</span>
 
     <span data-phrase="how.local">一塊一塊算出來的閾值</span><span data-phrase="how.inverted">把深淺對調</span><span data-phrase="how.global">整張圖共用一個閾值</span><span data-phrase="how.softened">先把圖片放柔一點</span><span data-phrase="how.dense">，並且逐行都查了一遍</span>
+
+    <span data-phrase="preview.one">它看過的圖</span>
+    <span data-phrase="preview.many">它看過的 {n} 張圖</span>
+    <span data-phrase="preview.nothing">沒找到碼</span>
+    <span data-phrase="preview.broken">打不開</span>
 
     <span data-phrase="status.reading">正在讀這張圖&hellip;</span>
     <span data-phrase="status.nothing">這張圖裡沒找到碼。需要整個符號連同白色留白都在畫面裡，光也要夠，讓深色方塊真的是深的。</span><span data-phrase="status.broken">這個檔案打不開成圖片。</span><span data-phrase="status.looking">正在找&hellip;把碼拿穩，讓它佔到畫面一半左右。</span><span data-phrase="status.on">鏡頭開著。什麼都沒有在錄。</span>

--- a/locales/zh/tools/qr-barcode-reader.html
+++ b/locales/zh/tools/qr-barcode-reader.html
@@ -16,6 +16,15 @@
 
     {% include "partials/file-picker.html" %}
 
+    <!--
+      进去的东西，再画出来。不是那个文件，而是读码时真正用的那张图：同一次解码、
+      同样的缩放、同样的白底。所以这里的缩略图看着不对，就是答案不对的原因。
+    -->
+    <div id="preview" class="preview" hidden>
+      <p id="preview-caption" class="preview-caption" role="status"></p>
+      <ul id="preview-list" class="preview-list"></ul>
+    </div>
+
     <div class="run-row">
       <button type="button" id="start-camera" class="primary">用摄像头</button>
       <button type="button" id="stop-camera" class="ghost" hidden>停止摄像头</button>
@@ -123,6 +132,18 @@
   </template>
 
   <!--
+    预览里的一张图。按文件复制，里面每一个字都写在这份标记里，因为这份文件
+    按语言翻译，而 src/*.js 是所有语言共用的一份。
+  -->
+  <template id="preview-template">
+    <li class="preview-item">
+      <span class="preview-shot"></span>
+      <span class="preview-name"></span>
+      <span class="preview-state"></span>
+    </li>
+  </template>
+
+  <!--
     脚本要用的那些词，放在标记里，让翻译的人在遇到这一页其余部分的地方就能
     遇到它们。里面的 {host} 会被读到的主机填上，别的都不替换。
   -->
@@ -140,6 +161,11 @@
     <span data-phrase="mode.numeric">只有数字</span><span data-phrase="mode.alphanumeric">大写字母和数字</span><span data-phrase="mode.byte">字节</span><span data-phrase="mode.kanji">汉字</span>
 
     <span data-phrase="how.local">一块一块算出来的阈值</span><span data-phrase="how.inverted">把深浅对调</span><span data-phrase="how.global">整张图共用一个阈值</span><span data-phrase="how.softened">先把图片放柔一点</span><span data-phrase="how.dense">，并且逐行都查了一遍</span>
+
+    <span data-phrase="preview.one">它看过的图</span>
+    <span data-phrase="preview.many">它看过的 {n} 张图</span>
+    <span data-phrase="preview.nothing">没找到码</span>
+    <span data-phrase="preview.broken">打不开</span>
 
     <span data-phrase="status.reading">正在读这张图&hellip;</span>
     <span data-phrase="status.nothing">这张图里没找到码。需要整个符号连同白色留白都在画面里，光也要够，让深色方块真的是深的。</span><span data-phrase="status.broken">这个文件打不开成图片。</span><span data-phrase="status.looking">正在找&hellip;把码拿稳，让它占到画面一半左右。</span><span data-phrase="status.on">摄像头开着。什么都没有在录。</span>

--- a/shared/css/tool-frame.css
+++ b/shared/css/tool-frame.css
@@ -786,9 +786,40 @@ main, .topbar, .crumbs, .privacy, .pledge, .faq, .tool-next, footer {
 }
 .card-head > h2 { margin-bottom: 0; }
 
-/* `auto` rather than `space-between`, so the button still sits right when the
-   row wraps and the heading is alone on the line above it. */
-.dropzone-example { margin: 0 0 0 auto; }
+/* The other shape of that row. Where buildlib/cards.py has folded the card's
+   explanation behind its heading, what sits in the row is the whole <details>:
+   its <summary> is the heading line and the paragraphs under it are what
+   opens.
+
+   `1 1 0` rather than the `auto` a flex item defaults to, because a fold's
+   basis on `auto` is the width its paragraphs would like to be - wide enough
+   that this row would sooner wrap the button onto a line of its own than let
+   them be narrower. */
+.card-head > .card-note {
+  flex: 1 1 0;
+  min-width: 0;
+  margin-bottom: 0;
+}
+
+/* Closed, the fold is exactly as tall as its heading and the two centre on one
+   line, which is the same row every unfolded card has. Opened, it is a
+   paragraph or three, and centring would carry the button halfway down them -
+   so the row stops centring and the button stays up on the heading it belongs
+   to. */
+.card-head:has(> .card-note[open]) { align-items: flex-start; }
+
+/* An auto margin rather than `space-between`, so the button still sits at the
+   end when the row wraps and the heading is alone on the line above it.
+
+   Logical and not `margin-left`, which is the same thing in English and the
+   opposite of it in Arabic: an auto margin absorbs the free space beside the
+   item rather than the space at the end of the row, so a left one in a
+   right-to-left row left the button tucked against the heading with the whole
+   width of the card empty beside it. */
+.dropzone-example {
+  margin: 0;
+  margin-inline-start: auto;
+}
 .dropzone-example button { font-size: 0.88rem; padding: 0.35rem 0.9rem; }
 
 /* Only ever filled in when building the example failed, and a block of its own

--- a/shared/js/file-picker.js
+++ b/shared/js/file-picker.js
@@ -278,19 +278,36 @@ function wireExample({ example, hand, busy, done, dropzone }) {
 /**
  * Move the button up onto the step's heading row.
  *
- * Quietly does nothing if the shape is not what it expects - a tool whose
- * first card has no heading keeps the button under the drop zone, which is
- * where it already was and is not wrong, only lower.
+ * There are two shapes to find that row in, because the build makes the second
+ * one. A card that opens with a paragraph explaining the step has had that
+ * paragraph - and its heading with it - folded into a <details> by
+ * buildlib/cards.py, so the <h2> is no longer the card's child and the row the
+ * reader sees is the fold's <summary>. Looking only for the child <h2> found
+ * nothing on those cards and left the button under the drop zone, between it
+ * and the step's own controls, on five tools: document-scanner, heic-to-jpg,
+ * id-photo, qr-barcode-reader and redact-image.
+ *
+ * The whole <details> moves in that case rather than the heading inside it.
+ * Taking the <h2> out of the summary would leave the fold unnamed and the
+ * button on a row of its own, which is the bug over again one line lower.
+ *
+ * Quietly does nothing if the shape is neither - a tool whose first card has
+ * no heading at all keeps the button under the drop zone, which is where it
+ * already was and is not wrong, only lower.
  */
 function liftToHeading(holder, dropzone) {
   const card = dropzone?.closest('.card');
-  const heading = card?.querySelector(':scope > h2');
-  if (!heading || !holder) return;
+  if (!card || !holder) return;
+
+  const fold = card.querySelector(':scope > details.card-note');
+  const head = card.querySelector(':scope > h2')
+    ?? (fold?.querySelector(':scope > summary > h2') ? fold : null);
+  if (!head) return;
 
   const row = document.createElement('div');
   row.className = 'card-head';
-  heading.before(row);
-  row.append(heading, holder);
+  head.before(row);
+  row.append(head, holder);
 }
 
 /**

--- a/tests/python/test_cards.py
+++ b/tests/python/test_cards.py
@@ -16,6 +16,7 @@ that would have caught the gap in the first place.
 """
 
 import re
+import tomllib
 import unittest
 from pathlib import Path
 
@@ -23,6 +24,15 @@ from buildlib import cards
 
 ROOT = Path(__file__).resolve().parents[2]
 TOOLS = ROOT / 'tools'
+LOCALES = ROOT / 'locales'
+
+PICKER = '{% include "partials/file-picker.html" %}'
+
+# A <details> and everything in it, so what is left is the card's own children.
+DETAILS = re.compile(r'<details\b.*?</details>', re.S)
+
+# The fold this module makes, as shared/js/file-picker.js looks for it.
+FOLD_HEADING = re.compile(r'<details class="card-note">\s*<summary>\s*<h2\b', re.S)
 
 FOLD = re.compile(r'<details class="card-note">.*?</details>', re.S)
 SUMMARY = re.compile(r'<p class="field-summary"([^>]*)>((?:(?!</p>).)*)</p>', re.S)
@@ -110,3 +120,47 @@ class EveryTool(unittest.TestCase):
 
         self.assertEqual([], loose, '\nstill on the page:\n' + '\n'.join(loose))
         self.assertEqual([], lost, '\nfolded but is a status:\n' + '\n'.join(lost))
+
+    def test_a_worked_example_keeps_a_heading_its_button_can_sit_on(self):
+        """The fold leaves a heading row the "Try an example" button can find.
+
+        shared/js/file-picker.js moves that button out of the drop zone and onto
+        the step's heading row, and it knows the two shapes a heading is left in
+        here: the card's own <h2>, or the <summary> this module moved that <h2>
+        into. A third shape would fail nothing and stop nothing - the button
+        would quietly stay where the partial renders it, under the drop zone and
+        above the step's own controls, which is where it sat on five tools for
+        as long as only the first shape was looked for.
+
+        Every language, because the fold runs on every language and a translated
+        body is a whole file, free to drift from the English one it came from.
+        """
+        astray = []
+        for slug, body in _bodies_with_an_example():
+            inner = _picker_card(cards.fold_ledes(body.read_text(encoding='utf-8')))
+            if inner is None:
+                astray.append(f'{slug}: {body.name} - no card holds the drop zone')
+            elif not (FOLD_HEADING.search(inner) or '<h2' in DETAILS.sub('', inner)):
+                astray.append(f'{slug}: {body.name} - no heading the button can reach')
+
+        self.assertEqual([], astray, '\n' + '\n'.join(astray))
+
+
+def _bodies_with_an_example():
+    """Every body of a tool that renders the button, English and translated."""
+    for config in sorted(TOOLS.glob('*/tool.toml')):
+        tool = tomllib.loads(config.read_text(encoding='utf-8'))
+        if not tool.get('picker', {}).get('example'):
+            continue
+        slug = config.parent.name
+        yield slug, config.parent / 'body.html'
+        for body in sorted(LOCALES.glob(f'*/tools/{slug}.html')):
+            yield slug, body
+
+
+def _picker_card(html):
+    """The inside of the card the drop zone is in, or None if there is not one."""
+    for match in cards.CARD.finditer(html):
+        if PICKER in match.group('inner'):
+            return match.group('inner')
+    return None

--- a/tools/qr-barcode-reader/README.md
+++ b/tools/qr-barcode-reader/README.md
@@ -64,12 +64,26 @@ misread rather than a long string; and on the linear side, a format with no
 check digit has to be read identically from two different scan lines before it
 counts.
 
-### It shows what it sampled
+### It shows what it sampled, and what it was given
 
 Under every QR result is a canvas holding the modules that were actually read
 off the picture. It is not decoration. It is the one thing that lets somebody
 check the answer rather than believe it: if that grid looks like the code they
 photographed, the string came from the right pixels.
+
+Step 1 does the same job one stage earlier. Every picture handed over is drawn
+back out under the drop zone with its name and what came of it — the symbology,
+or that no code was found in it, or that the file never opened as a picture at
+all. Four files in and one answer out is otherwise a page that cannot be
+checked: nothing on it says which of the four the answer came from, or whether
+the other three were even opened. The thumbnail is drawn from the decoded
+picture rather than from the file, on the same white ground `pixelsOf` lays
+down, so what is shown is what the reader worked from and not a second opinion
+about it.
+
+The camera has no entry there on purpose: its preview is the viewfinder, and a
+still of a frame that has already been thrown away would contradict the card it
+would sit under.
 
 ## Things that took a second attempt
 

--- a/tools/qr-barcode-reader/body.html
+++ b/tools/qr-barcode-reader/body.html
@@ -11,6 +11,22 @@
 
     {% include "partials/file-picker.html" %}
 
+    <!--
+      What went in, drawn back out.
+
+      A reader that hands back a string and nothing else asks to be believed:
+      four files in and one answer out, and nothing on the page says which of
+      the four it came from or whether the other three were even opened. What
+      is drawn here is not the file - it is the picture the reader worked from,
+      off the same decode, scaled the same way, on the same white ground a
+      transparent PNG is flattened onto. So a thumbnail that looks wrong is the
+      reason the answer is.
+    -->
+    <div id="preview" class="preview" hidden>
+      <p id="preview-caption" class="preview-caption" role="status"></p>
+      <ul id="preview-list" class="preview-list"></ul>
+    </div>
+
     <div class="run-row">
       <button type="button" id="start-camera" class="primary">Use the camera</button>
       <button type="button" id="stop-camera" class="ghost" hidden>Stop the camera</button>
@@ -129,6 +145,20 @@
   </template>
 
   <!--
+    One picture in that preview. Cloned per file, filled in from script, and
+    here for the same reason the result template is: every word in it is in
+    the markup, because this file is translated per language and src/*.js is
+    one file serving them all.
+  -->
+  <template id="preview-template">
+    <li class="preview-item">
+      <span class="preview-shot"></span>
+      <span class="preview-name"></span>
+      <span class="preview-state"></span>
+    </li>
+  </template>
+
+  <!--
     The words script needs, sitting in the markup so that a translator meets
     them where they meet the rest of the page. A `{host}` in one of these is
     filled in with the host that was read; nothing else is substituted.
@@ -217,6 +247,11 @@
     <span data-phrase="how.global">one threshold for the whole picture</span>
     <span data-phrase="how.softened">softening the picture first</span>
     <span data-phrase="how.dense">, checking every row</span>
+
+    <span data-phrase="preview.one">The picture it looked at</span>
+    <span data-phrase="preview.many">The {n} pictures it looked at</span>
+    <span data-phrase="preview.nothing">No code found</span>
+    <span data-phrase="preview.broken">Could not be opened</span>
 
     <span data-phrase="status.reading">Reading the picture&hellip;</span>
     <span data-phrase="status.nothing">No code found in that picture. It needs

--- a/tools/qr-barcode-reader/src/main.js
+++ b/tools/qr-barcode-reader/src/main.js
@@ -24,6 +24,10 @@ const el = {
   resultsCard: $('results-card'),
   results: $('results'),
   resultTemplate: $('result-template'),
+  preview: $('preview'),
+  previewCaption: $('preview-caption'),
+  previewList: $('preview-list'),
+  previewTemplate: $('preview-template'),
   privacyToggle: $('privacy-toggle'),
   privacyPanel: $('privacy-panel'),
 };
@@ -94,11 +98,50 @@ async function pictureFrom(file) {
   }
 }
 
+/**
+ * The longest side a picture is drawn at for the preview.
+ *
+ * Twice the width the tile shows it at, so it is not soft on a screen with two
+ * device pixels to the CSS pixel, and nothing like large enough to be a second
+ * copy of somebody's photograph sitting in the page.
+ */
+const PREVIEW_SIDE = 260;
+
+/**
+ * The picture as the reader saw it, small.
+ *
+ * Drawn from the decoded picture rather than from the file, and on the same
+ * white ground pixelsOf lays down, because the file is not what was read: a
+ * transparent PNG of a code is flattened onto white before it is thresholded,
+ * and a preview that showed it any other way would be a picture of something
+ * the answer did not come from.
+ */
+function thumbnailOf(picture, width, height) {
+  const scale = Math.min(1, PREVIEW_SIDE / Math.max(width, height));
+  const canvas = document.createElement('canvas');
+  canvas.width = Math.max(1, Math.round(width * scale));
+  canvas.height = Math.max(1, Math.round(height * scale));
+  // Decoration, and declared as such: the file's name and what came of it sit
+  // beside this as text, so there is nothing here a screen reader is missing.
+  canvas.setAttribute('aria-hidden', 'true');
+
+  const context = canvas.getContext('2d');
+  context.fillStyle = '#ffffff';
+  context.fillRect(0, 0, canvas.width, canvas.height);
+  context.drawImage(picture, 0, 0, canvas.width, canvas.height);
+  return canvas;
+}
+
 /** Read one file, at the working size and then, if that found nothing, whole. */
 async function readFile(file) {
   const picture = await pictureFrom(file);
   const width = picture.width ?? picture.naturalWidth;
   const height = picture.height ?? picture.naturalHeight;
+
+  // Before the scan rather than after it: a picture that opened is a picture
+  // worth showing whatever the search makes of it, and the scan is the half
+  // that can throw.
+  const thumbnail = thumbnailOf(picture, width, height);
 
   let found = scan(pixelsOf(picture, width, height, WORKING_SIDE));
   if (!found && Math.max(width, height) > WORKING_SIDE) {
@@ -106,7 +149,7 @@ async function readFile(file) {
   }
 
   picture.close?.();
-  return found;
+  return { found, thumbnail };
 }
 
 /* -------------------------------------------------------------- the results */
@@ -271,6 +314,55 @@ function fail(key) {
   el.pickError.textContent = phrase(key);
 }
 
+/* -------------------------------------------------------------- the preview
+ *
+ * What went in, beside what came of it.
+ *
+ * The results are cumulative and this is not: it is the batch that was just
+ * handed over, cleared when the next one arrives. That is the question it
+ * answers - is the picture I chose the picture that arrived, and which of the
+ * four did the one answer come from - and a preview that kept growing would
+ * stop answering it after the second drop.
+ *
+ * The camera has no entry here on purpose. Its preview is the viewfinder,
+ * which is live, and a still of a frame that has already been thrown away
+ * would say the opposite of what the card underneath it says.
+ */
+
+/** Start again: the preview is this batch, not the last one. */
+function clearPreview() {
+  el.previewList.replaceChildren();
+  el.preview.hidden = true;
+}
+
+/** One picture, whatever came of it. */
+function showPicture(file, thumbnail, found) {
+  const node = el.previewTemplate.content.firstElementChild.cloneNode(true);
+
+  // Absent only for a file that would not open as a picture at all, where the
+  // name and the reason are the whole of what there is to say.
+  if (thumbnail) node.querySelector('.preview-shot').append(thumbnail);
+
+  const name = node.querySelector('.preview-name');
+  name.textContent = file.name;
+  // A phone's file names are long, alike, and different only near the end,
+  // which is the end the ellipsis eats.
+  name.title = file.name;
+
+  const state = node.querySelector('.preview-state');
+  if (found) {
+    state.textContent = symbologyName(found.symbology);
+  } else {
+    state.textContent = phrase(thumbnail ? 'preview.nothing' : 'preview.broken');
+    node.classList.add(thumbnail ? 'nothing' : 'broken');
+  }
+
+  el.previewList.append(node);
+  const count = el.previewList.children.length;
+  el.previewCaption.textContent = phrase(count === 1 ? 'preview.one' : 'preview.many', { n: count });
+  el.preview.hidden = false;
+}
+
 /* --------------------------------------------------------------- the files */
 
 const picker = wireFilePicker({
@@ -283,15 +375,18 @@ const picker = wireFilePicker({
 async function readFiles(files) {
   el.pickError.hidden = true;
   picker.busy(readingLabel(files.length));
+  clearPreview();
 
   let any = false;
   let broken = false;
   for (const file of files) {
     try {
-      const found = await readFile(file);
+      const { found, thumbnail } = await readFile(file);
       if (found) any = report(found) || any;
+      showPicture(file, thumbnail, found);
     } catch {
       broken = true;
+      showPicture(file, null, null);
     }
   }
 

--- a/tools/qr-barcode-reader/styles.css
+++ b/tools/qr-barcode-reader/styles.css
@@ -88,6 +88,95 @@ kbd {
   min-width: 0;
 }
 
+/* ------------------------------------------------------------ the preview */
+
+/*
+  The pictures that went in, under the box they went into.
+
+  Sized to be checked rather than admired: what somebody is looking for here is
+  whether the thing they meant to hand over is the thing that arrived, and
+  which of four files the one answer below came from. A thumbnail large enough
+  to read a code off would be a second copy of their picture on the page and
+  would push the answer under the fold, which is the wrong way round.
+*/
+.preview { margin-top: 1.2rem; }
+
+.preview-caption {
+  margin: 0 0 0.55rem;
+  font-size: 0.84rem;
+  font-weight: 600;
+  color: var(--text-dim);
+}
+
+.preview-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+}
+
+.preview-item {
+  flex: none;
+  width: 8.5rem;
+  min-width: 0;
+}
+
+/* White, and not the page's own surface: white is the ground the picture was
+   read on - pixelsOf fills it before it draws, so a transparent PNG of a code
+   is not thresholded as black on black - and a preview on a different ground
+   would be a different picture from the one the answer came from. */
+.preview-shot {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 6.5rem;
+  padding: 0.35rem;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: #fff;
+}
+
+.preview-shot canvas {
+  display: block;
+  max-width: 100%;
+  max-height: 100%;
+}
+
+/* One line, cut off at the end. A phone camera's file names are long, alike,
+   and only distinguishable at the end, so the whole name is on the element as
+   its title for anybody who needs it. */
+.preview-name {
+  display: block;
+  margin-top: 0.45rem;
+  font-size: 0.78rem;
+  line-height: 1.4;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.preview-state {
+  display: block;
+  font-size: 0.78rem;
+  line-height: 1.4;
+  color: var(--text-dim);
+}
+
+/* Amber, for the same reason the warnings are and the errors are not: a
+   picture with no code in it is not a fault, it is an answer - but it is the
+   answer somebody is hunting for when four went in and three came back. */
+.preview-item.nothing .preview-state,
+.preview-item.broken .preview-state { color: var(--warn); }
+
+/* A file that never opened has no picture to show, and an empty white box
+   would say something untrue about it: that it opened and was blank. */
+.preview-item.broken .preview-shot {
+  background: var(--surface-2);
+  border-style: dashed;
+}
+
 /* ------------------------------------------------------------ the results */
 
 .result {


### PR DESCRIPTION
Two things on `/qr-barcode-reader/`: the "Try an example" button was in the
wrong place, and a reader that answers without showing you what it looked at
cannot be checked.

## The button

It is meant to sit on the first step's heading row, over on the right.
`shared/js/file-picker.js` moves it there, and it looked for the card's own
`<h2>` — which is where a heading is until `buildlib/cards.py` folds the step's
explanation behind it, and from then on it is inside a `<summary>`. So on every
tool whose first card opens with a paragraph the lookup found nothing and
quietly did nothing, leaving the button under the drop zone, between the box you
drop a file on and the step's own controls. Five tools were in that state:
`document-scanner`, `heic-to-jpg`, `id-photo`, `qr-barcode-reader` and
`redact-image`.

Both shapes are looked for now, and when it is the folded one the whole
`<details>` goes into the row rather than the heading being pulled out of it —
the `<summary>` has to keep the `<h2>`, because that is what names the fold for a
screen reader, and a button placed in there would open the fold on every click.
The row centres on a closed fold, which is the row every unfolded card already
has, and stops centring while it is open so the button stays on the heading
instead of drifting down beside a paragraph.

One more thing found on the way: the auto margin that pushes the button to the
end of the row was `margin-left`, which is the end in English and the beginning
in Arabic. It is logical now, so all fifteen languages put it in the same place.

## The preview

Four files go in, one answer comes out, and nothing on the page said which of
the four it came from — or whether the other three had even been opened, since
the failure line is one sentence for the whole batch however many pictures were
in it.

Every picture handed over is now drawn back out under the drop zone with its
name and what came of it: the symbology it turned out to hold, that no code was
found in it, or that the file never opened as a picture at all. That last one
gets a dashed empty frame rather than a white one, because a blank white box
says something untrue — that the file opened and was blank.

The thumbnail comes from the decoded picture rather than from the file, on the
white ground `pixelsOf` lays down before it thresholds, so what is shown is what
the reader worked from and not a second opinion about it. It is the same
argument as the sampled-module grid under each result, one stage earlier. The
camera has no entry in it: its preview is the viewfinder, and a still of a frame
that has already been thrown away would contradict the card it sat under.

Four new phrases, translated into all fourteen languages; `zh-TW` is the output
of `zh-tw-sync.py` rather than hand-written, and `cjk_fix.py` reports nothing to
change in `ja` or `zh`.

## Pictures

The same three files pasted into the page — a QR code, a photograph with no code
in it, and a file that is not really a PNG.

| Before | After |
|---|---|
| <img width="2560" height="786" alt="before-three" src="https://github.com/user-attachments/assets/e3c7047d-51d3-4851-848f-30d88c8f6404" /> | <img width="2560" height="1124" alt="after-three" src="https://github.com/user-attachments/assets/78cd8d14-8258-40c0-984e-a62851325dc8" /> |

Narrow, at 390&nbsp;px:

| Before | After |
|---|---|
| <img width="780" height="874" alt="before-narrow" src="https://github.com/user-attachments/assets/9da56771-220d-416c-a99d-708cebe7ebd8" /> | <img width="780" height="1544" alt="after-narrow" src="https://github.com/user-attachments/assets/fc8bd75d-e471-4905-a679-51724b0a78a3" /> |

Japanese and Arabic, to check the wrap and the bidi:

| 日本語 | العربية |
|---|---|
| <img width="2560" height="1160" alt="after-ja" src="https://github.com/user-attachments/assets/c39713c0-9d79-41fd-ac39-b6467cee149e" /> | <img width="2560" height="1124" alt="after-ar" src="https://github.com/user-attachments/assets/5f09145d-83eb-4d99-a720-0410cabcde28" /> |

## Verified

- `python build.py --out _plain --clean --no-minify` — the full CI build, clean.
- `python scripts/check_locales.py` reports nothing new against
  `qr-barcode-reader` in any check.
- `python scripts/cjk_fix.py {zh,ja} --only tools/qr-barcode-reader.html` — no
  changes; `python zh-tw-sync.py` regenerated `zh-TW`.
- Driven in a browser: one picture, three at once, a file that will not open,
  the fold opened and closed, and the same in `ja`, `zh` and `ar`.

`tests/python/test_cards.py` gains a test that asserts the contract rather than
the fix — after the fold, every tool that renders the button still has its
heading in one of the two shapes the lift knows about, in every language. A
third shape would fail nothing and stop nothing, which is exactly how this one
lasted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
