### PR TITLE
Stop two tool names arriving with a literal &amp; in them

### DIFF
--- a/locales/fr/tools/base64.toml
+++ b/locales/fr/tools/base64.toml
@@ -5,7 +5,7 @@
 # the icon, the CSP and the list of shared parts stay where they are.
 #
 
-name = "Encodeur &amp; décodeur Base64"
+name = "Encodeur & décodeur Base64"
 heading = "Encodeur&nbsp;&amp;&nbsp;décodeur&nbsp;Base64 <span class=\"h1-kw\">&mdash; et URL, entités HTML, hexadécimal et échappements</span>"
 tagline = "Base64, encodage pourcent, entités HTML, hexadécimal et échappements antislash, dans les deux sens. Rien n'est collé dans le serveur de quelqu'un d'autre."
 

--- a/locales/id/tools/base64.toml
+++ b/locales/id/tools/base64.toml
@@ -5,7 +5,7 @@
 # the icon, the CSP and the list of shared parts stay where they are.
 #
 
-name = "Pengode &amp; Pengurai Base64"
+name = "Pengode & Pengurai Base64"
 heading = "Pengode&nbsp;&amp;&nbsp;Pengurai&nbsp;Base64 <span class=\"h1-kw\">&mdash; dan URL, entitas HTML, heksadesimal, dan escape</span>"
 tagline = "Base64, pengodean persen, entitas HTML, heksadesimal, dan escape garis miring terbalik, dua arah. Tidak ada yang ditempelkan ke server orang lain."
 


### PR DESCRIPTION
`name` is plain text. Every template that prints a tool's name escapes it —
`{{ t.name | e }}` in the footer, the related-tools ring, the breadcrumb, the
hub, the 404 and the roadmap — and `tool_jsonld` puts it straight into JSON,
which is plain text too. The French and Indonesian Base64 names were written
with `&amp;` where English has a bare `&`, so the escape ran over an entity
that was already there and each of those surfaces showed the reader the five
characters `&amp;`.

```diff
-name = "Encodeur &amp; décodeur Base64"
+name = "Encodeur & décodeur Base64"

-name = "Pengode &amp; Pengurai Base64"
+name = "Pengode & Pengurai Base64"
```

## What it looked like

The "Also in the box" ring on `/fr/formater-du-json/` and `/id/format-json/`,
photographed from a `--no-minify` build of this branch and one of its parent.

| | Before | After |
|---|---|---|
| **fr** | ![fr before](https://github.com/user-attachments/assets/cf22df8d-e152-485e-a8f1-da0609263ea4) | ![fr after](https://github.com/user-attachments/assets/7daf0e4b-eac4-4593-978c-c890cdfcba17) |
| **id** | ![id before](https://github.com/user-attachments/assets/8f3297fa-74eb-40e8-9870-1c0ad9915c6e) | ![id after](https://github.com/user-attachments/assets/e42a43ec-aaed-475f-b4f1-4dc82a762892) |

The neighbouring cards are the control: they are the same in both columns.
So is `Hachage & somme de contrôle` further down the French footer, which has
always been written with a bare `&` and has always rendered as one.

## What is deliberately not touched

The sibling fields on the same line are markup and keep their entities —
`heading` and `title` are rendered raw, which is why they still read
`&nbsp;&amp;&nbsp;` a line below the change. So do the hub's category names
(`Video &amp; animation`) and a prose page's `nav` (`Privacy &amp; Cookies`),
both printed without `| e`; English writes those with `&amp;` on purpose.

Two sinks were already right, and they are why this went unnoticed for so
long: the web app manifest and the markdown twin both run the name through
`site.to_text`, which unescapes. The Atom feed would have shown it — it
escapes into `type="html"` — but neither language is offered, so neither has
a feed.

## The sweep

`name` is the only plain-text field authored per locale, so it is the only one
that can go wrong this way. Every other `name` carrying an entity across
`config/` and `locales/` is a hub category or a roadmap group, both rendered
raw; every `nav` carrying one is rendered raw as well. The other tool names
that contain an ampersand — de, nl, ko and the rest of fr and id — already use
a bare `&`. These two were the only ones.

Both languages are in `unadvertised_languages`, so this is cosmetic rather
than urgent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
