### PR TITLE
Keep one build on `dist` rather than a history of them

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -445,16 +445,21 @@ jobs:
           git config user.name  'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
-          # Check out the dist branch beside the working tree, creating it as an
-          # orphan the first time. A worktree rather than a second clone, so the
-          # push reuses the credentials actions/checkout already configured.
+          # The deployed tree, beside the working tree. A worktree rather than
+          # a second clone, so the push reuses the credentials actions/checkout
+          # already configured; --depth=1 because one commit is all there is to
+          # fetch - see the root commit at the bottom of this step.
+          #
+          # `deployed` is the tree id of what is live, and it is wanted for the
+          # comparison below rather than for the commit. Empty on the first
+          # deploy, when there is no branch yet and everything is new.
+          deployed=
           if git ls-remote --exit-code --heads origin dist >/dev/null 2>&1; then
-            git fetch origin dist
-            git worktree add .publish FETCH_HEAD
-            git -C .publish switch -C dist
+            git fetch --depth=1 origin dist
+            git worktree add --detach .publish FETCH_HEAD
+            deployed=$(git rev-parse 'FETCH_HEAD^{tree}')
           else
             git worktree add --detach .publish
-            git -C .publish checkout --orphan dist
           fi
 
           # A fingerprint of every deployed page's <main>, taken before
@@ -474,14 +479,48 @@ jobs:
           cp -a _site/. .publish/
 
           git -C .publish add -A
-          if git -C .publish diff --cached --quiet; then
+
+          # Two trees compared, rather than the index against HEAD. The commit
+          # below has no parent for an index to be diffed against, and a tree
+          # id is the same question asked of the thing itself: equal ids are
+          # equal sites, whatever history stands either side of them.
+          built=$(git -C .publish write-tree)
+          if [ "$built" = "$deployed" ]; then
             echo 'The build is identical to what is already deployed; nothing to push.'
             exit 0
           fi
 
+          # A ROOT COMMIT EVERY TIME, force-pushed over the last one, so `dist`
+          # holds one build and never a history of them.
+          #
+          # It used to accumulate. Every deploy committed on top of the last,
+          # and a frame-wide change - a footer, a hub listing - rewrites all
+          # 19,672 files, so those deploys added 1,600 to 3,000 new blobs each,
+          # 59 to 102 MB of content apiece before compression. The repository
+          # was 449 MB of a GitHub Pages source limit that is recommended at
+          # 1 GB, and nothing was reading a byte of what it was spending that
+          # on.
+          #
+          # NOTHING READS THE HISTORY, which is what makes this safe rather
+          # than merely cheap. `--check` asks for `dist^{tree}` and compares
+          # blob ids against a fresh build (buildlib/deployed.py); the IndexNow
+          # baseline a few lines up reads the checked-out worktree, not a
+          # commit range. The record of how the site got here is `main`'s
+          # history, which is the sources and is kept forever - and each build
+          # commit still names the `main` commit it was built from, so the tip
+          # points back into that record.
+          #
+          # WHAT IT COSTS a reader: `dist` is force-pushed, so a fetched copy
+          # will not fast-forward. `git fetch origin dist` still updates
+          # `origin/dist` - the default refspec is forced - but a local `dist`
+          # branch has to be reset onto it rather than pulled. The published
+          # size will not drop the day this lands either; unreachable objects
+          # are GitHub's to reclaim, on their schedule. What changes today is
+          # that the branch stops growing.
           subject=$(git log -1 --pretty=%s "$SHA")
-          git -C .publish commit -m "Build ${SHA:0:7}: ${subject}"
-          git -C .publish push origin dist
+          commit=$(git -C .publish commit-tree "$built" \
+            -m "Build ${SHA:0:7}: ${subject}")
+          git -C .publish push --force origin "$commit:refs/heads/dist"
 
       # The version, as a tag on the commit that shipped it.
       #

--- a/buildlib/deployed.py
+++ b/buildlib/deployed.py
@@ -43,16 +43,37 @@ def check_against_branch(out, branch='dist'):
     A fresh clone has the branch only as origin/dist, so try that too rather
     than shrugging and reporting success.
     """
-    for ref_name in (branch, f'origin/{branch}'):
+    def tree_of(ref_name):
         # utf-8 for the same reason as the call in compare() below. This one
         # reads back a hex id and would survive any codec, but it captures
         # git's stderr too, and a git that has been translated writes that in
         # whatever it likes.
         found = subprocess.run(['git', 'rev-parse', '--verify', f'{ref_name}^{{tree}}'],
                                capture_output=True, encoding='utf-8', cwd=ROOT)
-        if found.returncode == 0:
-            branch = ref_name
-            break
+        return found.stdout.strip() if found.returncode == 0 else None
+
+    local, remote = branch, f'origin/{branch}'
+    trees = {name: tree_of(name) for name in (local, remote)}
+
+    # THE REMOTE REF WINS WHEN THE TWO DISAGREE, and that is not a general
+    # preference for freshness - it is because `dist` is force-pushed. Every
+    # deploy replaces it with a root commit holding one build, so a local
+    # branch left from an earlier fetch does not fast-forward on the next one:
+    # it simply stays where it was, and `git fetch` updates origin/dist around
+    # it. Checking against the stale one would compare this build with a site
+    # that is no longer served and report every page that has moved since as a
+    # difference - a wrong answer delivered with complete confidence, which is
+    # the one failure this command exists to prevent. See "Publish to the dist
+    # branch" in .github/workflows/build.yml.
+    if trees[local] and trees[remote] and trees[local] != trees[remote]:
+        print(f'  {local} is behind {remote}, which is what is deployed - '
+              f'checking against that instead')
+        print(f'  (git branch -f {local} {remote}, to catch the local one up)')
+        branch = remote
+    elif trees[local]:
+        branch = local
+    elif trees[remote]:
+        branch = remote
     else:
         print(f'\n  no {branch} branch here to check against '
               f'(try: git fetch origin {branch})', file=sys.stderr)

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -26,7 +26,7 @@ To see what would be deployed before pushing, run `python build.py` and look at
 | a working branch | one change | builds and checks it; previews it once a pull request is open |
 | `dev` | everything merged since the last release | builds it, and previews it twice: at `dev.abox-preview.pages.dev`, and at `dev-pr-<n>.abox-preview.pages.dev` for the merge that caused it |
 | `main` | what is live | builds, publishes to `dist`, tags the version, tells IndexNow |
-| `dist` | the built site, and nothing else | GitHub Pages serves it |
+| `dist` | the built site, and nothing else — one commit, replaced every deploy | GitHub Pages serves it |
 
 Work is opened against `dev`. **Releasing is opening a pull request from `dev`
 to `main`** and merging it — there is no other step, and no file in the tree has
@@ -158,6 +158,35 @@ output instead buys one specific thing: a reader can run `python build.py` on
 their own machine and diff the result against the branch that is actually being
 served. A site whose entire pitch is "check this rather than believe it" should
 not ask anyone to take the deployment on trust either.
+
+### `dist` keeps no history
+
+Every deploy replaces the branch with a **root commit** — one commit, no
+parent — and force-pushes it. `dist` therefore holds the site as it stands and
+no record of how it got there.
+
+The record is `main`'s history, which is the sources and is kept forever; each
+build commit still names the `main` commit it was built from, so the tip points
+back into it. Nothing reads the deploy history: `--check` asks for
+`dist^{tree}`, and the IndexNow baseline reads the checked-out worktree rather
+than a commit range.
+
+What it saves is repository size, and the branch was the whole of the problem.
+A frame-wide change — a footer, a hub listing — rewrites all 19,672 built
+files, so those deploys were adding 1,600 to 3,000 new blobs each, 59 to 102 MB
+apiece before compression, to a repository already at 449 MB of the 1 GB
+GitHub recommends for a Pages source.
+
+Two things follow for anyone who has fetched the branch:
+
+- **A local `dist` will not fast-forward.** `git fetch origin dist` still moves
+  `origin/dist` — the default refspec is forced — but a local branch left from
+  an earlier fetch stays where it was. `--check` notices when the two disagree,
+  says so, and checks against `origin/dist`; `git branch -f dist origin/dist`
+  catches the local one up.
+- **The published size will not drop the day this changes.** Unreachable
+  objects are GitHub's to reclaim, on their own schedule. What changes
+  immediately is that the branch stops growing.
 
 ## DNS at Cloudflare
 


### PR DESCRIPTION
Every deploy committed on top of the last, so `dist` was a record of every build the site has ever had. Nothing reads that record, and it is not cheap:

| | |
|---|---|
| Repository now | **449 MB** — of the **1 GB** GitHub recommends for a Pages source |
| A frame-wide deploy (footer, hub listing) | **1,600–3,000 new blobs**, 59–102 MB before compression |
| A small deploy | ~40 blobs |
| Built site itself | 19,672 files, 300.8 MB |

A footer change rewrites all 19,672 files, so the expensive deploys are the routine ones.

## What this does

The publish step writes a **root commit** — `git commit-tree` with no parent — and force-pushes it over the last. `dist` holds the site as it stands and nothing else.

**Nothing reads the history**, which is what makes this safe rather than merely cheap, and it was checked rather than assumed:

- `--check` asks git for `dist^{tree}` and compares blob ids against a fresh build (`buildlib/deployed.py`)
- the IndexNow baseline reads the checked-out worktree a few lines above, not a commit range

The record of how the site got here is `main`'s history — the sources, kept forever — and each build commit still names the `main` commit it was built from, so the tip points back into it.

## Two things it needed beyond the force-push

**The identical-build skip** no longer works by diffing the index against HEAD, because a root commit has no HEAD to diff against — `git add -A` in a fresh worktree stages the whole site as new every time, and the step would have pushed a deploy that changed nothing on every run. It compares the tree it just wrote against the tree of what is deployed instead.

**`--check` had to learn which of two refs is deployed.** It tried `dist` first and `origin/dist` second, which was right while the branch only moved forward. Under a force-push a local `dist` does not fast-forward — `git fetch` moves `origin/dist` around it and leaves the local one where it was — so the old order would compare a fresh build against a site that is no longer served and report every page moved since as a difference. A wrong answer delivered with complete confidence is the one failure that command exists to prevent.

## Verified against a real repository

Not by reading. Three deploys through the actual step — a first, an identical one, and a changed one:

```
=== deploy 1 (first ever) ===     -> pushed eda265d
=== deploy 2 (identical build) === -> identical to what is deployed; nothing to push.
=== deploy 3 (changed build) ===   -> pushed 09e1818

history depth:    1
parents of tip:   ''
tip content:      v2
```

Then a second clone that had fetched the branch before the force-push:

```
 + 09e1818...29b9ff6 dist -> origin/dist  (forced update)
origin/dist now: 29b9ff6 -> v3
local dist still: v2

  dist is behind origin/dist, which is what is deployed - checking against that instead
  (git branch -f dist origin/dist, to catch the local one up)
  origin/dist matches a fresh build of these sources
```

The two paths that did not change still behave as they did: a fresh clone with only `origin/dist` uses it, and a checkout with neither prints `no dist branch here to check against` and exits 0.

## What this does not do

Shrink anything today. Unreachable objects are GitHub's to reclaim, on their own schedule. What changes immediately is that the branch stops growing.

## Notes

Nothing a visitor sees changes, so there are no before and after pictures. `buildlib/` is not on the version rule's invisible list, so this tags a patch version — correct, and the cheaper of the two mistakes.

Independent of #406 and #407, which touch the preview job only; this touches the publish step, which is identical on `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
