### PR TITLE
Ask the deployments endpoint for a page it will give

### DIFF
--- a/.github/workflows/preview-tidy.yml
+++ b/.github/workflows/preview-tidy.yml
@@ -85,12 +85,21 @@ jobs:
           auth="Authorization: Bearer $CLOUDFLARE_API_TOKEN"
 
           # Every deployment the project holds, as `id<TAB>branch<TAB>commit`.
-          # Paged, because a busy month is more than a hundred of them and the
+          # Paged, because a busy month is more than one page of them and the
           # oldest are the ones most likely to be finished with.
+          #
+          # NO `per_page`, and that is not an oversight. Asking for 100 is
+          # refused outright - `Invalid list options provided. Review the page
+          # or per_page parameter.`, error 8000024 - and the endpoint does not
+          # document what it will accept, so any number here would be a guess
+          # that fails the same way the day it changes. Taking the page size
+          # the API chooses and reading until it hands back an empty page
+          # needs no such number. The cap below is a runaway guard, not a
+          # limit anybody should meet.
           : > all.tsv
           page=1
-          while [ "$page" -le 20 ]; do
-            body=$(curl -sS -H "$auth" "$api?per_page=100&page=$page") || body=''
+          while [ "$page" -le 40 ]; do
+            body=$(curl -sS -H "$auth" "$api?page=$page") || body=''
             if [ "$(printf '%s' "$body" | jq -r '.success // false')" != 'true' ]; then
               echo "::error::Could not list the deployments of $PROJECT."
               printf '%s' "$body" | head -c 800
@@ -107,7 +116,6 @@ jobs:
                 (.deployment_trigger.metadata.branch // "?"),
                 (.deployment_trigger.metadata.commit_hash // "?")
               ] | @tsv' >> all.tsv
-            if [ "$n" -lt 100 ]; then break; fi
             page=$((page + 1))
           done
 


### PR DESCRIPTION
The tidy workflow failed on its first live run, on its first request:

```
Invalid list options provided. Review the `page` or `per_page` parameter.
  (code 8000024)
```

`per_page=100` is refused by the Pages deployments endpoint, and the endpoint does not document what it *would* accept — so any number put there is a guess that fails the same way again the day it changes.

**So there is no number now.** Taking whatever page size the API chooses and reading until it hands back an empty page is correct at any size. The remaining count cap is a runaway guard, not a limit anyone should meet.

## The guard is why this was cheap

The loud-failure guard was written for the case where branch names come back unreadable. It caught the case where *nothing* came back at all — the same failure wearing a different hat — and the run said so on the first attempt, in one line, instead of a tidy that silently deleted nothing for months while the project filled up.

That was the whole argument for it: *a tidy that has quietly stopped working looks exactly like a tidy with nothing to do, and the only other place that would ever say so is the bill.*

## Now tested against the failure itself

The stubbed API refuses `per_page` exactly as the live one did, so the case that broke it is now one of the cases it is tested on. All seven decision cases and both guards pass against real jq 1.8.2, and paging reads each of the 7 fixture deployments exactly once before terminating on the empty page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
