### PR TITLE
Ask for ads only when somebody could see them, and stop offering thirteen unread languages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,6 +256,15 @@ is still built and readable, and is kept out of the sitemap, the hreflang sets
 and the switcher. `complete = true` claims only that the frame is translated,
 so shipping a tool does not break the finished languages.
 
+**Thirteen of the fourteen translations are deliberately not offered**, and
+that is not a bug to fix. `unadvertised_languages` in `config/site.toml` names
+them: finished, readable at every address they always had, and kept out of the
+sitemap, the hreflang sets, the switcher and the feeds, with `noindex` on every
+page. The traffic is the reason and the comment on that list has it — 99% of
+arrivals land on an English page. `i18n.offered` is where that decision and
+"not translated yet" meet, so the three lists still cannot disagree. Taking a
+language off the list is one line; nothing else about it has to change.
+
 Lists whose English entries carry an `id` are merged **by id**; lists of plain
 strings are still positional. That distinction is the whole reason
 `locales/*/planned.toml` needs care and `[[hub.categories]]` no longer does.

--- a/build.py
+++ b/build.py
@@ -831,7 +831,14 @@ def frame(locale, locales, site, slug, base, links, lang_v, extra=None):
         'base': base,
         'links': links,
         'canonical': i18n.locale_url(locale, slug, site),
-        'alternates': i18n.alternates(locales, slug, site),
+        # A page in a language the site does not offer belongs to no cluster,
+        # so it claims no alternates either. The set below is reciprocal by
+        # construction - each page in it names the same set back - and this
+        # page is not in it, so pointing at them from here would be exactly the
+        # annotation Google discards: an alternate that is not named back. The
+        # canonical above still stands and still points at this page.
+        'alternates': (i18n.alternates(locales, slug, site)
+                       if i18n.offered(locale) else []),
         'languages': i18n.switcher(locales, locale, slug, site),
         # Root-absolute, and the same URL on every page in every language, so
         # that crossing from one language to another is not also a second copy
@@ -842,8 +849,16 @@ def frame(locale, locales, site, slug, base, links, lang_v, extra=None):
         # unpublished one would point at a file that is not there - the same
         # trap the hreflang set avoids by being built from published() too.
         'feed_href': (f'/{locale["prefix"]}feed.xml'
-                      if locale['is_base'] or locale['complete'] else ''),
+                      if i18n.offered(locale) else ''),
         'feed_title': locale['site']['name'],
+        # A language the site does not offer asks not to be indexed, which is
+        # the half that keeping it out of the sitemap cannot do on its own: a
+        # page already in the index, or linked from outside, stays there until
+        # the page itself says otherwise. `follow` rather than `nofollow`,
+        # because the links out of it go to pages that ARE indexed and there is
+        # nothing to gain by stranding them. The roadmap and the 404 say this
+        # for themselves and in every language, so their templates do not ask.
+        'noindex': not i18n.offered(locale),
     }
     context.update(extra or {})
     return context

--- a/buildlib/i18n.py
+++ b/buildlib/i18n.py
@@ -332,6 +332,7 @@ def base_locale(site):
         'hreflang': site['lang'],
         'dir': 'ltr',
         'complete': True,
+        'advertised': True,
         'is_base': True,
         'prefix': '',
         'fallback': None,
@@ -376,6 +377,12 @@ def load_locale(path, site):
         'hreflang': config.get('hreflang', config['lang']),
         'dir': config.get('dir', 'ltr'),
         'complete': bool(config.get('complete', False)),
+        # Whether the site offers this language at all, which is a decision
+        # about readers rather than a fact about the translation - so it is
+        # named in config/site.toml, where the whole set can be seen and
+        # weighed at once, and not thirteen times over in the folders it
+        # judges. A locale never says of itself that it is not worth showing.
+        'advertised': config['lang'] not in site.get('unadvertised_languages', []),
         'is_base': False,
         'prefix': f'{config["lang"]}/',
         # A name, not the locale itself - locales/*/locale.toml files are
@@ -1002,16 +1009,34 @@ def check_complete(locale):
           'the sitemap, the hreflang tags and the switcher until it is ready.')
 
 
-def translated(locale, slug):
-    """Is this one page finished in this one language?
+def offered(locale):
+    """Is this language one the site holds out to a reader at all?
 
-    English is finished by definition. A locale that has not finished its frame
-    publishes nothing at all, however many of its pages are done, because every
-    one of them would be wearing an English nav.
+    Two ways to answer no, and they are different facts about different things.
+    A locale that has not finished its frame is not ready, and every page in it
+    would be wearing an English nav. A locale named in `unadvertised_languages`
+    is finished and is deliberately not offered, because the traffic said
+    nobody was reading it - see the comment on that list in config/site.toml.
+
+    Both answers arrive here so that the sitemap, the hreflang sets, the
+    switcher and the feeds cannot come to different conclusions, which is the
+    same reason `published` below exists.
+    """
+    return locale['is_base'] or (locale['complete'] and locale['advertised'])
+
+
+def translated(locale, slug):
+    """Is this one page fit to be advertised in this one language?
+
+    English is finished by definition. A language the site does not offer
+    publishes nothing at all, however many of its pages are done - see
+    `offered` above for the two reasons that happens. Past that it is a
+    question about the one page: a language can be finished and still owe this
+    particular body.
     """
     if locale['is_base']:
         return True
-    if not locale['complete']:
+    if not offered(locale):
         return False
     return not locale['debt'].get(slug)
 
@@ -1028,7 +1053,7 @@ def published(locales, slug=None):
     which is what the language switcher on the 404 has to work from. With one,
     it is the narrower set that has also finished that page.
     """
-    ready = [locale for locale in locales if locale['is_base'] or locale['complete']]
+    ready = [locale for locale in locales if offered(locale)]
     if slug is None:
         return ready
     return [locale for locale in ready if translated(locale, slug)]

--- a/config/site.toml
+++ b/config/site.toml
@@ -18,6 +18,32 @@ source_url = "https://github.com/A-Box-of-Tools/website"
 source_label = "github.com/A-Box-of-Tools/website"
 contact_email = "hi@abox.tools"
 
+# Languages built and readable at their own addresses, and advertised nowhere:
+# no sitemap entry, no hreflang, no switcher link, no feed, and `noindex` on
+# every page. A reader who has one of these bookmarked still gets it, and it is
+# still translated; the site simply stops offering it.
+#
+# Not a judgement on the translations, which are finished. It is a judgement on
+# who reads them. Over the 28 days to 6 September 2026 the site was landed on
+# 56,713 times: 99.05% of those arrivals were on an English page and 0.95% on
+# all fourteen translations put together. Only Chinese had a readership worth
+# the name - 395, from China, Hong Kong and Singapore. The best of the rest was
+# Arabic on 35, the worst were Italian, Indonesian and Traditional Chinese on
+# one apiece, and zh-TW's single reader was in Canada while Hong Kong and
+# Taiwan were landing on the Simplified pages anyway.
+#
+# What makes that worth acting on rather than noting: at 102 URLs a locale,
+# these thirteen were 1,326 of the site's 1,530 indexed pages. Google's spam
+# policy names translation among the "automated transformations" that turn into
+# many pages of little value, and a site that is seven-eighths unread
+# translation has that shape whether or not it was built with that intent.
+#
+# Reversible, and meant to be. A language comes off this list the day it has
+# readers, and nothing else about it changes - the pages were never taken away.
+unadvertised_languages = [
+  "ar", "de", "es", "fr", "hi", "id", "it", "ja", "ko", "nl", "pt", "tr", "zh-TW",
+]
+
 # The account the site posts from. It is here rather than in the footer markup
 # because it is the same fact twice: the link a reader follows, and the `sameAs`
 # a search engine reads off the Organization node to decide that the profile and

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -86,6 +86,29 @@ the one to read before starting another. Which locales are actually finished is
 not written here on purpose: every build prints it, and a sentence in a README
 goes stale the first time a tool ships.
 
+## Finished, and still not offered
+
+There is a second way for a language to be absent from those three lists, and
+it is a different fact about a different thing. `unadvertised_languages` in
+`config/site.toml` names languages whose translations are **finished** and
+which the site does not offer anyway, because too few people were reading them
+to justify asking Google to index them. Thirteen of the fourteen are on it; the
+comment beside the list has the traffic that decided it.
+
+A language on that list is built and readable at every address it always had.
+What changes is that it is not claimed: no hreflang, no sitemap entry, no
+switcher link, no feed — and, unlike an unfinished locale, every one of its
+pages carries `<meta name="robots" content="noindex, follow">`. That last part
+is the half that keeping a page out of the sitemap cannot do on its own. A page
+already in the index, or linked to from outside, stays indexed until the page
+itself says otherwise, so the two have to happen together or the change does
+nothing it was made for.
+
+`i18n.offered` is where the two reasons meet, and `i18n.published` is built on
+it, so the three lists still cannot disagree. Taking a language off the list is
+one line and needs nothing else: the pages were never taken away, so they
+simply start being advertised again.
+
 ## The language a first-time visitor gets
 
 Somebody who types `abox.tools` and reads German used to be shown English and

--- a/templates/analytics.js
+++ b/templates/analytics.js
@@ -55,9 +55,32 @@ window.gtag = gtag;
 // production - which is what makes testing them worth anything - so the file
 // cannot be built differently there; it has to notice where it is. A visit
 // to a preview is a developer checking their work, not a visitor.
-if (navigator.webdriver || location.origin + '/' !== '{{ site.domain }}') {
+var notAVisit = navigator.webdriver || location.origin + '/' !== '{{ site.domain }}';
+
+if (notAVisit) {
   window['ga-disable-{{ site.analytics_id }}'] = true;
 }
 
 gtag('js', new Date());
 gtag('config', '{{ site.analytics_id }}');
+
+// AdSense, behind the same test, for a sharper version of the same reason. It
+// used to be a plain async <script> in the head, so every one of those
+// automated loads asked Google for an ad as well: noise while the account is
+// unapproved, and invalid traffic against our own account the moment it is
+// not - thousands of requests a day from a runner that is not a person who
+// could ever see one, which is how an approved account gets disabled.
+//
+// A <script> tag cannot test anything, and the Content-Security-Policy forbids
+// the inline script that would test it for them, so the decision lives here
+// beside the one it has to agree with. Verification does not run through this
+// and is unaffected: that is the inert <meta name="google-adsense-account">
+// tag the hub, the guides and the prose pages carry, and the ads.txt entry -
+// neither of which is script, which is why they work here at all.
+if (!notAVisit) {
+  var ad = document.createElement('script');
+  ad.async = true;
+  ad.crossOrigin = 'anonymous';
+  ad.src = 'https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client={{ site.adsense_client }}';
+  document.head.appendChild(ad);
+}

--- a/templates/guides.html
+++ b/templates/guides.html
@@ -25,6 +25,7 @@
 <meta name="description" content="{{ site.guides.description }}">
 
 <link rel="canonical" href="{{ canonical }}">
+{% include "partials/robots.html" %}
 {% include "partials/alternates.html" %}
 {% include "partials/feed.html" %}
 {% include "partials/lang-script.html" %}

--- a/templates/hub.html
+++ b/templates/hub.html
@@ -28,6 +28,7 @@
 <meta name="description" content="{{ site.hub.description }}">
 
 <link rel="canonical" href="{{ canonical }}">
+{% include "partials/robots.html" %}
 {% include "partials/alternates.html" %}
 {% include "partials/feed.html" %}
 {% include "partials/lang-script.html" %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -33,6 +33,7 @@
 <meta name="description" content="{{ page.description }}">
 
 <link rel="canonical" href="{{ page.url }}">
+{% include "partials/robots.html" %}
 {% include "partials/alternates.html" %}
 {% include "partials/feed.html" %}
 <!--

--- a/templates/partials/head-scripts.html
+++ b/templates/partials/head-scripts.html
@@ -1,10 +1,10 @@
 <!--
-  AdSense. Async so it cannot delay the app; crossorigin="anonymous" is
-  Google's own snippet, unchanged.
--->
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client={{ site.adsense_client }}"
-        crossorigin="anonymous"></script>
+  Google tag (gtag.js). The configuration half lives in analytics.js.
 
-<!-- Google tag (gtag.js). The configuration half lives in analytics.js. -->
+  AdSense is loaded from there as well, rather than by a tag of its own here.
+  Both have to answer the same question first - whether this load is a real
+  visit rather than the QA suite or a preview - and a <script> tag in the head
+  cannot ask it.
+-->
 <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.analytics_id }}"></script>
 <script src="analytics.js" defer></script>

--- a/templates/partials/robots.html
+++ b/templates/partials/robots.html
@@ -1,0 +1,17 @@
+{% if noindex %}<!--
+  This language is built, readable at its own addresses, and advertised
+  nowhere - config/site.toml's `unadvertised_languages` says which languages
+  those are and why. Leaving them out of the sitemap keeps them from being
+  found; this is the half that deals with the pages already in the index, or
+  linked to from somewhere that is not us. Neither half works without the
+  other.
+
+  `follow` rather than `nofollow`: everything this page links to is indexed,
+  and stranding it would cost the pages that ARE read.
+
+  The roadmap and the 404 carry their own robots meta, in every language and
+  for their own reasons, so neither includes this - two of them on one page
+  would be a rule arguing with itself.
+-->
+<meta name="robots" content="noindex, follow">
+{% endif %}

--- a/templates/tool.html
+++ b/templates/tool.html
@@ -41,6 +41,7 @@
 <meta name="description" content="{{ tool.description }}">
 
 <link rel="canonical" href="{{ tool.url }}">
+{% include "partials/robots.html" %}
 {% include "partials/alternates.html" %}
 {% include "partials/feed.html" %}
 <!--

--- a/tests/python/test_build.py
+++ b/tests/python/test_build.py
@@ -1345,6 +1345,39 @@ class BuildTheSite(unittest.TestCase):
             with self.subTest(lang=locale['lang']):
                 self.assertEqual(offered, locale['lang'] in self.advertised)
 
+    # -- the advertising --------------------------------------------------
+    #
+    # AdSense is asked for from analytics.js, in the branch that runs when the
+    # visit is one worth counting, and never by a <script> tag in the markup.
+    # A tag in the head fires on every load there is, and this site's own QA
+    # suite opens every page against production several times a day: an ad
+    # requested by a runner that could never see one is invalid traffic
+    # against this site's own account, which is how an approved account gets
+    # disabled. Putting the tag back is a one-line change that reads as
+    # harmless, and nothing else here would notice it.
+
+    def test_no_page_asks_for_ads_from_its_markup(self):
+        for name in self.written:
+            if not name.endswith('.html'):
+                continue
+            with self.subTest(page=name):
+                page = (self.out / name).read_text(encoding='utf-8')
+                # The bare host is in the Content-Security-Policy on every one
+                # of these pages and belongs there; the path is what only a
+                # request for the script has.
+                self.assertNotIn('pagead2.googlesyndication.com/pagead/js', page)
+
+    def test_the_ad_script_is_asked_for_only_when_the_visit_is_counted(self):
+        """The request and the decision to count it sit in one file on purpose.
+
+        Split across two they would be two statements of one rule to keep in
+        step, and the one that drifted would be the one nobody could see."""
+        script = (self.out / self.a_tool() / 'analytics.js').read_text(encoding='utf-8')
+        self.assertIn('var notAVisit = navigator.webdriver ||', script)
+        self.assertIn('if (!notAVisit) {', script)
+        self.assertLess(script.index('if (!notAVisit) {'),
+                        script.index('pagead2.googlesyndication.com/pagead/js'))
+
     def test_the_404_page_is_written(self):
         self.assertIn('404.html', self.written)
         self.assertTrue((self.out / '404.html').is_file())

--- a/tests/python/test_build.py
+++ b/tests/python/test_build.py
@@ -353,6 +353,12 @@ class BuildTheSite(unittest.TestCase):
         # files rather than written down here, so adding a language - or
         # finishing one - does not also mean remembering to edit a test.
         site = buildmod.sitelib.load_toml(ROOT / 'config' / 'site.toml')
+        cls.site = site
+        # Finished languages the site deliberately does not offer. Read off the
+        # config rather than listed here, for the same reason as `unfinished`
+        # below: taking a language off that list should not also mean
+        # remembering to edit a test.
+        cls.unadvertised = set(site.get('unadvertised_languages', []))
         cls.locales = buildmod.i18n.load_locales(ROOT / 'locales', site)
         cls.unfinished = [locale['lang'] for locale in cls.locales
                           if not locale['is_base'] and not locale['complete']]
@@ -1269,6 +1275,46 @@ class BuildTheSite(unittest.TestCase):
                     text = (self.out / name).read_text(encoding='utf-8')
                     self.assertNotIn(f'hreflang="{locale}"', text)
                     self.assertNotIn(f'href="/{locale}/"', text)
+
+    # -- languages the site does not offer ---------------------------------
+    #
+    # A finished translation nobody reads is still built and still readable at
+    # its own address; what it stops doing is asking to be found. Two halves,
+    # and neither works alone: out of the sitemap so it is not discovered, and
+    # noindex so the pages already in the index - or linked from somewhere that
+    # is not us - come back out of it.
+
+    def test_a_language_the_site_does_not_offer_asks_not_to_be_indexed(self):
+        self.assertTrue(self.unadvertised, 'nothing is held back; test is moot')
+        for name in self.written:
+            if not name.endswith('index.html'):
+                continue
+            if name.split('/')[0] not in self.unadvertised:
+                continue
+            with self.subTest(page=name):
+                page = (self.out / name).read_text(encoding='utf-8')
+                self.assertIn('name="robots" content="noindex', page)
+
+    def test_a_language_the_site_does_not_offer_is_out_of_the_sitemap(self):
+        sitemap = (self.out / 'sitemap.xml').read_text(encoding='utf-8')
+        for lang in sorted(self.unadvertised):
+            with self.subTest(lang=lang):
+                self.assertNotIn(f'{self.site["domain"]}{lang}/', sitemap)
+
+    def test_a_language_the_site_does_offer_is_left_indexable(self):
+        """The other side of it, so a bug that noindexed everything would show.
+
+        English and any language still on the list keep asking to be found, and
+        say nothing about robots at all - the absence of the tag is the claim.
+        """
+        offered = [locale for locale in self.locales
+                   if locale['complete'] and locale['advertised']]
+        pages = ['index.html', f'{self.a_tool()}/index.html']
+        pages += [f'{locale["prefix"]}index.html' for locale in offered]
+        for name in pages:
+            with self.subTest(page=name):
+                page = (self.out / name).read_text(encoding='utf-8')
+                self.assertNotIn('name="robots"', page)
 
     # -- /llms.txt ------------------------------------------------------
     #

--- a/tests/python/test_i18n.py
+++ b/tests/python/test_i18n.py
@@ -36,7 +36,8 @@ SITE = {
 def locale(**over):
     base = {
         'lang': 'de', 'name': 'German', 'endonym': 'Deutsch', 'hreflang': 'de',
-        'dir': 'ltr', 'complete': False, 'is_base': False, 'prefix': 'de/',
+        'dir': 'ltr', 'complete': False, 'advertised': True, 'is_base': False,
+        'prefix': 'de/',
         'fallback': None, 'fallback_locale': None,
         'slugs': {}, 'site': SITE, 'tools': {}, 'pages': {}, 'bodies': {},
         'planned': {}, 'frame': [], 'debt': {},
@@ -519,6 +520,32 @@ class Advertising(unittest.TestCase):
         self.assertNotIn('fr', langs)
         self.assertNotIn('fr', [entry['lang'] for entry in
                                 i18n.switcher(locales, self.english, 'widget', SITE)])
+
+    def test_a_finished_language_the_site_does_not_offer_is_never_advertised(self):
+        """The other way to be absent, and a different fact from being unfinished.
+
+        These pages are translated and readable. They are held back because
+        nobody was arriving on them, and thirteen unread languages were seven
+        eighths of what the site was asking to have indexed - see
+        `unadvertised_languages` in config/site.toml."""
+        quiet = locale(lang='it', hreflang='it', prefix='it/',
+                       complete=True, advertised=False)
+        locales = [self.english, self.german, quiet]
+        self.assertNotIn('it', [entry['hreflang'] for entry in
+                                i18n.alternates(locales, 'widget', SITE)])
+        self.assertNotIn('it', [entry['lang'] for entry in
+                                i18n.switcher(locales, self.english, 'widget', SITE)])
+        self.assertNotIn(quiet, i18n.published(locales))
+        self.assertFalse(i18n.translated(quiet, 'widget'))
+
+    def test_offered_tells_not_ready_apart_from_not_wanted(self):
+        """Both keep a language out of all three lists, and they are not one
+        state: the first is waiting on a translator, and the second is a
+        decision that comes undone by deleting a line."""
+        self.assertTrue(i18n.offered(self.english))
+        self.assertTrue(i18n.offered(self.german))
+        self.assertFalse(i18n.offered(self.draft))
+        self.assertFalse(i18n.offered(locale(complete=True, advertised=False)))
 
     def test_the_switcher_stays_on_the_same_page(self):
         """Not on the front door of the other language.


### PR DESCRIPTION
AdSense has now refused the site twice for 低价值内容, and the identity work from
the first refusal is live and verified — About and Contact with their schema,
the Organization node, the roadmap out of the sitemap, `ads.txt`. So the second
refusal is about something else. Two things came out of looking, and they are
independent enough to be two commits.

## Ask Google for an ad only when somebody could see it

`adsbygoogle.js` was a plain async `<script>` in every page's head, so it fired
on every load there is — and the QA suite opens every page against production
several times a day. Unapproved, those requests are noise nobody had counted;
approved, they are invalid traffic against our own account, which is the
quickest way to lose one.

The decision was already being made a few lines away: `analytics.js` has
switched GA4 off for an automated browser or a non-production origin since
`7bc48aa66`. That condition had no name and nothing else used it. It has one
now, and the ad script is requested in the branch where it is false.

Verification is untouched and never ran through the script — it is the inert
`<meta name="google-adsense-account">` tag and the `ads.txt` entry, neither of
which is script. Googlebot does not set `navigator.webdriver`, so what the
crawler renders is what it always rendered.

## Stop offering the thirteen languages nobody was reading

Over the 28 days to 6 September the site was landed on 56,713 times. **99.05% of
those arrivals were on an English page**; all fourteen translations together
took 0.95%. Only Chinese has a readership worth the name — 395, from China,
Hong Kong and Singapore.

| locale | users | | locale | users |
|---|---:|---|---|---:|
| `zh` | 395 | | `ko` | 11 |
| `ar` | 35 | | `es` | 9 |
| `hi` | 30 | | `fr` | 8 |
| `pt` | 15 | | `ja` | 2 |
| `de` | 15 | | `zh-TW` | **1** |
| `tr` | 15 | | `it` / `id` | 1 each |

At 102 URLs a locale that is 1,326 of the site's 1,530 indexed pages, asking to
be indexed on behalf of readers who are not there. Google's spam policy names
translation among the "automated transformations" that turn into many pages of
little value, and a site that is seven-eighths unread translation has that shape
whether or not it was built with that intent.

`unadvertised_languages` in `config/site.toml` names the thirteen. **Nothing is
deleted and no address moves** — the pages are built and readable exactly where
they were, and a reader who has one bookmarked still gets it, with a switcher
that still offers English and Chinese so they can leave.

`locale.toml` is untouched and those thirteen still say `complete = true`,
because they are. Whether a translation is finished is a fact about the
translation; whether the site offers it is a judgement about readers, and that
wants making once where the whole set can be weighed.

`i18n.offered` is where the two reasons a language goes unadvertised now meet,
and `translated()` and `published()` both defer to it — so the sitemap, hreflang
sets, switcher and feeds still cannot disagree. `shared/lang.js` reads the
hreflang links off the page, so the first-visit redirect stops sending people
there without being told.

Two things this needed beyond the existing machinery:

- **Out of the sitemap is only half.** A page already indexed, or linked from
  outside, stays until the page itself says otherwise — so every page of an
  unoffered language carries `noindex, follow`. The roadmap and the 404 already
  say it for themselves, so no page ends up saying it twice.
- **A page in no cluster should claim no alternates.** The Italian page pointed
  hreflang at the English and Chinese pages, which do not point back: exactly
  the annotation Google discards. Its canonical still stands.

## Before / after

The footer's language row is what a visitor sees change — fifteen languages to
two. "Before" is production, which is the same footer as `dev`.

| Before | After |
|---|---|
| <img width="2560" height="2748" alt="languages-before" src="https://github.com/user-attachments/assets/59cefd01-1bca-4b5b-ad43-5e3bde4cc12f" /> | <img width="2560" height="2748" alt="languages-after" src="https://github.com/user-attachments/assets/5a7719bb-4ae6-4f15-abee-c0e230db8690" /> |

## Verified

- `python build.py --out _plain --clean --no-minify` — exit 0, all fifteen
  languages, links checked, sitemap and feeds written
- an unadvertised locale's page: `noindex, follow`, **0** hreflang links, feed
  link gone, canonical still itself
- an offered locale's page: no robots meta, 3 hreflang links
- no built page names the ad script's path in its markup; the bare host stays in
  the CSP, where the injected script needs it
- both AdSense paths driven in a browser: on a non-production origin nothing is
  requested; on a production-equivalent origin the script is injected and runs,
  which also proves the CSP permits the dynamic insertion

Tests come with each commit. The unadvertised set is read from config rather
than restated, so taking a language off the list does not also mean editing a
test.

## Follow-up, deliberately not here

A page in an *offered* language that still owes its own translation has the same
non-reciprocal hreflang problem: it emits the full set and is not in it. That is
pre-existing, and the fix is `translated(locale, slug)` in place of
`offered(locale)` on one line — but it changes behaviour for pages that are
published today, so it gets its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
