### PR TITLE
Run only the browser tests a pull request could have broken

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -708,6 +708,116 @@ jobs:
             gh api --method POST "repos/$REPO/issues/$PR/comments" -f body="$body" > /dev/null
           fi
 
+      # WHAT THIS PULL REQUEST CAN REACH, and therefore how much of the suite
+      # has to see it.
+      #
+      # The suite is twelve runners and about fourteen minutes, and a pull
+      # request that edits one tool spends all of it re-testing forty others
+      # that its diff cannot touch. So a change confined to `tools/<slug>/`
+      # asks the qa repository for that tool's cases and no more: a slug is
+      # enough to find them, because every case about a tool carries the slug
+      # in its title. Measured over the forty-one tools the site ships, a slug
+      # selects between 29 and 71 cases of the 1573 a project runs - 37 on
+      # average, and never none of that tool's own functional spec.
+      #
+      # EVERYTHING ELSE RUNS EVERYTHING, and the list of reasons is meant to
+      # be read as "what can reach a page this diff does not name":
+      #
+      #   the base is not `dev`   The `dev` -> `main` pull request is the
+      #                           release. It is one per release and the last
+      #                           gate before production, so it is never
+      #                           scoped, whatever it happens to contain.
+      #   a tool.toml added or    The footer, the hub, the 404, the sitemap
+      #   deleted                 and llms.txt all list every tool, so a tool
+      #                           arriving or leaving rewrites every page -
+      #                           and the cases that count the list say
+      #                           "lists every shipped tool", naming no slug,
+      #                           so a scoped run would be exactly blind to
+      #                           what changed. This is the failure
+      #                           A-Box-of-Tools/qa#94 was written for, met
+      #                           from the other direction.
+      #   anything outside one    `shared/`, `templates/`, `config/`,
+      #   tool's folder           `build.py`, `buildlib/`, `locales/`, a
+      #                           script, the root of `tools/` - all of them
+      #                           reach pages this diff does not name.
+      #   the diff could not be   The compare endpoint stops listing at 300
+      #   listed                  files, and a reply that was cut short is
+      #                           missing exactly the path this is looking
+      #                           for.
+      #
+      # The exempt list is short and is an allowlist: prose that cannot reach
+      # a page at all. Anything unrecognised runs the whole suite. This is the
+      # same bargain the `test` job makes above and for the same reason - the
+      # failure mode has to be a suite that ran when it need not have, and
+      # never a change that shipped untested.
+      #
+      # A pull request that changes only prose still runs the whole suite,
+      # deliberately: it builds a site identical to `dev`'s, so the run is
+      # wasted either way, and inventing a third answer here to save it would
+      # be a rule to get wrong for no gain.
+      #
+      # The judgement lives here because this is the end that can see the
+      # diff. The qa repository is handed a list and filters; it does not
+      # second-guess it.
+      - name: What the suite has to cover
+        id: scope
+        if: steps.gate.outputs.ready == 'true' && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          BASE: ${{ github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -uo pipefail
+
+          everything() {
+            echo 'tools=' >> "$GITHUB_OUTPUT"
+            echo "why=$1" >> "$GITHUB_OUTPUT"
+            echo "The whole suite, because $1."
+            exit 0
+          }
+
+          if [ "$BASE" != 'dev' ]; then
+            everything "this pull request is against \`$BASE\` rather than \`dev\`, so it is the release"
+          fi
+
+          listed=$(gh api "repos/$REPO/compare/$BASE_SHA...$SHA" --jq '.files[] | .status + " " + .filename') || listed=''
+          count=$(grep -c . <<< "$listed" || true)
+          if [ "$count" -eq 0 ] || [ "$count" -ge 300 ]; then
+            everything 'what this changed could not be listed in full'
+          fi
+
+          slugs=''
+          while read -r status path; do
+            [ -n "$path" ] || continue
+            case "$path" in
+              tools/*/tool.toml)
+                if [ "$status" != 'modified' ]; then
+                  everything "\`$path\` was $status, so every page that lists the tools changed with it"
+                fi ;;
+            esac
+            case "$path" in
+              tools/*/*)
+                slug=${path#tools/}
+                slug=${slug%%/*}
+                case " $slugs " in
+                  *" $slug "*) ;;
+                  *) slugs="${slugs:+$slugs }$slug" ;;
+                esac ;;
+              README.md|CLAUDE.md|ROADMAP.md|LICENSE|LICENSE-CONTENT|LICENSE-BRAND) ;;
+              docs/*|.claude/*|.github/*) ;;
+              *) everything "\`$path\` is not inside one tool, so it can reach pages this diff does not name" ;;
+            esac
+          done <<< "$listed"
+
+          if [ -z "$slugs" ]; then
+            everything 'nothing here is a tool, and a run that covers everything is the safe answer'
+          fi
+
+          echo "tools=$slugs" >> "$GITHUB_OUTPUT"
+          echo "why=only these tools changed: $slugs" >> "$GITHUB_OUTPUT"
+          echo "Only the cases naming: $slugs"
+
       # The same token QA (post-deploy) uses; see that workflow's header for
       # why the default token cannot start a run in another repository.
       - name: Ask the QA suite to run against it
@@ -715,6 +825,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.QA_DISPATCH_TOKEN }}
           URL: ${{ steps.upload.outputs.url }}
+          TOOLS: ${{ steps.scope.outputs.tools }}
+          WHY: ${{ steps.scope.outputs.why }}
         run: |
           set -euo pipefail
           if [ -z "${GH_TOKEN}" ]; then
@@ -722,8 +834,8 @@ jobs:
             exit 1
           fi
           gh workflow run report.yml --repo A-Box-of-Tools/qa \
-            -f "base_url=$URL" -f "pr=$PR" -f "sha=$SHA"
-          echo "Dispatched against $URL"
+            -f "base_url=$URL" -f "pr=$PR" -f "sha=$SHA" -f "tools=$TOOLS"
+          echo "Dispatched against $URL - $WHY"
 
       - name: Summary
         if: always()

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -63,6 +63,28 @@ reaches `dev`; and the pull request from `dev` to `main` builds the bundle,
 previews it, and runs the QA suite against that preview before any of it is
 live. See [cloudflare/README.md](../cloudflare/README.md), "Previews".
 
+**A pull request into `dev` runs only the browser tests that could see it.**
+The QA suite is twelve runners and about fourteen minutes, and a change to one
+tool spent all of it re-testing forty others its diff cannot touch. A change
+confined to `tools/<slug>/` now asks for that tool's cases and no more — a slug
+is enough to find them, because every case about a tool carries the slug in its
+title, and over the tools the site ships a slug selects between 29 and 71 cases
+of the 1573 a project runs.
+
+Everything else runs the whole suite, and the list is meant to read as *what
+can reach a page the diff does not name*: a tool added or removed (the footer,
+the hub, the 404, the sitemap and `llms.txt` all list every tool, and the cases
+that count that list name no slug); anything outside one tool's folder —
+`shared/`, `templates/`, `config/`, `build.py`, `buildlib/`, `locales/`; a diff
+too long for the compare endpoint to list; and the `dev` → `main` pull request,
+which is the release and is never scoped. Anything unrecognised runs
+everything, so the failure mode is a suite that ran when it need not have and
+never a change that shipped untested.
+
+The build and the unit tests are **not** scoped. They are nine minutes on one
+runner between them, and they are what catches a change that breaks every page
+— which a build of one tool, by construction, cannot see.
+
 **`main` stays this repository's default branch**, and that is load-bearing
 rather than inertia. The QA suite reads the tool list and the CSP out of a
 checkout of this repository rather than keeping its own copy, and a run that


### PR DESCRIPTION
The QA suite is twelve runners and ~14 minutes, and a pull request that edits one tool spends all of it re-testing forty others its diff cannot touch. A change confined to `tools/<slug>/` now asks for that tool's cases and no more — **42× fewer tests**, measured.

Depends on [qa#96](https://github.com/A-Box-of-Tools/qa/pull/96), **which must merge first**: this starts sending `-f tools=…`, and a dispatch carrying an input the workflow does not declare is refused.

## What decides the scope

The judgement lives here because this is the end that can see the diff. The qa repo is handed a list and filters; it does not second-guess it.

| The diff | What runs |
|---|---|
| only `tools/<slug>/…` | that tool's cases |
| a `tool.toml` added or removed | **everything** |
| anything outside one tool's folder | **everything** |
| base is not `dev` (the release PR) | **everything** |
| diff too long to list (≥300 files) | **everything** |
| anything unrecognised | **everything** |

The tool-added case is the subtle one. The footer, the hub, the 404, the sitemap and `llms.txt` all list every tool, so a tool arriving rewrites every page — and the cases that count that list are titled `lists every shipped tool`, naming no slug. A scoped run would be *exactly blind* to what changed. That is the failure [qa#94](https://github.com/A-Box-of-Tools/qa/pull/94) was written for, met from the other direction.

## Tested, before committing

The decision script was extracted from the workflow and run against twelve scenarios:

```
  ok   one tool edited          -> [compress-image]
  ok   two tools edited         -> [base64 text-diff]
  ok   same tool, many files    -> [merge-pdf]
  ok   a NEW tool               -> []   `tools/newthing/tool.toml` was added…
  ok   a tool REMOVED           -> []   `tools/oldthing/tool.toml` was removed…
  ok   shared CSS               -> []   `shared/site.css` is not inside one tool…
  ok   the build                -> []   `build.py` is not inside one tool…
  ok   a locale                 -> []   `locales/de/…` is not inside one tool…
  ok   tool + shared            -> []   shared wins
  ok   docs only                -> []   nothing here is a tool
  ok   the release PR           -> []   against `main` rather than `dev`
  ok   empty diff               -> []   could not be listed in full
```

(`[]` means *run everything*.) Every ambiguous case fails safe — the failure mode is a suite that ran when it need not have, never a change that shipped untested. That is the same bargain the `test` job above already makes.

## What is deliberately not scoped

**The build and the unit tests.** Nine minutes on one runner between them, and they are what catches a change that breaks every page — which a build of one tool, by construction, cannot see. `build.py --only <slug>` skips the hub, 404, sitemap and `llms.txt`: precisely the pages a tool change breaks.

**A prose-only pull request** still runs the whole suite. It builds a site identical to `dev`'s, so the run is wasted either way, and inventing a third answer to save it would be one more rule to get wrong for no gain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
