### PR TITLE
Ask which merges have shipped by number, because the hashes do not survive

### DIFF
--- a/.github/workflows/preview-tidy.yml
+++ b/.github/workflows/preview-tidy.yml
@@ -15,18 +15,31 @@
 #                production itself.
 #
 # There is a third, and it is the same upload as the second wearing the branch
-# `dev`: the stable dev.<project>.pages.dev that a release is read at. Only the
-# newest of those is that address. Every earlier one is reachable by its own
-# hash and by nothing else, and holds bytes that `dev-pr-<n>` is already
-# keeping, so it is finished with on exactly the terms that one is.
+# `dev`: the stable dev.<project>.pages.dev that a release is read at. Exactly
+# one of those is that address - the newest - and it is the only one worth
+# keeping. Every copy under it is reachable by its own hash and by nothing
+# else, and the `dev-pr-<n>` at the same commit is holding the same bytes for
+# as long as anybody could want them, so the next push to `dev` is what
+# finishes with it.
 #
 # So a closed pull request takes its own preview down, and a push to `main`
-# takes down every `dev-pr-<n>` whose merge has arrived there, and every
-# superseded `dev` beside it. NOT all of them: `dev` carries on while a release
-# is in flight, and a merge that is on `dev` but not yet in `main` is exactly
-# the case those addresses exist for. Each is asked about by commit rather than
-# assumed, which is the reason the upload passes `--commit-hash` in the first
-# place.
+# takes down every `dev-pr-<n>` whose change has been released, and every `dev`
+# but the newest. NOT all of the first: `dev` carries on while a release is in
+# flight, and a merge that is on `dev` and not yet released is exactly the case
+# those addresses exist for. The copies under `dev` are asked nothing, because
+# the question has only one answer: one of them is the address and the rest are
+# unreachable.
+#
+# WHICH ONES HAVE BEEN RELEASED IS ASKED BY NUMBER, and that is the whole of
+# what this gets right. A release replays the commits it carries - `main` holds
+# `... (#371)` at a hash of its own - and `dev` is rebased on to `main`
+# afterwards, so the hash a `dev-pr-<n>` was uploaded with belongs to no branch
+# at all within minutes of the release that shipped it. Asking
+# `compare/main...<that hash>` then answers `diverged`, which is
+# indistinguishable from "still waiting for a release" and kept every one of
+# them for ever. The number is in the subject of the commit wherever the change
+# is replayed, so the pull requests on `dev` and not in `main` are the
+# unreleased ones, and every `dev-pr-<n>` outside that set has shipped.
 #
 # RUN BY HAND, it does all of that and one thing more: it takes down every
 # `pr-<n>` whose pull request has closed, however long ago that was. Those two
@@ -100,8 +113,7 @@ jobs:
           api="https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$PROJECT/deployments"
           auth="Authorization: Bearer $CLOUDFLARE_API_TOKEN"
 
-          # Every deployment the project holds, as
-          # `id<TAB>branch<TAB>commit<TAB>created`.
+          # Every deployment the project holds, as `id<TAB>branch<TAB>created`.
           # Paged, because a busy month is more than one page of them and the
           # oldest are the ones most likely to be finished with.
           #
@@ -124,14 +136,13 @@ jobs:
             fi
             n=$(printf '%s' "$body" | jq '.result | length')
             if [ "$n" -eq 0 ]; then break; fi
-            # The branch and the commit are the ones `wrangler pages deploy`
-            # was given as --branch and --commit-hash. Read back defensively:
-            # this part of the API has been renamed before, and the failure it
-            # would cause here is a tidy that matches nothing and says nothing.
+            # The branch is the one `wrangler pages deploy` was given as
+            # --branch. Read back defensively: this part of the API has been
+            # renamed before, and the failure it would cause here is a tidy
+            # that matches nothing and says nothing.
             printf '%s' "$body" | jq -r '.result[] | [
                 .id,
                 (.deployment_trigger.metadata.branch // "?"),
-                (.deployment_trigger.metadata.commit_hash // "?"),
                 (.created_on // "")
               ] | @tsv' >> all.tsv
             page=$((page + 1))
@@ -149,28 +160,33 @@ jobs:
             exit 1
           fi
 
-          # Has the merge this one holds reached `main`? `behind` and
-          # `identical` are the two answers meaning "already there"; `ahead`
-          # and `diverged` mean `dev` has moved on without a release, which is
-          # the state these addresses are for. Not being able to ask is its own
-          # answer and is not one of those two: it leaves the deployment alone
-          # and says which one and why, because a tidy that deletes on a
-          # question it could not get an answer to is worse than one that waits
-          # for the next run.
-          arrived_in_main() {
-            local branch=$1 commit=$2 where
-            if [ "$commit" = '?' ]; then
-              echo "  $branch: no commit recorded; left alone."
-              return 1
-            fi
-            where=$(gh api "repos/$REPO/compare/main...$commit" --jq '.status' 2>/dev/null) || where=''
-            case "$where" in
-              behind|identical) return 0 ;;
-              '') echo "  $branch: could not ask about ${commit:0:7}; left alone." ;;
-              *)  echo "  $branch: ${commit:0:7} is not in main yet ($where); left alone." ;;
-            esac
-            return 1
+          # What became of pull request #n - `open`, `closed`, or nothing at
+          # all when the question could not be asked. `closed` covers a merged
+          # pull request as well as an abandoned one, which is the point:
+          # neither has anything left to review.
+          pull_state() {
+            gh api "repos/$REPO/pulls/$1" --jq '.state' 2>/dev/null || true
           }
+
+          # THE PULL REQUESTS THAT ARE ON `dev` AND NOT YET RELEASED, one
+          # number per line. Read out of the subjects rather than the hashes,
+          # for the reason at the top of this file: the hashes do not survive a
+          # release and the numbers do.
+          #
+          # One question for the whole run, not one per deployment. An empty
+          # answer is a true and ordinary one - it is what `dev` looks like the
+          # moment a release lands - so the failure to ask has to be told apart
+          # from it, and is: nothing is taken down on a question that went
+          # unanswered.
+          if unreleased=$(gh api "repos/$REPO/compare/main...dev" \
+               --jq '.commits[].commit.message | split("\n")[0]' 2>/dev/null \
+               | sed -n 's/.*(#\([0-9][0-9]*\))[[:space:]]*$/\1/p'); then
+            asked=yes
+            echo "Unreleased on dev: $(printf '%s' "${unreleased:-none}" | tr '\n' ' ')"
+          else
+            asked=no
+            echo '::warning::Could not ask which merges are still unreleased, so every dev-pr is being left alone.'
+          fi
 
           # The one `dev` deployment that IS dev.<project>.pages.dev, and so
           # the one address a release is being read at while this runs. Chosen
@@ -180,7 +196,7 @@ jobs:
           # workflow could do. `created_on` is ISO-8601 in UTC, so the newest
           # is the largest as text.
           keep_dev=$(awk -F'\t' 'BEGIN { newest = "" }
-            $2 == "dev" && $4 > newest { newest = $4; keep = $1 }
+            $2 == "dev" && $3 > newest { newest = $3; keep = $1 }
             END { print keep }' all.tsv)
 
           # And if that question came back empty while `dev` deployments exist,
@@ -193,18 +209,16 @@ jobs:
 
           # WHICH ARE FINISHED WITH
           : > doomed.tsv
-          while IFS="$(printf '\t')" read -r id branch commit created; do
+          while IFS="$(printf '\t')" read -r id branch created; do
             case "$EVENT:$branch" in
               "pull_request:pr-$PR")
                 printf '%s\t%s\n' "$id" "$branch" >> doomed.tsv
                 ;;
               workflow_dispatch:pr-*)
                 # The backlog sweep, and the only place any pull request but
-                # the one that just closed is asked about. `state` is `closed`
-                # for a merged pull request as well as an abandoned one, which
-                # is the whole point: neither has anything left to review.
+                # the one that just closed is asked about.
                 n=${branch#pr-}
-                state=$(gh api "repos/$REPO/pulls/$n" --jq '.state' 2>/dev/null) || state=''
+                state=$(pull_state "$n")
                 case "$state" in
                   closed)
                     printf '%s\t%s\n' "$id" "$branch" >> doomed.tsv ;;
@@ -215,19 +229,38 @@ jobs:
                 esac
                 ;;
               push:dev-pr-*|workflow_dispatch:dev-pr-*)
-                if arrived_in_main "$branch" "$commit"; then
-                  printf '%s\t%s\n' "$id" "$branch" >> doomed.tsv
+                n=${branch#dev-pr-}
+                if [ "$asked" = no ]; then
+                  : # Said once above, for all of them rather than each.
+                elif printf '%s\n' "$unreleased" | grep -qx "$n"; then
+                  echo "  $branch: #$n is on dev and not released yet; left alone."
+                else
+                  # The number on one of these is not always the merge that
+                  # made it: a commit on `dev` is claimed by any open pull
+                  # request whose branch contains it, the release itself
+                  # included, so `dev-pr-392` can be the state after #391. A
+                  # number that names something still open is therefore about
+                  # work in flight whatever it is, and stays.
+                  case "$(pull_state "$n")" in
+                    closed)
+                      printf '%s\t%s\n' "$id" "$branch" >> doomed.tsv ;;
+                    open)
+                      echo "  $branch: #$n is still open; left alone." ;;
+                    *)
+                      echo "  $branch: could not ask what became of #$n; left alone." ;;
+                  esac
                 fi
                 ;;
               push:dev|workflow_dispatch:dev)
-                # Superseded copies only, on the same terms as the `dev-pr-<n>`
-                # holding the same commit. The newest is the stable address and
-                # is never touched.
+                # One is kept - the newest, which is the address - and every
+                # copy under it goes, whatever commit it holds. Nothing is
+                # asked about them: `main` is the wrong question for a
+                # deployment nobody can reach and nothing points at.
                 if [ -z "$keep_dev" ]; then
                   : # Said once above, for all of them rather than each.
                 elif [ "$id" = "$keep_dev" ]; then
-                  echo "  dev: the stable address; left alone."
-                elif arrived_in_main "dev (${created:0:10})" "$commit"; then
+                  echo "  dev: the stable address (${created:0:10}); left alone."
+                else
                   printf '%s\t%s\n' "$id" "$branch" >> doomed.tsv
                 fi
                 ;;


### PR DESCRIPTION
`dev-pr-371` was still standing with #371 long since released, and every other
one would have stood beside it for ever.

The test was whether the commit a deployment was uploaded with had arrived in
`main`, and that commit does not exist anywhere by the time the question is
worth asking. A release replays what it carries - `main` holds #371 as
`e7e985b` - and `dev` is rebased on to the release afterwards, so the
`de9075b` that `dev-pr-371` was made from is on neither branch:

| question | answer |
|---|---|
| `compare/main...de9075b` | `diverged` |
| `compare/dev...de9075b` | `diverged` |

`diverged` is also the answer for a merge that genuinely has not been released,
so the tidy read "shipped weeks ago" as "still needed". Nothing about that is
visible from a run: it looks exactly like a release that freed nothing.

**The number survives what the hash does not**, because it is in the subject of
the commit wherever the change is replayed. So one question is asked for the
whole run - which pull requests are on `dev` and not in `main` - and a
`dev-pr-<n>` outside that set has shipped. Being unable to ask is told apart
from an empty answer, which is what `dev` looks like the moment a release lands,
and takes nothing down.

**A number is not always the merge that made the deployment**, so a second
question guards the first: a commit on `dev` is claimed by any open pull request
whose branch contains it, the release included, which is how `dev-pr-392` comes
to hold the state after #391. One named by something still open is about work in
flight whatever it is, and stays.

The commit is no longer read at all and the column it filled is gone with it.
`--commit-hash` stays in build.yml, where it is what the Cloudflare dashboard
shows beside a deployment.

**Also, as asked: only the newest `dev` is kept**, and the copies under it go
without being asked anything. They were being held until their commit reached
`main`, which was both the wrong question and an unanswerable one.

### Proof

Fourteen cases against a stub of both APIs, three of them new: a `dev-pr` whose
change shipped under another hash, one named after a pull request that is still
open, and one the pulls endpoint will not answer about.

Then run for real from this branch -
[34194929283](https://github.com/A-Box-of-Tools/website/actions/runs/34194929283):

```
Unreleased on dev: 388 389 390 391 395 396
  dev-pr-392: #392 is still open; left alone.
  dev-pr-390: #390 is on dev and not released yet; left alone.
  dev-pr-389: #389 is on dev and not released yet; left alone.
  dev: the stable address (2026-09-08); left alone.
Deleted 21 of 21.
```

Those 21 are `dev-pr-371`, `374`, `376`, `380` through `383`, `387` - every one
released - and every superseded `dev` copy. The project is down from 67 to 13.
`dev`, `pr-392`, `pr-393` and `pr-395` all still answer 200.

Nothing a visitor can see changes, so there is nothing to photograph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
