### PR TITLE
Parse the minified scripts in one process, not thirteen thousand

### DIFF
--- a/.github/scripts/parse-modules.mjs
+++ b/.github/scripts/parse-modules.mjs
@@ -1,0 +1,60 @@
+/**
+ * Parse every emitted script as an ES module, in one process.
+ *
+ *   node --experimental-vm-modules .github/scripts/parse-modules.mjs <dir>
+ *
+ * This is the second opinion on buildlib/minify.py: it compares its own
+ * tokens on every file and fails the build if they moved, and this asks a
+ * real parser the same question. It used to be `node --check`, once per file,
+ * and that was the shape of the problem: the site emits about nine hundred
+ * scripts per language and fifteen languages, and thirteen thousand Node
+ * start-ups at twenty-five milliseconds each were six minutes of a seven
+ * minute job - four times what the two builds it was checking took together.
+ *
+ * `vm.SourceTextModule` parses the text as a module - so `import` and
+ * `export` are grammar rather than the syntax error a bare .js read as
+ * CommonJS would have reported, which is why the old loop copied every file
+ * to .mjs first - and the constructor throws the SyntaxError itself, before
+ * anything is linked or evaluated. Nothing in the file runs. The whole tree
+ * takes a few seconds.
+ *
+ * The constructor is behind --experimental-vm-modules on every Node this
+ * runs on, and has been since 9.6; the flag is the only thing about it that
+ * is experimental for this use, which reads a source and throws or does not.
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import vm from 'node:vm';
+
+const root = process.argv[2];
+if (!root) {
+  console.error('usage: node --experimental-vm-modules parse-modules.mjs <dir>');
+  process.exit(2);
+}
+
+const scripts = [];
+(function walk(dir) {
+  for (const name of readdirSync(dir)) {
+    const path = join(dir, name);
+    if (statSync(path).isDirectory()) walk(path);
+    else if (name.endsWith('.js')) scripts.push(path);
+  }
+}(root));
+scripts.sort();
+
+// One annotation per file that fails, in the form the Actions log turns into
+// a mark on the file, exactly as the per-file loop reported it.
+let broken = 0;
+for (const path of scripts) {
+  try {
+    // eslint-disable-next-line no-new
+    new vm.SourceTextModule(readFileSync(path, 'utf8'), { identifier: path });
+  } catch (error) {
+    broken += 1;
+    console.log(`::error file=${path}::does not parse after minifying`);
+    console.log(`    ${error.message}`);
+  }
+}
+console.log(`parsed ${scripts.length} scripts`);
+process.exit(broken === 0 ? 0 : 1);

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -419,33 +419,21 @@ jobs:
       # the second opinion, from a real parser rather than the one that did the
       # work.
       #
-      # Every emitted script is parsed by Node as a real ES module - copied to
-      # .mjs first, because a bare .js is read as CommonJS and `import` would be
-      # a syntax error for the wrong reason. Then the two builds are compared by
-      # filename, so a module that vanished is caught even if everything left
-      # behind parses.
+      # Every emitted script is parsed by Node as a real ES module, all of them
+      # in one process - see .github/scripts/parse-modules.mjs for why not one
+      # `node --check` each: there are thirteen thousand of them, and the
+      # start-ups were six minutes of this job. Then the two builds are
+      # compared by filename, so a module that vanished is caught even if
+      # everything left behind parses.
       - name: Check the minified output
         if: env.BUILDS == 'true'
         run: |
           set -euo pipefail
-          work=$(mktemp -d)
           status=0
 
-          count=0
-          while IFS= read -r script; do
-            cp "$script" "$work/check.mjs"
-            if ! node --check "$work/check.mjs" 2>"$work/err"; then
-              echo "::error file=$script::does not parse after minifying"
-              sed 's/^/    /' "$work/err"
-              status=1
-            fi
-            count=$((count + 1))
-          done < <(find _site -name '*.js' | sort)
-          echo "parsed $count scripts"
+          node --experimental-vm-modules .github/scripts/parse-modules.mjs _site             || status=1
 
-          diff <(cd _plain && find . -type f | sort) \
-               <(cd _site  && find . -type f | sort) \
-            || { echo '::error::the two builds do not contain the same files'; status=1; }
+          diff <(cd _plain && find . -type f | sort)                <(cd _site  && find . -type f | sort)             || { echo '::error::the two builds do not contain the same files'; status=1; }
 
           exit $status
 

--- a/docs/running.md
+++ b/docs/running.md
@@ -58,7 +58,16 @@ python build.py --no-minify
 
 A full build writes about twelve hundred pages, in every language the site has,
 and takes a couple of minutes. While the change in hand is to one tool, most of
-that is pages nobody is about to look at:
+that is pages nobody is about to look at.
+
+Those minutes are the machine's, not the generator's. CI builds all fifteen
+languages in about fifteen seconds; on Windows the same build takes eight
+minutes, English alone a minute, and `--clean` on a tree it wrote earlier
+can take three minutes just to delete it. That is Windows Defender pricing
+every file the build writes at some tens of milliseconds, and nothing in
+`build.py` can spend it any faster. An exclusion for the output folders -
+`dist`, `_plain`, `_site` - is the whole fix, and needs an administrator;
+until then, narrow the build to what you are looking at:
 
 ```bash
 python build.py --only trim-video --locale en --quiet


### PR DESCRIPTION
The build job's "Check the minified output" step was 347s of a ~7 minute job (from the last successful run on `dev`): one `node --check` process per emitted script, ~13,700 of them, at ~25ms of Node start-up each. The two builds it checks take 15s and 30s.

This replaces the loop with `.github/scripts/parse-modules.mjs`: one process, `new vm.SourceTextModule(text)` per file, which parses the text as an ES module and throws the `SyntaxError` before linking or evaluation, so nothing runs. Same `::error file=` annotation per failure, same filename diff between `_plain` and `_site` afterwards.

Measured on an English build (915 scripts): 0.46s for the whole step. With one script broken and one deleted, both were reported and the step exited 1.

`docs/running.md` gains a paragraph on where a *local* build's minutes go, since the same run answered it: CI builds all fifteen languages in ~15s, Windows takes ~8 minutes, and the difference is Defender's per-file scan on write.

Nothing visible to a visitor changes; CI and docs only, so the version stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
