### PR TITLE
Let serve.ps1 parse again, and notice next time

### DIFF
--- a/buildlib/version.py
+++ b/buildlib/version.py
@@ -79,6 +79,7 @@ INVISIBLE_FILES = (
     'LICENSE-BRAND',
     '.gitignore',
     '.gitattributes',
+    'serve.ps1',         # the local server; it serves a build, and ships in none
 )
 
 #: A tool announces itself by its configuration file and nothing else.

--- a/serve.ps1
+++ b/serve.ps1
@@ -56,7 +56,6 @@ $mimeTypes = @{
   '.mjs'  = 'text/javascript; charset=utf-8'
   '.css'  = 'text/css; charset=utf-8'
   '.json' = 'application/json; charset=utf-8'
-  '.md'   = 'text/markdown; charset=utf-8'
   '.svg'  = 'image/svg+xml'
   '.png'  = 'image/png'
   '.jpg'  = 'image/jpeg'

--- a/tests/python/test_serve.py
+++ b/tests/python/test_serve.py
@@ -1,0 +1,59 @@
+"""
+The local server's file, checked for the one way it has actually broken.
+
+`serve.ps1` is how the site is looked at on this machine, and it is also what
+the QA suite starts when it is run without a BASE_URL. Nothing in CI runs it:
+the build and both unit suites are Python and Node, and the browser suite in
+the qa repository is pointed at a deployed address. So a mistake in it is
+invisible to every check this repository has, and is found by a person trying
+to serve the site.
+
+That is not hypothetical. #364 added `.md` to the MIME table without noticing
+the entry already there, and a duplicate key in a PowerShell hash literal is
+not a warning - the parser refuses the file outright, with
+`DuplicateKeyInHashLiteral`, before a line of it runs. `serve.ps1` could not
+start at all for six merges, and the QA suite could not be run locally either,
+because its webServer is this script.
+
+The honest check would be to parse the file, and it is not available here:
+that needs PowerShell, and CI is Linux. This is the portable proxy for the one
+failure that has happened - the table is read with a regular expression and
+its keys are counted. A test that only knows about yesterday's bug is worth
+having when the bug cost six days and the alternative is nothing.
+"""
+
+import re
+import unittest
+from collections import Counter
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SERVE = ROOT / 'serve.ps1'
+
+#: The `$mimeTypes = @{ ... }` literal, and nothing else in the file.
+TABLE = re.compile(r'\$mimeTypes\s*=\s*@\{(.*?)\n\}', re.DOTALL)
+
+#: One `'.ext' = 'type'` line inside it. Comments do not match, so the
+#: explanatory ones between the entries are skipped rather than parsed.
+ENTRY = re.compile(r"^\s*'(\.[A-Za-z0-9]+)'\s*=", re.MULTILINE)
+
+
+class TheMimeTable(unittest.TestCase):
+    def setUp(self):
+        body = TABLE.search(SERVE.read_text(encoding='utf-8'))
+        self.assertIsNotNone(
+            body, 'serve.ps1 has no $mimeTypes = @{ ... } table to check')
+        self.keys = ENTRY.findall(body.group(1))
+
+    def test_it_was_found_at_all(self):
+        # A regular expression that silently matched nothing would make every
+        # other test here pass while checking no extensions whatsoever.
+        self.assertGreater(len(self.keys), 10)
+        self.assertIn('.html', self.keys)
+
+    def test_no_extension_is_listed_twice(self):
+        repeated = sorted(ext for ext, n in Counter(self.keys).items() if n > 1)
+        self.assertEqual(
+            repeated, [],
+            'PowerShell refuses to parse a hash literal with a repeated key, so '
+            'serve.ps1 would not start at all: ' + ', '.join(repeated))

--- a/tests/python/test_version.py
+++ b/tests/python/test_version.py
@@ -84,6 +84,7 @@ class WhatAVisitorCanSee(unittest.TestCase):
                      '.claude/skills/tool-development/SKILL.md',
                      'workers/rendezvous/worker.js',
                      'cloudflare/response-headers.json',
+                     'serve.ps1',
                      'README.md',
                      'CLAUDE.md'):
             self.assertFalse(version.visible(path), path)


### PR DESCRIPTION
`.md` was in the MIME table **twice**. A duplicate key in a PowerShell hash literal is not a warning — the parser refuses the whole file with `DuplicateKeyInHashLiteral` before a line of it runs:

```
+   '.md'   = 'text/markdown; charset=utf-8'
+   ~~~~~
Duplicate keys '.md' are not allowed in hash literals.
```

So `serve.ps1` did not start at all — and neither did the QA suite run locally, because its `webServer` is this script. `npx playwright test` only worked if you set `BASE_URL` by hand.

## Where it came from

`git log -L` on both lines: the entry beside `.txt` and `.xml` is the original, from the file's first commit. The one beside the other text types was added by [#364](https://github.com/A-Box-of-Tools/website/pull/364) (the Markdown twins) without noticing it already existed. The newer duplicate goes; the original stays.

**It has been broken for six merges.** That is the measure of how invisible it is: nothing in CI runs it. The build and both unit suites are Python and Node, and the browser suite is pointed at a deployed address, so no check this repository has could see it.

## So a test now watches it

`tests/python/test_serve.py` reads the `$mimeTypes` table and counts its keys.

The honest check would be to parse the file, and PowerShell is not available on a Linux runner — so this is the portable proxy for the one way it has actually broken. It was watched failing on the reintroduced bug before being kept:

```
FAILED: PowerShell refuses to parse a hash literal with a repeated key,
        so serve.ps1 would not start at all: .md
```

It also asserts the regex found the table at all, so a pattern that silently matched nothing cannot make the check pass while examining no extensions.

## And it mints no version

`serve.ps1` joins the files the version rule cannot see. It serves a build and ships in none, so a fix to it reaches no page — without this the deploy would have tagged a version whose reason read *"a change a visitor could notice"*, which would not be true.

```
$ python scripts/next_version.py
1.1.13 stands: nothing here reaches a page.
```

## Verified by actually serving the site

| Request | Result |
|---|---|
| `/` | 200 `text/html; charset=utf-8` |
| `/site.css` | 200 `text/css; charset=utf-8` |
| `/…/LICENSE.md` | 200 `text/markdown; charset=utf-8` |
| `/no-such-page/` | 404, custom page |

The `.md` row is the one that matters: removing a duplicate must not remove the mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
