### PR TITLE
Put the tools back on the English front page

### DIFF
--- a/build.py
+++ b/build.py
@@ -1632,7 +1632,16 @@ def build_hub(out, templates, locale, locales, site, by_slug, footer, links,
             # `listed` is still told about every slug, because it answers the
             # config's question - is any tool listed nowhere - which is about
             # the site and not about one language.
-            if not locale['debt'].get(slug):
+            #
+            # And `is_base` first, exactly as translated() does it and as the
+            # same filter over in build_locale does. English carries a debt
+            # entry for every page it has - it is the source every other
+            # language is measured against, not a language that owes anything
+            # - so reading that dict without this guard takes every card off
+            # the English front page. It did: this line shipped to dev without
+            # it and /index.html went out with four headings and no tools
+            # under any of them.
+            if locale['is_base'] or not locale['debt'].get(slug):
                 chosen.append(tool)
             listed.add(slug)
         # A category nobody in this language can use is not a heading worth

--- a/tests/python/test_build.py
+++ b/tests/python/test_build.py
@@ -1165,6 +1165,13 @@ class BuildTheSite(unittest.TestCase):
         entry for every page it has - it is the source, not a language that
         owes anything - so the filter has to let the base through before it
         reads that dict. Nothing here noticed a front page with no tools on it.
+
+        And this test, written to catch exactly that, did not either - because
+        it read the whole file for the slug, and the FOOTER of a hub links
+        every tool the language has whether or not a single card was drawn.
+        The half of the guard build_hub was missing shipped to dev under a
+        green suite. So what it looks for now is the card's own anchor, which
+        nothing but a card writes.
         """
         slugs = sorted(path.parent.name for path in (ROOT / 'tools').glob('*/tool.toml'))
         self.assertGreater(len(slugs), 1)
@@ -1172,9 +1179,11 @@ class BuildTheSite(unittest.TestCase):
             hub = (self.out / locale['prefix'] / 'index.html').read_text(encoding='utf-8')
             for slug in slugs:
                 has = locale['is_base'] or not locale['debt'].get(slug)
-                # The href the hub writes is relative, so the localized slug and
-                # the closing quote are what identify it.
-                linked = f'{locale["slugs"].get(slug, slug)}/"' in hub
+                # The card's anchor, not the slug: the href the hub writes is
+                # relative, so a bare `<slug>/"` matches the footer link too
+                # and a hub with no cards at all passes.
+                linked = (f'class="tool-card" href="'
+                          f'{locale["slugs"].get(slug, slug)}/"') in hub
                 with self.subTest(lang=locale['lang'], tool=slug):
                     self.assertEqual(
                         linked, has,


### PR DESCRIPTION
`dev` currently builds an English front page with no tools on it. Four
categories' worth of nothing, no cards, and no filter — `hub-filter.js`
reveals the search box only once it has found a card to filter, so that
disappears too. `/zh/` and the other fourteen languages are correct.

#399 filters the hub, the footer and the related strips down to the tools a
language actually has, and its own commit message says how that filter has to
start:

> `is_base` first, exactly as `translated()` does it. English carries a debt
> entry for every page it has — it is the source every other language is
> measured against, not a language that owes anything — so reading that dict
> without the guard empties the English hub, footer and related strips of all
> forty-two tools.

The guard went into the copy of the filter in `build_locale` and not into the
one in `build_hub`. One line.

## Before and after

The top of `/`, built from `dev` and built from this branch. Same shot, same
width: the guarantees, and then the footer.

| Before (`dev`) | After |
|---|---|
| <img width="470" alt="hub-before" src="https://github.com/user-attachments/assets/e8547526-25c7-4ed8-869b-0a19d052023e" /> | <img width="470" alt="hub-after" src="https://github.com/user-attachments/assets/bb84d9a3-0dca-4c33-904d-ccb291f30495" /> |

Counted rather than eyeballed as well: `class="tool-card"` appears 0 times in
`dev`'s `/index.html` and 42 times in this branch's, while `/zh/` stays at 41
either way — it is the one language holding `business-profile-preview` back,
which is what #399 was for.

## Why the test written for this did not catch it

`test_every_hub_lists_the_tools_that_language_has` exists precisely to stop an
empty hub shipping, and it passed on an empty hub. It read the whole page for
`<slug>/"`, and the **footer** of a hub links every tool the language has
whether or not a card was ever drawn — so `linked` was true for all forty-two
names on a page with none of them on it. The other half of the assertion, that
a held-back tool is absent, still worked, which is why the `/zh/` case it was
written for is right and the English one is not.

It now looks for `class="tool-card" href="<slug>/"`, which nothing but a card
writes. Watched failing with the guard removed — forty-two subtests, `en has
base64 and its hub does not link it` — before being kept.

## How it surfaced

The QA suite has been failing 53 cases against every preview since #399
merged: the whole of `hub-filter.spec.ts`, plus `hub page › lists every
shipped tool exactly once` and `every tool card points at a slug that actually
exists`. It came up while looking at a red `qa/preview` on an unrelated footer
branch (#401), which is stacked on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
