### PR TITLE
Lay the footer's tools out in the groups the hub already sorts them into

### DIFF
--- a/build.py
+++ b/build.py
@@ -755,7 +755,7 @@ def build_locale(out, templates, locale, locales, site, tools, prose, planned,
     # The slugs in it are localized, because a footer is a set of addresses.
     #
     footer = {
-        'tools': [{'name': tool['name'], 'slug': tool['out_slug']} for tool in here],
+        'groups': footer_tool_groups(root, here, 'out_slug'),
         'pages': [{'nav': page['nav'], 'slug': page['out_slug']}
                   for page in about + legal],
     }
@@ -1034,6 +1034,46 @@ def tie_guides_to_tools(guides, by_slug):
 # out of the page and few enough that the block stays a suggestion rather than
 # a second copy of the hub halfway down every tool.
 RELATED_COUNT = 4
+
+
+def footer_tool_groups(root, tools, address):
+    """The footer's tool list, in the groups the hub already sorts it into.
+
+    It used to be one flat column of every tool a language has, which read well
+    at a dozen and stopped reading at all somewhere in the thirties: forty-two
+    names down the second column of a footer four columns wide, with the
+    privacy link finishing a third of the way down beside them and nine hundred
+    pixels of nothing either side of the rest. Every name is still here - a
+    footer link is how a tool is reached from the far end of the site, and
+    buying the height back by dropping half of them would be paying in the
+    wrong currency - but they arrive in the categories the front page already
+    sorts them into, so the block is four short columns rather than one long
+    one and each name sits under a heading saying what kind of thing it is.
+
+    Nothing new is written down, and nothing is second-guessed. `tools` is the
+    list the caller has already settled - hub order, and for a locale the tools
+    that language actually HAS - and each tool names its own category, which
+    build_hub has already checked against the [[hub.categories]] it is listed
+    under. So a tool that moves between categories moves here, and one a
+    language is still waiting for is as absent here as it is from the hub.
+
+    A category with nothing under it is dropped rather than drawn, which is not
+    hypothetical twice over: a [[hub.categories]] table can be added before the
+    tool that goes in it, and a language can be waiting on every tool in one.
+    Either way the alternative is a heading over nothing, on every page of that
+    language.
+
+    `address` is the key holding the address to link to, because the two
+    callers disagree about which one that is: every page but the 404 links to
+    this language's slug, and the 404 links to the English one - see build_404.
+    """
+    held = {}
+    for tool in tools:
+        held.setdefault(tool['category'], []).append(tool)
+    return [{'name': category['name'],
+             'tools': [{'name': tool['name'], 'slug': tool[address]}
+                       for tool in held[category['id']]]}
+            for category in root['hub']['categories'] if held.get(category['id'])]
 
 
 def related_tools(ordered, count=RELATED_COUNT):
@@ -1806,7 +1846,7 @@ def build_404(out, templates, locale, locales, site, tools, pages, css_v, lang_v
     # link on it is root-absolute for the reason in the docstring above. `base`
     # is '/', so a slug appended to it is already the English address.
     footer = {
-        'tools': [{'name': tool['name'], 'slug': tool['slug']} for tool in tools],
+        'groups': footer_tool_groups(root, tools, 'slug'),
         'pages': [{'nav': page['nav'], 'slug': page['slug']}
                   for page in pages if page['kind'] in ('site', 'legal')],
     }

--- a/build.py
+++ b/build.py
@@ -1632,7 +1632,16 @@ def build_hub(out, templates, locale, locales, site, by_slug, footer, links,
             # `listed` is still told about every slug, because it answers the
             # config's question - is any tool listed nowhere - which is about
             # the site and not about one language.
-            if not locale['debt'].get(slug):
+            #
+            # And `is_base` first, exactly as translated() does it and as the
+            # same filter over in build_locale does. English carries a debt
+            # entry for every page it has - it is the source every other
+            # language is measured against, not a language that owes anything
+            # - so reading that dict without this guard takes every card off
+            # the English front page. It did: this line shipped to dev without
+            # it and /index.html went out with four headings and no tools
+            # under any of them.
+            if locale['is_base'] or not locale['debt'].get(slug):
                 chosen.append(tool)
             listed.add(slug)
         # A category nobody in this language can use is not a heading worth

--- a/shared/css/tool-frame.css
+++ b/shared/css/tool-frame.css
@@ -1288,6 +1288,10 @@ button, .as-button {
    the only route to the legal pages - a centred line of prose had nowhere to
    put them.
 
+   Two rows of it. The first says who this is and where the rest of the site
+   is; the second is every tool there is, grouped - see .footer-tools below for
+   why those are no longer a column of the first.
+
    Flex rather than grid, so the columns fall to two-up and then one-up on a
    narrow screen without a media query. The brand column gets twice the basis of
    a link column, because it carries a sentence rather than a list. */
@@ -1307,7 +1311,20 @@ footer {
 }
 
 .footer-col { flex: 1 1 150px; min-width: 0; }
-.footer-brand { flex: 2 1 240px; }
+
+/* Two link columns and the gap between them, 2 x 150px + 2.5rem, growing twice
+   as fast to match. That is what puts the two rows on one grid rather than
+   near one: both rows then have the same basis in total and the same grow in
+   total, so the free space lands in the same places and a tool column below
+   starts exactly where a column above it does. The three numbers are one
+   number - change any of them and work the others out again.
+
+   They also decide where the whole footer folds, which is why 150px rather
+   than something rounder: four columns and three gaps need 720px, and a tablet
+   held upright has 736px of footer to give them. A wider column would fold
+   that reader to three-up and leave the fourth group stranded on a line of its
+   own. */
+.footer-brand { flex: 2 1 340px; }
 
 .footer-col strong {
   display: block;
@@ -1328,6 +1345,25 @@ footer {
 }
 
 .footer-brand p { margin: 0.55rem 0 0; max-width: 34ch; }
+
+/* The tool directory: every tool the site has, across the foot of the footer
+   in the four groups the front page already sorts them into.
+
+   It was one of the columns above and it was one flat list, so a footer four
+   columns wide stood forty-two lines tall - the legal links finishing a third
+   of the way down it, and the space either side of them empty the rest of the
+   way. The same names in their groups are four columns and fourteen lines.
+   Nothing was dropped to get there: a link here is how a tool is reached from
+   the far end of the site, and the height was never the tools' fault.
+
+   Same gap and same basis as the row above, which is arithmetic rather than
+   coincidence - see .footer-brand. */
+.footer-tools {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem 2.5rem;
+  margin-top: 1.75rem;
+}
 
 /* "Get in touch" is the one column that is a row: three marks side by side
    rather than three lines of text. It is still a <ul>, because it is still a

--- a/shared/css/tool-frame.css
+++ b/shared/css/tool-frame.css
@@ -1312,19 +1312,53 @@ footer {
 
 .footer-col { flex: 1 1 150px; min-width: 0; }
 
-/* Two link columns and the gap between them, 2 x 150px + 2.5rem, growing twice
-   as fast to match. That is what puts the two rows on one grid rather than
-   near one: both rows then have the same basis in total and the same grow in
-   total, so the free space lands in the same places and a tool column below
-   starts exactly where a column above it does. The three numbers are one
-   number - change any of them and work the others out again.
+/* "This site" is the wide one: two link columns and the gap between them,
+   2 x 150px + 2.5rem, growing twice as fast to match. The brand and the marks
+   keep one column each, so the row is 1 + 2 + 1 = the four the tools below it
+   have, and that is what puts the two rows on one grid rather than near one -
+   both then have the same basis in total and the same grow in total, so the
+   free space lands in the same places and a tool column below starts exactly
+   where a column above it does. The three numbers are one number: change any
+   of them and work the others out again.
 
    They also decide where the whole footer folds, which is why 150px rather
    than something rounder: four columns and three gaps need 720px, and a tablet
    held upright has 736px of footer to give them. A wider column would fold
    that reader to three-up and leave the fourth group stranded on a line of its
    own. */
-.footer-brand { flex: 2 1 340px; }
+.footer-site { flex: 2 1 340px; }
+
+/* "This site" is eight links and was one column of eight, which set the height
+   of the whole row: a sentence beside it, three icons beside that, and the
+   rest of both of those columns empty down to the eighth. Two columns of four
+   is the same eight links and half the row. It takes the width for the second
+   from the brand column beside it, which was two columns wide to hold a
+   sentence that `max-width: 34ch` was capping well inside one.
+
+   Named through `.footer-col` as well, for the reason `.footer-marks` below
+   is: the rule it is overriding is `.footer-col ul`, which is exactly as
+   specific, so on a bare class the one that wins is whichever is written
+   second - and the symptom of losing is a list that quietly stays in one
+   column, because a grid box takes no notice of `columns` at all.
+
+   `columns` rather than a second <ul> or a media query, because the list is
+   built from the folders that exist and nothing here should have to know how
+   many there are - it balances whatever it is given. And the count is a
+   MAXIMUM sitting on a minimum width, so the split undoes itself: below about
+   340px, which is where the footer has already folded to one column a phone's
+   width, two columns of five characters would be worse than one of ten, and
+   there is one. */
+.footer-col.footer-site ul {
+  display: block;
+  columns: 150px 2;
+  column-gap: 2.5rem;
+}
+
+/* The gap the grid above was giving these, put back by hand: a multi-column
+   box is not a grid and does not take one. On the last item too, which costs a
+   third of a line at the foot of the column and saves knowing which item is
+   last in either of them. */
+.footer-col.footer-site li { margin-bottom: 0.35rem; }
 
 .footer-col strong {
   display: block;

--- a/shared/site.css
+++ b/shared/site.css
@@ -775,6 +775,10 @@ code {
    the only route to the legal pages - a centred line of prose had nowhere to
    put them.
 
+   Two rows of it. The first says who this is and where the rest of the site
+   is; the second is every tool there is, grouped - see .footer-tools below for
+   why those are no longer a column of the first.
+
    Flex rather than grid, so the columns fall to two-up and then one-up on a
    narrow screen without a media query. The brand column gets twice the basis of
    a link column, because it carries a sentence rather than a list. */
@@ -794,7 +798,20 @@ footer {
 }
 
 .footer-col { flex: 1 1 150px; min-width: 0; }
-.footer-brand { flex: 2 1 240px; }
+
+/* Two link columns and the gap between them, 2 x 150px + 2.5rem, growing twice
+   as fast to match. That is what puts the two rows on one grid rather than
+   near one: both rows then have the same basis in total and the same grow in
+   total, so the free space lands in the same places and a tool column below
+   starts exactly where a column above it does. The three numbers are one
+   number - change any of them and work the others out again.
+
+   They also decide where the whole footer folds, which is why 150px rather
+   than something rounder: four columns and three gaps need 720px, and a tablet
+   held upright has 736px of footer to give them. A wider column would fold
+   that reader to three-up and leave the fourth group stranded on a line of its
+   own. */
+.footer-brand { flex: 2 1 340px; }
 
 .footer-col strong {
   display: block;
@@ -815,6 +832,25 @@ footer {
 }
 
 .footer-brand p { margin: 0.55rem 0 0; max-width: 34ch; }
+
+/* The tool directory: every tool the site has, across the foot of the footer
+   in the four groups the front page already sorts them into.
+
+   It was one of the columns above and it was one flat list, so a footer four
+   columns wide stood forty-two lines tall - the legal links finishing a third
+   of the way down it, and the space either side of them empty the rest of the
+   way. The same names in their groups are four columns and fourteen lines.
+   Nothing was dropped to get there: a link here is how a tool is reached from
+   the far end of the site, and the height was never the tools' fault.
+
+   Same gap and same basis as the row above, which is arithmetic rather than
+   coincidence - see .footer-brand. */
+.footer-tools {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem 2.5rem;
+  margin-top: 1.75rem;
+}
 
 /* "Get in touch" is the one column that is a row: three marks side by side
    rather than three lines of text. It is still a <ul>, because it is still a

--- a/shared/site.css
+++ b/shared/site.css
@@ -799,19 +799,53 @@ footer {
 
 .footer-col { flex: 1 1 150px; min-width: 0; }
 
-/* Two link columns and the gap between them, 2 x 150px + 2.5rem, growing twice
-   as fast to match. That is what puts the two rows on one grid rather than
-   near one: both rows then have the same basis in total and the same grow in
-   total, so the free space lands in the same places and a tool column below
-   starts exactly where a column above it does. The three numbers are one
-   number - change any of them and work the others out again.
+/* "This site" is the wide one: two link columns and the gap between them,
+   2 x 150px + 2.5rem, growing twice as fast to match. The brand and the marks
+   keep one column each, so the row is 1 + 2 + 1 = the four the tools below it
+   have, and that is what puts the two rows on one grid rather than near one -
+   both then have the same basis in total and the same grow in total, so the
+   free space lands in the same places and a tool column below starts exactly
+   where a column above it does. The three numbers are one number: change any
+   of them and work the others out again.
 
    They also decide where the whole footer folds, which is why 150px rather
    than something rounder: four columns and three gaps need 720px, and a tablet
    held upright has 736px of footer to give them. A wider column would fold
    that reader to three-up and leave the fourth group stranded on a line of its
    own. */
-.footer-brand { flex: 2 1 340px; }
+.footer-site { flex: 2 1 340px; }
+
+/* "This site" is eight links and was one column of eight, which set the height
+   of the whole row: a sentence beside it, three icons beside that, and the
+   rest of both of those columns empty down to the eighth. Two columns of four
+   is the same eight links and half the row. It takes the width for the second
+   from the brand column beside it, which was two columns wide to hold a
+   sentence that `max-width: 34ch` was capping well inside one.
+
+   Named through `.footer-col` as well, for the reason `.footer-marks` below
+   is: the rule it is overriding is `.footer-col ul`, which is exactly as
+   specific, so on a bare class the one that wins is whichever is written
+   second - and the symptom of losing is a list that quietly stays in one
+   column, because a grid box takes no notice of `columns` at all.
+
+   `columns` rather than a second <ul> or a media query, because the list is
+   built from the folders that exist and nothing here should have to know how
+   many there are - it balances whatever it is given. And the count is a
+   MAXIMUM sitting on a minimum width, so the split undoes itself: below about
+   340px, which is where the footer has already folded to one column a phone's
+   width, two columns of five characters would be worse than one of ten, and
+   there is one. */
+.footer-col.footer-site ul {
+  display: block;
+  columns: 150px 2;
+  column-gap: 2.5rem;
+}
+
+/* The gap the grid above was giving these, put back by hand: a multi-column
+   box is not a grid and does not take one. On the last item too, which costs a
+   third of a line at the foot of the column and saves knowing which item is
+   last in either of them. */
+.footer-col.footer-site li { margin-bottom: 0.35rem; }
 
 .footer-col strong {
   display: block;

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -11,8 +11,9 @@
 
   The tool list and the legal-page list are passed in by build.py from the
   folders that exist, so a new tool or a new page appears here without anybody
-  remembering to add it. The guides are reached through their index rather than
-  listed one by one - see the comment above that link.
+  remembering to add it. The tools come already grouped the way the front page
+  groups them - see footer_tool_groups. The guides are reached through their
+  index rather than listed one by one - see the comment above that link.
 -->
 <footer>
   <div class="footer-cols">
@@ -24,13 +25,6 @@
       <p>
 {{ site.footer.blurb }}
       </p>
-    </div>
-
-    <div class="footer-col">
-      <strong>{{ ui.footer_tools }}</strong>
-      <ul>
-{% for t in footer.tools %}        <li><a href="{{ base }}{{ t.slug }}/">{{ t.name | e }}</a></li>
-{% endfor %}      </ul>
     </div>
 
     <!--
@@ -105,6 +99,37 @@
       </ul>
     </div>
   </div>
+
+  <!--
+    The tool directory: every tool the site has, across the foot of the footer
+    in the groups the front page already sorts them into.
+
+    It used to be one of the columns above and it was one flat list, so the
+    footer was as tall as that list - forty-two names down the second column,
+    the legal links beside them finishing a third of the way down, and nine
+    hundred pixels of white space either side of the rest. Grouped, the same
+    names are four columns and fourteen lines. Nothing was dropped to get
+    there: a link here is how a tool is reached from the far end of the site,
+    and the height was never the tools' fault.
+
+    A <nav>, because that is what it is, and the heading it used to carry is
+    its label rather than a line of its own - the four category names are the
+    headings now, and "Tools" over the top of them would be a second level of
+    one. The word is still translated and still read out, to anybody who lands
+    on the landmark.
+
+    It comes last in the source as well as at the bottom of the page, so a
+    reader tabbing into the footer for the privacy policy reaches it before the
+    forty links rather than after them.
+  -->
+  <nav class="footer-tools" aria-label="{{ ui.footer_tools }}">
+{% for group in footer.groups %}    <div class="footer-col">
+      <strong>{{ group.name }}</strong>
+      <ul>
+{% for t in group.tools %}        <li><a href="{{ base }}{{ t.slug }}/">{{ t.name | e }}</a></li>
+{% endfor %}      </ul>
+    </div>
+{% endfor %}  </nav>
 
 {% include "partials/languages.html" %}
 

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -39,7 +39,7 @@
       It sits directly under "All tools" because the two are the same kind of
       thing - the front door to each half of the site.
     -->
-    <div class="footer-col">
+    <div class="footer-col footer-site">
       <strong>{{ ui.footer_site }}</strong>
       <ul>
         <li><a href="{{ base }}">{{ ui.all_tools }}</a></li>
@@ -51,22 +51,22 @@
     </div>
 
     <!--
-      The one column that is drawn rather than written. A repository, an account
-      and an address are recognised by their marks in a way that no other link
-      here is, and three sentences stacked in a column - "Read the code on
-      GitHub", a handle, an email address - were three lines saying the same
-      thing three times. The marks fit on one row.
+      The one column that is drawn rather than written. A repository, an
+      account and an address are recognised by their marks in a way that no
+      other link here is, and three sentences stacked in a column - "Read the
+      code on GitHub", a handle, an email address - were three lines saying the
+      same thing three times. The marks fit on one row.
 
-      Each link still carries the sentence, as `aria-label` for a screen reader
-      and `title` for a pointer, so nothing is lost by not being able to see the
-      drawing. The <svg>s are hidden from the accessibility tree rather than
-      labelled themselves: the name belongs on the link, which is the thing that
-      is focused and announced.
+      Each link still carries the sentence, as `aria-label` for a screen
+      reader and `title` for a pointer, so nothing is lost by not being able
+      to see the drawing. The <svg>s are hidden from the accessibility tree
+      rather than labelled themselves: the name belongs on the link, which is
+      the thing that is focused and announced.
 
       The two brand marks are their owners' - GitHub's Octicon and X's logo -
       and are drawn here as those companies publish them, because a redrawn
-      logo is a wrong logo. They are outside shared/icons/ for that reason: that
-      folder is Lucide's, byte for byte, and is checkable against it.
+      logo is a wrong logo. They are outside shared/icons/ for that reason:
+      that folder is Lucide's, byte for byte, and is checkable against it.
     -->
     <div class="footer-col">
       <strong>{{ ui.footer_contact }}</strong>

--- a/tests/python/test_build.py
+++ b/tests/python/test_build.py
@@ -1165,6 +1165,13 @@ class BuildTheSite(unittest.TestCase):
         entry for every page it has - it is the source, not a language that
         owes anything - so the filter has to let the base through before it
         reads that dict. Nothing here noticed a front page with no tools on it.
+
+        And this test, written to catch exactly that, did not either - because
+        it read the whole file for the slug, and the FOOTER of a hub links
+        every tool the language has whether or not a single card was drawn.
+        The half of the guard build_hub was missing shipped to dev under a
+        green suite. So what it looks for now is the card's own anchor, which
+        nothing but a card writes.
         """
         slugs = sorted(path.parent.name for path in (ROOT / 'tools').glob('*/tool.toml'))
         self.assertGreater(len(slugs), 1)
@@ -1172,9 +1179,11 @@ class BuildTheSite(unittest.TestCase):
             hub = (self.out / locale['prefix'] / 'index.html').read_text(encoding='utf-8')
             for slug in slugs:
                 has = locale['is_base'] or not locale['debt'].get(slug)
-                # The href the hub writes is relative, so the localized slug and
-                # the closing quote are what identify it.
-                linked = f'{locale["slugs"].get(slug, slug)}/"' in hub
+                # The card's anchor, not the slug: the href the hub writes is
+                # relative, so a bare `<slug>/"` matches the footer link too
+                # and a hub with no cards at all passes.
+                linked = (f'class="tool-card" href="'
+                          f'{locale["slugs"].get(slug, slug)}/"') in hub
                 with self.subTest(lang=locale['lang'], tool=slug):
                     self.assertEqual(
                         linked, has,


### PR DESCRIPTION
> **Stacked on #402**, which puts the tools back on the English front page —
> `dev` builds it with no cards at all today, which is what was making
> `qa/preview` red here. Merge that one first; this base retargets to `dev`
> by itself when it lands. The diff below is this branch alone.

The footer carried every tool the site has in one flat column. At forty-two
that is a footer 1,375px tall under a 940px page: the legal links finish a
third of the way down beside it, there are nine hundred pixels of nothing
either side of the rest, and the language switcher sits a screen and a half
below the fold.

Every name is still there and every address is unchanged — a footer link is
how a tool is reached from the far end of the site. What changed is that they
arrive in the four categories the front page already sorts them into, as a row
of columns under the row that was there. Four columns and fourteen lines
rather than one and forty-two.

`footer_tool_groups` is handed the list the caller has already settled — hub
order, and for a locale the tools that language actually has, which is what
#399 was about — and groups it by the category each tool declares. So a tool
that moves between categories moves here, one a language is still waiting for
is as absent here as it is from that language's hub, and a category with
nothing under it is dropped rather than drawn as a heading over nothing.

The second commit does the same thing to the row above. "This site" is eight
links and was one column of eight, so it set the height of that row on its
own: a sentence beside it, three icons beside that, and the rest of both of
those columns empty down to Sitemap. Four and four is the same eight links and
half the row. The width for the second column comes from the brand, which was
two columns wide to hold a sentence `max-width: 34ch` was already capping well
inside one — 450 pixels holding a 238-pixel paragraph. So the row is now
1 + 2 + 1, the same four the tools below it have and in the same places, and
"Get in touch" keeps a column of its own.

**1,375px of footer becomes 770px**, and the row above the tools is four lines
rather than nine.

The two rows line up because the numbers make them: a link column's basis is
150px, the gap is 2.5rem, and "This site" is two of the first plus one of the
second and grows twice as fast, so both rows have the same total basis and the
same total grow. 150px is also what decides where the footer folds — four
columns and three gaps need 720px, and a tablet held upright has 736px of
footer to give them.

"Tools" is no longer a visible heading. The four category names are the
headings now, and the word is the `<nav>`'s `aria-label` instead, so it is
still translated and still read out to anybody who lands on the landmark. The
block comes last in the source too, so a reader tabbing into the footer for
the privacy policy reaches it before the forty links rather than after them.

Both stylesheets, identically — `shared/site.css` dresses the hub, the guides
and the prose pages, `shared/css/tool-frame.css` dresses a tool page, and
`test_duplicates` fails if they disagree about a footer rule.

## Before and after

The front page footer at 1200 CSS px wide. 1,375px tall, and 770px.

| Before | After |
|---|---|
| <img width="486" alt="footer-before" src="https://github.com/user-attachments/assets/91c82c41-ddb1-4fc2-be43-55692ed56622" /> | <img width="486" alt="footer-after" src="https://github.com/user-attachments/assets/4b4f7535-146e-4f85-85e6-9910aa3e222c" /> |

Two of the checks that matter more than the wide one — a phone, where every
list folds and the tool groups go 2×2 rather than one column of forty-two, and
Arabic, where the whole thing mirrors, the split list reads right to left, and
the columns still line up:

| 380px wide | Arabic, 1200px |
|---|---|
| <img width="300" alt="footer-after-380px" src="https://github.com/user-attachments/assets/61219133-96c1-4164-9cce-7fac7313942e" /> | <img width="486" alt="footer-after-arabic" src="https://github.com/user-attachments/assets/02725b16-53f1-4ad6-8889-54093a55b04e" /> |

## Checked

A full build passes with links checked. The hrefs inside `<footer>` are
identical before and after on every kind of page, and every front page carries
four groups and either forty-two links or, for the languages still waiting on
`business-profile-preview`, forty-one. Photographed at 1200, 800, 768, 700,
520 and 380 CSS px, on a tool page and the 404 as well as the hub, and in
Chinese and Arabic as well as French — which has the longest category headings
and the longest legal links on the site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
