### PR TITLE
Bundle changes on a dev branch, and release from it to main

### DIFF
--- a/.claude/skills/tool-development/SKILL.md
+++ b/.claude/skills/tool-development/SKILL.md
@@ -39,7 +39,9 @@ read the message; it is the fastest route to done.
 - **Open the pull request against `dev`.** `main` is what is live, and a push
   to it deploys, tags a version and tells the search engines; `dev` is where
   changes are bundled until somebody opens the pull request from `dev` to
-  `main` that releases them. `docs/deploying.md` has the rest.
+  `main` that releases them. Your change is done when it is on `dev` — never
+  open or merge that release pull request unless you were asked to by name.
+  `docs/deploying.md` has the rest.
 - **Match the prose voice.** Commit messages, comments and `tool.toml` prose
   here explain *why*, in full sentences, and assume the reader can see the
   code. A comment that restates the line below it does not belong.

--- a/.claude/skills/tool-development/SKILL.md
+++ b/.claude/skills/tool-development/SKILL.md
@@ -36,6 +36,10 @@ read the message; it is the fastest route to done.
   copied unchanged into every language, so a string written there is English
   at all of its addresses but one. Put it in the markup and read it back with
   `phrase()` — the full pattern is under "Job: update an existing tool" below.
+- **Open the pull request against `dev`.** `main` is what is live, and a push
+  to it deploys, tags a version and tells the search engines; `dev` is where
+  changes are bundled until somebody opens the pull request from `dev` to
+  `main` that releases them. `docs/deploying.md` has the rest.
 - **Match the prose voice.** Commit messages, comments and `tool.toml` prose
   here explain *why*, in full sentences, and assume the reader can see the
   code. A comment that restates the line below it does not belong.
@@ -54,6 +58,7 @@ the change:
 | the legal pages, what Privacy claims | `docs/prose-pages.md` |
 | anything under `locales/` | `docs/languages.md` |
 | build flags, tests, serving locally | `docs/running.md` |
+| the branches, previews, what a deploy does | `docs/deploying.md` |
 
 Every tool also documents itself: `tools/<slug>/README.md` says how that tool
 works and why it works that way, and the header comment of its `tool.toml`
@@ -226,8 +231,8 @@ the code rather than over the site it made. `--clean` matters: building
 several branches into one output directory leaves pages from all of them, and
 the link checker then reports dozens of broken links that look exactly like
 "main is broken". `python build.py --check` compares against the deployed
-`dist` branch, which tracks `main` — on a feature branch it exits 1 by
-construction, so do not read that as failure.
+`dist` branch, which tracks `main` — on `dev` and on any working branch it
+exits 1 by construction, so do not read that as failure.
 
 While iterating on one tool, scope the build instead:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,11 +11,39 @@
 # that is being served. `python build.py --check` does exactly that. That is
 # only meaningful if the served files are committed somewhere a reader can see.
 #
-# On a pull request this builds but does not publish, so a change that breaks
-# the build is caught before it reaches main. It does put the build somewhere
-# a browser can reach - a preview of its own on Cloudflare Pages, see the
-# `preview` job - and asks the QA suite to run against that, so the browser
-# tests see a change before visitors do rather than twenty minutes after.
+# WHERE A CHANGE GOES, AND IN WHAT ORDER
+#
+# Work is opened against `dev`, `dev` is opened against `main`, and `main` is
+# production:
+#
+#   pull request  ->  dev  ->  pull request  ->  main  ->  dist  ->  Pages
+#
+# The middle branch is the point of the arrangement. A fix no longer has to be
+# a release on its own: a week of them are bundled on `dev` and reach
+# production as one deploy, one version tag and one IndexNow submission rather
+# than fifteen of each. What it costs is that `main` is now two merges away
+# from a change rather than one, which is the trade being made.
+#
+# So this workflow has three destinations rather than two. The `build` job
+# names them once in its `env`, because the four steps that read them have to
+# agree with each other:
+#
+#   a pull request    builds, is checked, and goes to a preview of its own at
+#                     pr-<number>.abox-preview.pages.dev, which the QA suite
+#                     is then run against
+#   a push to `dev`   the same, to a preview at dev.abox-preview.pages.dev -
+#                     one stable address holding the bundle as it currently
+#                     stands, for looking at between releases
+#   a push to `main`  publishes to `dist`, tags the version, and tells
+#                     IndexNow. Nothing else does any of those
+#
+# Anything else - a manual run against a feature branch - builds, is checked,
+# and goes nowhere at all.
+#
+# On none of them but the last is anything published, so a change that breaks
+# the build is caught twice before it can reach production. The preview is why
+# the browser suite sees a change before visitors do rather than twenty
+# minutes after; see the `preview` job for the rest of that.
 #
 # The unit tests run first, in their own job, and the build waits on them. They
 # cover the hand-written code on both sides: the generator in Python and the
@@ -26,7 +54,7 @@ name: Build
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
   workflow_dispatch:
 
@@ -168,6 +196,21 @@ jobs:
   build:
     needs: test
     runs-on: ubuntu-latest
+    # The two questions the steps below ask, answered in one place. Here
+    # rather than four times over because the four answers have to agree: a
+    # run that published to `dist` without tagging the version, or tagged one
+    # without publishing, would be worse than either on its own.
+    #
+    # DEPLOYS used to read `github.event_name != 'pull_request'`, which was
+    # right while `main` was the only branch this ran on and is wrong now for
+    # two separate reasons. A push to `dev` is not a pull request; neither is
+    # a `workflow_dispatch` against a feature branch, which could therefore
+    # already publish an unreviewed branch straight to production. Naming the
+    # branch is what makes both impossible, and it is why these are conditions
+    # on the ref rather than on the event.
+    env:
+      DEPLOYS: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+      PREVIEWS: ${{ github.event_name == 'pull_request' || github.ref == 'refs/heads/dev' }}
     steps:
       # The version is a tag, so the deploy has to be able to see the tags. The
       # default checkout brings none: it fetches the one commit being deployed
@@ -255,11 +298,12 @@ jobs:
 
           exit $status
 
-      # On a pull request the deployed build goes to the preview job instead
-      # of the dist branch. A day is plenty: the preview is uploaded within
-      # minutes, and the next push to the pull request builds again.
+      # A build bound for a preview rather than for `dist` - a pull request,
+      # or a push to `dev` - reaches the job below through an artifact. A day
+      # is plenty: the preview is uploaded within minutes, and the next push
+      # builds again.
       - name: Hand the build to the preview
-        if: github.event_name == 'pull_request'
+        if: env.PREVIEWS == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: site-preview
@@ -269,7 +313,7 @@ jobs:
 
       - name: Publish to the dist branch
         id: publish
-        if: github.event_name != 'pull_request'
+        if: env.DEPLOYS == 'true'
         env:
           SHA: ${{ github.sha }}
         run: |
@@ -338,8 +382,17 @@ jobs:
       # After the publish and not before: a tag is a claim that this version is
       # live, and a tag pushed ahead of a deploy that then failed would be a
       # claim about something that never happened.
+      #
+      # Bundling through `dev` does not disturb any of this, and it is worth
+      # saying why rather than leaving it to be rediscovered. The span
+      # measured is the last version tag to what is being deployed, not the
+      # previous commit - so a merge from `dev` carrying fifteen changes is
+      # counted exactly the way fifteen merges from fifteen branches were, and
+      # moves the number once. A bundle that adds a tool still earns the
+      # middle digit, because `next_version.py` sees every added `tool.toml`
+      # in the span whatever order they arrived in.
       - name: Tag the version, if this deploy moved it
-        if: github.event_name != 'pull_request'
+        if: env.DEPLOYS == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -423,7 +476,7 @@ jobs:
       # announce if nothing was published, and `_site/sitemap.xml` might not
       # even exist.
       - name: Tell IndexNow what changed
-        if: ${{ !cancelled() && github.event_name != 'pull_request' && steps.publish.outcome == 'success' }}
+        if: ${{ !cancelled() && env.DEPLOYS == 'true' && steps.publish.outcome == 'success' }}
         continue-on-error: true
         run: |
           set -uo pipefail
@@ -470,7 +523,8 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # A PREVIEW OF EVERY PULL REQUEST, AND THE QA SUITE RUN AGAINST IT
+  # A PREVIEW OF EVERY PULL REQUEST AND OF `dev`, AND THE QA SUITE RUN
+  # AGAINST THE PULL REQUESTS
   #
   # Until this job existed the browser suite only ever saw a change after it
   # was live: merge, build, push to dist, Pages, and then QA (post-deploy)
@@ -492,6 +546,24 @@ jobs:
   # job made - the same `_site` that would have gone to dist - which is the
   # point: what is tested is what ships.
   #
+  # `dev` gets one too, at `dev.<project>.pages.dev`. Every other address here
+  # belongs to a pull request and goes away with it; this one stays, and it is
+  # the only place the bundle as it currently stands can be looked at -
+  # `main` is the last release, and a pull request's preview is one change
+  # against `dev` rather than the sum of them. It is one more branch alias in
+  # the same project, so it costs no second project, no second token and no
+  # standing server.
+  #
+  # The QA suite is NOT run against that one, and that is a decision rather
+  # than an oversight. Every pull request into `dev` has already been through
+  # the suite, and the pull request from `dev` to `main` goes through it again
+  # on the whole bundle - which is the run that decides whether production
+  # gets it. A third run on every merge into `dev` would re-test what was
+  # tested minutes earlier, twelve runners at a time, and gate nothing. To
+  # change that, drop the `github.event_name == 'pull_request'` from the
+  # dispatch step below: the qa repository is handed a `base_url` and does not
+  # care where it came from.
+  #
   # The suite itself runs in the qa repository, as it does after a deploy,
   # dispatched with the preview's address and this pull request's head
   # commit. Its result comes back as a commit status, `qa/preview`, on that
@@ -509,15 +581,25 @@ jobs:
   # deploy with this repository's credentials.
   preview:
     needs: build
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/dev'
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      # For the sticky comment that carries the preview's address.
+      # For the sticky comment that carries the preview's address. A push to
+      # `dev` has no pull request to write one on, and the step that would is
+      # skipped rather than the permission being made conditional.
       pull-requests: write
     env:
+      # Empty on a push to `dev`, which is how the steps that only make sense
+      # for a pull request tell the two apart.
       PR: ${{ github.event.pull_request.number }}
-      SHA: ${{ github.event.pull_request.head.sha }}
+      SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      # The Pages branch alias, which is the whole of the address. Never
+      # `main`: that is the preview project's own production branch, and
+      # deploying to it would turn a build from here into that project's
+      # production deployment - losing the noindex Pages puts on every other
+      # deployment, and pointing the project's bare address at it.
+      ALIAS: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'dev' }}
       PROJECT: ${{ vars.CLOUDFLARE_PAGES_PROJECT || 'abox-preview' }}
     steps:
       - name: Is there somewhere to put it?
@@ -545,12 +627,11 @@ jobs:
         with:
           node-version: '20'
 
-      # `--branch pr-<n>` is what makes this a preview rather than the
-      # project's production: Pages gives every non-production branch an
-      # alias of its own, <branch>.<project>.pages.dev, stable across the
-      # pull request's pushes, which is the address the comment and the QA
-      # run use. There is no git checkout in this job, so the commit is
-      # named by hand.
+      # `--branch` is what makes this a preview rather than the project's
+      # production: Pages gives every non-production branch an alias of its
+      # own, <branch>.<project>.pages.dev, stable across the pushes that
+      # follow it, which is the address the comment and the QA run use. There
+      # is no git checkout in this job, so the commit is named by hand.
       - name: Upload it to Cloudflare Pages
         if: steps.gate.outputs.ready == 'true'
         id: upload
@@ -559,13 +640,14 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           set -euo pipefail
+          if [ -n "$PR" ]; then what="pull request #$PR"; else what='the dev branch'; fi
           npx --yes wrangler@3 pages deploy _site \
             --project-name "$PROJECT" \
-            --branch "pr-$PR" \
+            --branch "$ALIAS" \
             --commit-hash "$SHA" \
-            --commit-message "Preview of pull request #$PR at ${SHA:0:7}" \
+            --commit-message "Preview of $what at ${SHA:0:7}" \
             --commit-dirty=true
-          echo "url=https://pr-$PR.$PROJECT.pages.dev/" >> "$GITHUB_OUTPUT"
+          echo "url=https://$ALIAS.$PROJECT.pages.dev/" >> "$GITHUB_OUTPUT"
 
       # The alias takes a moment to answer after the first upload for a
       # branch. Waiting here, as QA (post-deploy) waits for production, keeps
@@ -590,7 +672,7 @@ jobs:
       # to, so the address is always at the top of the conversation and never
       # repeated down it.
       - name: Say where it is, on the pull request
-        if: steps.gate.outputs.ready == 'true'
+        if: steps.gate.outputs.ready == 'true' && github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
           URL: ${{ steps.upload.outputs.url }}
@@ -611,7 +693,7 @@ jobs:
       # The same token QA (post-deploy) uses; see that workflow's header for
       # why the default token cannot start a run in another repository.
       - name: Ask the QA suite to run against it
-        if: steps.gate.outputs.ready == 'true'
+        if: steps.gate.outputs.ready == 'true' && github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ secrets.QA_DISPATCH_TOKEN }}
           URL: ${{ steps.upload.outputs.url }}
@@ -633,10 +715,13 @@ jobs:
           {
             echo '### Preview'
             echo
-            if [ -n "$URL" ]; then
+            if [ -z "$URL" ]; then
+              echo 'Not deployed: the Cloudflare secrets are not set. See cloudflare/README.md, "Previews".'
+            elif [ -n "$PR" ]; then
               echo "- $URL"
               echo '- The QA suite runs against it in [A-Box-of-Tools/qa](https://github.com/A-Box-of-Tools/qa/actions); the result is the `qa/preview` status on this commit.'
             else
-              echo 'Not deployed: the Cloudflare secrets are not set. See cloudflare/README.md, "Previews".'
+              echo "- $URL - the bundle as \`dev\` currently stands."
+              echo '- The QA suite is not run against this one. It runs on the pull request from `dev` to `main`, on the same bundle, which is the run that gates production.'
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,12 @@
 # than fifteen of each. What it costs is that `main` is now two merges away
 # from a change rather than one, which is the trade being made.
 #
+# The second of those two merges is made by hand, and nothing in this file
+# will ever make it: no schedule, no auto-merge, and no step anywhere here
+# pushes `main`. A release is somebody deciding the bundle is ready, having
+# read its preview and its QA run - and that decision is the one thing
+# everything else is automated in order to leave room for.
+#
 # So this workflow has three destinations rather than two. The `build` job
 # names them once in its `env`, because the four steps that read them have to
 # agree with each other:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -576,6 +576,18 @@ jobs:
   # commit, with the run as its link. Report-only for now; once it has been
   # green for a while, branch protection can require it.
   #
+  # THAT HEAD COMMIT IS DOING TWO JOBS, and the second one is why this
+  # arrangement depends on a change over there. It is where the status is
+  # written; it is also the tree the suite reads this repository's tool list
+  # and CSP out of, because it keeps no copy of either. Basing pull requests
+  # on `dev` makes that second job load-bearing. A preview used to differ from
+  # `main` by one pull request, so a suite reading `main` miscounted the hub's
+  # cards only on a pull request that shipped a tool; a preview now differs by
+  # the whole bundle, so it would miscount on every pull request opened
+  # between one release and the next. A-Box-of-Tools/qa#94 is what makes the
+  # suite read the commit it was given rather than a branch, and this
+  # arrangement wants it merged.
+  #
   # SETUP, ONCE: a Cloudflare Pages project (direct upload) and two secrets
   # here, CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID; a WEBSITE_STATUS_TOKEN
   # in the qa repository for the status; QA_DISPATCH_TOKEN as before. The

--- a/.github/workflows/qa-on-deploy.yml
+++ b/.github/workflows/qa-on-deploy.yml
@@ -125,6 +125,21 @@ jobs:
           echo "::error::abox.tools never responded after 5 minutes."
           exit 1
 
+      # Dispatched with no inputs at all, which is what makes it a production
+      # run over there: `base_url` falls back to https://abox.tools/, and `pr`
+      # and `sha` stay empty.
+      #
+      # THAT EMPTY `sha` IS WHY THIS REPOSITORY'S DEFAULT BRANCH HAS TO STAY
+      # `main`. The suite does not keep its own copy of the tool list or the
+      # CSP - it reads them out of a checkout of this repository - and a run
+      # that was told no commit takes this repository's default branch, which
+      # is every production run. That fallback is right only while the default
+      # branch is the one production was built from. Point it at `dev` and
+      # every production run would count the bundle's tools against the live
+      # site's cards: four assertions failing on the hub and the 404, each
+      # right about its own numbers and about two different sites. The same
+      # trap on the preview side, where the commit IS known, is
+      # A-Box-of-Tools/qa#94.
       - name: Ask the QA repo to run its suite
         if: steps.deployed.outputs.deployed == 'true'
         env:

--- a/.github/workflows/qa-on-deploy.yml
+++ b/.github/workflows/qa-on-deploy.yml
@@ -20,6 +20,14 @@
 # that pushes nothing, and re-testing an unchanged site is a full run of the
 # suite for nothing. The first step below asks the dist branch.
 #
+# Nor when the Build was a `dev` one. Work is merged to `dev` and released
+# from there to `main`; only `main` publishes, so only a Build on `main` can
+# have deployed anything. That is a condition on the job below rather than
+# something left to the dist check inside it - the check would catch it, since
+# a `dev` build pushes nothing and the head of dist would not name its commit,
+# but only after a runner had started, and every merge in the repository is a
+# push to `dev`.
+#
 # This only dispatches; it does not run the suite itself. The qa repo's own
 # report.yml runs it and publishes the result to that repo's gh-pages
 # branch, so there is one place the suite runs and one report to read -
@@ -57,13 +65,14 @@ concurrency:
 jobs:
   qa:
     runs-on: ubuntu-latest
-    # Only a build that succeeded and actually published. build.yml runs on
-    # pull requests too and skips its publish step there, so a pull request
-    # build finishing is not a deploy and there is nothing new to check.
+    # Only a build that succeeded on `main` and actually published. build.yml
+    # runs on pull requests and on `dev` as well and publishes on neither, so
+    # neither of those finishing is a deploy and there is nothing new to check.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.event == 'push')
+       github.event.workflow_run.event == 'push' &&
+       github.event.workflow_run.head_branch == 'main')
     steps:
       # A Build that finished is not a deploy. The publish step pushes to dist
       # only when the built site differs from what is there, and says

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,12 @@ IndexNow, and nothing else does any of those. Releasing is opening a pull
 request from `dev` to `main` and merging it — that one gets a preview and a
 full QA run on the whole bundle, which is the last gate before production.
 
+**Never open or merge the `dev` → `main` pull request unless you were asked
+to, by name.** It is the release, and it is meant to be a person's decision
+rather than a step at the end of a task: merging it deploys, tags a version
+and tells five search engines. Finishing a change means getting it on to
+`dev`. Nothing automates the rest, and you are not the exception.
+
 The reason is the version and the deploy rather than ceremony: every merge
 used to be a release of its own, and most changes do not deserve one. See
 [docs/deploying.md](docs/deploying.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,32 @@ No dependencies, no lockfile, no build step for the JavaScript. What is in
 `?v=<hash>` on every relative import so a deploy never pairs a new page with a
 cached old module (`sitelib.version_imports`); nothing else is transformed.
 
+## Branches
+
+**Open your pull request against `dev`, not `main`.**
+
+```
+your branch  ->  pull request  ->  dev  ->  pull request  ->  main  ->  live
+```
+
+`dev` holds everything merged since the last release. `main` is what is live:
+a push to it builds, publishes to the `dist` branch, tags a version and tells
+IndexNow, and nothing else does any of those. Releasing is opening a pull
+request from `dev` to `main` and merging it — that one gets a preview and a
+full QA run on the whole bundle, which is the last gate before production.
+
+The reason is the version and the deploy rather than ceremony: every merge
+used to be a release of its own, and most changes do not deserve one. See
+[docs/deploying.md](docs/deploying.md).
+
+Two things follow that will otherwise surprise you:
+
+- **A pull request is built and previewed on top of `dev`**, not on top of
+  what is live, so a preview can differ from production in ways your diff does
+  not explain.
+- **`--check` cannot pass on `dev`** — see below, and do not read it as
+  breakage.
+
 ## Commands
 
 ```bash
@@ -82,7 +108,8 @@ that do not exist on the branch under test. It looks exactly like "main is
 broken".
 
 `--check` diffs against the deployed `dist` branch, which tracks `main`
-exactly. On any feature branch it exits 1 by construction. CI does not run it.
+exactly. On `dev` and on any working branch it exits 1 by construction — both
+are ahead of what is deployed. CI does not run it.
 
 ## Layout
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ lockfile, no dependency to fetch. Both test suites run in CI on every push and
 every pull request, and nothing is published if either fails.
 
 Pull requests are opened against **`dev`**, which is where changes are bundled;
-`main` is what is live, and a release is a pull request from `dev` to `main`.
+`main` is what is live, and a release is a pull request from `dev` to `main`,
+opened and merged by hand when somebody decides the bundle is ready. Nothing
+merges it on a schedule.
 [Deploying](docs/deploying.md) has the whole path and why there is a branch in
 the middle of it.
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ Python 3.11 or newer, Node 22.15 or newer, nothing to install for either — no
 lockfile, no dependency to fetch. Both test suites run in CI on every push and
 every pull request, and nothing is published if either fails.
 
+Pull requests are opened against **`dev`**, which is where changes are bundled;
+`main` is what is live, and a release is a pull request from `dev` to `main`.
+[Deploying](docs/deploying.md) has the whole path and why there is a branch in
+the middle of it.
+
 See [Running it](docs/running.md) for `--check` (does the deployed site match
 these sources) and the double-click failure that is worth knowing about before
 it surprises you.
@@ -67,7 +72,7 @@ finding the part you need does not mean scrolling through the parts you don't:
 | [The prose pages](docs/prose-pages.md) | `pages/`, the legal pages, About and Contact, and what Privacy does and does not claim |
 | [The guides](docs/guides.md) | the longer answer behind each tool, why tool pages link to each other, and the feedback panel |
 | [Languages](docs/languages.md) | what a locale is and is not, half-translated pages, and adding a language |
-| [Deploying](docs/deploying.md) | GitHub Pages behind Cloudflare, cache lifetimes, the 404 page, `/llms.txt`, and every page's `index.md` |
+| [Deploying](docs/deploying.md) | the branches a change passes through, GitHub Pages behind Cloudflare, cache lifetimes, the 404 page, `/llms.txt`, and every page's `index.md` |
 | [What can be built here](docs/what-can-be-built-here.md) | the test a new tool has to pass, what needs a vendored engine, and what was ruled out |
 | [Licence](docs/licence.md) | MIT for the code, CC BY 4.0 for the words, and why it is split that way |
 

--- a/buildlib/version.py
+++ b/buildlib/version.py
@@ -65,6 +65,7 @@ INVISIBLE = (
     'docs/',
     '.claude/',
     'workers/',          # deployed by hand, and not part of a page
+    'cloudflare/',       # the edge rules, applied by hand the same way
     'media/',            # artwork for profiles and press; the build never copies it
 )
 

--- a/cloudflare/README.md
+++ b/cloudflare/README.md
@@ -96,13 +96,24 @@ rule fights that control. Same for **Always Use HTTPS**.
 - **Editing in the dashboard is fine, but temporary.** The next apply overwrites
   it. Change the JSON and re-run instead, so the change survives and gets reviewed.
 
-## Previews, for a pull request
+## Previews, for a pull request and for `dev`
 
-Production stays on GitHub Pages. A pull request, though, gets a build of its
+Production stays on GitHub Pages. Everything upstream of it gets a build of its
 own on **Cloudflare Pages** - a second, separate project, direct upload, no
-git integration - at `https://pr-<number>.abox-preview.pages.dev/`, and the QA
-suite is run against that before anything reaches `main`. See the `preview`
-job in `.github/workflows/build.yml` for what it does and why.
+git integration:
+
+| What | Address | Is the QA suite run against it |
+|---|---|---|
+| a pull request | `https://pr-<number>.abox-preview.pages.dev/` | yes, and the result is the `qa/preview` check on the pull request |
+| the `dev` branch | `https://dev.abox-preview.pages.dev/` | no |
+
+The pull request previews are the gate: the suite runs against one before the
+change reaches `dev`, and against the `dev` -> `main` pull request before the
+bundle reaches production. `dev`'s own address is not a gate but a place to
+look - one stable URL that always holds everything merged since the last
+release, which neither `main` nor any single pull request shows. See the
+`preview` job in `.github/workflows/build.yml` for what it does and why, and
+[docs/deploying.md](../docs/deploying.md) for why `dev` is there at all.
 
 Pages reads `_headers`, so a preview carries the same security headers as
 production without the transform rule above; and Pages marks every deployment
@@ -116,9 +127,11 @@ visits either.
 1. In the Cloudflare dashboard, **Workers & Pages → Create application**, then
    the **Pages** tab rather than Workers, then **Upload assets**. Name the
    project `abox-preview` and upload anything - the first deployment from the
-   workflow replaces it. Leave the production branch as `main`: the workflow
-   deploys to branches named `pr-<number>`, which is what makes each one a
-   preview rather than the project's production.
+   workflow replaces it. Leave the production branch as `main`, and note that
+   the workflow never deploys to it: it deploys to `pr-<number>` and to `dev`,
+   and a branch that is not the project's production branch is what makes a
+   deployment a preview - noindex, and at an alias of its own rather than at
+   the project's bare address.
 
    The same from a terminal, with no placeholder to upload, once the token
    below exists:

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -6,19 +6,58 @@ The site is one domain, `abox.tools`. It is served by **GitHub Pages** from the
 `dist` branch of this repository, behind **Cloudflare's proxy**.
 
 ```
-push to main  ->  GitHub Action runs build.py  ->  dist branch
+a change  ->  pull request  ->  dev  ->  pull request  ->  main  ->  dist  ->  Pages
 
 visitor  ->  Cloudflare (DNS, TLS, response headers)  ->  GitHub Pages (dist branch)
 ```
 
-`main` holds the sources. `dist` holds the built site, and nothing else: it is
-written only by [the Build workflow](../.github/workflows/build.yml), never by
-hand. A pull request builds without publishing, so a change that breaks the
-build is caught before it can reach `main`.
+`main` holds the sources of what is live. `dist` holds the built site, and
+nothing else: it is written only by
+[the Build workflow](../.github/workflows/build.yml), never by hand.
 
 To see what would be deployed before pushing, run `python build.py` and look at
 `dist/`. To check that what *is* deployed matches these sources, run
 `python build.py --check`, which diffs a fresh build against the `dist` branch.
+
+## The branches, and why there is one in the middle
+
+| Branch | What it holds | What a push to it does |
+|---|---|---|
+| a working branch | one change | builds and checks it; previews it once a pull request is open |
+| `dev` | everything merged since the last release | builds it, and previews it at `dev.abox-preview.pages.dev` |
+| `main` | what is live | builds, publishes to `dist`, tags the version, tells IndexNow |
+| `dist` | the built site, and nothing else | GitHub Pages serves it |
+
+Work is opened against `dev`. **Releasing is opening a pull request from `dev`
+to `main`** and merging it — there is no other step, and no file in the tree has
+to be edited to do it.
+
+`main` used to be where pull requests landed, which made every merge a release:
+its own deploy, its own version tag, its own IndexNow submission. Most changes
+do not deserve one — a phrase in one language, a colour, a fix to one tool — and
+on 27 August thirty-seven of them went out in a day. The cost is not runner
+time. It is that a version tag then names the last change rather than a set of
+them; that thirty-seven deploys are thirty-seven chances to be the one that
+broke something; and that finding which one did means bisecting a day instead
+of reading a pull request.
+
+Bundling on `dev` changes that and nothing else. Production moves once, with
+everything reviewed and previewed since the last time, under one version tag
+that names the whole set. What it costs is one more merge between a change and
+the visitor, and a `dev` that has to be merged forward whenever `main` moves
+without it — a hotfix taken straight to `main`, which is the one occasion to go
+round this rather than through it.
+
+The gates are unchanged in kind and doubled in number. A pull request builds
+without publishing, so a change that breaks the build is caught before it
+reaches `dev`; and the pull request from `dev` to `main` builds the bundle,
+previews it, and runs the QA suite against that preview before any of it is
+live. See [cloudflare/README.md](../cloudflare/README.md), "Previews".
+
+**`python build.py --check` cannot pass on `dev`.** It diffs a fresh build
+against `dist`, `dist` tracks `main` exactly, and `dev` is ahead of `main` by
+construction whenever it is holding anything at all. That is not a failure to
+investigate, and CI does not run it.
 
 ## GitHub Pages
 

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -32,6 +32,15 @@ Work is opened against `dev`. **Releasing is opening a pull request from `dev`
 to `main`** and merging it — there is no other step, and no file in the tree has
 to be edited to do it.
 
+**That merge is done by hand, on purpose, and nothing here will ever do it for
+you.** No schedule opens the pull request, no workflow merges it, and nothing
+fast-forwards `main` on to `dev`. Auto-merge is not to be enabled on it either.
+Deciding that what is on `dev` is ready to be live is the one judgement this
+arrangement exists to make room for: `main` moving is a deploy, a version tag
+and a submission to five search engines, and it should happen because somebody
+looked at the bundle and its QA run and said yes. Everything upstream of that
+merge is automatic so that this one step can be deliberate.
+
 `main` used to be where pull requests landed, which made every merge a release:
 its own deploy, its own version tag, its own IndexNow submission. Most changes
 do not deserve one — a phrase in one language, a colour, a fix to one tool — and

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -63,6 +63,15 @@ reaches `dev`; and the pull request from `dev` to `main` builds the bundle,
 previews it, and runs the QA suite against that preview before any of it is
 live. See [cloudflare/README.md](../cloudflare/README.md), "Previews".
 
+**`main` stays this repository's default branch**, and that is load-bearing
+rather than inertia. The QA suite reads the tool list and the CSP out of a
+checkout of this repository rather than keeping its own copy, and a run that
+was told no commit reads the default branch — which is every production run.
+Point the default at `dev` and each of those would count the bundle's tools
+against the live site's cards and fail, correctly, about two different sites.
+The cost of leaving it is that a pull request opened by hand in the GitHub UI
+arrives based on `main`, and the base has to be changed to `dev`.
+
 **`python build.py --check` cannot pass on `dev`.** It diffs a fresh build
 against `dist`, `dist` tracks `main` exactly, and `dev` is ahead of `main` by
 construction whenever it is holding anything at all. That is not a failure to

--- a/tests/python/test_version.py
+++ b/tests/python/test_version.py
@@ -83,6 +83,7 @@ class WhatAVisitorCanSee(unittest.TestCase):
                      'docs/deploying.md',
                      '.claude/skills/tool-development/SKILL.md',
                      'workers/rendezvous/worker.js',
+                     'cloudflare/response-headers.json',
                      'README.md',
                      'CLAUDE.md'):
             self.assertFalse(version.visible(path), path)


### PR DESCRIPTION
Every merge is currently a release: its own deploy, its own version tag, its own IndexNow submission. Most changes do not deserve one — a phrase in one language, a colour, a fix to one tool — and on 27 August thirty-seven of them went out in a day. The cost is not runner time. It is that a version tag names the last change rather than a set of them, and that finding the deploy which broke something means bisecting a day instead of reading a pull request.

So work is opened against `dev`, and **releasing is opening a pull request from `dev` to `main`** and merging it. Production moves once, with everything reviewed and previewed since the last time, under one tag that names the whole set.

```
a change  ->  pull request  ->  dev  ->  pull request  ->  main  ->  dist  ->  Pages
```

## The release merge is a person's job, and now says so

There was never any automation for `dev` -> `main` — no schedule, no auto-merge, no step that pushes `main`; the only refs any workflow here writes are `dist` and a version tag. But nothing said so, and a rule that holds only because nobody has written the code to break it lasts until somebody does. It is now stated in the workflow header, in `docs/deploying.md` beside the sentence that defines releasing, in the README, and in the imperative in `CLAUDE.md` and the `tool-development` skill — an agent that has just landed a change on `dev` is the reader most likely to treat the last merge as one more step in the task rather than as the deploy it is.

Everything upstream of that merge is automated — build, preview, QA, version, IndexNow — so that this one step can be somebody reading the bundle's preview and its QA run and deciding it is ready. **Do not enable auto-merge on the release pull request.**

## The preview, on `dev` too

`dev` gets a Cloudflare Pages preview of its own at `dev.abox-preview.pages.dev` — one more branch alias in the project that already holds the per-pull-request ones, so no second project, no second token and no standing server. It is the only place the bundle as it stands can be looked at: `main` is the last release, and a pull request's preview is one change against `dev` rather than the sum of them.

The QA suite is **not** run against it. Every pull request into `dev` has been through the suite already, and the pull request out of `dev` goes through it again on the whole bundle — which is the run that gates production. A third run on every merge into `dev` would re-test what was tested minutes earlier, twelve runners at a time, and gate nothing. The one-line change to turn it on is named in the workflow comment.

| What | Address | QA suite |
|---|---|---|
| a pull request | `pr-<number>.abox-preview.pages.dev` | yes — the `qa/preview` check |
| `dev` | `dev.abox-preview.pages.dev` | no |
| `main` | `abox.tools` | yes, after the deploy |

## What the conditions now say, and why they moved

The four steps that publish read one pair of job-level answers rather than asking four times over, because they have to agree — a run that published to `dist` without tagging the version, or tagged one without publishing, would be worse than either:

```yaml
DEPLOYS:  github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
PREVIEWS: github.event_name == 'pull_request' || github.ref == 'refs/heads/dev'
```

Both name the branch. `github.event_name != 'pull_request'` was right while `main` was the only branch this ran on and is wrong twice now: a push to `dev` is not a pull request, and **neither is a `workflow_dispatch` against a feature branch** — which could already publish an unreviewed branch straight to production. That is fixed here as a side effect.

| event | ref | DEPLOYS | PREVIEWS |
|---|---|---|---|
| push | `main` | true | false |
| push | `dev` | false | true |
| pull_request | any | false | true |
| workflow_dispatch | `main` | true | false |
| workflow_dispatch | `dev` | false | true |
| workflow_dispatch | a feature branch | false | false |

QA (post-deploy) grows the same guard — `head_branch == 'main'`. The dist check inside it would have caught a `dev` build (nothing is pushed, so the head of `dist` would not name its commit) but only after a runner had started, and every merge in the repository is now a push to `dev`.

## The version needs nothing

The span measured is the last tag to what is being deployed, not the previous commit — so a merge from `dev` carrying fifteen changes is counted exactly the way fifteen merges from fifteen branches were, and moves the number once. A bundle that adds a tool still earns the middle digit, because `next_version.py` sees every added `tool.toml` in the span whatever order they arrived in.

`cloudflare/` joins `workers/` among the trees the version rule cannot see: both are applied to their host by hand, neither is part of a build, so neither can move what a deploy ships. Without it the doc change in this PR would have minted a patch version for a CI change.

## Depends on A-Box-of-Tools/qa#94

**Merge [qa#94](https://github.com/A-Box-of-Tools/qa/pull/94) first.** It stops the suite reading this repository's tool list off the default branch and reads it at the commit the site under test was built from. It was written for a bug of its own — a website PR that adds a tool failed four assertions on the hub and the 404 for as long as it stayed open, counting one tree's tools against another tree's cards — and basing pull requests on `dev` turns it from a fix into a dependency.

The reason is the size of the gap. A preview used to differ from `main` by one pull request, so the miscount happened only on a PR that shipped a tool. Based on `dev`, a preview differs from `main` by the whole bundle — so without #94 the miscount would happen on **every** PR opened between one release and the next, failing for reasons no author could act on. That is how a check stops being believed.

The same fallback is why **`main` has to stay the default branch**. Production runs are dispatched with no commit at all, so the suite reads the default branch — right only while the default branch is what production was built from. Pointed at `dev`, every production run would count the bundle's tools against the live site's cards. That is now written down in `qa-on-deploy.yml`, beside the dispatch that omits the commit, and in `docs/deploying.md`, where somebody thinking about moving the default branch would be reading.

## After this merges

1. `git switch main && git pull && git switch -c dev && git push -u origin dev` — `dev` has to be branched *from* `main` after this lands, so it carries the workflow.
2. Open future pull requests against `dev`. `main` stays the default branch, so a PR opened by hand in the UI needs its base changed; `CLAUDE.md` and the `tool-development` skill tell agents to target `dev`.
3. Nothing to do at Cloudflare — the `dev.abox-preview.pages.dev` alias is created by the first deploy, the way `pr-<n>` aliases are.

## Tested

- `python -m unittest discover -t . -s tests/python` — 554 passed
- `node --import ./tests/js/resolve-shared.mjs --test "tests/js/*.test.js"` — exit 0
- Both workflows parse as YAML, and every `run:` block passes `bash -n`

No page changes, so no before/after pictures: this touches CI, the version rule and prose only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


