### PR TITLE
Release 1.2.1: ads only where they can be seen, and thirteen languages withdrawn from offer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,6 +102,10 @@ jobs:
   # still cannot happen without it.
   test:
     runs-on: ubuntu-latest
+    # Read by `build` and `preview` below. One decision, three consumers: the
+    # suites, the build, and the preview and QA run that follow it.
+    outputs:
+      site: ${{ steps.covered.outputs.code }}
     steps:
       # What this actually changed, asked of the API rather than worked out
       # from a clone: it is one request, and fetching enough history to diff
@@ -115,9 +119,31 @@ jobs:
       # failure mode is a suite that ran when it need not have, and never a
       # change that shipped untested.
       #
-      # The exempt list is an allowlist, and short on purpose: prose the build
+      # The exempt list is an allowlist, and short on purpose: files the build
       # never reads and no test opens. Anything else - anything new, anything
-      # unrecognised - runs the suites until somebody decides otherwise here.
+      # unrecognised - builds and runs the suites until somebody decides
+      # otherwise here.
+      #
+      # THE STANDARD AN ENTRY HAS TO MEET is that no test OPENS it, which is
+      # not the same as no test mentioning it. Nearly every path on this list
+      # appears in tests/python/test_version.py, as a string in the fixture
+      # asserting the version rule cannot see it; naming a path is not reading
+      # one. Three that look like they belong here do not, and each was checked
+      # rather than assumed:
+      #
+      #   workers/    tests/js/rendezvous.test.js imports worker.js outright
+      #   serve.ps1   tests/python/test_serve.py reads its MIME table
+      #   tests/      the suites are the thing being changed
+      #
+      # `.github/` is OFF the list, and for a different reason from the three
+      # above - it would qualify under the rule, because no test opens a
+      # workflow. A workflow exempt from the run it defines never gets one:
+      # the first thing to exercise a step edited here would be the deploy
+      # that needed it, and the first sign of a mistake a release that did not
+      # happen. GitHub parsing the file is not the same assurance, because a
+      # workflow can load perfectly and still hold a condition that never
+      # fires - which is most of what this file is made of. So a change here
+      # builds and runs both suites like any other.
       - name: Is there anything here a test could see?
         id: covered
         env:
@@ -143,8 +169,9 @@ jobs:
               code=false
               while IFS= read -r path; do
                 case "$path" in
-                  README.md|CLAUDE.md|ROADMAP.md|LICENSE|LICENSE-CONTENT) continue ;;
-                  docs/*|.claude/*) continue ;;
+                  README.md|CLAUDE.md|ROADMAP.md) continue ;;
+                  LICENSE|LICENSE-CONTENT|LICENSE-BRAND) continue ;;
+                  docs/*|.claude/*|media/*|cloudflare/*) continue ;;
                 esac
                 code=true
                 why="\`$path\` is a file a test could see"
@@ -154,9 +181,9 @@ jobs:
           fi
 
           if [ "$code" = true ]; then
-            said="Running both suites, because $why."
+            said="Building and running both suites, because $why."
           else
-            said="Skipping both suites: everything this changed is prose the build never reads and no test opens. The build still runs."
+            said="Nothing here reaches the site: everything this changed is a file the build never reads and no test opens, so the build and both suites are skipped."
           fi
 
           # Twice on purpose. The summary is where somebody looks to find out
@@ -214,9 +241,16 @@ jobs:
     # already publish an unreviewed branch straight to production. Naming the
     # branch is what makes both impossible, and it is why these are conditions
     # on the ref rather than on the event.
+    #
+    # All three rest on the `test` job's answer, so a change that reaches no
+    # page is not built, not published and not previewed. The steps are skipped
+    # and the job is not, for the reason given over that job: a skipped job
+    # skips everything that needs it, and `needs: test` is the only thing
+    # standing between a broken test and the deployed branch.
     env:
-      DEPLOYS: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
-      PREVIEWS: ${{ github.event_name == 'pull_request' || github.ref == 'refs/heads/dev' }}
+      BUILDS: ${{ needs.test.outputs.site }}
+      DEPLOYS: ${{ needs.test.outputs.site == 'true' && github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+      PREVIEWS: ${{ needs.test.outputs.site == 'true' && (github.event_name == 'pull_request' || github.ref == 'refs/heads/dev') }}
     steps:
       # The version is a tag, so the deploy has to be able to see the tags. The
       # default checkout brings none: it fetches the one commit being deployed
@@ -243,13 +277,16 @@ jobs:
       # refuses to name the first version while the remote holds one, so if
       # this fetch ever stops working the step fails instead of agreeing.
       - uses: actions/checkout@v4
+        if: env.BUILDS == 'true'
       - name: Fetch the version tags the checkout leaves behind
+        if: env.BUILDS == 'true'
         run: git fetch --depth=1 origin '+refs/tags/*:refs/tags/*'
 
       # The build uses tomllib, which is standard library from 3.11 onwards.
       # Python alone produces a working, readable site: that is what plain
       # `python build.py` does, and it needs nothing installed.
       - uses: actions/setup-python@v5
+        if: env.BUILDS == 'true'
         with:
           python-version: '3.12'
 
@@ -257,6 +294,7 @@ jobs:
       # installed from npm: the build itself is Python and the standard
       # library, start to finish.
       - uses: actions/setup-node@v4
+        if: env.BUILDS == 'true'
         with:
           node-version: '20'
 
@@ -264,9 +302,11 @@ jobs:
       # against. Cheap, and it means a file that went missing has something to
       # go missing from.
       - name: Build (readable)
+        if: env.BUILDS == 'true'
         run: python build.py --out _plain --clean --no-minify
 
       - name: Build (deployed)
+        if: env.BUILDS == 'true'
         run: python build.py --out _site --clean
 
       # Minifying is the one step here that could break the site quietly, so
@@ -281,6 +321,7 @@ jobs:
       # filename, so a module that vanished is caught even if everything left
       # behind parses.
       - name: Check the minified output
+        if: env.BUILDS == 'true'
         run: |
           set -euo pipefail
           work=$(mktemp -d)
@@ -524,9 +565,13 @@ jobs:
           {
             echo '### Build'
             echo
-            echo '```'
-            find _site -type f | sort | sed 's|^_site/|  |'
-            echo '```'
+            if [ -d _site ]; then
+              echo '```'
+              find _site -type f | sort | sed 's|^_site/|  |'
+              echo '```'
+            else
+              echo 'Not built: nothing this changed reaches a page. See the Tests section above.'
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
 
   # A PREVIEW OF EVERY PULL REQUEST AND OF `dev`, AND THE QA SUITE RUN
@@ -609,8 +654,15 @@ jobs:
   # is GitHub's rule, and the right one: a fork's workflow must not be able to
   # deploy with this repository's credentials.
   preview:
-    needs: build
-    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/dev'
+    needs: [test, build]
+    # There is no artifact to take when the build did not run, and nothing to
+    # look at or test if there were: the site it would have made is the one
+    # already deployed. A pull request that changes only prose therefore gets
+    # no preview and no `qa/preview` check - worth knowing before that check is
+    # ever made a required one.
+    if: >-
+      needs.test.outputs.site == 'true' &&
+      (github.event_name == 'pull_request' || github.ref == 'refs/heads/dev')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/preview-tidy.yml
+++ b/.github/workflows/preview-tidy.yml
@@ -167,6 +167,41 @@ jobs:
           if [ "$count" -eq 0 ]; then
             echo 'Nothing was finished with.'
             echo 'Nothing was finished with.' >> "$GITHUB_STEP_SUMMARY"
+
+            # WHY NOTHING MATCHED, said out loud.
+            #
+            # "Nothing was finished with" is the ordinary answer on most runs
+            # and is also what a broken match looks like, which is the whole
+            # difficulty with this workflow - the first version listed the
+            # deployments perfectly and took down nothing, and it took a curl
+            # against a preview that should have been gone to notice. So when
+            # there was something to look for and none of it matched, this
+            # says which names it did see, and shows one deployment whole. A
+            # single run then answers the question instead of a guess at an
+            # endpoint that has already been guessed at once.
+            # A run looking for one exact name asks whether that name is
+            # there; a release looking for a shape asks whether the shape is.
+            # Getting this the other way round would dump a deployment on
+            # every healthy release, because `dev-pr-<n>` is a description and
+            # never a name.
+            case "$EVENT" in
+              pull_request)
+                looked="pr-$PR"
+                seen=$(cut -f2 all.tsv | grep -cxF "$looked" || true) ;;
+              *)
+                looked='dev-pr-<n>'
+                seen=$(cut -f2 all.tsv | grep -c '^dev-pr-' || true) ;;
+            esac
+            {
+              echo
+              echo "Looked for: $looked"
+              echo 'Branches the project actually reports:'
+              cut -f2 all.tsv | sort | uniq -c | sort -rn | head -40
+            } >&2
+            if [ "$seen" -eq 0 ]; then
+              echo 'Nothing of that shape is there at all, which is a match that has stopped working rather than a quiet week. One deployment in full, to show where the name lives:' >&2
+              curl -sS -H "$auth" "$api?page=1" | jq '.result[0]' >&2
+            fi
             exit 0
           fi
 

--- a/.github/workflows/preview-tidy.yml
+++ b/.github/workflows/preview-tidy.yml
@@ -14,12 +14,28 @@
 #                because from then on the thing to compare against is
 #                production itself.
 #
+# There is a third, and it is the same upload as the second wearing the branch
+# `dev`: the stable dev.<project>.pages.dev that a release is read at. Only the
+# newest of those is that address. Every earlier one is reachable by its own
+# hash and by nothing else, and holds bytes that `dev-pr-<n>` is already
+# keeping, so it is finished with on exactly the terms that one is.
+#
 # So a closed pull request takes its own preview down, and a push to `main`
-# takes down every `dev-pr-<n>` whose merge has arrived there. NOT all of them:
-# `dev` carries on while a release is in flight, and a merge that is on `dev`
-# but not yet in `main` is exactly the case those addresses exist for. Each is
-# asked about by commit rather than assumed, which is the reason the upload
-# passes `--commit-hash` in the first place.
+# takes down every `dev-pr-<n>` whose merge has arrived there, and every
+# superseded `dev` beside it. NOT all of them: `dev` carries on while a release
+# is in flight, and a merge that is on `dev` but not yet in `main` is exactly
+# the case those addresses exist for. Each is asked about by commit rather than
+# assumed, which is the reason the upload passes `--commit-hash` in the first
+# place.
+#
+# RUN BY HAND, it does all of that and one thing more: it takes down every
+# `pr-<n>` whose pull request has closed, however long ago that was. Those two
+# events only ever see what is in front of them - a pull request closing knows
+# one number, and a release knows the merges below it - so a preview uploaded
+# before this workflow existed, or while it was broken, is invisible to both
+# for ever. A dispatch is how that backlog is swept, and asking GitHub the
+# state of every pull request it finds a preview for is worth doing on demand
+# and not on every release.
 #
 # Nothing here gates anything. It runs after the fact, on addresses nobody is
 # reading, so it reports rather than fails: a tidy that goes wrong must not put
@@ -84,7 +100,8 @@ jobs:
           api="https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$PROJECT/deployments"
           auth="Authorization: Bearer $CLOUDFLARE_API_TOKEN"
 
-          # Every deployment the project holds, as `id<TAB>branch<TAB>commit`.
+          # Every deployment the project holds, as
+          # `id<TAB>branch<TAB>commit<TAB>created`.
           # Paged, because a busy month is more than one page of them and the
           # oldest are the ones most likely to be finished with.
           #
@@ -114,7 +131,8 @@ jobs:
             printf '%s' "$body" | jq -r '.result[] | [
                 .id,
                 (.deployment_trigger.metadata.branch // "?"),
-                (.deployment_trigger.metadata.commit_hash // "?")
+                (.deployment_trigger.metadata.commit_hash // "?"),
+                (.created_on // "")
               ] | @tsv' >> all.tsv
             page=$((page + 1))
           done
@@ -131,31 +149,87 @@ jobs:
             exit 1
           fi
 
+          # Has the merge this one holds reached `main`? `behind` and
+          # `identical` are the two answers meaning "already there"; `ahead`
+          # and `diverged` mean `dev` has moved on without a release, which is
+          # the state these addresses are for. Not being able to ask is its own
+          # answer and is not one of those two: it leaves the deployment alone
+          # and says which one and why, because a tidy that deletes on a
+          # question it could not get an answer to is worse than one that waits
+          # for the next run.
+          arrived_in_main() {
+            local branch=$1 commit=$2 where
+            if [ "$commit" = '?' ]; then
+              echo "  $branch: no commit recorded; left alone."
+              return 1
+            fi
+            where=$(gh api "repos/$REPO/compare/main...$commit" --jq '.status' 2>/dev/null) || where=''
+            case "$where" in
+              behind|identical) return 0 ;;
+              '') echo "  $branch: could not ask about ${commit:0:7}; left alone." ;;
+              *)  echo "  $branch: ${commit:0:7} is not in main yet ($where); left alone." ;;
+            esac
+            return 1
+          }
+
+          # The one `dev` deployment that IS dev.<project>.pages.dev, and so
+          # the one address a release is being read at while this runs. Chosen
+          # by date rather than by the position it came back in: the API hands
+          # them back newest first today, and a tidy that took the live one
+          # down the day that changed would be the single worst thing this
+          # workflow could do. `created_on` is ISO-8601 in UTC, so the newest
+          # is the largest as text.
+          keep_dev=$(awk -F'\t' 'BEGIN { newest = "" }
+            $2 == "dev" && $4 > newest { newest = $4; keep = $1 }
+            END { print keep }' all.tsv)
+
+          # And if that question came back empty while `dev` deployments exist,
+          # the live one cannot be told from the copies - so none of them is
+          # touched. Deleting the address a release is being read at, to save a
+          # few megabytes, is not a trade this workflow is allowed to make.
+          if [ -z "$keep_dev" ] && cut -f2 all.tsv | grep -qx dev; then
+            echo '::warning::No dev deployment came back with a date, so the stable address cannot be told from the superseded copies. Leaving every dev deployment alone.'
+          fi
+
           # WHICH ARE FINISHED WITH
           : > doomed.tsv
-          while IFS="$(printf '\t')" read -r id branch commit; do
+          while IFS="$(printf '\t')" read -r id branch commit created; do
             case "$EVENT:$branch" in
               "pull_request:pr-$PR")
                 printf '%s\t%s\n' "$id" "$branch" >> doomed.tsv
                 ;;
-              push:dev-pr-*|workflow_dispatch:dev-pr-*)
-                # Only once the merge it holds has reached `main`. `behind` and
-                # `identical` are the two answers meaning "already there";
-                # `ahead` and `diverged` mean `dev` has moved on without a
-                # release, which is the state these addresses are for.
-                if [ "$commit" = '?' ]; then
-                  echo "  $branch: no commit recorded; left alone."
-                  continue
-                fi
-                where=$(gh api "repos/$REPO/compare/main...$commit" --jq '.status' 2>/dev/null) || where=''
-                case "$where" in
-                  behind|identical)
+              workflow_dispatch:pr-*)
+                # The backlog sweep, and the only place any pull request but
+                # the one that just closed is asked about. `state` is `closed`
+                # for a merged pull request as well as an abandoned one, which
+                # is the whole point: neither has anything left to review.
+                n=${branch#pr-}
+                state=$(gh api "repos/$REPO/pulls/$n" --jq '.state' 2>/dev/null) || state=''
+                case "$state" in
+                  closed)
                     printf '%s\t%s\n' "$id" "$branch" >> doomed.tsv ;;
-                  '')
-                    echo "  $branch: could not ask about ${commit:0:7}; left alone." ;;
+                  open)
+                    echo "  $branch: still open; left alone." ;;
                   *)
-                    echo "  $branch: ${commit:0:7} is not in main yet ($where); left alone." ;;
+                    echo "  $branch: could not ask what became of #$n; left alone." ;;
                 esac
+                ;;
+              push:dev-pr-*|workflow_dispatch:dev-pr-*)
+                if arrived_in_main "$branch" "$commit"; then
+                  printf '%s\t%s\n' "$id" "$branch" >> doomed.tsv
+                fi
+                ;;
+              push:dev|workflow_dispatch:dev)
+                # Superseded copies only, on the same terms as the `dev-pr-<n>`
+                # holding the same commit. The newest is the stable address and
+                # is never touched.
+                if [ -z "$keep_dev" ]; then
+                  : # Said once above, for all of them rather than each.
+                elif [ "$id" = "$keep_dev" ]; then
+                  echo "  dev: the stable address; left alone."
+                elif arrived_in_main "dev (${created:0:10})" "$commit"; then
+                  printf '%s\t%s\n' "$id" "$branch" >> doomed.tsv
+                fi
                 ;;
             esac
           done < all.tsv

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,6 +256,15 @@ is still built and readable, and is kept out of the sitemap, the hreflang sets
 and the switcher. `complete = true` claims only that the frame is translated,
 so shipping a tool does not break the finished languages.
 
+**Thirteen of the fourteen translations are deliberately not offered**, and
+that is not a bug to fix. `unadvertised_languages` in `config/site.toml` names
+them: finished, readable at every address they always had, and kept out of the
+sitemap, the hreflang sets, the switcher and the feeds, with `noindex` on every
+page. The traffic is the reason and the comment on that list has it — 99% of
+arrivals land on an English page. `i18n.offered` is where that decision and
+"not translated yet" meet, so the three lists still cannot disagree. Taking a
+language off the list is one line; nothing else about it has to change.
+
 Lists whose English entries carry an `id` are merged **by id**; lists of plain
 strings are still positional. That distinction is the whole reason
 `locales/*/planned.toml` needs care and `[[hub.categories]]` no longer does.

--- a/build.py
+++ b/build.py
@@ -477,11 +477,15 @@ def build(out, clean=False, minify_output=True, jobs=None, only=None,
     # look identical in a directory listing, and the difference is the only
     # thing anybody wants to know about it.
     #
-    # Two different states are worth two different sentences. A locale that has
-    # not finished its frame is not published at all. A locale that has is
+    # Three different states are worth three different sentences. A locale that
+    # has not finished its frame is not published at all. A locale that has is
     # published, and owes a number of PAGES - which is the unit that decides
     # anything now, since a page with one string left is as held back as a page
-    # with four hundred.
+    # with four hundred. And a locale on `unadvertised_languages` is finished
+    # and is not offered anyway, which was reported as "published" until this
+    # said otherwise - a build that calls a language published while keeping it
+    # out of the sitemap is the one reader of this output nobody can correct.
+    unoffered = []
     for locale in targets:
         if locale['is_base']:
             continue
@@ -493,6 +497,14 @@ def build(out, clean=False, minify_output=True, jobs=None, only=None,
             left = len(set(i18n.all_debt(locale)))
             print(f'  {locale["lang"]}: {left} strings still in English '
                   f'(not advertised until complete = true)')
+            continue
+        if not locale['advertised']:
+            # Named together below rather than a line each. That they are held
+            # back is one fact about thirteen languages, not thirteen facts,
+            # and thirteen lines of it would bury the ones still being worked
+            # on. What each of them owes page by page stops mattering while
+            # nothing is offering them.
+            unoffered.append(locale['lang'])
             continue
         behind = i18n.debt_report(locale, tools, prose)
         if behind:
@@ -507,6 +519,12 @@ def build(out, clean=False, minify_output=True, jobs=None, only=None,
                   f'(built and readable, kept out of the sitemap): '
                   + ', '.join(sorted(behind)[:4])
                   + (' ...' if len(behind) > 4 else ''))
+
+    if unoffered:
+        print(f'  not offered: {", ".join(unoffered)} - translated, built and '
+              f'readable at their own addresses, and kept out of the sitemap, '
+              f'the hreflang sets and the switcher '
+              f'(unadvertised_languages in config/site.toml)')
 
     # One 404 for the whole domain, in English, because GitHub Pages serves one
     # file for every address it cannot find and has no way to know which

--- a/build.py
+++ b/build.py
@@ -831,7 +831,14 @@ def frame(locale, locales, site, slug, base, links, lang_v, extra=None):
         'base': base,
         'links': links,
         'canonical': i18n.locale_url(locale, slug, site),
-        'alternates': i18n.alternates(locales, slug, site),
+        # A page in a language the site does not offer belongs to no cluster,
+        # so it claims no alternates either. The set below is reciprocal by
+        # construction - each page in it names the same set back - and this
+        # page is not in it, so pointing at them from here would be exactly the
+        # annotation Google discards: an alternate that is not named back. The
+        # canonical above still stands and still points at this page.
+        'alternates': (i18n.alternates(locales, slug, site)
+                       if i18n.offered(locale) else []),
         'languages': i18n.switcher(locales, locale, slug, site),
         # Root-absolute, and the same URL on every page in every language, so
         # that crossing from one language to another is not also a second copy
@@ -842,8 +849,16 @@ def frame(locale, locales, site, slug, base, links, lang_v, extra=None):
         # unpublished one would point at a file that is not there - the same
         # trap the hreflang set avoids by being built from published() too.
         'feed_href': (f'/{locale["prefix"]}feed.xml'
-                      if locale['is_base'] or locale['complete'] else ''),
+                      if i18n.offered(locale) else ''),
         'feed_title': locale['site']['name'],
+        # A language the site does not offer asks not to be indexed, which is
+        # the half that keeping it out of the sitemap cannot do on its own: a
+        # page already in the index, or linked from outside, stays there until
+        # the page itself says otherwise. `follow` rather than `nofollow`,
+        # because the links out of it go to pages that ARE indexed and there is
+        # nothing to gain by stranding them. The roadmap and the 404 say this
+        # for themselves and in every language, so their templates do not ask.
+        'noindex': not i18n.offered(locale),
     }
     context.update(extra or {})
     return context

--- a/buildlib/i18n.py
+++ b/buildlib/i18n.py
@@ -332,6 +332,7 @@ def base_locale(site):
         'hreflang': site['lang'],
         'dir': 'ltr',
         'complete': True,
+        'advertised': True,
         'is_base': True,
         'prefix': '',
         'fallback': None,
@@ -376,6 +377,12 @@ def load_locale(path, site):
         'hreflang': config.get('hreflang', config['lang']),
         'dir': config.get('dir', 'ltr'),
         'complete': bool(config.get('complete', False)),
+        # Whether the site offers this language at all, which is a decision
+        # about readers rather than a fact about the translation - so it is
+        # named in config/site.toml, where the whole set can be seen and
+        # weighed at once, and not thirteen times over in the folders it
+        # judges. A locale never says of itself that it is not worth showing.
+        'advertised': config['lang'] not in site.get('unadvertised_languages', []),
         'is_base': False,
         'prefix': f'{config["lang"]}/',
         # A name, not the locale itself - locales/*/locale.toml files are
@@ -1002,16 +1009,34 @@ def check_complete(locale):
           'the sitemap, the hreflang tags and the switcher until it is ready.')
 
 
-def translated(locale, slug):
-    """Is this one page finished in this one language?
+def offered(locale):
+    """Is this language one the site holds out to a reader at all?
 
-    English is finished by definition. A locale that has not finished its frame
-    publishes nothing at all, however many of its pages are done, because every
-    one of them would be wearing an English nav.
+    Two ways to answer no, and they are different facts about different things.
+    A locale that has not finished its frame is not ready, and every page in it
+    would be wearing an English nav. A locale named in `unadvertised_languages`
+    is finished and is deliberately not offered, because the traffic said
+    nobody was reading it - see the comment on that list in config/site.toml.
+
+    Both answers arrive here so that the sitemap, the hreflang sets, the
+    switcher and the feeds cannot come to different conclusions, which is the
+    same reason `published` below exists.
+    """
+    return locale['is_base'] or (locale['complete'] and locale['advertised'])
+
+
+def translated(locale, slug):
+    """Is this one page fit to be advertised in this one language?
+
+    English is finished by definition. A language the site does not offer
+    publishes nothing at all, however many of its pages are done - see
+    `offered` above for the two reasons that happens. Past that it is a
+    question about the one page: a language can be finished and still owe this
+    particular body.
     """
     if locale['is_base']:
         return True
-    if not locale['complete']:
+    if not offered(locale):
         return False
     return not locale['debt'].get(slug)
 
@@ -1028,7 +1053,7 @@ def published(locales, slug=None):
     which is what the language switcher on the 404 has to work from. With one,
     it is the narrower set that has also finished that page.
     """
-    ready = [locale for locale in locales if locale['is_base'] or locale['complete']]
+    ready = [locale for locale in locales if offered(locale)]
     if slug is None:
         return ready
     return [locale for locale in ready if translated(locale, slug)]

--- a/config/site.toml
+++ b/config/site.toml
@@ -18,6 +18,32 @@ source_url = "https://github.com/A-Box-of-Tools/website"
 source_label = "github.com/A-Box-of-Tools/website"
 contact_email = "hi@abox.tools"
 
+# Languages built and readable at their own addresses, and advertised nowhere:
+# no sitemap entry, no hreflang, no switcher link, no feed, and `noindex` on
+# every page. A reader who has one of these bookmarked still gets it, and it is
+# still translated; the site simply stops offering it.
+#
+# Not a judgement on the translations, which are finished. It is a judgement on
+# who reads them. Over the 28 days to 6 September 2026 the site was landed on
+# 56,713 times: 99.05% of those arrivals were on an English page and 0.95% on
+# all fourteen translations put together. Only Chinese had a readership worth
+# the name - 395, from China, Hong Kong and Singapore. The best of the rest was
+# Arabic on 35, the worst were Italian, Indonesian and Traditional Chinese on
+# one apiece, and zh-TW's single reader was in Canada while Hong Kong and
+# Taiwan were landing on the Simplified pages anyway.
+#
+# What makes that worth acting on rather than noting: at 102 URLs a locale,
+# these thirteen were 1,326 of the site's 1,530 indexed pages. Google's spam
+# policy names translation among the "automated transformations" that turn into
+# many pages of little value, and a site that is seven-eighths unread
+# translation has that shape whether or not it was built with that intent.
+#
+# Reversible, and meant to be. A language comes off this list the day it has
+# readers, and nothing else about it changes - the pages were never taken away.
+unadvertised_languages = [
+  "ar", "de", "es", "fr", "hi", "id", "it", "ja", "ko", "nl", "pt", "tr", "zh-TW",
+]
+
 # The account the site posts from. It is here rather than in the footer markup
 # because it is the same fact twice: the link a reader follows, and the `sameAs`
 # a search engine reads off the Organization node to decide that the profile and

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -90,7 +90,28 @@ until the second merged. The `dev` → `main` pull request is not excused it, so
 nothing ships untested, and the QA repository opens an issue for a missing spec
 daily regardless.
 
-The build and the unit tests are **not** scoped. They are nine minutes on one
+**A change that reaches no page is not built at all.** If everything a pull
+request touches is on a short allowlist — `docs/`, `.claude/`, `media/`,
+`cloudflare/`, and the root markdown files — then the build, both
+unit suites, the preview and the QA run are all skipped, because the site it
+would produce is the one already deployed. Anything else, anything new,
+anything unrecognised, builds and runs everything.
+
+The standard for being on that list is that **no test opens the file**, which
+is not the same as no test mentioning it. Three that look like they belong
+are deliberately absent, each checked rather than assumed: `workers/`, which
+`tests/js/rendezvous.test.js` imports outright; `serve.ps1`, which
+`tests/python/test_serve.py` reads; and `tests/` itself.
+
+`.github/` is deliberately **not** on the list, though it would qualify under
+that rule — no test opens a workflow. A workflow exempt from the run it defines
+never gets one: the first thing to exercise an edited step would be the deploy
+that needed it, and the first sign of a mistake a release that did not happen.
+GitHub parsing the file is not the same assurance, since a workflow can load
+perfectly and still hold a condition that never fires. So a change to CI builds
+and runs both suites like any other.
+
+The build and the unit tests are **not** scoped by tool. They are nine minutes on one
 runner between them, and they are what catches a change that breaks every page
 — which a build of one tool, by construction, cannot see.
 

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -86,6 +86,29 @@ the one to read before starting another. Which locales are actually finished is
 not written here on purpose: every build prints it, and a sentence in a README
 goes stale the first time a tool ships.
 
+## Finished, and still not offered
+
+There is a second way for a language to be absent from those three lists, and
+it is a different fact about a different thing. `unadvertised_languages` in
+`config/site.toml` names languages whose translations are **finished** and
+which the site does not offer anyway, because too few people were reading them
+to justify asking Google to index them. Thirteen of the fourteen are on it; the
+comment beside the list has the traffic that decided it.
+
+A language on that list is built and readable at every address it always had.
+What changes is that it is not claimed: no hreflang, no sitemap entry, no
+switcher link, no feed — and, unlike an unfinished locale, every one of its
+pages carries `<meta name="robots" content="noindex, follow">`. That last part
+is the half that keeping a page out of the sitemap cannot do on its own. A page
+already in the index, or linked to from outside, stays indexed until the page
+itself says otherwise, so the two have to happen together or the change does
+nothing it was made for.
+
+`i18n.offered` is where the two reasons meet, and `i18n.published` is built on
+it, so the three lists still cannot disagree. Taking a language off the list is
+one line and needs nothing else: the pages were never taken away, so they
+simply start being advertised again.
+
 ## The language a first-time visitor gets
 
 Somebody who types `abox.tools` and reads German used to be shown English and

--- a/templates/analytics.js
+++ b/templates/analytics.js
@@ -55,9 +55,32 @@ window.gtag = gtag;
 // production - which is what makes testing them worth anything - so the file
 // cannot be built differently there; it has to notice where it is. A visit
 // to a preview is a developer checking their work, not a visitor.
-if (navigator.webdriver || location.origin + '/' !== '{{ site.domain }}') {
+var notAVisit = navigator.webdriver || location.origin + '/' !== '{{ site.domain }}';
+
+if (notAVisit) {
   window['ga-disable-{{ site.analytics_id }}'] = true;
 }
 
 gtag('js', new Date());
 gtag('config', '{{ site.analytics_id }}');
+
+// AdSense, behind the same test, for a sharper version of the same reason. It
+// used to be a plain async <script> in the head, so every one of those
+// automated loads asked Google for an ad as well: noise while the account is
+// unapproved, and invalid traffic against our own account the moment it is
+// not - thousands of requests a day from a runner that is not a person who
+// could ever see one, which is how an approved account gets disabled.
+//
+// A <script> tag cannot test anything, and the Content-Security-Policy forbids
+// the inline script that would test it for them, so the decision lives here
+// beside the one it has to agree with. Verification does not run through this
+// and is unaffected: that is the inert <meta name="google-adsense-account">
+// tag the hub, the guides and the prose pages carry, and the ads.txt entry -
+// neither of which is script, which is why they work here at all.
+if (!notAVisit) {
+  var ad = document.createElement('script');
+  ad.async = true;
+  ad.crossOrigin = 'anonymous';
+  ad.src = 'https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client={{ site.adsense_client }}';
+  document.head.appendChild(ad);
+}

--- a/templates/guides.html
+++ b/templates/guides.html
@@ -25,6 +25,7 @@
 <meta name="description" content="{{ site.guides.description }}">
 
 <link rel="canonical" href="{{ canonical }}">
+{% include "partials/robots.html" %}
 {% include "partials/alternates.html" %}
 {% include "partials/feed.html" %}
 {% include "partials/lang-script.html" %}

--- a/templates/hub.html
+++ b/templates/hub.html
@@ -28,6 +28,7 @@
 <meta name="description" content="{{ site.hub.description }}">
 
 <link rel="canonical" href="{{ canonical }}">
+{% include "partials/robots.html" %}
 {% include "partials/alternates.html" %}
 {% include "partials/feed.html" %}
 {% include "partials/lang-script.html" %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -33,6 +33,7 @@
 <meta name="description" content="{{ page.description }}">
 
 <link rel="canonical" href="{{ page.url }}">
+{% include "partials/robots.html" %}
 {% include "partials/alternates.html" %}
 {% include "partials/feed.html" %}
 <!--

--- a/templates/partials/head-scripts.html
+++ b/templates/partials/head-scripts.html
@@ -1,10 +1,10 @@
 <!--
-  AdSense. Async so it cannot delay the app; crossorigin="anonymous" is
-  Google's own snippet, unchanged.
--->
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client={{ site.adsense_client }}"
-        crossorigin="anonymous"></script>
+  Google tag (gtag.js). The configuration half lives in analytics.js.
 
-<!-- Google tag (gtag.js). The configuration half lives in analytics.js. -->
+  AdSense is loaded from there as well, rather than by a tag of its own here.
+  Both have to answer the same question first - whether this load is a real
+  visit rather than the QA suite or a preview - and a <script> tag in the head
+  cannot ask it.
+-->
 <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.analytics_id }}"></script>
 <script src="analytics.js" defer></script>

--- a/templates/partials/robots.html
+++ b/templates/partials/robots.html
@@ -1,0 +1,17 @@
+{% if noindex %}<!--
+  This language is built, readable at its own addresses, and advertised
+  nowhere - config/site.toml's `unadvertised_languages` says which languages
+  those are and why. Leaving them out of the sitemap keeps them from being
+  found; this is the half that deals with the pages already in the index, or
+  linked to from somewhere that is not us. Neither half works without the
+  other.
+
+  `follow` rather than `nofollow`: everything this page links to is indexed,
+  and stranding it would cost the pages that ARE read.
+
+  The roadmap and the 404 carry their own robots meta, in every language and
+  for their own reasons, so neither includes this - two of them on one page
+  would be a rule arguing with itself.
+-->
+<meta name="robots" content="noindex, follow">
+{% endif %}

--- a/templates/tool.html
+++ b/templates/tool.html
@@ -41,6 +41,7 @@
 <meta name="description" content="{{ tool.description }}">
 
 <link rel="canonical" href="{{ tool.url }}">
+{% include "partials/robots.html" %}
 {% include "partials/alternates.html" %}
 {% include "partials/feed.html" %}
 <!--

--- a/tests/python/test_build.py
+++ b/tests/python/test_build.py
@@ -353,6 +353,12 @@ class BuildTheSite(unittest.TestCase):
         # files rather than written down here, so adding a language - or
         # finishing one - does not also mean remembering to edit a test.
         site = buildmod.sitelib.load_toml(ROOT / 'config' / 'site.toml')
+        cls.site = site
+        # Finished languages the site deliberately does not offer. Read off the
+        # config rather than listed here, for the same reason as `unfinished`
+        # below: taking a language off that list should not also mean
+        # remembering to edit a test.
+        cls.unadvertised = set(site.get('unadvertised_languages', []))
         cls.locales = buildmod.i18n.load_locales(ROOT / 'locales', site)
         cls.unfinished = [locale['lang'] for locale in cls.locales
                           if not locale['is_base'] and not locale['complete']]
@@ -1270,6 +1276,46 @@ class BuildTheSite(unittest.TestCase):
                     self.assertNotIn(f'hreflang="{locale}"', text)
                     self.assertNotIn(f'href="/{locale}/"', text)
 
+    # -- languages the site does not offer ---------------------------------
+    #
+    # A finished translation nobody reads is still built and still readable at
+    # its own address; what it stops doing is asking to be found. Two halves,
+    # and neither works alone: out of the sitemap so it is not discovered, and
+    # noindex so the pages already in the index - or linked from somewhere that
+    # is not us - come back out of it.
+
+    def test_a_language_the_site_does_not_offer_asks_not_to_be_indexed(self):
+        self.assertTrue(self.unadvertised, 'nothing is held back; test is moot')
+        for name in self.written:
+            if not name.endswith('index.html'):
+                continue
+            if name.split('/')[0] not in self.unadvertised:
+                continue
+            with self.subTest(page=name):
+                page = (self.out / name).read_text(encoding='utf-8')
+                self.assertIn('name="robots" content="noindex', page)
+
+    def test_a_language_the_site_does_not_offer_is_out_of_the_sitemap(self):
+        sitemap = (self.out / 'sitemap.xml').read_text(encoding='utf-8')
+        for lang in sorted(self.unadvertised):
+            with self.subTest(lang=lang):
+                self.assertNotIn(f'{self.site["domain"]}{lang}/', sitemap)
+
+    def test_a_language_the_site_does_offer_is_left_indexable(self):
+        """The other side of it, so a bug that noindexed everything would show.
+
+        English and any language still on the list keep asking to be found, and
+        say nothing about robots at all - the absence of the tag is the claim.
+        """
+        offered = [locale for locale in self.locales
+                   if locale['complete'] and locale['advertised']]
+        pages = ['index.html', f'{self.a_tool()}/index.html']
+        pages += [f'{locale["prefix"]}index.html' for locale in offered]
+        for name in pages:
+            with self.subTest(page=name):
+                page = (self.out / name).read_text(encoding='utf-8')
+                self.assertNotIn('name="robots"', page)
+
     # -- /llms.txt ------------------------------------------------------
     #
     # The plain-text index, for a reader that fetches one address and decides
@@ -1344,6 +1390,39 @@ class BuildTheSite(unittest.TestCase):
             offered = locale['lang'] in listed
             with self.subTest(lang=locale['lang']):
                 self.assertEqual(offered, locale['lang'] in self.advertised)
+
+    # -- the advertising --------------------------------------------------
+    #
+    # AdSense is asked for from analytics.js, in the branch that runs when the
+    # visit is one worth counting, and never by a <script> tag in the markup.
+    # A tag in the head fires on every load there is, and this site's own QA
+    # suite opens every page against production several times a day: an ad
+    # requested by a runner that could never see one is invalid traffic
+    # against this site's own account, which is how an approved account gets
+    # disabled. Putting the tag back is a one-line change that reads as
+    # harmless, and nothing else here would notice it.
+
+    def test_no_page_asks_for_ads_from_its_markup(self):
+        for name in self.written:
+            if not name.endswith('.html'):
+                continue
+            with self.subTest(page=name):
+                page = (self.out / name).read_text(encoding='utf-8')
+                # The bare host is in the Content-Security-Policy on every one
+                # of these pages and belongs there; the path is what only a
+                # request for the script has.
+                self.assertNotIn('pagead2.googlesyndication.com/pagead/js', page)
+
+    def test_the_ad_script_is_asked_for_only_when_the_visit_is_counted(self):
+        """The request and the decision to count it sit in one file on purpose.
+
+        Split across two they would be two statements of one rule to keep in
+        step, and the one that drifted would be the one nobody could see."""
+        script = (self.out / self.a_tool() / 'analytics.js').read_text(encoding='utf-8')
+        self.assertIn('var notAVisit = navigator.webdriver ||', script)
+        self.assertIn('if (!notAVisit) {', script)
+        self.assertLess(script.index('if (!notAVisit) {'),
+                        script.index('pagead2.googlesyndication.com/pagead/js'))
 
     def test_the_404_page_is_written(self):
         self.assertIn('404.html', self.written)

--- a/tests/python/test_build.py
+++ b/tests/python/test_build.py
@@ -1089,6 +1089,15 @@ class BuildTheSite(unittest.TestCase):
         above covers the other half - a page that DOES name alternates - and
         skips exactly the pages this one looks at.
         """
+        # By `hreflang` and not by `lang`: the switcher renders the hreflang
+        # into both attributes, and the two differ wherever a language is
+        # written in more than one script - `zh` is served as `zh-Hans`. Every
+        # entry German ever had made the two look interchangeable.
+        offered_langs = {
+            locale['hreflang'] for locale in buildmod.i18n.published(self.locales)
+        }
+        base_lang = next(
+            locale['hreflang'] for locale in self.locales if locale['is_base'])
         for name in self.written:
             if not name.endswith('.html') or name == '404.html':
                 continue
@@ -1098,21 +1107,47 @@ class BuildTheSite(unittest.TestCase):
             switch = text.split('class="lang-switch"', 1)[1].split('</nav>', 1)[0]
             with self.subTest(page=name):
                 self.assertIn('<details class="lang-pick">', text)
-                self.assertEqual(switch.count('<li>'), 1)
-                # And that one entry is English, whatever language the frame
-                # around it is in. `lang` rather than `hreflang`, because the
-                # entry for the language you are already in is a span with no
-                # href to describe.
-                self.assertIn('lang="en"', switch)
+                # Every entry is a language the site offers, and English is
+                # always one of them. This used to assert a single entry, which
+                # was the same statement while the only page naming no
+                # alternates was an English one nobody had translated. It is
+                # not any more: a page in a language the site has stopped
+                # offering names no alternate either - it is in no cluster, so
+                # claiming one would point at pages that do not point back -
+                # and it still carries a switcher, because a reader who cannot
+                # read the page needs the way out more than anybody. What must
+                # never happen is the switcher naming a language the site does
+                # not offer, and that is what is asserted instead of a count.
+                #
+                # `lang` rather than `hreflang`: the entry for the language you
+                # are already in is a span with no href to describe.
+                listed = set(re.findall(r'\blang="([^"]+)"', switch))
+                self.assertIn(base_lang, listed)
+                self.assertLessEqual(listed, offered_langs)
                 for absent in ('lang-partial', 'data-lang'):
                     self.assertNotIn(absent, switch)
 
     def test_the_switcher_links_this_page_and_not_the_front_door(self):
-        """Somebody reading about compressing an image who asks for German
-        wants that page in German. The German hub is reached from the English
-        hub; the German privacy page is reached from the English one."""
+        """Somebody reading about compressing an image who asks for another
+        language wants that page in it. The German hub is reached from the
+        English hub; the German privacy page is reached from the English one.
+
+        Asked of whichever languages the site actually offers rather than of
+        German, which it named until German stopped being offered - a test that
+        names one language is a test that has to be edited every time the list
+        moves, and this one was found by a release rather than by the change
+        that moved it.
+        """
         page = (self.out / 'privacy' / 'index.html').read_text(encoding='utf-8')
-        self.assertIn('<a href="/de/datenschutz/" lang="de" hreflang="de">Deutsch</a>', page)
+        others = [locale for locale in buildmod.i18n.published(self.locales)
+                  if not locale['is_base']]
+        self.assertTrue(others, 'the site offers no translation to switch to')
+        for locale in others:
+            with self.subTest(lang=locale['lang']):
+                href = buildmod.i18n.locale_path(locale, 'privacy')
+                # The page, not the front door it would be easiest to link.
+                self.assertNotEqual(href, f'/{locale["prefix"]}')
+                self.assertIn(f'<a href="{href}" lang="{locale["hreflang"]}"', page)
 
     def test_no_template_tag_survives_into_the_output(self):
         for name in self.written:

--- a/tests/python/test_i18n.py
+++ b/tests/python/test_i18n.py
@@ -36,7 +36,8 @@ SITE = {
 def locale(**over):
     base = {
         'lang': 'de', 'name': 'German', 'endonym': 'Deutsch', 'hreflang': 'de',
-        'dir': 'ltr', 'complete': False, 'is_base': False, 'prefix': 'de/',
+        'dir': 'ltr', 'complete': False, 'advertised': True, 'is_base': False,
+        'prefix': 'de/',
         'fallback': None, 'fallback_locale': None,
         'slugs': {}, 'site': SITE, 'tools': {}, 'pages': {}, 'bodies': {},
         'planned': {}, 'frame': [], 'debt': {},
@@ -519,6 +520,32 @@ class Advertising(unittest.TestCase):
         self.assertNotIn('fr', langs)
         self.assertNotIn('fr', [entry['lang'] for entry in
                                 i18n.switcher(locales, self.english, 'widget', SITE)])
+
+    def test_a_finished_language_the_site_does_not_offer_is_never_advertised(self):
+        """The other way to be absent, and a different fact from being unfinished.
+
+        These pages are translated and readable. They are held back because
+        nobody was arriving on them, and thirteen unread languages were seven
+        eighths of what the site was asking to have indexed - see
+        `unadvertised_languages` in config/site.toml."""
+        quiet = locale(lang='it', hreflang='it', prefix='it/',
+                       complete=True, advertised=False)
+        locales = [self.english, self.german, quiet]
+        self.assertNotIn('it', [entry['hreflang'] for entry in
+                                i18n.alternates(locales, 'widget', SITE)])
+        self.assertNotIn('it', [entry['lang'] for entry in
+                                i18n.switcher(locales, self.english, 'widget', SITE)])
+        self.assertNotIn(quiet, i18n.published(locales))
+        self.assertFalse(i18n.translated(quiet, 'widget'))
+
+    def test_offered_tells_not_ready_apart_from_not_wanted(self):
+        """Both keep a language out of all three lists, and they are not one
+        state: the first is waiting on a translator, and the second is a
+        decision that comes undone by deleting a line."""
+        self.assertTrue(i18n.offered(self.english))
+        self.assertTrue(i18n.offered(self.german))
+        self.assertFalse(i18n.offered(self.draft))
+        self.assertFalse(i18n.offered(locale(complete=True, advertised=False)))
 
     def test_the_switcher_stays_on_the_same_page(self):
         """Not on the front door of the other language.


### PR DESCRIPTION
Four merges since `1.2.0`. One a visitor can see, three to the release machinery.

**Merging this publishes to `dist`, tags `1.2.1`, cuts a GitHub release and tells the search engines.**

```
$ python scripts/next_version.py
1.2.1
1.2.0 -> 1.2.1: a change a visitor could notice.
```

The last digit: nothing here adds a tool.

## What a visitor gets

[#391](https://github.com/A-Box-of-Tools/website/pull/391), two independent changes behind one refusal:

- **The ad script is requested only when somebody could see it.** `adsbygoogle.js` fired on every load there is, including the QA suite opening every page against production several times a day — noise while unapproved, invalid traffic against our own account once approved. It now uses the condition `analytics.js` has applied to GA4 since `7bc48aa66`. Verification is untouched: it is the inert `<meta>` tag and the `ads.txt` entry, neither of which is script, and Googlebot sets no `navigator.webdriver`.
- **Thirteen translations are no longer offered.** Over 28 days to 6 September, 99.05% of 56,713 arrivals were on an English page; all fourteen translations together took 0.95%, and only `zh` has a readership worth the name. Nothing is deleted and no address moves — the pages are built and answer where they always did. They leave the sitemap, carry `noindex, follow`, claim no hreflang alternates, and go from the switcher.

## What they do not

- [#387](https://github.com/A-Box-of-Tools/website/pull/387) — the preview tidy asks the deployments endpoint for a page it will give
- [#389](https://github.com/A-Box-of-Tools/website/pull/389) — a change that reaches no page is not built at all
- [#390](https://github.com/A-Box-of-Tools/website/pull/390) — the tidy says which branch names it found when it finds none it wants

## The QA side is already in place

[qa#120](https://github.com/A-Box-of-Tools/qa/pull/120) is merged. It reads `unadvertised_languages` from this repository rather than keeping its own list, so it was correct against production before this lands and stays correct after — there was no window in which either side had to go first.

## Expect this to fail, for a reason that predates it

`qa/preview` will almost certainly go red on **`business-profile-preview` having no translation in any language** — 0 of 14 — and on the slug-parity checks that follow from it. Those failures are not caused by anything in this release. They are the ones that blocked [#384](https://github.com/A-Box-of-Tools/website/pull/384) and were merged past; the tool has been live and untranslated since.

They matter more now, not less: `zh` is the one translation still offered, and it is missing this tool too.

Three ways forward, none of them mine to pick — translate the tool and re-run; drop `business-profile-preview` from the release by reverting it on `dev`; or merge knowing what is red and why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
