### PR TITLE
Say which branch names it found, when it finds none it wants

### DIFF
--- a/.github/workflows/preview-tidy.yml
+++ b/.github/workflows/preview-tidy.yml
@@ -167,6 +167,41 @@ jobs:
           if [ "$count" -eq 0 ]; then
             echo 'Nothing was finished with.'
             echo 'Nothing was finished with.' >> "$GITHUB_STEP_SUMMARY"
+
+            # WHY NOTHING MATCHED, said out loud.
+            #
+            # "Nothing was finished with" is the ordinary answer on most runs
+            # and is also what a broken match looks like, which is the whole
+            # difficulty with this workflow - the first version listed the
+            # deployments perfectly and took down nothing, and it took a curl
+            # against a preview that should have been gone to notice. So when
+            # there was something to look for and none of it matched, this
+            # says which names it did see, and shows one deployment whole. A
+            # single run then answers the question instead of a guess at an
+            # endpoint that has already been guessed at once.
+            # A run looking for one exact name asks whether that name is
+            # there; a release looking for a shape asks whether the shape is.
+            # Getting this the other way round would dump a deployment on
+            # every healthy release, because `dev-pr-<n>` is a description and
+            # never a name.
+            case "$EVENT" in
+              pull_request)
+                looked="pr-$PR"
+                seen=$(cut -f2 all.tsv | grep -cxF "$looked" || true) ;;
+              *)
+                looked='dev-pr-<n>'
+                seen=$(cut -f2 all.tsv | grep -c '^dev-pr-' || true) ;;
+            esac
+            {
+              echo
+              echo "Looked for: $looked"
+              echo 'Branches the project actually reports:'
+              cut -f2 all.tsv | sort | uniq -c | sort -rn | head -40
+            } >&2
+            if [ "$seen" -eq 0 ]; then
+              echo 'Nothing of that shape is there at all, which is a match that has stopped working rather than a quiet week. One deployment in full, to show where the name lives:' >&2
+              curl -sS -H "$auth" "$api?page=1" | jq '.result[0]' >&2
+            fi
             exit 0
           fi
 


### PR DESCRIPTION
`Nothing was finished with` is the ordinary answer on most runs. It is also exactly what a match that has stopped working says.

That is the whole difficulty with this workflow, and it has now bitten twice in two days:

1. **The listing was refused outright** (`per_page`, error 8000024). The loud guard caught it — one red run, one-line fix.
2. **The matching then found nothing**, and no guard could catch that, because finding nothing is a legitimate answer. `pr-389` was left standing after its pull request merged and the run reported success.

What actually noticed the second one was `curl https://pr-389.abox-preview.pages.dev/` returning 200 for a preview that should have been gone. Not the run, which was green.

## So it diagnoses itself

When there was something to look for and none of it is there, it now prints what it looked for, the branch names the project actually reports, and **one deployment in full** — so a single run answers where the name lives, instead of a second guess at an endpoint that has already been guessed at once and was wrong.

```
Looked for: pr-389
Branches the project actually reports:
      2 main
Nothing of that shape is there at all, which is a match that has stopped
working rather than a quiet week. One deployment in full, to show where
the name lives:
{ "id": "m1", "aliases": ["https://pr-389.abox-preview.pages.dev"],
  "deployment_trigger": { "metadata": { "branch": "main", ... } } }
```

## The two questions are asked differently, on purpose

A closed pull request looks for **one exact name** and asks whether that name is present. A release looks for **a shape** (`dev-pr-*`) and asks whether the shape is. The other way round would print a deployment on every healthy release, since `dev-pr-<n>` is a description and never a name — which I checked both ways:

```
  healthy release, dev-pr-* present but none released  ->  0 dumps
  broken match, nothing of the shape present           ->  1 dump
```

## Decisions untouched

All five deletion cases and both guards still pass. This adds diagnosis; it changes nothing about what gets taken down.

**This does not fix the matching** — it is what tells us how to. The next closed pull request will report where the branch name actually lives, and the fix after that should be one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
