### PR TITLE
Carry a whole batch of results on, not just a single one

### DIFF
--- a/docs/adding-a-tool.md
+++ b/docs/adding-a-tool.md
@@ -237,6 +237,83 @@ Only *choosing* the files is shared. What a tool does with them afterwards — t
 list, the thumbnails, the reordering, the per-row buttons — differs enough per
 tool that sharing it would cost more than it saved.
 
+## Carrying a result into the next tool
+
+A result made on one page here so often wants to be the input of another: the
+scanned pages join the emailed contract, the compressed photos become the PDF,
+the trimmed clip becomes the GIF. Without help the route is download, find the
+file, drop it on the next page — three manual steps carrying a file the browser
+was already holding.
+
+One line in `tool.toml` replaces them with a link:
+
+```toml
+handoff = ["compress-image", "resize-image"]
+```
+
+That renders a row of links under the finished result — "Carry the result
+straight into:" — and `shared/handoff.js` does the rest: it reads the bytes back
+out of the page's own `blob:` URL, parks them in IndexedDB under the receiving
+tool's slug, and navigates. The next page finds them, feeds them through the
+same file input a dropped file goes through, and deletes the record. Records are
+consumed exactly once and swept after ten minutes, so an abandoned handoff is
+not still holding somebody's contract at the end of the day.
+
+**The receiving tool needs nothing at all.** It is not listed anywhere, it
+imports nothing, and it has no idea it is being fed: the files arrive through
+its own `#file-input` with a `DataTransfer` and a synthetic `change` event, so
+every tool keeps exactly one way of accepting a file. Being a *target* is free.
+Being a *sender* costs the two things below.
+
+**One directive.** Reading a `blob:` URL back is a `fetch`, and the policy has
+to permit it:
+
+```toml
+[csp]
+"connect-src" = ["blob:"]
+```
+
+`blob:` names bytes inside this page, so this gains no reach over the network —
+but say so in `csp_note`, which is where the generated policy comment explains
+itself, and which no locale translates.
+
+**And a page that can still make its promise.** This is the part to check
+before writing the line. Several tools argue on their own pages that
+`connect-src` is shut — `/heic-to-jpg/` explains that its engine embeds its
+binary rather than fetching one *because* connect-src is untouched, and
+`/images-to-video/` tells the reader "`img-src` is opened, `connect-src` is
+not". Those sentences sit in `[[privacy]]`, which **is** translated, so opening
+the directive would mean rewriting a promise in fifteen languages. A carry-on
+row is a convenience; it does not outrank a claim the page already makes. Where
+the no-fetch prose is scoped to `src/` — "no `fetch` ... anywhere in
+`src/`", which is how most tools word it — it stays true, because `handoff.js`
+is a frame script and not part of any tool's `src/`.
+
+**Two shapes are carried, and a batch travels whole.** A tool that makes one
+thing reveals the single `#download` anchor its `body.html` declares. A tool
+that works through a batch has no such anchor: it builds a row per result
+inside `.result-list`, each with its own link. `handoff.js` looks for both, and
+a batch tool hands over everything it finished — twelve compressed photos
+arrive as twelve files, which is the detour most worth skipping, because saving
+twelve files and handing twelve back is the part nobody does twice. A tool that
+lists results under some other class is not seen; give it `.result-list` from
+`css_parts = ["results"]` rather than widening the selector.
+
+The build checks each target names a tool that exists and that no tool names
+itself. It does **not** check that the target can open what the sender makes —
+nothing declares what a tool produces, and the output format is usually the
+visitor's choice anyway — so that pairing is a judgement, made against the
+receiving tool's `[picker]`. Two questions, and the build will ship a wrong
+answer to either without complaint:
+
+- would its `accept` take the file? Point an image tool at a PDF tool and the
+  row is a link to a page that refuses what it is handed;
+- if this tool finishes a **batch**, is the target `multiple = true`? All of
+  them arrive at once. A single-file picker takes a `DataTransfer` of twelve
+  happily — `multiple` constrains the picker dialog, not an assignment — and
+  what the visitor then sees depends on what that tool does with a list it was
+  never written to expect.
+
 ## A vendored engine
 
 A codec nobody here wrote goes in `tools/<slug>/vendor/`, and only one tool has

--- a/shared/handoff.js
+++ b/shared/handoff.js
@@ -11,12 +11,20 @@
  *
  * WHAT THIS DOES, AND WHAT IT NEVER DOES
  *
- * When a tool that declares handoff targets finishes a result - its download
- * link gets a blob: URL and becomes visible - a small row of links appears
- * beside that link: the other tools this result can go straight into. Clicking
- * one reads the result out of the page's own blob: URL, parks it in
- * IndexedDB, and navigates. The next page finds it there, feeds it through
- * the same file input a dropped file goes through, and deletes it.
+ * When a tool that declares handoff targets finishes - a download link gets a
+ * blob: URL and becomes visible - a small row of links appears under the
+ * result: the other tools it can go straight into. Clicking one reads the
+ * bytes back out of the page's own blob: URLs, parks them in IndexedDB, and
+ * navigates. The next page finds them there, feeds them through the same file
+ * input a dropped file goes through, and deletes the record.
+ *
+ * A result is not always one file. Many tools here work through a batch -
+ * twelve photos compressed, a folder of pictures stripped of their metadata -
+ * and show a row per result rather than a single download button. Those are
+ * the pages where the detour costs most, because it is twelve files to save
+ * and twelve to hand over again, and they are the reason this file looks for
+ * results in two shapes rather than one. Everything a page has finished
+ * travels together; see `results` below.
  *
  * Nothing in that journey touches the network. A blob: URL names bytes inside
  * this page; IndexedDB is the browser's own storage on this machine, the same
@@ -112,11 +120,11 @@
   var page = document.getElementById('feedback');
   var slug = page ? page.getAttribute('data-tool') : '';
 
-  function deliver(file) {
+  function deliver(files) {
     var input = document.getElementById('file-input');
-    if (!input || typeof DataTransfer === 'undefined') return;
+    if (!input || !files.length || typeof DataTransfer === 'undefined') return;
     var carrier = new DataTransfer();
-    carrier.items.add(file);
+    for (var i = 0; i < files.length; i++) carrier.items.add(files[i]);
     input.files = carrier.files;
     // The same event a real pick fires, so the tool's own wiring - reading,
     // thumbnails, error messages - runs unchanged and this page needs no
@@ -124,12 +132,27 @@
     input.dispatchEvent(new Event('change', { bubbles: true }));
   }
 
+  /**
+   * What a record is carrying, whichever shape parked it.
+   *
+   * `files` is the shape a batch sender parks and the one every sender parks
+   * now; `file` is what a single-result sender parked before this file learned
+   * to carry a list. Both are read because a record outlives the page that
+   * wrote it: a visitor with a tool open in another tab from before a deploy
+   * can still click carry, and the receiving page is the new one. Ten minutes
+   * of overlap costs one line here and is invisible to everybody.
+   */
+  function carried(record) {
+    if (!record) return [];
+    if (record.files && record.files.length) return record.files;
+    return record.file ? [record.file] : [];
+  }
+
   function receive() {
     if (!slug) return;
     take(slug).then(function (record) {
-      if (record && record.file && record.time
-          && Date.now() - record.time <= FRESH) {
-        deliver(record.file);
+      if (record && record.time && Date.now() - record.time <= FRESH) {
+        deliver(carried(record));
       }
       return sweep();
     }).catch(function () {
@@ -149,12 +172,67 @@
   var nav = document.getElementById('handoff');
   if (!nav) return;
 
-  /** The finished result: a visible download link naming bytes in this page. */
-  function result() {
-    var anchor = document.getElementById('download');
-    if (!anchor || anchor.hidden || !anchor.hasAttribute('download')) return null;
+  /** A download link is carriable when it is on screen and names bytes here. */
+  function carriable(anchor) {
+    if (!anchor || anchor.hidden || !anchor.hasAttribute('download')) return false;
     var href = anchor.getAttribute('href') || '';
-    return href.indexOf('blob:') === 0 ? anchor : null;
+    if (href.indexOf('blob:') !== 0) return false;
+    // A row inside a results block the tool is still holding back is not
+    // hidden itself - its container is - so `hidden` alone would carry the
+    // leftovers of a previous run. `offsetParent` is null for anything inside
+    // a display:none ancestor, which is the one read that answers for the
+    // whole chain.
+    return anchor.offsetParent !== null;
+  }
+
+  /**
+   * The finished results: every visible download link naming bytes in this
+   * page, in the order the page shows them.
+   *
+   * Two shapes, because tools finish in two shapes. A tool that makes ONE
+   * thing - a trimmed clip, a merged PDF - reveals the single `#download`
+   * anchor its body.html declares, and that was the only shape this file knew
+   * how to carry. A tool that works through a BATCH - the compressor, the
+   * resizer, the EXIF cleaner - has no such anchor at all: it builds a row per
+   * result inside `.result-list`, each with its own link, and offers a ZIP of
+   * the lot beside the heading. Those are the tools where the download
+   * detour hurts most, because it is not one file to fetch and hand on but
+   * twelve, and until this function looked for them the carry row could never
+   * appear on any of them.
+   *
+   * Both shapes are read rather than one or the other, and the rows come
+   * second, so a tool that grows a list beside its single result carries them
+   * in the order a reader sees them.
+   */
+  function results() {
+    var found = [];
+    var one = document.getElementById('download');
+    if (carriable(one)) found.push(one);
+    var rows = document.querySelectorAll('.result-list a[download]');
+    for (var i = 0; i < rows.length; i++) {
+      if (carriable(rows[i])) found.push(rows[i]);
+    }
+    return found;
+  }
+
+  /**
+   * The first carriable result, or null - all `show` below needs to know.
+   *
+   * Separate from `results` because of what watches it. The observer has to
+   * include childList to see a batch tool's rows arrive at all (see there),
+   * which puts this function on the end of every DOM insertion the page makes
+   * while it works - and `carriable` reads `offsetParent`, which forces
+   * layout. Stopping at the first hit keeps that to one read per call instead
+   * of one per result, on a page that may be building fifty of them.
+   */
+  function firstResult() {
+    var one = document.getElementById('download');
+    if (carriable(one)) return one;
+    var rows = document.querySelectorAll('.result-list a[download]');
+    for (var i = 0; i < rows.length; i++) {
+      if (carriable(rows[i])) return rows[i];
+    }
+    return null;
   }
 
   /**
@@ -187,7 +265,7 @@
   }
 
   function show() {
-    var anchor = result();
+    var anchor = firstResult();
     // Every write in here is guarded by a read. The observer below watches
     // `hidden` across the page, and that includes this nav's own attribute:
     // setting it to the value it already has still records a mutation, which
@@ -198,6 +276,15 @@
       // is a false one until there is a result: the strip used to sit under
       // the last card, greyed, promising to pass on something the page had
       // not made.
+      return;
+    }
+    // Already up, and already in the block this result lives in: nothing to
+    // do. Worth the two reads because of what calls this - the observer fires
+    // once per appended row, and `seat` below walks the ancestors asking
+    // getComputedStyle for each, which forces layout on a page that is in the
+    // middle of building fifty of them.
+    if (!nav.hidden && nav.parentNode && nav.parentNode !== document.body
+        && nav.parentNode.contains(anchor) && nav.parentNode.lastElementChild === nav) {
       return;
     }
     // Under the result the download belongs to. A tool laid out in a way this
@@ -216,12 +303,23 @@
     if (nav.hidden) nav.hidden = false;
   }
 
-  // Tools reveal the link by unhiding it and swapping its href for each new
-  // result; both are attribute changes, and new anchors never appear - the
-  // markup is static - so watching attributes is enough.
+  // A tool with one result reveals its link by unhiding it and swaps the href
+  // for each new result; both are attribute changes, and that anchor is in the
+  // markup from the start.
+  //
+  // A batch tool's rows are not. They are built and appended as the run
+  // finishes, and - checked in every tool that has them - the results block is
+  // unhidden BEFORE the first row goes in. So the `hidden` change this used to
+  // rely on arrives while the list is still empty. It happens to work anyway,
+  // because a MutationObserver delivers at the end of the task and the appends
+  // are in the same one; that is a coincidence of how those tools are written
+  // rather than anything this file is owed, and it would break silently the
+  // day a tool appended its rows from a promise. childList is what actually
+  // answers the question being asked.
   var watch = new MutationObserver(show);
   watch.observe(document.body, {
-    subtree: true, attributes: true, attributeFilter: ['href', 'hidden'],
+    subtree: true, childList: true,
+    attributes: true, attributeFilter: ['href', 'hidden'],
   });
   show();
 
@@ -237,26 +335,39 @@
       ? event.target.closest('a[data-slug]') : null;
     if (!link) return;
     if (carrying) { event.preventDefault(); return; }
-    var anchor = result();
-    if (!anchor) return;    // stale click; let the plain navigation happen
+    // Read again rather than trusting what `show` last saw: the row is revealed
+    // once and the list behind it goes on growing, so this is the only moment
+    // the full set is known.
+    var anchors = results();
+    if (!anchors.length) return;    // stale click; let the plain navigation happen
 
     event.preventDefault();
     carrying = true;
     // Says "this click landed" for the moment before the page changes, in the
     // one way that needs no words: the styling is in tool-frame.css.
     link.setAttribute('aria-busy', 'true');
-    var name = anchor.getAttribute('download') || 'result';
 
-    // Read the page's own bytes back out of the blob: URL, park them for the
+    // Read the page's own bytes back out of its blob: URLs, park them for the
     // next page, and go. If any step refuses - CSP, storage, anything - the
     // fallback is the navigation alone: the reader lands on the tool and drops
-    // the file by hand, which is exactly the journey this button shortens.
-    window.fetch(anchor.href)
-      .then(function (response) { return response.blob(); })
-      .then(function (blob) {
-        var file = new File([blob], name, { type: blob.type });
+    // the files by hand, which is exactly the journey this button shortens.
+    //
+    // All of them or none: Promise.all rejects on the first failure and the
+    // catch below falls through to the plain visit. Parking the subset that
+    // did read would be worse than parking nothing, because the next page
+    // cannot tell a short delivery from a complete one and neither can the
+    // reader - they would see eleven of their twelve photos and no reason why.
+    window.Promise.all(anchors.map(function (anchor) {
+      return window.fetch(anchor.href)
+        .then(function (response) { return response.blob(); })
+        .then(function (blob) {
+          return new File([blob], anchor.getAttribute('download') || 'result',
+                          { type: blob.type });
+        });
+    }))
+      .then(function (files) {
         return park(link.getAttribute('data-slug'),
-                    { file: file, from: slug, time: Date.now() });
+                    { files: files, from: slug, time: Date.now() });
       })
       .catch(function () { /* fall through to the plain visit */ })
       .then(function () { window.location.assign(link.href); });

--- a/tests/python/test_build.py
+++ b/tests/python/test_build.py
@@ -966,6 +966,36 @@ class BuildTheSite(unittest.TestCase):
                         folder = by_slug[target].split('/')[-1]
                         self.assertIn(f'href="../{folder}/"', page)
 
+    def test_a_tool_that_offers_a_handoff_has_a_result_the_row_can_find(self):
+        """A sender needs somewhere for shared/handoff.js to look.
+
+        The row reads the page's finished work out of the DOM, because it is a
+        frame script and has no access to the tool's own variables. It knows
+        two shapes: the single `#download` anchor a one-result tool declares,
+        and the per-result links a batch tool builds inside `.result-list`. A
+        tool with neither renders the row and then never reveals it - the
+        offer is in the markup, in fifteen languages, and no visitor ever sees
+        it, which is the failure this catches. It is exactly how the row came
+        to be missing from the compressor, the resizer and the rest for as
+        long as the script looked for `#download` alone.
+
+        Checked in each tool's own body.html rather than the built page,
+        because that is where the answer would have to be fixed, and a batch
+        tool's rows do not exist until it has run.
+        """
+        senders = {tool.parent.name
+                   for tool in ROOT.glob('tools/*/tool.toml')
+                   if buildmod.sitelib.load_toml(tool).get('handoff')}
+        self.assertTrue(senders, 'no tool declares handoff targets')
+
+        for slug in sorted(senders):
+            body = (ROOT / 'tools' / slug / 'body.html').read_text(encoding='utf-8')
+            with self.subTest(tool=slug):
+                self.assertTrue(
+                    'id="download"' in body or 'result-list' in body,
+                    f'{slug} offers a handoff but has neither a #download '
+                    'anchor nor a .result-list for the row to read')
+
     def test_a_tool_page_carries_its_work_across_a_language_switch(self):
         """shared/lang-keep.js, on every tool page and nowhere else.
 

--- a/tools/compress-image/README.md
+++ b/tools/compress-image/README.md
@@ -162,3 +162,21 @@ under the target coming back as the identical `File` object; PNG output reaching
 a target by resizing alone; `compare()` returning SSIM 1 and an infinite PSNR for
 a picture against itself, and dropping to ~0.83 at quality 0.05; and the zip
 carrying a valid local-file header.
+
+## Carrying the result on
+
+The compressed pictures can go straight into `/images-to-pdf/` without
+being saved first: `handoff` in `tool.toml` names it, and
+`shared/handoff.js` puts a row of links under the results. This tool
+finishes a whole batch, and the row carries **all** of it — twelve
+compressed photos arrive as twelve files, which is the point, because
+saving twelve and handing twelve back is the part nobody does twice.
+
+What that costs the policy is one directive: `connect-src` carries `blob:`,
+because the row reads the finished result back out of this page before
+parking it for the next tool. So this page does permit `fetch()` of a
+`blob:` URL, and a result can be read back in the page's own console. That
+is the one place this tool's policy differs from a tool with no carry-on
+row, and it is worth knowing before concluding that a `blob:` fetch failing
+somewhere else on the site is a bug. Nothing else is widened, and `blob:`
+names bytes inside this page — it gains no reach over the network.

--- a/tools/compress-image/tool.toml
+++ b/tools/compress-image/tool.toml
@@ -33,7 +33,14 @@ css_parts = ["file-list", "progress", "results", "form", "checks", "notes"]
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.
 js_parts = ["file-picker", "zip", "crc32", "message-box", "download", "media", "example-photo"]
-lastmod = "2026-09-07"
+# Where a finished result can be carried without being saved first: the row
+# of links shared/handoff.js shows under the results once there are any.
+# This tool finishes a whole batch at once and the row carries all of it,
+# which is the detour worth skipping here - saving twelve files and handing
+# twelve back is the part nobody does twice. Checked against the tools that
+# exist by the build.
+handoff = ["images-to-pdf"]
+lastmod = "2026-09-10"
 
 # --- what search engines and chat apps are told ------------------------------
 
@@ -53,7 +60,10 @@ og_card = "Name the size you need and it finds the least compression that gets t
 csp_note = """
   img-src needs blob: for the previews and the compressed results this page
   draws from the files you chose, and https: because ad creatives come from
-  anywhere."""
+  anywhere. connect-src carries blob: because the carry-on row reads the
+  finished result back out of this page before parking it for the next
+  tool. blob: names bytes inside this page; neither gains any reach over
+  the network."""
 
 # --- the pledge block --------------------------------------------------------
 
@@ -307,3 +317,10 @@ hint = "or click to browse &mdash; JPEG, PNG, WebP and anything else your browse
 # shapes would compress to nothing and make this tool look like it works
 # miracles, which is the one thing an example must not do.
 example = true
+
+# The carry-on row reads the finished result back out of this page's own
+# blob: URL before parking it for the next tool (see shared/handoff.js), and
+# reading a blob: URL is a fetch the policy has to permit. blob: names bytes
+# inside this page; nothing here gains any reach over the network.
+[csp]
+"connect-src" = ["blob:"]

--- a/tools/document-scanner/tool.toml
+++ b/tools/document-scanner/tool.toml
@@ -37,8 +37,8 @@ js_parts = ["file-picker", "zip", "crc32", "pdf-page-writer", "message-box", "ex
 # links shared/handoff.js shows beside the download once there is one. Slugs of
 # tools whose picker takes what this page produces; checked against the tools
 # that exist by the build.
-handoff = ["merge-pdf", "compress-pdf"]
-lastmod = "2026-09-07"
+handoff = ["merge-pdf", "compress-pdf", "redact-pdf"]
+lastmod = "2026-09-10"
 
 # --- what search engines and chat apps are told ------------------------------
 
@@ -56,10 +56,12 @@ og_card = "Photograph a page. The corners are found, the angle undone, the shado
 # Appended to the Content-Security-Policy comment in the generated page, for
 # whatever this tool needs that the rest of the site does not.
 csp_note = """
-  This tool widens nothing. The photo and the straightened page are drawn
-  straight into a canvas rather than loaded through a URL, and the finished
-  document is a blob: link you download rather than anything this page
-  fetches."""
+  connect-src carries blob:, and that is the whole of what this tool widens.
+  The photo and the straightened page are drawn straight into a canvas rather
+  than loaded through a URL; what the policy has to permit is the carry-on row
+  reading the finished document back out of this page before parking it for the
+  next tool. blob: names bytes inside this page and gains no reach over the
+  network."""
 
 # --- the pledge block --------------------------------------------------------
 

--- a/tools/exif-editor/README.md
+++ b/tools/exif-editor/README.md
@@ -135,3 +135,21 @@ parsed values match; the EXIF block round-tripping through
 `serializeExif` → `parseExif` unchanged; stripped output still decoding, and its
 JPEG scan being byte-identical to the original's; a WebP produced by
 `canvas.toBlob`, given an EXIF block, read back, and decoded again.
+
+## Carrying the result on
+
+A cleaned photo can go straight into `/compress-image/` or
+`/resize-image/` without being saved first, which is the usual next
+step: the reason to strip the tags is normally that the picture is
+about to be posted somewhere. `handoff` in `tool.toml` names them and
+`shared/handoff.js` puts a row of links under the results. The whole
+batch travels.
+
+What that costs the policy is one directive: `connect-src` carries `blob:`,
+because the row reads the finished result back out of this page before
+parking it for the next tool. So this page does permit `fetch()` of a
+`blob:` URL, and a result can be read back in the page's own console. That
+is the one place this tool's policy differs from a tool with no carry-on
+row, and it is worth knowing before concluding that a `blob:` fetch failing
+somewhere else on the site is a bug. Nothing else is widened, and `blob:`
+names bytes inside this page — it gains no reach over the network.

--- a/tools/exif-editor/tool.toml
+++ b/tools/exif-editor/tool.toml
@@ -37,7 +37,14 @@ css_parts = ["file-list", "form", "checks", "notes"]
 # the PNG writer need. This tool carried its own copy of those two until the
 # tests learned to follow a ./shared/ import (tests/js/resolve-shared.mjs).
 js_parts = ["file-picker", "zip", "crc32", "message-box", "download", "media", "example-photo", "example-exif"]
-lastmod = "2026-09-07"
+# Where a finished result can be carried without being saved first: the row
+# of links shared/handoff.js shows under the results once there are any.
+# This tool finishes a whole batch at once and the row carries all of it,
+# which is the detour worth skipping here - saving twelve files and handing
+# twelve back is the part nobody does twice. Checked against the tools that
+# exist by the build.
+handoff = ["compress-image", "resize-image"]
+lastmod = "2026-09-10"
 
 # --- what search engines and chat apps are told ------------------------------
 
@@ -56,7 +63,10 @@ og_card = "See what a photo says about you, then take it out - without re-encodi
 # whatever this tool needs that the rest of the site does not.
 csp_note = """
   img-src needs blob: for the previews this page draws from the file you chose,
-  and https: because ad creatives come from anywhere."""
+  and https: because ad creatives come from anywhere. connect-src carries blob: because the carry-on row reads the
+  finished result back out of this page before parking it for the next
+  tool. blob: names bytes inside this page; neither gains any reach over
+  the network."""
 
 # --- the pledge block --------------------------------------------------------
 
@@ -305,3 +315,10 @@ hint = "or click to browse &mdash; JPEG, PNG and WebP"
 # date and GPS. A picture with an empty header would say nothing, which is the
 # one thing this tool is for reading.
 example = true
+
+# The carry-on row reads the finished result back out of this page's own
+# blob: URL before parking it for the next tool (see shared/handoff.js), and
+# reading a blob: URL is a fetch the policy has to permit. blob: names bytes
+# inside this page; nothing here gains any reach over the network.
+[csp]
+"connect-src" = ["blob:"]

--- a/tools/merge-pdf/tool.toml
+++ b/tools/merge-pdf/tool.toml
@@ -41,8 +41,8 @@ js_parts = ["file-picker", "zip", "crc32", "pdf-objects", "pdf-filters", "pdf-re
 # links shared/handoff.js shows beside the download once there is one. Slugs of
 # tools whose picker takes what this page produces; checked against the tools
 # that exist by the build.
-handoff = ["compress-pdf"]
-lastmod = "2026-09-07"
+handoff = ["compress-pdf", "redact-pdf"]
+lastmod = "2026-09-10"
 
 # --- what search engines and chat apps are told ------------------------------
 

--- a/tools/redact-image/README.md
+++ b/tools/redact-image/README.md
@@ -126,3 +126,19 @@ undoing: the picture itself is untouched until the button is pressed.
 **The output filename always ends `-redacted`.** Two files called `scan.jpg` in
 a downloads folder is exactly how the original gets attached to the email
 instead of the copy, and nothing this page does can undo that one.
+
+## Carrying the result on
+
+The redacted picture can go straight into `/compress-image/` or
+`/resize-image/` without being saved first — the file is usually on its
+way into an email. `handoff` in `tool.toml` names them and
+`shared/handoff.js` puts a row of links under the result.
+
+What that costs the policy is one directive: `connect-src` carries `blob:`,
+because the row reads the finished result back out of this page before
+parking it for the next tool. So this page does permit `fetch()` of a
+`blob:` URL, and a result can be read back in the page's own console. That
+is the one place this tool's policy differs from a tool with no carry-on
+row, and it is worth knowing before concluding that a `blob:` fetch failing
+somewhere else on the site is a bug. Nothing else is widened, and `blob:`
+names bytes inside this page — it gains no reach over the network.

--- a/tools/redact-image/tool.toml
+++ b/tools/redact-image/tool.toml
@@ -33,7 +33,12 @@ css_parts = ["results", "form", "checks", "notes"]
 # list of boxes underneath the picture is this tool's own, because it is a list
 # of rectangles rather than a list of files.
 js_parts = ["file-picker", "message-box", "example-document", "example-statement", "example-photo"]
-lastmod = "2026-09-07"
+# Where a finished result can be carried without being saved first: the row
+# of links shared/handoff.js shows under the result once there is one. Slugs
+# of tools whose picker takes what this page produces; checked against the
+# tools that exist by the build.
+handoff = ["compress-image", "resize-image"]
+lastmod = "2026-09-10"
 
 # --- what search engines and chat apps are told ------------------------------
 
@@ -53,7 +58,10 @@ og_card = "Draw a box, and the pixels under it stop existing before the file is 
 csp_note = """
   img-src needs blob: because the finished picture is shown to you by decoding
   the file this page just made, and https: because ad creatives come from
-  anywhere."""
+  anywhere. connect-src carries blob: because the carry-on row reads the
+  finished result back out of this page before parking it for the next
+  tool. blob: names bytes inside this page; neither gains any reach over
+  the network."""
 
 # --- the pledge block --------------------------------------------------------
 
@@ -324,3 +332,10 @@ hint = "or click to browse &mdash; JPEG, PNG, WebP and anything else your browse
 # something with information on it worth covering, and nobody has ever wanted
 # to black out a hillside.
 example = true
+
+# The carry-on row reads the finished result back out of this page's own
+# blob: URL before parking it for the next tool (see shared/handoff.js), and
+# reading a blob: URL is a fetch the policy has to permit. blob: names bytes
+# inside this page; nothing here gains any reach over the network.
+[csp]
+"connect-src" = ["blob:"]

--- a/tools/redact-pdf/README.md
+++ b/tools/redact-pdf/README.md
@@ -244,3 +244,20 @@ Tests are in [`tests/js/`](../../tests/js/): `redact-pdf-content`,
 `redact-pdf-fonts`, `redact-pdf-text`, `redact-pdf-matches` and
 `redact-pdf-edit`. The last of those is the one that matters — it writes whole
 documents, opens them again, and searches them.
+
+## Carrying the result on
+
+The redacted file can go straight into `/compress-pdf/` or
+`/merge-pdf/` without being saved first — a redacted document is
+usually one part of something about to be sent. `handoff` in
+`tool.toml` names them and `shared/handoff.js` puts a row of links
+under the result.
+
+What that costs the policy is one directive: `connect-src` carries `blob:`,
+because the row reads the finished result back out of this page before
+parking it for the next tool. So this page does permit `fetch()` of a
+`blob:` URL, and a result can be read back in the page's own console. That
+is the one place this tool's policy differs from a tool with no carry-on
+row, and it is worth knowing before concluding that a `blob:` fetch failing
+somewhere else on the site is a bug. Nothing else is widened, and `blob:`
+names bytes inside this page — it gains no reach over the network.

--- a/tools/redact-pdf/tool.toml
+++ b/tools/redact-pdf/tool.toml
@@ -47,7 +47,12 @@ css_parts = ["progress", "form", "checks", "notes"]
 # nothing about placing a glyph is particular to redaction. What stays in src/
 # is what this tool does once it knows: choosing, editing and proving.
 js_parts = ["file-picker", "pdf-objects", "pdf-filters", "pdf-reader", "pdf-writer", "pdf-content", "pdf-base14", "pdf-fonts", "pdf-strings", "pdf-text", "message-box", "example-pdf", "pdf-page-writer", "example-statement"]
-lastmod = "2026-09-09"
+# Where a finished result can be carried without being saved first: the row
+# of links shared/handoff.js shows under the result once there is one. Slugs
+# of tools whose picker takes what this page produces; checked against the
+# tools that exist by the build.
+handoff = ["compress-pdf", "merge-pdf"]
+lastmod = "2026-09-10"
 
 # --- what search engines and chat apps are told ------------------------------
 
@@ -61,6 +66,15 @@ og_image_alt = "Redact a PDF by deleting the text, not by covering it"
 # card's heading is `name` above and its footer is the same line on every
 # card, so this is the only part of it that belongs to this tool.
 og_card = "Delete the words from the file, then search the file to prove they are gone."
+
+# Appended to the Content-Security-Policy comment in the generated page, for
+# whatever this tool needs that the rest of the site does not.
+csp_note = """
+  connect-src carries blob: because the carry-on row reads the redacted file
+  back out of this page before parking it for the next tool. blob: names
+  bytes inside this page, and reading them back is how the row hands them on
+  without the detour through your downloads folder; it gains no reach over
+  the network. Nothing else here is widened."""
 
 # --- the pledge block --------------------------------------------------------
 
@@ -428,3 +442,10 @@ hint = "or click to browse &mdash; one document at a time"
 # amounts - what people actually redact. Its text is real text, because a
 # picture of text would have nothing in it for this tool to delete.
 example = true
+
+# The carry-on row reads the finished result back out of this page's own
+# blob: URL before parking it for the next tool (see shared/handoff.js), and
+# reading a blob: URL is a fetch the policy has to permit. blob: names bytes
+# inside this page; nothing here gains any reach over the network.
+[csp]
+"connect-src" = ["blob:"]

--- a/tools/resize-image/README.md
+++ b/tools/resize-image/README.md
@@ -232,3 +232,21 @@ then
   333 result for its 1200 x 1600 original in place;
 - and the whole of the above again against the **minified** build, which is what
   actually deploys.
+
+## Carrying the result on
+
+The resized pictures can go straight into `/compress-image/` without
+being saved first — resize to the dimensions you want, then squeeze the
+file down to a byte budget, which is the order those two jobs actually
+happen in. `handoff` in `tool.toml` names the target and
+`shared/handoff.js` puts a row of links under the results; the whole
+batch travels, not the first row.
+
+What that costs the policy is one directive: `connect-src` carries `blob:`,
+because the row reads the finished result back out of this page before
+parking it for the next tool. So this page does permit `fetch()` of a
+`blob:` URL, and a result can be read back in the page's own console. That
+is the one place this tool's policy differs from a tool with no carry-on
+row, and it is worth knowing before concluding that a `blob:` fetch failing
+somewhere else on the site is a bug. Nothing else is widened, and `blob:`
+names bytes inside this page — it gains no reach over the network.

--- a/tools/resize-image/tool.toml
+++ b/tools/resize-image/tool.toml
@@ -33,7 +33,14 @@ css_parts = ["file-list", "progress", "results", "form", "checks", "cropper", "n
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.
 js_parts = ["file-picker", "zip", "crc32", "message-box", "download", "media", "format", "cropper", "example-photo"]
-lastmod = "2026-09-07"
+# Where a finished result can be carried without being saved first: the row
+# of links shared/handoff.js shows under the results once there are any.
+# This tool finishes a whole batch at once and the row carries all of it,
+# which is the detour worth skipping here - saving twelve files and handing
+# twelve back is the part nobody does twice. Checked against the tools that
+# exist by the build.
+handoff = ["compress-image"]
+lastmod = "2026-09-10"
 
 # --- what search engines and chat apps are told ------------------------------
 
@@ -52,7 +59,10 @@ og_card = "Resize, crop and convert a picture - or a whole folder - on your own 
 # whatever this tool needs that the rest of the site does not.
 csp_note = """
   img-src needs blob: for the crop preview and the results this page draws from
-  the files you chose, and https: because ad creatives come from anywhere."""
+  the files you chose, and https: because ad creatives come from anywhere. connect-src carries blob: because the carry-on row reads the
+  finished result back out of this page before parking it for the next
+  tool. blob: names bytes inside this page; neither gains any reach over
+  the network."""
 
 # --- the pledge block --------------------------------------------------------
 
@@ -334,3 +344,10 @@ hint = "or click to browse &mdash; JPEG, PNG, WebP and anything else your browse
 # A photograph at 2400 x 1600, drawn in the page by
 # shared/js/example-photo.js, so the width box has something to shrink.
 example = true
+
+# The carry-on row reads the finished result back out of this page's own
+# blob: URL before parking it for the next tool (see shared/handoff.js), and
+# reading a blob: URL is a fetch the policy has to permit. blob: names bytes
+# inside this page; nothing here gains any reach over the network.
+[csp]
+"connect-src" = ["blob:"]

--- a/tools/stack-images/tool.toml
+++ b/tools/stack-images/tool.toml
@@ -59,7 +59,12 @@ csp_note = """
   worker-src is named explicitly because this is the only tool here that runs
   its work in a Worker, and a directive that is merely inherited is one nobody
   reading the policy can see was intended. It is 'self' and nothing else: the
-  worker is a file in this folder, cached by the service worker beside it."""
+  worker is a file in this folder, cached by the service worker beside it.
+
+  connect-src carries blob: for the other reason a directive is named here: the
+  carry-on row reads the stacked image back out of this page before parking it
+  for the next tool. blob: names bytes inside this page; neither directive
+  gains any reach over the network."""
 
 # --- the pledge block --------------------------------------------------------
 

--- a/tools/svg-to-image/README.md
+++ b/tools/svg-to-image/README.md
@@ -181,3 +181,19 @@ error. So there are two numbers, both in `sizing.js`:
 Tests: `tests/js/svg-to-image.test.js`, covering the first, the second and the
 naming in the fourth — everything with a decision in it that does not need a
 browser to run.
+
+## Carrying the result on
+
+The rasterised picture can go straight into `/compress-image/` without
+being saved first. `handoff` in `tool.toml` names it and
+`shared/handoff.js` puts a row of links under the results; every size
+this page rendered travels together.
+
+What that costs the policy is one directive: `connect-src` carries `blob:`,
+because the row reads the finished result back out of this page before
+parking it for the next tool. So this page does permit `fetch()` of a
+`blob:` URL, and a result can be read back in the page's own console. That
+is the one place this tool's policy differs from a tool with no carry-on
+row, and it is worth knowing before concluding that a `blob:` fetch failing
+somewhere else on the site is a bug. Nothing else is widened, and `blob:`
+names bytes inside this page — it gains no reach over the network.

--- a/tools/svg-to-image/tool.toml
+++ b/tools/svg-to-image/tool.toml
@@ -33,7 +33,14 @@ css_parts = ["file-list", "progress", "results", "form", "notes"]
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.
 js_parts = ["file-picker", "zip", "crc32", "message-box", "format", "example-mark"]
-lastmod = "2026-09-07"
+# Where a finished result can be carried without being saved first: the row
+# of links shared/handoff.js shows under the results once there are any.
+# This tool finishes a whole batch at once and the row carries all of it,
+# which is the detour worth skipping here - saving twelve files and handing
+# twelve back is the part nobody does twice. Checked against the tools that
+# exist by the build.
+handoff = ["compress-image"]
+lastmod = "2026-09-10"
 
 # --- what search engines and chat apps are told ------------------------------
 
@@ -53,7 +60,10 @@ og_card = "Rasterize a vector to PNG, JPEG or WebP at any size, on your own mach
 csp_note = """
   img-src needs blob: because the rasteriser is an &lt;img&gt; holding the SVG
   this page rewrote to the size you asked for, and https: because ad creatives
-  come from anywhere."""
+  come from anywhere. connect-src carries blob: because the carry-on row reads the
+  finished result back out of this page before parking it for the next
+  tool. blob: names bytes inside this page; neither gains any reach over
+  the network."""
 
 # --- the pledge block --------------------------------------------------------
 
@@ -381,3 +391,10 @@ hint = "or click to browse &mdash; several at once is fine"
 # A hand-written SVG with a viewBox and no pixel size, because
 # having no size of its own is the thing this tool is about.
 example = true
+
+# The carry-on row reads the finished result back out of this page's own
+# blob: URL before parking it for the next tool (see shared/handoff.js), and
+# reading a blob: URL is a fetch the policy has to permit. blob: names bytes
+# inside this page; nothing here gains any reach over the network.
+[csp]
+"connect-src" = ["blob:"]

--- a/tools/unlock-pdf/README.md
+++ b/tools/unlock-pdf/README.md
@@ -162,3 +162,19 @@ AES-128 document.
   the results.
 - **Open a certificate-encrypted document.** That needs the private key it was
   issued to.
+
+## Carrying the result on
+
+The unlocked file can go straight into `/merge-pdf/`, `/compress-pdf/` or
+`/redact-pdf/` without being saved first. That matters more here than on most
+tools: this page is where the other PDF tools send a reader who handed them a
+locked file, so without a way out the journey ends in a download and a second
+upload to the tool they wanted in the first place. `handoff` in `tool.toml`
+names the three, and `shared/handoff.js` puts a row of links under the result.
+
+What that costs the policy is one directive: `connect-src` carries `blob:`,
+because the row reads the finished file back out of this page before parking
+it for the next tool. So this page does permit `fetch()` of a `blob:` URL,
+which is worth knowing before concluding that a `blob:` fetch failing
+somewhere else on the site is a bug. `blob:` names bytes inside this page and
+gains no reach over the network.

--- a/tools/unlock-pdf/tool.toml
+++ b/tools/unlock-pdf/tool.toml
@@ -62,6 +62,12 @@ css_parts = ["progress", "form", "checks", "notes", "results"]
 # pdf-page-writer and example-statement are for the example alone: it has to be
 # a document that really is locked, which means writing one.
 js_parts = ["file-picker", "pdf-objects", "pdf-filters", "pdf-reader", "pdf-writer", "message-box", "format", "md5", "hash-blocks", "pdf-page-writer", "example-statement"]
+# Where a finished result can be carried without being saved first: the row
+# of links shared/handoff.js shows under the result once there is one. This
+# tool is the way IN to the PDF chain - every tool that refuses a locked file
+# sends its reader here - so it needs a way out, or the journey ends on a
+# download and a second upload to the tool they wanted in the first place.
+handoff = ["merge-pdf", "compress-pdf", "redact-pdf"]
 lastmod = "2026-09-10"
 
 # --- what search engines and chat apps are told ------------------------------
@@ -76,6 +82,14 @@ og_image_alt = "Unlock a PDF in your browser, without uploading it"
 # card's heading is `name` above and its footer is the same line on every
 # card, so this is the only part of it that belongs to this tool.
 og_card = "Take off the password and the restrictions, without the document leaving your machine."
+
+# Appended to the Content-Security-Policy comment in the generated page, for
+# whatever this tool needs that the rest of the site does not.
+csp_note = """
+  connect-src carries blob: because the carry-on row reads the unlocked file
+  back out of this page before parking it for the next tool. blob: names
+  bytes inside this page; it gains no reach over the network, and nothing
+  else here is widened."""
 
 # --- the pledge block --------------------------------------------------------
 
@@ -452,3 +466,10 @@ hint = "or click to browse &mdash; one document at a time"
 # with no open password and printing and copying switched off, which is the
 # commonest protected file in the world. See src/example.js.
 example = true
+
+# The carry-on row reads the finished result back out of this page's own
+# blob: URL before parking it for the next tool (see shared/handoff.js), and
+# reading a blob: URL is a fetch the policy has to permit. blob: names bytes
+# inside this page; nothing here gains any reach over the network.
+[csp]
+"connect-src" = ["blob:"]


### PR DESCRIPTION
One click from a finished result to the next tool, instead of a download and a
re-upload. The row that does this already existed — it just could not see the
results on the tools where the detour actually costs something.

## What was wrong

`shared/handoff.js` looked for one `#download` anchor. That is what a tool
which makes **one** thing declares in its `body.html`. A tool that works
through a **batch** has no such anchor at all: it builds a row per result
inside `.result-list`, each with its own link, and offers a ZIP beside the
heading.

So the carry-on row could never appear on the compressor, the resizer, the EXIF
cleaner or the SVG rasteriser — the four pages where a visitor is most likely to
be saving twelve files and handing twelve back. Thirteen tools declared targets;
all thirteen happened to be single-result tools.

## What this does

`results()` reads both shapes, and a batch travels whole — twelve compressed
photos arrive at the next tool as twelve files, through the same file input a
dropped file goes through. Three things came with it, each of which would
otherwise have shipped the feature dead or slow:

- **the observer needed `childList`.** Every batch tool unhides its results
  block *before* appending the rows, so the `hidden` change the row relied on
  arrives while the list is still empty. It happens to work today only because a
  MutationObserver delivers at the end of the task and the appends are in the
  same one — a coincidence of how those tools are written, not something the
  script is owed;
- **`carriable()` asks `offsetParent`**, because a row inside a results block
  the tool is still holding back is not itself `hidden`. That also settles a
  case the old check got wrong: it would offer to carry a result out of a block
  the page had hidden;
- **`show()` returns early once the row is seated**, since the observer now
  fires once per appended row and `seat()` walks the ancestors asking
  `getComputedStyle` — a forced layout per call, on a page building fifty rows.

## Coverage

Seven tools become senders, two gain a target — 13 → 20:

| sender | carries into | why that pair |
|---|---|---|
| `compress-image` | `images-to-pdf` | a set of compressed photos into one document |
| `resize-image` | `compress-image` | resize to the dimensions, *then* hit a byte budget |
| `exif-editor` | `compress-image`, `resize-image` | the reason to strip the tags is usually that it is about to be posted |
| `svg-to-image` | `compress-image` | rasterise, then squeeze |
| `redact-image` | `compress-image`, `resize-image` | the file is on its way into an email |
| `redact-pdf` | `compress-pdf`, `merge-pdf` | a redacted document is usually one part of something |
| `unlock-pdf` | `merge-pdf`, `compress-pdf`, `redact-pdf` | the way *in* to the PDF chain needed a way out — see below |
| `merge-pdf` | + `redact-pdf` | bind, then black out |
| `document-scanner` | + `redact-pdf` | scan a contract, then black out |

Every batch sender points at a `multiple = true` picker — checked, because all
of the files arrive at once and `multiple` does not constrain a `DataTransfer`.

`/unlock-pdf/` landed in #411 while this was being written, and it is the tool
that most needed a way out: every tool that refuses a locked PDF now sends its
reader there, so without one the journey ends on a download and a second upload
to the tool they wanted in the first place. Rebased onto it — which is also what
the first `qa/preview` failure was: the preview is built on top of `dev`, so it
had 44 tools while the QA suite's metadata came from this branch's 43, and the
hub tests counted the difference. Nothing to do with this change.

## Two chains deliberately left out

`/heic-to-jpg/` → compress is the single most valuable pair on the site, and it
is **not** here. That page argues in `[[privacy]]` that its engine embeds its
binary rather than fetching one *because* `connect-src` is untouched, and that
"`connect-src` names Google's measurement endpoints and nothing else".
`/images-to-video/` tells the reader "`img-src` is opened, `connect-src` is
not". A carry-on row needs `connect-src blob:`, so enabling it there means
rewriting a promise in fifteen languages — `[[privacy]]` is translated. That is
a decision about what those pages claim, not a line of config, so it is yours
rather than mine. Say the word and I will do it.

## Claims kept true

The five new senders all scope their no-fetch prose to `src/` ("no `fetch` …
anywhere in `src/`"), which stays true — `handoff.js` is a frame script. Each
gained a `csp_note` sentence naming the widened directive.

Two pre-existing inaccuracies fell out of the same reading and are fixed here:
`document-scanner` said *"This tool widens nothing"* while carrying
`connect-src blob:`, and `stack-images` enumerated its widenings and named only
one of the two. `csp_note` is not a translatable key, so neither costs a locale
anything.

## Before / after

`/compress-image/`, same three example photos, same run.

| Before | After |
|---|---|
| <img width="2560" height="1050" alt="handoff-before" src="https://github.com/user-attachments/assets/ce8dcd27-f8b8-4412-b308-739ba0fd44be" /> | <img width="2560" height="1188" alt="handoff-after" src="https://github.com/user-attachments/assets/5ef64df4-3663-4a9a-91fc-f6ff5875cf9c" /> |

## About the red `qa/preview`

**None of it is this branch.** The failing set here is a superset of #411's own
run by exactly one test, and that one passed on this branch's previous QA run
with byte-identical `handoff.js`:

| run | failed | |
|---|---|---|
| #411 (merged into `dev`) | 37 | |
| this branch | 38 | the 37 above, plus one `text-diff` Safari typing race |

The 37 are translation debt that came in with #411 and that a PR inherits
because it is previewed on top of `dev`:

- `unlock-pdf has no translated copy in: zh` — the new tool ships untranslated,
  which is normal and expected on the day a tool lands;
- `ar/compress-pdf is missing 1 element id(s) the English page has:
  unlock-hint` — #411 added an `unlock-hint` element to the English `body.html`
  of `compress-pdf`, `merge-pdf` and `redact-pdf` and to **2 of 14** locales.
  Twelve languages × three tools is the bulk of the count.

That second one is worth someone's attention separately: it is the locale
body-parity failure mode where only phrase keys are compared, so added markup
goes missing in fourteen languages silently and whatever the script does with
that id is dead on those pages. It is not fixed here, because it is #411's
catch-up and not this change's.

The one extra failure is `text-diff` › "identical text is reported as
identical" on Desktop Safari: it typed `one
two
three` into both panes and
read back "1 added, 3 removed", i.e. one pane had not settled. `text-diff`
declares no handoff, so `handoff.js` returns at `if (!nav) return` before any
line this PR changes.

## Verified

- full minified build with link checking, `python build.py --clean` — exit 0
- driven in a browser end to end: compress three photos → row appears, seated
  under the results list → click → all three arrive at `/images-to-pdf/`
  ("Reading 3 files…") and the IndexedDB record is consumed
- an existing single-result sender (`/video-to-gif/`) still reveals and seats
  its row under the new `carriable()` check
- the Japanese page carries the translated lead with the English `data-slug`

The new test asserts a sender has one of the two shapes to read, so a future
tool cannot declare targets and render a row no visitor will ever see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
