### PR TITLE
Tell the QA suite which branch this pull request is against

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -904,6 +904,21 @@ jobs:
 
       # The same token QA (post-deploy) uses; see that workflow's header for
       # why the default token cannot start a run in another repository.
+      #
+      # `pr_base` is the branch this pull request is against, and it decides
+      # one thing over there: whether a tool may exist without a functional
+      # spec. A tool and its spec live in different repositories and cannot
+      # land in one change, so on a pull request into `dev` the qa repository
+      # reports that rather than failing, and on the `dev` -> `main` pull
+      # request - the release - it fails as it always did. A tool reaches
+      # `dev` without a spec; it does not reach production without one. See
+      # tests/coverage.spec.ts there, and A-Box-of-Tools/qa#97.
+      #
+      # It is a fact sent from here rather than a policy decided here: this end
+      # knows what the pull request is against, and the end that owns the check
+      # decides what to do about it. That is the opposite of the split above,
+      # where the scope is judged here because this is the end that can see the
+      # diff - each decision sits with whoever can actually answer it.
       - name: Ask the QA suite to run against it
         if: steps.gate.outputs.ready == 'true' && github.event_name == 'pull_request'
         env:
@@ -911,6 +926,7 @@ jobs:
           URL: ${{ steps.upload.outputs.url }}
           TOOLS: ${{ steps.scope.outputs.tools }}
           WHY: ${{ steps.scope.outputs.why }}
+          BASE: ${{ github.event.pull_request.base.ref }}
         run: |
           set -euo pipefail
           if [ -z "${GH_TOKEN}" ]; then
@@ -918,7 +934,7 @@ jobs:
             exit 1
           fi
           gh workflow run report.yml --repo A-Box-of-Tools/qa \
-            -f "base_url=$URL" -f "pr=$PR" -f "sha=$SHA" -f "tools=$TOOLS"
+            -f "base_url=$URL" -f "pr=$PR" -f "sha=$SHA" -f "tools=$TOOLS" -f "pr_base=$BASE"
           echo "Dispatched against $URL - $WHY"
 
       - name: Summary

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -81,6 +81,15 @@ which is the release and is never scoped. Anything unrecognised runs
 everything, so the failure mode is a suite that ran when it need not have and
 never a change that shipped untested.
 
+**A tool may reach `dev` without its QA spec, but not a release.** The tool
+lives here and the spec that tests what it *does* lives in the QA repository,
+so the two cannot land in one change. On a pull request into `dev` the coverage
+check reports the missing spec instead of failing — otherwise every tool would
+need two pull requests in two repositories in a fixed order, with the first red
+until the second merged. The `dev` → `main` pull request is not excused it, so
+nothing ships untested, and the QA repository opens an issue for a missing spec
+daily regardless.
+
 The build and the unit tests are **not** scoped. They are nine minutes on one
 runner between them, and they are what catches a change that breaks every page
 — which a build of one tool, by construction, cannot see.


### PR DESCRIPTION
The other half of [qa#97](https://github.com/A-Box-of-Tools/qa/pull/97), which is already merged.

`pr_base` decides one thing over there: **whether a tool may exist without a functional spec.**

The tool lives in this repository and the spec that tests what it *does* lives in the QA repository, so the two cannot land in one change. Since that suite began reading the tree its preview was built from ([qa#94](https://github.com/A-Box-of-Tools/qa/pull/94)), a pull request adding a tool failed the coverage check until a spec had been merged in the other repository first — two pull requests in two repositories, in a fixed order, with the first red the whole time. That is a check telling an author to do something they cannot do yet.

| This pull request is against | Coverage check |
|---|---|
| `dev` | reports the missing spec |
| `main` (the release) | fails |
| *(no pull request — production, scheduled)* | fails |

A tool reaches the bundle without a spec. It does not reach production without one.

## A fact sent, not a policy decided

This end knows what the pull request is against; the end that owns the check decides what to do about it.

That is deliberately the **opposite** of the split one step above it, where the QA scope is judged here because this is the end that can see the diff. Each decision sits with whoever can actually answer it, and both comments say so, because the inconsistency is the point and would otherwise read as an oversight.

## Ordering

qa#97 is already on `main` (`b620761`), so the input exists and this dispatch will not be refused. The reverse order is what gave #381 its `HTTP 422: Unexpected inputs provided`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
