### PR TITLE
Stop the build log calling a language published while hiding it

### DIFF
--- a/build.py
+++ b/build.py
@@ -477,11 +477,15 @@ def build(out, clean=False, minify_output=True, jobs=None, only=None,
     # look identical in a directory listing, and the difference is the only
     # thing anybody wants to know about it.
     #
-    # Two different states are worth two different sentences. A locale that has
-    # not finished its frame is not published at all. A locale that has is
+    # Three different states are worth three different sentences. A locale that
+    # has not finished its frame is not published at all. A locale that has is
     # published, and owes a number of PAGES - which is the unit that decides
     # anything now, since a page with one string left is as held back as a page
-    # with four hundred.
+    # with four hundred. And a locale on `unadvertised_languages` is finished
+    # and is not offered anyway, which was reported as "published" until this
+    # said otherwise - a build that calls a language published while keeping it
+    # out of the sitemap is the one reader of this output nobody can correct.
+    unoffered = []
     for locale in targets:
         if locale['is_base']:
             continue
@@ -493,6 +497,14 @@ def build(out, clean=False, minify_output=True, jobs=None, only=None,
             left = len(set(i18n.all_debt(locale)))
             print(f'  {locale["lang"]}: {left} strings still in English '
                   f'(not advertised until complete = true)')
+            continue
+        if not locale['advertised']:
+            # Named together below rather than a line each. That they are held
+            # back is one fact about thirteen languages, not thirteen facts,
+            # and thirteen lines of it would bury the ones still being worked
+            # on. What each of them owes page by page stops mattering while
+            # nothing is offering them.
+            unoffered.append(locale['lang'])
             continue
         behind = i18n.debt_report(locale, tools, prose)
         if behind:
@@ -507,6 +519,12 @@ def build(out, clean=False, minify_output=True, jobs=None, only=None,
                   f'(built and readable, kept out of the sitemap): '
                   + ', '.join(sorted(behind)[:4])
                   + (' ...' if len(behind) > 4 else ''))
+
+    if unoffered:
+        print(f'  not offered: {", ".join(unoffered)} - translated, built and '
+              f'readable at their own addresses, and kept out of the sitemap, '
+              f'the hreflang sets and the switcher '
+              f'(unadvertised_languages in config/site.toml)')
 
     # One 404 for the whole domain, in English, because GitHub Pages serves one
     # file for every address it cannot find and has no way to know which


### PR DESCRIPTION
#391 stopped offering thirteen languages. The build log did not notice, and
went on saying this about every one of them:

```
  ar: published, 2 of 102 pages still in English (built and readable, kept out of the sitemap)
```

They are not published. They are complete, built, readable, and deliberately
out of the sitemap, the hreflang sets and the switcher — which is most of what
that sentence claims the opposite of. A build that calls a language published
while keeping it out of the sitemap is misinforming the one reader of this
output who cannot check it against anything.

Worse, a language on the list with **no** page debt printed nothing at all, so
a full build said nothing whatsoever about thirteen of its fifteen languages
being held back. The most consequential fact about the last release was absent
from the output of the thing that did it.

There were two states worth a sentence and now there are three, so:

```
  zh: published, 2 of 102 pages still in English (built and readable, kept out of
      the sitemap): business-profile-preview, guides/preview-a-google-business-profile
  not offered: ar, de, es, fr, hi, id, it, ja, ko, nl, pt, tr, zh-TW - translated,
      built and readable at their own addresses, and kept out of the sitemap, the
      hreflang sets and the switcher (unadvertised_languages in config/site.toml)
```

Named together rather than a line each: that they are held back is one fact
about thirteen languages, not thirteen facts, and thirteen lines of it would
bury the languages still being worked on. What each of them owes page by page
stops mattering while nothing offers them — that count is there to tell a
translator what is left, and nobody is translating toward an address the site
does not advertise.

No behaviour changes: this is `print` and a list, in the block that already
existed for exactly this purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
