### PR TITLE
List, on a hub and in a footer, only the tools that language has

### DIFF
--- a/build.py
+++ b/build.py
@@ -709,9 +709,38 @@ def build_locale(out, templates, locale, locales, site, tools, prose, planned,
                for category in root['hub']['categories']
                for slug in category['order'] if slug in by_slug]
 
+    # THE TOOLS THIS LANGUAGE ACTUALLY HAS.
+    #
+    # A page held back until it is translated is "built and readable at its
+    # own address" and stays out of the sitemap, the hreflang set and the
+    # switcher. Everywhere the site LISTS its tools belongs in that sentence
+    # too, and did not, because until a tool shipped untranslated for the
+    # first time this list was every tool in every language and the filter
+    # would have removed nothing.
+    #
+    # What it looked like when the case finally arrived: on /zh/ a card among
+    # the Chinese ones under an English name, the same name in the hub's
+    # ItemList, a footer link on all hundred and five pages, and a "工具箱里还有"
+    # strip on every tool page - each leading to a page that serves English
+    # under `lang="zh-Hans"`.
+    #
+    # `debt` rather than `translated()`: the latter is false for every page of
+    # a language the site does not advertise, so it would empty thirteen
+    # languages instead of removing one entry from each. Whether a language is
+    # OFFERED and whether it HAS this page are different questions.
+    # `is_base` first, exactly as translated() does it, and for the reason
+    # that function does not spell out: English carries a debt entry for every
+    # page it has - it is the source every other language is measured against,
+    # not a language that owes anything - so consulting the dict without this
+    # guard empties the English hub, footer and related strips of all
+    # forty-two tools. Which is what the first draft of this did, and what no
+    # test caught.
+    here = [tool for tool in ordered
+            if locale['is_base'] or not locale['debt'].get(tool['slug'])]
+
     # The few other tools each tool page points at, off the same hub order. See
     # related_tools: one ring over every tool, siblings first.
-    related_of = related_tools(ordered)
+    related_of = related_tools(here)
 
     # What the footer on every page is built from. Derived from the folders that
     # exist rather than written down anywhere, so a new tool or a new legal page
@@ -724,8 +753,9 @@ def build_locale(out, templates, locale, locales, site, tools, prose, planned,
     # already built from the folders that exist.
     #
     # The slugs in it are localized, because a footer is a set of addresses.
+    #
     footer = {
-        'tools': [{'name': tool['name'], 'slug': tool['out_slug']} for tool in ordered],
+        'tools': [{'name': tool['name'], 'slug': tool['out_slug']} for tool in here],
         'pages': [{'nav': page['nav'], 'slug': page['out_slug']}
                   for page in about + legal],
     }
@@ -1580,9 +1610,36 @@ def build_hub(out, templates, locale, locales, site, by_slug, footer, links,
                 raise sitelib.ConfigError(
                     f'{slug} says category = {tool["category"]!r} but is listed under '
                     f'{category["id"]!r} in config/site.toml')
-            chosen.append(tool)
+            # Only if THIS language has the page. A held-back page is
+            # "built and readable at its own address" and stays out of the
+            # sitemap, the hreflang set and the switcher until it is
+            # translated - and the hub belongs in that list, which nothing
+            # noticed until a tool shipped untranslated for the first time.
+            # Until then every tool existed in every language and the filter
+            # would have removed nothing, so its absence looked like a
+            # decision rather than a case never met.
+            #
+            # What it looked like when it was met: a reader on /zh/ saw a card
+            # among the Chinese ones, headed with an English name, that led to
+            # a page serving English under `lang="zh-Hans"`. The hub's
+            # ItemList carried the English name too.
+            #
+            # `debt` and not `translated()`, deliberately. `translated()` is
+            # false for every page of a language the site does not advertise,
+            # so using it here would empty thirteen hubs instead of removing
+            # one card from each. Whether a language is OFFERED and whether it
+            # HAS this page are different questions, and this is the second.
+            # `listed` is still told about every slug, because it answers the
+            # config's question - is any tool listed nowhere - which is about
+            # the site and not about one language.
+            if not locale['debt'].get(slug):
+                chosen.append(tool)
             listed.add(slug)
-        categories.append({**category, 'tools': chosen})
+        # A category nobody in this language can use is not a heading worth
+        # rendering. It cannot happen today - no language is missing a whole
+        # category - but an empty one would render as a title over nothing.
+        if chosen:
+            categories.append({**category, 'tools': chosen})
 
     stray = sorted(set(by_slug) - listed)
     if stray:

--- a/tests/python/test_build.py
+++ b/tests/python/test_build.py
@@ -1149,6 +1149,40 @@ class BuildTheSite(unittest.TestCase):
                 self.assertNotEqual(href, f'/{locale["prefix"]}')
                 self.assertIn(f'<a href="{href}" lang="{locale["hreflang"]}"', page)
 
+    def test_every_hub_lists_the_tools_that_language_has(self):
+        """A hub lists what its language has: all of them, or all but the ones
+        held back.
+
+        Both halves matter, and the first is the one that was missing. A page
+        held back until it is translated stays out of the sitemap, the hreflang
+        set and the switcher, and it has to stay off the hub too - it was
+        appearing on /zh/ as a card among the Chinese ones, under an English
+        name, leading to a page serving English under `lang="zh-Hans"`.
+
+        The other half is here because leaving it out cost an afternoon. The
+        first attempt at that filter emptied the ENGLISH hub of all forty-two
+        tools and the whole of this file still passed: English carries a debt
+        entry for every page it has - it is the source, not a language that
+        owes anything - so the filter has to let the base through before it
+        reads that dict. Nothing here noticed a front page with no tools on it.
+        """
+        slugs = sorted(path.parent.name for path in (ROOT / 'tools').glob('*/tool.toml'))
+        self.assertGreater(len(slugs), 1)
+        for locale in self.locales:
+            hub = (self.out / locale['prefix'] / 'index.html').read_text(encoding='utf-8')
+            for slug in slugs:
+                has = locale['is_base'] or not locale['debt'].get(slug)
+                # The href the hub writes is relative, so the localized slug and
+                # the closing quote are what identify it.
+                linked = f'{locale["slugs"].get(slug, slug)}/"' in hub
+                with self.subTest(lang=locale['lang'], tool=slug):
+                    self.assertEqual(
+                        linked, has,
+                        f'{locale["lang"]} '
+                        + ('has' if has else 'does not have')
+                        + f' {slug} and its hub '
+                        + ('does not link it' if has else 'links it anyway'))
+
     def test_no_template_tag_survives_into_the_output(self):
         for name in self.written:
             if not name.endswith('.html'):


### PR DESCRIPTION
The release has been red twice on this:

```
locales/parity.spec.ts › translated everywhere: business-profile-preview
locales/parity.spec.ts › ar / de / es / fr translates all its slugs or none
```

**The check is not too strict. The site was wrong**, and this fixes the site.

## What a reader actually got

`business-profile-preview` is the first tool ever to ship untranslated — every one of the other 41 has all 14 languages. So a code path that had never been exercised finally was, and on `/zh/` it produced:

- a **card** among the Chinese ones, headed with an English name
- the same English name in the hub's **ItemList** structured data
- a **footer link on all 105 pages** of the language
- a **"工具箱里还有" strip** on every tool page

Each leading to a page that serves English under `lang="zh-Hans"`.

The documented policy already covers this — a held-back page "stays out of the sitemap, the hreflang sets and the switcher". Everywhere the site *lists* its tools belongs in that sentence. It wasn't, because while every tool existed in every language the filter would have removed nothing, so its absence looked like a decision rather than a case never met.

There is now one list per language, and the hub, the footer and the related strips are all built from it.

## Two things about the predicate, both learned the hard way

**`debt` rather than `translated()`.** The latter is false for *every* page of a language the site does not advertise, so it would empty thirteen hubs instead of taking one card out of each. Whether a language is OFFERED and whether it HAS this page are different questions; this is the second.

**`is_base` first, exactly as `translated()` does it.** English carries a debt entry for every page it has — it is the source, not a language that owes anything. Reading that dict without the guard empties the English hub, footer and related strips of **all forty-two tools**:

```
PROBE en: ordered=42 here=0  debt=102     ← the first draft
PROBE ar: ordered=42 here=41 debt=103
```

**The full suite passed on that.** 564 tests, and not one looks at whether the front page has any tools on it.

## So there is a test now

It asserts both directions — a language links what it has, and does not link what it has not — and I watched it fail with the guard removed before keeping it:

```
AssertionError: en has base64 and its hub does not link it
```

**565 Python tests pass.**

## What this does not do

It does not translate the tool. `parity.spec.ts › translated everywhere` checks for the locale *file*, so it will still be red until `business-profile-preview` is translated — about 3,300 words × 14 languages, the standard every other tool meets. What this removes is the reader-facing damage in the meantime: nobody is now shown an English page dressed as their language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
