### PR TITLE
Do not build what cannot reach a page

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,6 +102,10 @@ jobs:
   # still cannot happen without it.
   test:
     runs-on: ubuntu-latest
+    # Read by `build` and `preview` below. One decision, three consumers: the
+    # suites, the build, and the preview and QA run that follow it.
+    outputs:
+      site: ${{ steps.covered.outputs.code }}
     steps:
       # What this actually changed, asked of the API rather than worked out
       # from a clone: it is one request, and fetching enough history to diff
@@ -115,9 +119,28 @@ jobs:
       # failure mode is a suite that ran when it need not have, and never a
       # change that shipped untested.
       #
-      # The exempt list is an allowlist, and short on purpose: prose the build
+      # The exempt list is an allowlist, and short on purpose: files the build
       # never reads and no test opens. Anything else - anything new, anything
-      # unrecognised - runs the suites until somebody decides otherwise here.
+      # unrecognised - builds and runs the suites until somebody decides
+      # otherwise here.
+      #
+      # THE STANDARD AN ENTRY HAS TO MEET is that no test OPENS it, which is
+      # not the same as no test mentioning it. Nearly every path on this list
+      # appears in tests/python/test_version.py, as a string in the fixture
+      # asserting the version rule cannot see it; naming a path is not reading
+      # one. Three that look like they belong here do not, and each was checked
+      # rather than assumed:
+      #
+      #   workers/    tests/js/rendezvous.test.js imports worker.js outright
+      #   serve.ps1   tests/python/test_serve.py reads its MIME table
+      #   tests/      the suites are the thing being changed
+      #
+      # `.github/` is on the list, which costs something worth naming: a change
+      # to this file no longer gets a run of its own to prove its steps work.
+      # What still holds is that GitHub parses the workflow before it can skip
+      # anything, so a file that will not load is still refused - and a change
+      # here that needs exercising can be pushed with a one-line change beside
+      # it, or dispatched by hand.
       - name: Is there anything here a test could see?
         id: covered
         env:
@@ -143,8 +166,9 @@ jobs:
               code=false
               while IFS= read -r path; do
                 case "$path" in
-                  README.md|CLAUDE.md|ROADMAP.md|LICENSE|LICENSE-CONTENT) continue ;;
-                  docs/*|.claude/*) continue ;;
+                  README.md|CLAUDE.md|ROADMAP.md) continue ;;
+                  LICENSE|LICENSE-CONTENT|LICENSE-BRAND) continue ;;
+                  docs/*|.claude/*|.github/*|media/*|cloudflare/*) continue ;;
                 esac
                 code=true
                 why="\`$path\` is a file a test could see"
@@ -154,9 +178,9 @@ jobs:
           fi
 
           if [ "$code" = true ]; then
-            said="Running both suites, because $why."
+            said="Building and running both suites, because $why."
           else
-            said="Skipping both suites: everything this changed is prose the build never reads and no test opens. The build still runs."
+            said="Nothing here reaches the site: everything this changed is a file the build never reads and no test opens, so the build and both suites are skipped."
           fi
 
           # Twice on purpose. The summary is where somebody looks to find out
@@ -214,9 +238,16 @@ jobs:
     # already publish an unreviewed branch straight to production. Naming the
     # branch is what makes both impossible, and it is why these are conditions
     # on the ref rather than on the event.
+    #
+    # All three rest on the `test` job's answer, so a change that reaches no
+    # page is not built, not published and not previewed. The steps are skipped
+    # and the job is not, for the reason given over that job: a skipped job
+    # skips everything that needs it, and `needs: test` is the only thing
+    # standing between a broken test and the deployed branch.
     env:
-      DEPLOYS: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
-      PREVIEWS: ${{ github.event_name == 'pull_request' || github.ref == 'refs/heads/dev' }}
+      BUILDS: ${{ needs.test.outputs.site }}
+      DEPLOYS: ${{ needs.test.outputs.site == 'true' && github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+      PREVIEWS: ${{ needs.test.outputs.site == 'true' && (github.event_name == 'pull_request' || github.ref == 'refs/heads/dev') }}
     steps:
       # The version is a tag, so the deploy has to be able to see the tags. The
       # default checkout brings none: it fetches the one commit being deployed
@@ -243,13 +274,16 @@ jobs:
       # refuses to name the first version while the remote holds one, so if
       # this fetch ever stops working the step fails instead of agreeing.
       - uses: actions/checkout@v4
+        if: env.BUILDS == 'true'
       - name: Fetch the version tags the checkout leaves behind
+        if: env.BUILDS == 'true'
         run: git fetch --depth=1 origin '+refs/tags/*:refs/tags/*'
 
       # The build uses tomllib, which is standard library from 3.11 onwards.
       # Python alone produces a working, readable site: that is what plain
       # `python build.py` does, and it needs nothing installed.
       - uses: actions/setup-python@v5
+        if: env.BUILDS == 'true'
         with:
           python-version: '3.12'
 
@@ -257,6 +291,7 @@ jobs:
       # installed from npm: the build itself is Python and the standard
       # library, start to finish.
       - uses: actions/setup-node@v4
+        if: env.BUILDS == 'true'
         with:
           node-version: '20'
 
@@ -264,9 +299,11 @@ jobs:
       # against. Cheap, and it means a file that went missing has something to
       # go missing from.
       - name: Build (readable)
+        if: env.BUILDS == 'true'
         run: python build.py --out _plain --clean --no-minify
 
       - name: Build (deployed)
+        if: env.BUILDS == 'true'
         run: python build.py --out _site --clean
 
       # Minifying is the one step here that could break the site quietly, so
@@ -281,6 +318,7 @@ jobs:
       # filename, so a module that vanished is caught even if everything left
       # behind parses.
       - name: Check the minified output
+        if: env.BUILDS == 'true'
         run: |
           set -euo pipefail
           work=$(mktemp -d)
@@ -524,9 +562,13 @@ jobs:
           {
             echo '### Build'
             echo
-            echo '```'
-            find _site -type f | sort | sed 's|^_site/|  |'
-            echo '```'
+            if [ -d _site ]; then
+              echo '```'
+              find _site -type f | sort | sed 's|^_site/|  |'
+              echo '```'
+            else
+              echo 'Not built: nothing this changed reaches a page. See the Tests section above.'
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
 
   # A PREVIEW OF EVERY PULL REQUEST AND OF `dev`, AND THE QA SUITE RUN
@@ -609,8 +651,15 @@ jobs:
   # is GitHub's rule, and the right one: a fork's workflow must not be able to
   # deploy with this repository's credentials.
   preview:
-    needs: build
-    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/dev'
+    needs: [test, build]
+    # There is no artifact to take when the build did not run, and nothing to
+    # look at or test if there were: the site it would have made is the one
+    # already deployed. A pull request that changes only prose therefore gets
+    # no preview and no `qa/preview` check - worth knowing before that check is
+    # ever made a required one.
+    if: >-
+      needs.test.outputs.site == 'true' &&
+      (github.event_name == 'pull_request' || github.ref == 'refs/heads/dev')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,12 +135,15 @@ jobs:
       #   serve.ps1   tests/python/test_serve.py reads its MIME table
       #   tests/      the suites are the thing being changed
       #
-      # `.github/` is on the list, which costs something worth naming: a change
-      # to this file no longer gets a run of its own to prove its steps work.
-      # What still holds is that GitHub parses the workflow before it can skip
-      # anything, so a file that will not load is still refused - and a change
-      # here that needs exercising can be pushed with a one-line change beside
-      # it, or dispatched by hand.
+      # `.github/` is OFF the list, and for a different reason from the three
+      # above - it would qualify under the rule, because no test opens a
+      # workflow. A workflow exempt from the run it defines never gets one:
+      # the first thing to exercise a step edited here would be the deploy
+      # that needed it, and the first sign of a mistake a release that did not
+      # happen. GitHub parsing the file is not the same assurance, because a
+      # workflow can load perfectly and still hold a condition that never
+      # fires - which is most of what this file is made of. So a change here
+      # builds and runs both suites like any other.
       - name: Is there anything here a test could see?
         id: covered
         env:
@@ -168,7 +171,7 @@ jobs:
                 case "$path" in
                   README.md|CLAUDE.md|ROADMAP.md) continue ;;
                   LICENSE|LICENSE-CONTENT|LICENSE-BRAND) continue ;;
-                  docs/*|.claude/*|.github/*|media/*|cloudflare/*) continue ;;
+                  docs/*|.claude/*|media/*|cloudflare/*) continue ;;
                 esac
                 code=true
                 why="\`$path\` is a file a test could see"

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -90,7 +90,26 @@ until the second merged. The `dev` → `main` pull request is not excused it, so
 nothing ships untested, and the QA repository opens an issue for a missing spec
 daily regardless.
 
-The build and the unit tests are **not** scoped. They are nine minutes on one
+**A change that reaches no page is not built at all.** If everything a pull
+request touches is on a short allowlist — `docs/`, `.claude/`, `.github/`,
+`media/`, `cloudflare/`, and the root markdown files — then the build, both
+unit suites, the preview and the QA run are all skipped, because the site it
+would produce is the one already deployed. Anything else, anything new,
+anything unrecognised, builds and runs everything.
+
+The standard for being on that list is that **no test opens the file**, which
+is not the same as no test mentioning it. Three that look like they belong
+are deliberately absent, each checked rather than assumed: `workers/`, which
+`tests/js/rendezvous.test.js` imports outright; `serve.ps1`, which
+`tests/python/test_serve.py` reads; and `tests/` itself.
+
+`.github/` being on the list has a cost worth naming: a change to a workflow
+no longer gets a run of its own to prove its steps work. GitHub still parses
+the file before it can skip anything, so one that will not load is still
+refused — but a change that needs exercising should be pushed with a one-line
+change beside it, or dispatched by hand.
+
+The build and the unit tests are **not** scoped by tool. They are nine minutes on one
 runner between them, and they are what catches a change that breaks every page
 — which a build of one tool, by construction, cannot see.
 

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -91,8 +91,8 @@ nothing ships untested, and the QA repository opens an issue for a missing spec
 daily regardless.
 
 **A change that reaches no page is not built at all.** If everything a pull
-request touches is on a short allowlist — `docs/`, `.claude/`, `.github/`,
-`media/`, `cloudflare/`, and the root markdown files — then the build, both
+request touches is on a short allowlist — `docs/`, `.claude/`, `media/`,
+`cloudflare/`, and the root markdown files — then the build, both
 unit suites, the preview and the QA run are all skipped, because the site it
 would produce is the one already deployed. Anything else, anything new,
 anything unrecognised, builds and runs everything.
@@ -103,11 +103,13 @@ are deliberately absent, each checked rather than assumed: `workers/`, which
 `tests/js/rendezvous.test.js` imports outright; `serve.ps1`, which
 `tests/python/test_serve.py` reads; and `tests/` itself.
 
-`.github/` being on the list has a cost worth naming: a change to a workflow
-no longer gets a run of its own to prove its steps work. GitHub still parses
-the file before it can skip anything, so one that will not load is still
-refused — but a change that needs exercising should be pushed with a one-line
-change beside it, or dispatched by hand.
+`.github/` is deliberately **not** on the list, though it would qualify under
+that rule — no test opens a workflow. A workflow exempt from the run it defines
+never gets one: the first thing to exercise an edited step would be the deploy
+that needed it, and the first sign of a mistake a release that did not happen.
+GitHub parsing the file is not the same assurance, since a workflow can load
+perfectly and still hold a condition that never fires. So a change to CI builds
+and runs both suites like any other.
 
 The build and the unit tests are **not** scoped by tool. They are nine minutes on one
 runner between them, and they are what catches a change that breaks every page


### PR DESCRIPTION
The `test` job already knew how to spot a change no test could see, and skipped both suites for one. **The build ran anyway** — six minutes generating a site byte-identical to the one already deployed, then a preview of it, then twelve runners of browser tests against that. A pull request touching one README paid the full price of a release.

So the answer that job works out is now published as an output, and the build, the publish, the preview and the QA dispatch all rest on it. One decision, four consumers — four conditions asking the same question separately is how they come to disagree.

## What is exempt

`docs/`, `.claude/`, `media/`, `cloudflare/`, and the root markdown files.

**The standard is that no test *opens* the file — not that no test mentions one.** That distinction matters, because nearly every path on the list appears in `tests/python/test_version.py` as a string in the fixture asserting the version rule cannot see it. Naming a path is not reading one, and a grep that missed the difference would have exempted all six.

Three that look like they belong were checked and left off:

| Path | Why it stays |
|---|---|
| `workers/` | `tests/js/rendezvous.test.js` imports `worker.js` outright |
| `serve.ps1` | `tests/python/test_serve.py` reads its MIME table |
| `tests/` | the suites are the thing being changed |

## `.github/` is deliberately not exempt

It *qualifies* under the rule above — no test opens a workflow — and that is exactly the case the rule does not cover. **A workflow exempt from the run it defines never gets one.** The first thing to exercise an edited step would be the deploy that needed it, and the first sign of a mistake a release that did not happen.

GitHub parsing the file is not the same assurance: a workflow can load perfectly and still hold a condition that never fires, which is most of what `build.yml` is made of — the `if:` expressions added over the last few days were each proved by a run, not by loading.

So a change to CI builds and runs both suites like any other, and the reason it is an exception to a rule it satisfies is recorded where the rule is. **This pull request touches `.github/` and so exercises itself.**

## One consequence worth knowing early

A prose-only pull request now gets **no `qa/preview` check at all** — there is no preview to run it against. Worth knowing before that check is ever made a required one, since a required check that never reports blocks the merge.

## Steps skipped, jobs not

Same reason as the existing note over the `test` job: a skipped job skips everything that needs it, and `needs: test` is the only thing standing between a broken test and the deployed branch.

## Tested

Thirteen path sets run against the extracted decision:

```
  ok  a workflow / workflow AND README / an issue template  -> builds+tests
  ok  a tool page / the worker / serve.ps1 / a test         -> builds+tests
  ok  something unrecognised                                -> builds+tests
  ok  docs / README / CLAUDE.md                             -> skipped
  ok  cloudflare config / press artwork                     -> skipped
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
