### PR TITLE
Read an ID photo's rules out of pasted text, and fill the boxes from them

### DIFF
--- a/locales/zh/tools/id-photo.html
+++ b/locales/zh/tools/id-photo.html
@@ -37,6 +37,22 @@
     <p class="spec-source" id="spec-source"></p>
 
     <!--
+      The same boxes, filled in from the rule's own words, and only for
+      "Anywhere else", like the boxes. src/requirements.js says what it reads
+      and why it quotes every figure back rather than asking to be trusted.
+    -->
+    <div class="read-rules" id="read-rules" hidden>
+      <label for="read-text">要求是一段文字？贴在这里，下面的格子会照着它填好。它读得懂中文和英文；别的语言也照样认得出里面的尺寸。</label>
+      <textarea id="read-text" rows="4" spellcheck="false"></textarea>
+      <button type="button" id="read-button" class="ghost">读取要求</button>
+      <div id="read-result" class="read-result" hidden>
+        <p id="read-status" class="hint-line" role="status"></p>
+        <ul id="read-found" class="read-list"></ul>
+        <ul id="read-notes" class="read-list read-notes"></ul>
+      </div>
+    </div>
+
+    <!--
       Only the "Anywhere else" entry unlocks these. A country's own numbers are
       not editable on purpose: an editable rule is a rule somebody can quietly
       break and then believe they met.
@@ -287,6 +303,18 @@
     <span data-phrase="size.mb">{n} MB</span>
     <span data-phrase="source.line">转录自 {authority} &mdash; {document}。{checked} 核对。规定会变；上面的数字是拿去跟你面前那张表格对照的。</span>
     <span data-phrase="source.own">你自己填的数字。这里不跟任何东西对照。</span>
+    <span data-phrase="read.done">已照你贴的文字填好。每个数字都列在它读出来的那几个字下面，请对照着核一遍。文字里没提到的格子保持原样。</span>
+    <span data-phrase="read.none">这段文字里读不出照片尺寸、头高、背景、上传尺寸或文件大小，所以没有改动任何格子。请直接在下面填写数字。</span>
+    <span data-phrase="read.kept">没有改动任何格子。下面是它读到的内容，以及每一项为什么没有填：</span>
+    <span data-phrase="read.sizes">文字里给了不止一种照片尺寸，所以尺寸没有填。请填上你的证件要的那一种：</span>
+    <span data-phrase="read.named">文字只说了尺寸的叫法，没给具体数字，而各家照相馆对这些叫法的尺寸说法不一，所以尺寸没有填。请按你的证件要求填入毫米数：</span>
+    <span data-phrase="read.colour">文字要的背景色，这个页面没法检查（它只检查白、米白、浅灰和奶油色），所以背景没有改：</span>
+    <span data-phrase="read.pxrange">文字允许不止一种上传尺寸，已填入最小的那一种：</span>
+    <span data-phrase="read.unused.headwidth">头部宽度，没有用上：这个页面量的是从下巴到头顶的高度，不量宽度</span>
+    <span data-phrase="read.unused.eye">眼睛位置，没有用上：这个页面的眼睛线按 ICAO 标准来定</span>
+    <span data-phrase="read.unused.margin">边距，没有用上：这个页面按头高来裁切，边距跟着头高走</span>
+    <span data-phrase="read.unused.paper">用来打印的相纸尺寸，不是照片本身的尺寸</span>
+    <span data-phrase="read.unused.other">一个对不上任何格子的尺寸</span>
     <span data-phrase="lede.signature">签名的检查方式不一样：纸是不是浅色、上面有没有墨、以及裁的时候有没有把横线或者纸边框进来。</span>
     <span data-phrase="lede.portrait">从裁切框顶部横过去的一条带，以及两侧往下、肩膀以上的部分读出来——画面里本该只有背景的地方。用 CIE Lab 而不是 RGB 来量，因为相差四十个 RGB 单位的两种灰根本分不出来，而四十个单位的蓝已经是另一种颜色了。</span>
     <span data-phrase="dpi.note">这条规格的下限是 {floor} dpi。在 {chosen} dpi 下文件出来是 {size}，而且 JPEG 会把这个分辨率写在自己的头里，这样冲印店就按正确尺寸出片，而不是靠猜。</span>

--- a/tests/js/id-photo-requirements.test.js
+++ b/tests/js/id-photo-requirements.test.js
@@ -1,0 +1,191 @@
+/**
+ * tools/id-photo/src/requirements.js - the rule, read out of its own words.
+ *
+ * The risk here is a box filled confidently and wrongly: a head width in the
+ * head height box, a floor read as a ceiling, a paper size read as the photo's.
+ * Every one of those makes a photograph that passes every check on the page -
+ * because the page checks against the boxes - and is refused by the form.
+ *
+ * So each test is a rule written the way rules are written, in English and in
+ * both Chinese scripts, and asserts what went in which box and what was quoted
+ * for it. The texts are written for these tests in the manner of the published
+ * ones, not copied from any of them.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { normalise, readRequirements } from '../../tools/id-photo/src/requirements.js';
+
+/** What was filled in, and the words each was read from. */
+function filled(text) {
+  const reading = readRequirements(text);
+  return Object.fromEntries(reading.found.map((f) => [f.field, [f.value, text.slice(f.from, f.to)]]));
+}
+
+const quoted = (text, spans) => spans.map((s) => text.slice(s.from, s.to));
+
+test('a square rule stated in inches and again in millimetres is one size, in millimetres', () => {
+  const text = 'Photo size: 2 x 2 inches (51 x 51 mm). The head must be between 1 inch and '
+    + '1 3/8 inches (25 mm - 35 mm) from the bottom of the chin to the top of the head. '
+    + 'Plain white or off-white background. File size less than or equal to 240 KB.';
+  const reading = readRequirements(text);
+  assert.deepEqual(filled(text), {
+    widthMm: [51, '51 x 51 mm'],
+    heightMm: [51, '51 x 51 mm'],
+    headMinMm: [25, '25 mm - 35 mm'],
+    headMaxMm: [35, '25 mm - 35 mm'],
+    maxKb: [240, '240 KB'],
+    background: ['off-white', 'off-white'],
+  });
+  // The inches restate what was filled in, so nothing is left over to report.
+  assert.deepEqual(reading.unused, []);
+  assert.deepEqual(reading.notes, []);
+});
+
+test('a size written height first, with the words after the numbers', () => {
+  const text = 'The photo must be 45mm high x 35mm wide. Head height between 29mm and 34mm. '
+    + 'Plain cream or light grey background.';
+  assert.deepEqual(filled(text), {
+    widthMm: [35, '35mm'],
+    heightMm: [45, '45mm'],
+    headMinMm: [29, 'between 29mm and 34mm'],
+    headMaxMm: [34, 'between 29mm and 34mm'],
+    background: ['cream', 'cream'],
+  });
+});
+
+test('a label before its number is not read as belonging to the number before it', () => {
+  assert.deepEqual(filled('Width: 35 mm Height: 45 mm'), {
+    widthMm: [35, '35 mm'],
+    heightMm: [45, '45 mm'],
+  });
+});
+
+test('a simplified Chinese rule: the head width is read and not used', () => {
+  const text = '照片规格：宽33mm，高48mm；头部宽度15-22mm，头部长度28-33mm；白色背景；'
+    + '电子照片358×441像素，分辨率300dpi，文件大小20KB至200KB。';
+  const reading = readRequirements(text);
+  assert.deepEqual(filled(text), {
+    widthMm: [33, '33mm'],
+    heightMm: [48, '48mm'],
+    pxWidth: [358, '358×441像素'],
+    pxHeight: [441, '358×441像素'],
+    headMinMm: [28, '28-33mm'],
+    headMaxMm: [33, '28-33mm'],
+    dpi: [300, '300dpi'],
+    minKb: [20, '20KB至200KB'],
+    maxKb: [200, '20KB至200KB'],
+    background: ['white', '白色'],
+  });
+  assert.deepEqual(reading.unused.map((u) => [u.key, text.slice(u.from, u.to)]),
+    [['read.unused.headwidth', '15-22mm']]);
+});
+
+test('a traditional Chinese rule in centimetres, with a floor and a ceiling said separately', () => {
+  const text = '照片尺寸：3.5公分×4.5公分，頭部長度3.2至3.6公分，白色背景，檔案大小不小於20KB，不大於200KB。';
+  assert.deepEqual(filled(text), {
+    widthMm: [35, '3.5公分×4.5公分'],
+    heightMm: [45, '3.5公分×4.5公分'],
+    headMinMm: [32, '3.2至3.6公分'],
+    headMaxMm: [36, '3.2至3.6公分'],
+    minKb: [20, '20KB'],
+    maxKb: [200, '200KB'],
+    background: ['white', '白色'],
+  });
+});
+
+test('"不大于" is a ceiling, not the "大于" inside it', () => {
+  assert.deepEqual(filled('照片大小不大于200KB'), { maxKb: [200, '200KB'] });
+  assert.deepEqual(filled('照片大小不小于20KB'), { minKb: [20, '20KB'] });
+  assert.deepEqual(filled('no less than 20 KB'), { minKb: [20, '20 KB'] });
+  assert.deepEqual(filled('not more than 200 KB'), { maxKb: [200, '200 KB'] });
+});
+
+test('以上 and 以下 bound the number before them', () => {
+  assert.deepEqual(filled('文件大小20KB以上，200KB以下'), {
+    minKb: [20, '20KB'],
+    maxKb: [200, '200KB'],
+  });
+});
+
+test('a bare file size is a ceiling', () => {
+  assert.deepEqual(filled('File size: 500 KB'), { maxKb: [500, '500 KB'] });
+  assert.deepEqual(filled('Max 1 MB'), { maxKb: [1024, '1 MB'] });
+});
+
+test('"2M" is a file size in a sentence about the file, and a distance otherwise', () => {
+  assert.deepEqual(filled('大小不超过2M'), { maxKb: [2048, '2M'] });
+  assert.deepEqual(filled('Stand 1.5m from the wall.'), {});
+});
+
+test('two different photo sizes are not chosen between', () => {
+  const text = 'Passport photo 35 x 45 mm; visa photo 50 x 50 mm.';
+  const reading = readRequirements(text);
+  assert.deepEqual(reading.found, []);
+  assert.equal(reading.notes.length, 1);
+  assert.equal(reading.notes[0].key, 'read.sizes');
+  assert.deepEqual(quoted(text, reading.notes[0].spans), ['35 x 45 mm', '50 x 50 mm']);
+});
+
+test('a size given by name is reported, not converted', () => {
+  const text = '上传照片要求：蓝底，二寸，大小不超过2M，jpg格式。';
+  const reading = readRequirements(text);
+  assert.deepEqual(filled(text), { maxKb: [2048, '2M'] });
+  assert.deepEqual(reading.notes.map((n) => [n.key, quoted(text, n.spans)]), [
+    ['read.named', ['二寸']],
+    ['read.colour', ['蓝底']],
+  ]);
+});
+
+test('a colour the page can check wins over one it cannot, and one it cannot is not swapped', () => {
+  assert.deepEqual(filled('Background: white or light blue.').background, ['white', 'white']);
+  const text = 'Background must be plain blue.';
+  const reading = readRequirements(text);
+  assert.equal(reading.values.background, undefined);
+  assert.deepEqual(reading.notes.map((n) => [n.key, quoted(text, n.spans)]), [['read.colour', ['blue']]]);
+});
+
+test('a range of upload sizes fills in the smallest and says so', () => {
+  const text = 'Digital: 600 x 600 pixels minimum, 1200 x 1200 pixels maximum.';
+  const reading = readRequirements(text);
+  assert.deepEqual(filled(text), {
+    pxWidth: [600, '600 x 600 pixels'],
+    pxHeight: [600, '600 x 600 pixels'],
+  });
+  assert.deepEqual(reading.notes.map((n) => n.key), ['read.pxrange']);
+});
+
+test('a paper size is not the photo size', () => {
+  const text = 'Print on 4x6 inch photo paper. The photo is 35 x 45 mm.';
+  const reading = readRequirements(text);
+  assert.deepEqual(filled(text), { widthMm: [35, '35 x 45 mm'], heightMm: [45, '35 x 45 mm'] });
+  assert.deepEqual(reading.unused.map((u) => [u.key, text.slice(u.from, u.to)]),
+    [['read.unused.paper', '4x6 inch']]);
+});
+
+test('an eye position is read and not used', () => {
+  const text = 'Eyes must be between 28 and 35 mm from the bottom of the photo.';
+  const reading = readRequirements(text);
+  assert.deepEqual(reading.found, []);
+  assert.deepEqual(reading.unused.map((u) => u.key), ['read.unused.eye']);
+});
+
+test('text with nothing in it reads as nothing', () => {
+  const reading = readRequirements('Please bring two recent photographs to the appointment.');
+  assert.deepEqual(reading, { values: {}, found: [], notes: [], unused: [] });
+});
+
+test('normalising keeps every offset where it was', () => {
+  const text = '照片３５ｍｍ×４５ｍｍ，头部３２–３６ｍｍ 😀 2” x 2”';
+  const out = normalise(text);
+  assert.equal(out.length, text.length);
+  assert.ok(out.includes('35mmx45mm'));
+  assert.ok(out.includes('32-36mm'));
+  assert.ok(out.includes('2" x 2"'));
+  // A full-width rule is read, and quoted back in the characters it was pasted in.
+  assert.deepEqual(filled('照片３５ｍｍ×４５ｍｍ'), {
+    widthMm: [35, '３５ｍｍ×４５ｍｍ'],
+    heightMm: [45, '３５ｍｍ×４５ｍｍ'],
+  });
+});

--- a/tools/id-photo/body.html
+++ b/tools/id-photo/body.html
@@ -43,6 +43,23 @@
     <p class="spec-source" id="spec-source"></p>
 
     <!--
+      The same boxes, filled in from the rule's own words, and only for
+      "Anywhere else", like the boxes. src/requirements.js says what it reads
+      and why it quotes every figure back rather than asking to be trusted.
+    -->
+    <div class="read-rules" id="read-rules" hidden>
+      <label for="read-text">Have the rules as text? Paste them here and the boxes below are filled in
+        from them. It reads English and Chinese; in any other language it still finds the sizes.</label>
+      <textarea id="read-text" rows="4" spellcheck="false"></textarea>
+      <button type="button" id="read-button" class="ghost">Read the rules</button>
+      <div id="read-result" class="read-result" hidden>
+        <p id="read-status" class="hint-line" role="status"></p>
+        <ul id="read-found" class="read-list"></ul>
+        <ul id="read-notes" class="read-list read-notes"></ul>
+      </div>
+    </div>
+
+    <!--
       Only the "Anywhere else" entry unlocks these. A country's own numbers are
       not editable on purpose: an editable rule is a rule somebody can quietly
       break and then believe they met.
@@ -348,6 +365,26 @@
     <span data-phrase="source.line">Transcribed from {authority} &mdash; {document}. Checked {checked}. Rules change;
       the figures above are what to check against the form in front of you.</span>
     <span data-phrase="source.own">Your own figures. Nothing here is checked against anything.</span>
+    <span data-phrase="read.done">Filled in from what you pasted. Each figure is listed under the words it was read
+      from, so check the two against each other. A box the text does not mention keeps what it had.</span>
+    <span data-phrase="read.none">Nothing in that text reads as a photo size, a head height, a background, an upload
+      size or a file size, so no box was changed. Type the figures in below instead.</span>
+    <span data-phrase="read.kept">No box was changed. What it did find, and why each was left alone:</span>
+    <span data-phrase="read.sizes">It gives more than one photo size, so the size was left alone. Type in the one
+      your document asks for:</span>
+    <span data-phrase="read.named">It names the size rather than measuring it, and studios do not agree on what those
+      names measure, so the size was left alone. Type in the millimetres your document asks for:</span>
+    <span data-phrase="read.colour">It asks for a background this page has no check for - it checks white, off-white,
+      light grey and cream - so the background was left alone:</span>
+    <span data-phrase="read.pxrange">It allows more than one upload size, and the smallest was filled in:</span>
+    <span data-phrase="read.unused.headwidth">a head width, which is not used: this page measures the head from chin to
+      crown, not across</span>
+    <span data-phrase="read.unused.eye">an eye position, which is not used: this page takes the eye line from the ICAO
+      standard</span>
+    <span data-phrase="read.unused.margin">a margin, which is not used: this page frames the photo by the head's
+      height, and the margins follow from it</span>
+    <span data-phrase="read.unused.paper">a paper size to print on, not the size of the photo</span>
+    <span data-phrase="read.unused.other">a measurement that matched none of the boxes</span>
     <span data-phrase="lede.signature">A signature is checked differently: that the paper is light, that there is ink on
       it, and that the crop has not taken in a ruled line or the edge of the page.</span>
     <span data-phrase="lede.portrait">Read from a band across the top of the crop and down each side, above the shoulders

--- a/tools/id-photo/src/main.js
+++ b/tools/id-photo/src/main.js
@@ -1,6 +1,6 @@
 /** UI wiring and application state. */
 
-import { phrase } from './shared/phrases.js';
+import { ltr, phrase } from './shared/phrases.js';
 import { messageBox } from './shared/message-box.js';
 import {
   SPECS, backgroundOf, pixelLabel, portalBytes, portalPixels, printLabel,
@@ -26,6 +26,7 @@ import {
 } from './files.js';
 import { readingLabel, wireFilePicker } from './shared/file-picker.js';
 import { makeExample } from './example.js';
+import { readRequirements } from './requirements.js';
 
 const $ = (id) => document.getElementById(id);
 
@@ -42,6 +43,13 @@ const el = {
   specNotes: $('spec-notes'),
   specSource: $('spec-source'),
   customPanel: $('custom-panel'),
+  readRules: $('read-rules'),
+  readText: $('read-text'),
+  readButton: $('read-button'),
+  readResult: $('read-result'),
+  readStatus: $('read-status'),
+  readFound: $('read-found'),
+  readNotes: $('read-notes'),
 
   frameEmpty: $('frame-empty'),
   frameControls: $('frame-controls'),
@@ -266,6 +274,7 @@ function renderSpec() {
     : phrase('source.own');
 
   el.customPanel.hidden = spec.id !== 'custom';
+  el.readRules.hidden = spec.id !== 'custom';
 
   // The signature specification is not a portrait and does not get a portrait's
   // overlay. Saying so on the page is better than showing an eye line for a
@@ -679,6 +688,105 @@ function renderBackground() {
     ? phrase('bg.signature.note')
     : phrase('bg.note', { colour: wanted.note });
 }
+
+/* ------------------------------------------------------ the rule, as text */
+
+/** A box's name as the page already shows it: the words of its own label,
+ *  which are in the reader's language without a phrase of their own. */
+function boxName(input) {
+  return input.closest('label')?.firstChild?.textContent.replace(/\s+/g, ' ').trim() ?? '';
+}
+
+/** What a box now holds: the option's words for the background, the figure
+ *  isolated for the rest so that Arabic does not turn "31.5" around. */
+function boxValue(input) {
+  return input instanceof HTMLSelectElement
+    ? input.selectedOptions[0]?.textContent.trim() ?? input.value
+    : ltr(input.value);
+}
+
+/** A stretch of what was pasted, quoted back in its own direction. */
+function quote(text, { from, to }) {
+  const q = document.createElement('q');
+  q.dir = 'auto';
+  q.textContent = text.slice(from, to).replace(/\s+/g, ' ').trim();
+  return q;
+}
+
+function fieldsLine(...children) {
+  const line = document.createElement('span');
+  line.className = 'read-fields';
+  line.append(...children);
+  return line;
+}
+
+/**
+ * Fill the boxes from the pasted rule, and show where every figure came from.
+ *
+ * The boxes are filled first and the list drawn from them afterwards, so what
+ * the list says is what the boxes hold, in the words and number format the
+ * boxes themselves use.
+ */
+function readRules() {
+  const text = el.readText.value;
+  if (!text.trim()) {
+    el.readResult.hidden = true;
+    el.readText.focus();
+    return;
+  }
+  const reading = readRequirements(text);
+  for (const { field, value } of reading.found) CUSTOM_FIELDS[field].value = String(value);
+
+  // One entry per stretch of the text, with every box it filled: "35 x 45 mm"
+  // is the width and the height.
+  const stretches = new Map();
+  for (const found of reading.found) {
+    const at = [found.from, found.to].join(':');
+    if (!stretches.has(at)) stretches.set(at, { from: found.from, to: found.to, fields: [] });
+    stretches.get(at).fields.push(found.field);
+  }
+  el.readFound.replaceChildren(...[...stretches.values()]
+    .sort((a, b) => a.from - b.from)
+    .map((stretch) => {
+      const li = document.createElement('li');
+      li.append(quote(text, stretch), fieldsLine(...stretch.fields.map((field) => {
+        const box = document.createElement('span');
+        const value = document.createElement('b');
+        value.textContent = boxValue(CUSTOM_FIELDS[field]);
+        box.append(`${boxName(CUSTOM_FIELDS[field])} `, value);
+        return box;
+      })));
+      return li;
+    }));
+
+  el.readNotes.replaceChildren(
+    ...reading.notes.map((note) => {
+      const li = document.createElement('li');
+      li.append(`${phrase(note.key)} `, ...note.spans.map((s) => quote(text, s)));
+      return li;
+    }),
+    ...reading.unused.map((unused) => {
+      const li = document.createElement('li');
+      li.append(quote(text, unused), fieldsLine(phrase(unused.key)));
+      return li;
+    }),
+  );
+
+  const anything = reading.notes.length || reading.unused.length;
+  el.readStatus.textContent = phrase(reading.found.length ? 'read.done'
+    : anything ? 'read.kept' : 'read.none');
+  el.readFound.hidden = !reading.found.length;
+  el.readNotes.hidden = !anything;
+  el.readResult.hidden = false;
+
+  if (reading.found.length) {
+    el.customPanel.open = true;
+    renderSpec();
+    readBackgroundNow();
+  }
+}
+
+el.readButton.addEventListener('click', readRules);
 
 /* --------------------------------------------------------------- the files */
 

--- a/tools/id-photo/src/requirements.js
+++ b/tools/id-photo/src/requirements.js
@@ -1,0 +1,574 @@
+/**
+ * An ID photo's rules, read out of the text that states them.
+ *
+ * Somebody applying for a document this tool has no entry for is holding the
+ * rule anyway - a paragraph off an embassy's page, a line in an exam's
+ * registration notice - and was left to copy ten numbers out of it into ten
+ * boxes by hand. This reads the paragraph and fills the boxes.
+ *
+ * WHY IT IS A READER AND NOT A MODEL
+ *
+ * Because the page runs on the visitor's machine and nowhere else. A language
+ * model would mean a server or megabytes of weights, for a job that turns out
+ * to be formulaic: every rule of this kind is numbers with units - 35 mm,
+ * 2 inches, 600 pixels, 300 dpi, 240 KB - and a few words that say what each
+ * number is for. Numbers and units read the same in any language; only the
+ * words that attach them to a box do not, and those are listed here for
+ * English and Chinese, in both scripts. Text in another language still has
+ * its sizes, resolution and file size read, because those name themselves by
+ * their units; what it loses is the head height and the background, which it
+ * names in words this does not know.
+ *
+ * WHAT IT PROMISES, AND WHAT IT DOES NOT
+ *
+ * It never guesses. Every value it fills in carries the stretch of the text it
+ * came from, and the page shows the two side by side, so the one check that
+ * matters - does this say what the rule says - takes a glance. A measurement
+ * it found and could not place is reported rather than dropped: a figure this
+ * does not recognise would otherwise vanish while its box kept a number the
+ * rule never mentioned. Two photo sizes on one page are not chosen between.
+ * A size given by name - 二寸, 2吋 - is not turned into millimetres, because
+ * studios do not agree on what those names measure. A background the page
+ * cannot check against is named rather than swapped for one it can.
+ *
+ * THE POSITIONS
+ *
+ * The text is normalised - full-width forms to ASCII, every dash to one, every
+ * multiplication sign to x - one character for one, so that an offset into the
+ * normalised text is the same offset into what was pasted, and the page can
+ * quote the visitor's own words back. That is also why units such as 毫米 are
+ * matched as written rather than rewritten to "mm": a rewrite would change the
+ * length, and every quote after it would point at the wrong words.
+ */
+
+/* --------------------------------------------------------------- the words */
+
+/**
+ * What a measurement is for, by the words next to it. Matched after
+ * lowercasing. Longer phrases are listed so that they end where the number's
+ * meaning does: "头部宽度" has to be seen as a head width, not as a head
+ * followed by a width.
+ */
+const WORDS = {
+  paper: /\bpaper\b|\bsheet\b|相纸|相紙|冲印|沖印/g,
+  headWidth: /head\s+width|width\s+of\s+(?:the\s+)?(?:head|face)|face\s+width|头部宽度?|頭部寬度?|头宽|頭寬|脸宽|臉寬|面部宽度?|面部寬度?/g,
+  margin: /(?:top|bottom)\s+of\s+(?:the\s+)?(?:photo|picture|image|frame)|above\s+the\s+head|chin\s+to\s+(?:the\s+)?bottom|\bmargins?\b|(?:头顶|頭頂)(?:距|到|至)(?:照片|相片)?上|(?:下巴|下颌|下頜)(?:距|到|至)(?:照片|相片)?下|上边[缘沿]|上邊[緣沿]|下边[缘沿]|下邊[緣沿]|边距|邊距/g,
+  head: /(?:head|face|chin)\s+(?:height|size|length)|height\s+of\s+(?:the\s+)?(?:head|face)|chin\s+to\s+(?:the\s+)?(?:top|crown)|crown\s+to\s+(?:the\s+)?chin|top\s+of\s+(?:the\s+)?head|\bhead\b|\bface\b|头部(?:长度|高度|长|高)?|頭部(?:長度|高度|長|高)?|头(?:长|高)度?|頭(?:長|高)度?|(?:头顶|頭頂)(?:至|到)(?:下巴|下颌|下頜)|(?:下巴|下颌|下頜)(?:至|到)(?:头顶|頭頂)|面部(?:长度|高度|長度)/g,
+  eye: /\beyes?\b|eye\s+line|眼睛|双眼|雙眼|眼部|瞳孔/g,
+  width: /\bwide\b|\bwidth\b|宽度?|寬度?/g,
+  height: /\bhigh\b|\bheight\b|\btall\b|高度?|长度?|長度?/g,
+};
+
+/** Which of two words that end at the same place is meant: the more particular
+ *  one. "head height" is a head before it is a height. */
+const PRIORITY = ['paper', 'headWidth', 'margin', 'head', 'eye', 'width', 'height'];
+
+/** The same words, straight after a number: "45 mm high", "35mm(宽)". */
+const POSTFIX = Object.fromEntries(PRIORITY.map((name) => [
+  name, new RegExp(`^\\s*\\(?\\s*(?:${WORDS[name].source})`),
+]));
+
+/** After a word that labels what follows - "width: 35 mm" - the word belongs
+ *  to the next number, not the last one. */
+const LABELS_NEXT = /^\s*\)?\s*[:=\d]/;
+
+/** How far after a size the word "paper" can be and still be naming it. */
+const PAPER_REACH = 12;
+
+/** A ceiling or a floor, said before the number. Chinese 以上 and 以下 are left
+ *  out here: before a number, 以下 means "the following". */
+const MOST = /no\s+(?:more|larger|bigger|greater)\s+than|not\s+(?:more|larger|bigger|greater)\s+than|(?:not\s+)?exceed\w*|\bat\s+most\b|\bup\s+to\b|\bmaximum\b|\bmax\b|less\s+than|smaller\s+than|\bunder\b|\bbelow\b|≤|<=|不超过|不超過|不大于|不大於|小于|小於|最大|上限|低于|低於/g;
+const LEAST = /\bat\s+least\b|no\s+(?:less|smaller)\s+than|not\s+(?:less|smaller)\s+than|\bminimum\b|\bmin\b|more\s+than|greater\s+than|larger\s+than|\babove\b|\bover\b|≥|>=|不小于|不小於|不低于|不低於|大于|大於|最小|下限|至少/g;
+
+/** The same, said after it: "240 KB or less", "200KB以下". */
+const MOST_AFTER = /^\s*(?:或?以下|或?以内|或?以內|or\s+(?:less|smaller|below|under)|at\s+most|max(?:imum)?\b)/;
+const LEAST_AFTER = /^\s*(?:或?以上|or\s+(?:more|larger|above|greater|over)|at\s+least|min(?:imum)?\b)/;
+
+/** Background colours, each with the BACKGROUNDS key the page checks it
+ *  against, or none for a colour it has no check for. Checked in order and
+ *  blanked once found: off-white before white, light grey before grey. */
+const COLOURS = [
+  { key: 'off-white', pattern: /off[\s-]?white|米白|乳白/ },
+  { key: 'cream', pattern: /\bcream\b|米色|奶油色/ },
+  { key: 'light-grey', pattern: /(?:light|pale)\s+gr[ae]y|\bgr[ae]y\b|浅灰|淺灰|淡灰|灰色|灰底/ },
+  { key: 'white', pattern: /\bwhite\b|白色|白底|纯白|純白|白背景/ },
+  { key: null, pattern: /(?:light|pale|sky)\s+blue|\bblue\b|浅蓝|淺藍|淡蓝|淡藍|天蓝|天藍|蓝色|藍色|蓝底|藍底/ },
+  { key: null, pattern: /\bred\b|红色|紅色|红底|紅底/ },
+];
+
+const BACKGROUND = /background|backdrop|背景|底色|[白蓝藍红紅灰]底/g;
+
+/** A size given by name rather than measured. */
+const NAMED = /(?<![\d.])(?:小|大)?[一二两兩12](?:寸|吋)/g;
+
+/** Words that make a bare "2m" a file size rather than a distance. */
+const FILE_WORDS = /\bfile\b|\bsize\b|大小|文件|体积|體積|容量/;
+
+/* ---------------------------------------------------------------- the units */
+
+const UNITS = {
+  mm: /mm|millimet(?:er|re)s?|毫米/,
+  cm: /cm|centimet(?:er|re)s?|厘米|公分/,
+  inch: /inch(?:es)?|in\b|"|″|英寸|英吋/,
+  dpi: /dpi|ppi|pixels?\s+per\s+inch|像素\/英寸/,
+  px: /px|pixels?|像素/,
+  kb: /kb|kib|kbytes?|kilobytes?|千字节|千字節|k(?![a-z])/,
+  mb: /mb|mib|megabytes?|兆字节|兆字節|兆/,
+  m: /m(?![a-z])/,
+};
+
+const MM_PER = { mm: 1, cm: 10, inch: 25.4 };
+
+const NUMBER = /\d+\s+\d\/\d{1,2}|\d\/\d{1,2}|\d+(?:[.,]\d+)?/.source;
+const TIMES = /x|by|乘/.source;
+const LABEL = /\([^()]{1,8}\)/.source;
+const BETWEEN = /between|从|從|在|介于|介於/.source;
+const BETWEEN_AND = /and|-|~|to|和|与|與|至|到/.source;
+const RANGE_MARK = /-|~|to|至|到/.source;
+
+/** The unit alternatives as named groups, prefixed so that the unit after the
+ *  first number and the unit after the second can both be in one pattern. */
+const unit = (prefix) => Object.entries(UNITS)
+  .map(([name, pattern]) => `(?<${prefix}${name}>${pattern.source})`).join('|');
+
+const A_SIDE = `(?<a>${NUMBER})\\s*(?:${unit('a')})?`;
+const B_SIDE = `(?<b>${NUMBER})\\s*(?:${unit('')})`;
+
+/** Longest shape first; a stretch one shape took is not read again. */
+const SHAPES = [
+  // Two directions at once: 35 x 45 mm, 35mm(宽) x 45mm(高).
+  { shape: 'pair', pattern: new RegExp(`${A_SIDE}\\s*(?:${LABEL})?\\s*(?:${TIMES})\\s*${B_SIDE}`, 'g') },
+  // A range: between 32 and 36 mm, 32-36 mm, 20KB至200KB.
+  { shape: 'range', pattern: new RegExp(`(?:${BETWEEN})\\s*${A_SIDE}\\s*(?:${BETWEEN_AND})\\s*${B_SIDE}`, 'g') },
+  { shape: 'range', pattern: new RegExp(`${A_SIDE}\\s*(?:${RANGE_MARK})\\s*${B_SIDE}`, 'g') },
+  { shape: 'single', pattern: new RegExp(B_SIDE, 'g') },
+];
+
+/** Where a clause ends. A comma does not end one: "宽33mm，高48mm" is one
+ *  clause of words and numbers taking turns. */
+const CLAUSE = /[\n。;!?•]|\.\s/g;
+
+/* ----------------------------------------------------------------- reading */
+
+/**
+ * @typedef {{from: number, to: number}} Span  offsets into the text as pasted
+ *
+ * @typedef {object} Reading
+ * @property {Record<string, number|string>} values  by the keys withCustom() reads
+ * @property {({field: string, value: number|string} & Span)[]} found
+ * @property {({key: string, spans: Span[]})[]} notes  phrase keys for the page
+ * @property {({key: string} & Span)[]} unused  figures read and not placed, each
+ *   with the phrase key that says why
+ */
+
+/**
+ * Read the rules out of some text.
+ *
+ * @param {string} text  as pasted
+ * @returns {Reading}
+ */
+export function readRequirements(text) {
+  const source = normalise(String(text ?? ''));
+  const measures = findMeasures(source);
+  const reading = { values: {}, found: [], notes: [], unused: [] };
+
+  placeSizes(source, measures, reading);
+  placeHead(measures, reading);
+  placeSimple(measures, reading);
+  placeBackground(source, reading);
+  dropRestatements(measures, reading);
+
+  for (const m of measures) {
+    if (!m.used && !m.noted) {
+      reading.unused.push({ from: m.from, to: m.to, key: WHY[m.word] ?? 'read.unused.other' });
+    }
+  }
+  return reading;
+}
+
+/** Why a figure was read and left alone, as the phrase that says so. */
+const WHY = {
+  paper: 'read.unused.paper',
+  headWidth: 'read.unused.headwidth',
+  eye: 'read.unused.eye',
+  margin: 'read.unused.margin',
+};
+
+/**
+ * One character for one: full-width forms to ASCII, every dash and every
+ * multiplication sign to one of each, curly double quotes to the inch mark
+ * they stand for after a number, and lowercase where lowercasing keeps the
+ * length.
+ */
+export function normalise(text) {
+  let out = '';
+  for (const ch of text) {
+    // A character outside the basic plane is two code units and has to stay
+    // two, or every offset after it moves.
+    if (ch.length > 1) { out += ch; continue; }
+    const code = ch.charCodeAt(0);
+    let c = code >= 0xff01 && code <= 0xff5e ? String.fromCharCode(code - 0xfee0) : ch;
+    if (c === '　' || c === ' ') c = ' ';
+    else if ('×✕✖*'.includes(c)) c = 'x';
+    else if ('‐‑‒–—―−'.includes(c)) c = '-';
+    else if (c === '〜') c = '~';
+    else if (c === '“' || c === '”') c = '"';
+    const lower = c.toLowerCase();
+    out += lower.length === 1 ? lower : c;
+  }
+  return out;
+}
+
+/** Every measurement in the text, none overlapping, in reading order. */
+function findMeasures(text) {
+  const taken = new Uint8Array(text.length);
+  const out = [];
+
+  for (const { shape, pattern } of SHAPES) {
+    pattern.lastIndex = 0;
+    for (const match of text.matchAll(pattern)) {
+      const from = match.index;
+      const to = from + match[0].length;
+      if (taken.subarray(from, to).some(Boolean)) continue;
+
+      let name = unitOf(match.groups, '');
+      if (name === 'm') {
+        // "2M" is a file size in a sentence about the file and a distance in
+        // one about where to stand.
+        if (!FILE_WORDS.test(text.slice(clauseStart(text, from), clauseEnd(text, to)))) continue;
+        name = 'mb';
+      }
+      const b = numberOf(match.groups.b);
+      let a = shape === 'single' ? b : numberOf(match.groups.a);
+      const aName = unitOf(match.groups, 'a');
+      if (aName && aName !== name) {
+        if (!MM_PER[aName] || !MM_PER[name]) continue;
+        a = (a * MM_PER[aName]) / MM_PER[name];
+      }
+      if (!Number.isFinite(a) || !Number.isFinite(b)) continue;
+
+      taken.fill(1, from, to);
+      out.push({ shape, unit: name, a, b, from, to });
+    }
+  }
+
+  out.sort((x, y) => x.from - y.from);
+  for (const [index, m] of out.entries()) {
+    const start = Math.max(index > 0 ? out[index - 1].to : 0, clauseStart(text, m.from));
+    const end = Math.min(index + 1 < out.length ? out[index + 1].from : text.length,
+      clauseEnd(text, m.to));
+    const before = text.slice(start, m.from);
+    const after = text.slice(m.to, end);
+    m.word = keyword(before, after);
+    m.bound = bound(before, after);
+  }
+  return out;
+}
+
+function unitOf(groups, prefix) {
+  for (const name of Object.keys(UNITS)) {
+    if (groups[prefix + name] !== undefined) return name;
+  }
+  return null;
+}
+
+/** "1,200" is twelve hundred, "3,5" is three and a half, "1 3/8" is 1.375. */
+function numberOf(text) {
+  if (text === undefined) return NaN;
+  const mixed = /^(?:(\d+)\s+)?(\d)\/(\d{1,2})$/.exec(text);
+  if (mixed) return Number(mixed[1] ?? 0) + Number(mixed[2]) / Number(mixed[3]);
+  if (/^\d{1,3}(?:,\d{3})+$/.test(text)) return Number(text.replace(/,/g, ''));
+  return Number(text.replace(',', '.'));
+}
+
+function clauseStart(text, at) {
+  let start = 0;
+  CLAUSE.lastIndex = 0;
+  for (const match of text.matchAll(CLAUSE)) {
+    if (match.index + match[0].length > at) break;
+    start = match.index + match[0].length;
+  }
+  return start;
+}
+
+function clauseEnd(text, at) {
+  const found = text.slice(at).search(CLAUSE);
+  return found < 0 ? text.length : at + found;
+}
+
+/**
+ * The last match of a pattern in some text; of two ending together, the
+ * longer, so that "不大于" is not read as the "大于" inside it.
+ *
+ * Every pattern here is global and shared, and matchAll() starts from the
+ * pattern's lastIndex, so it is put back first: one exec() left it partway
+ * along a clause once, and the next clause was searched from that offset.
+ */
+function lastOf(pattern, text) {
+  pattern.lastIndex = 0;
+  let found = null;
+  for (const match of text.matchAll(pattern)) {
+    const end = match.index + match[0].length;
+    if (!found || end > found.end || (end === found.end && match.index < found.start)) {
+      found = { start: match.index, end };
+    }
+  }
+  return found;
+}
+
+/**
+ * What a measurement is for. A word straight after the number, unless it is
+ * labelling the next one; otherwise the nearest before it; otherwise the
+ * first after it.
+ */
+function keyword(before, after) {
+  let best = null;
+  for (const name of PRIORITY) {
+    const match = POSTFIX[name].exec(after);
+    if (!match || LABELS_NEXT.test(after.slice(match[0].length))) continue;
+    if (!best || match[0].length > best.length) best = { name, length: match[0].length };
+  }
+  if (best) return best.name;
+
+  for (const name of PRIORITY) {
+    const found = lastOf(WORDS[name], before);
+    if (found && (!best || found.end > best.end)) best = { name, end: found.end };
+  }
+  if (best) return best.name;
+
+  // Paper only close by: "4x6 inch photo paper" is a paper size, and "35 x 45
+  // mm, printed on photo paper" is a photo size in a sentence about printing.
+  for (const name of PRIORITY) {
+    const at = after.search(WORDS[name]);
+    if (at < 0 || (name === 'paper' && at > PAPER_REACH)) continue;
+    if (!best || at < best.at) best = { name, at };
+  }
+  return best?.name ?? null;
+}
+
+/** Whether a figure is a ceiling or a floor. */
+function bound(before, after) {
+  if (MOST_AFTER.test(after)) return 'most';
+  if (LEAST_AFTER.test(after)) return 'least';
+  const most = lastOf(MOST, before);
+  const least = lastOf(LEAST, before);
+  if (!most && !least) return null;
+  if (!least) return 'most';
+  if (!most) return 'least';
+  if (most.end !== least.end) return most.end > least.end ? 'most' : 'least';
+  return most.start < least.start ? 'most' : 'least';
+}
+
+/* ----------------------------------------------------------------- placing */
+
+const tenth = (value) => Math.round(value * 10) / 10;
+
+const span = ({ from, to }) => ({ from, to });
+
+function fill(reading, field, value, m) {
+  reading.values[field] = value;
+  reading.found.push({ field, value, from: m.from, to: m.to });
+  m.used = true;
+}
+
+/** An ID photo is never wider than it is tall, so a rule that writes its size
+ *  height by width is asking for the same photograph. */
+function orient(a, b) {
+  return a <= b ? { w: a, h: b } : { w: b, h: a };
+}
+
+/**
+ * The printed size and the upload size.
+ *
+ * A printed size said twice - "2 x 2 inches (51 x 51 mm)" - is one size, and
+ * the millimetres win because they are what the boxes take. Two sizes that
+ * differ are two documents on one page, and choosing between them is not this
+ * reader's to do.
+ */
+function placeSizes(text, measures, reading) {
+  const printed = measures.filter((m) => m.shape === 'pair' && MM_PER[m.unit] && m.word !== 'paper');
+  const sizes = [];
+  for (const m of printed) {
+    const size = orient(m.a * MM_PER[m.unit], m.b * MM_PER[m.unit]);
+    const same = sizes.find((s) => Math.abs(s.w - size.w) <= 1 && Math.abs(s.h - size.h) <= 1);
+    if (!same) sizes.push({ ...size, m, all: [m] });
+    else {
+      same.all.push(m);
+      if (m.unit === 'mm' && same.m.unit !== 'mm') Object.assign(same, size, { m });
+    }
+  }
+
+  if (sizes.length === 1) {
+    const [{ w, h, m, all }] = sizes;
+    fill(reading, 'widthMm', tenth(w), m);
+    fill(reading, 'heightMm', tenth(h), m);
+    for (const other of all) other.used = true;
+  } else if (sizes.length > 1) {
+    reading.notes.push({ key: 'read.sizes', spans: sizes.map(({ m }) => span(m)) });
+    for (const s of sizes) for (const m of s.all) m.noted = true;
+  } else {
+    // Or the two directions said one at a time: "35 mm wide, 45 mm high".
+    for (const [field, word] of [['widthMm', 'width'], ['heightMm', 'height']]) {
+      const m = measures.find((x) => x.shape === 'single' && MM_PER[x.unit] && x.word === word);
+      if (m) fill(reading, field, tenth(m.b * MM_PER[m.unit]), m);
+    }
+  }
+
+  if (reading.values.widthMm === undefined && reading.values.heightMm === undefined) {
+    NAMED.lastIndex = 0;
+    const named = [...text.matchAll(NAMED)].map((match) => ({
+      from: match.index, to: match.index + match[0].length,
+    }));
+    if (named.length) reading.notes.push({ key: 'read.named', spans: named });
+  }
+
+  // The upload box takes one exact size. A rule that allows a range of them
+  // is met by its smallest, which is what is filled in, and the page says so.
+  const pixels = measures.filter((m) => m.shape === 'pair' && m.unit === 'px');
+  if (pixels.length) {
+    const smallest = pixels.reduce((x, y) => (x.a * x.b <= y.a * y.b ? x : y));
+    const { w, h } = orient(smallest.a, smallest.b);
+    fill(reading, 'pxWidth', Math.round(w), smallest);
+    fill(reading, 'pxHeight', Math.round(h), smallest);
+    if (pixels.some((m) => m.a * m.b !== smallest.a * smallest.b)) {
+      reading.notes.push({ key: 'read.pxrange', spans: pixels.map(span) });
+    }
+    for (const m of pixels) m.used = true;
+  } else {
+    for (const [field, word] of [['pxWidth', 'width'], ['pxHeight', 'height']]) {
+      const m = measures.find((x) => x.shape === 'single' && x.unit === 'px' && x.word === word);
+      if (m) fill(reading, field, Math.round(m.b), m);
+    }
+  }
+}
+
+/**
+ * The head, chin to crown.
+ *
+ * A range beats a single figure, and a range in millimetres beats the same
+ * range in inches: a rule that gives the head both ways gives one head twice,
+ * and the millimetres are what the boxes take. Head widths, eye positions and
+ * margins are measured by this page some other way or not at all, so they are
+ * left for the list of what was read and not used - filling a head width into
+ * a head height box would crop every face wrong.
+ */
+function placeHead(measures, reading) {
+  const heads = measures.filter((m) => MM_PER[m.unit] && !m.used && m.word === 'head');
+  const ranges = heads.filter((m) => m.shape === 'range');
+  const range = ranges.find((m) => m.unit === 'mm') ?? ranges.find((m) => m.unit === 'cm') ?? ranges[0];
+
+  if (range) {
+    const scale = MM_PER[range.unit];
+    fill(reading, 'headMinMm', tenth(Math.min(range.a, range.b) * scale), range);
+    fill(reading, 'headMaxMm', tenth(Math.max(range.a, range.b) * scale), range);
+    return;
+  }
+
+  // Single figures: "at least 32 mm", "no more than 36 mm", or one exact size.
+  for (const m of heads.filter((x) => x.shape === 'single')) {
+    const mm = tenth(m.b * MM_PER[m.unit]);
+    const { headMinMm: min, headMaxMm: max } = reading.values;
+    if (m.bound === 'least' && min === undefined) fill(reading, 'headMinMm', mm, m);
+    else if (m.bound === 'most' && max === undefined) fill(reading, 'headMaxMm', mm, m);
+    else if (!m.bound && min === undefined && max === undefined) {
+      fill(reading, 'headMinMm', mm, m);
+      fill(reading, 'headMaxMm', mm, m);
+    }
+  }
+}
+
+/** Resolution and file size, which name themselves by their units. */
+function placeSimple(measures, reading) {
+  // Of a range of resolutions, the lowest is the one every photo at or above
+  // it meets.
+  const dpi = measures.find((m) => m.unit === 'dpi');
+  if (dpi) fill(reading, 'dpi', Math.round(Math.min(dpi.a, dpi.b)), dpi);
+
+  for (const m of measures.filter((x) => x.unit === 'kb' || x.unit === 'mb')) {
+    const scale = m.unit === 'mb' ? 1024 : 1;
+    if (m.shape === 'range') {
+      if (reading.values.minKb === undefined) fill(reading, 'minKb', Math.round(Math.min(m.a, m.b) * scale), m);
+      if (reading.values.maxKb === undefined) fill(reading, 'maxKb', Math.round(Math.max(m.a, m.b) * scale), m);
+      continue;
+    }
+    // A single file size with nothing to say which end it is, is a ceiling:
+    // that is what "file size: 200 KB" means on every form that says it.
+    const field = m.bound === 'least' ? 'minKb' : 'maxKb';
+    if (reading.values[field] === undefined) fill(reading, field, Math.round(m.b * scale), m);
+  }
+}
+
+/**
+ * The background, from a colour named in a clause that says "background".
+ *
+ * A rule naming more than one colour accepts any of them, so a colour the page
+ * can check against wins over one it cannot; "white or off-white" is the
+ * page's own off-white entry and "light grey or cream" its cream one. A rule
+ * naming only colours the page has no check for - the blue and the red many
+ * forms ask for - gets a note, and the box is left alone: setting it to white
+ * would have the page check the photo against a rule it had just said it read.
+ */
+function placeBackground(text, reading) {
+  const clauses = new Map();
+  BACKGROUND.lastIndex = 0;
+  for (const match of text.matchAll(BACKGROUND)) {
+    const from = clauseStart(text, match.index);
+    if (!clauses.has(from)) clauses.set(from, clauseEnd(text, match.index + match[0].length));
+  }
+
+  const named = [];
+  for (const [from, to] of clauses) {
+    let rest = text.slice(from, to);
+    for (const colour of COLOURS) {
+      for (;;) {
+        const match = colour.pattern.exec(rest);
+        if (!match) break;
+        named.push({ key: colour.key, from: from + match.index, to: from + match.index + match[0].length });
+        // Blanked, so that "off-white" is not found again as "white".
+        rest = rest.slice(0, match.index) + ' '.repeat(match[0].length) + rest.slice(match.index + match[0].length);
+      }
+    }
+  }
+  if (!named.length) return;
+  named.sort((x, y) => x.from - y.from);
+
+  const checkable = named.filter((n) => n.key);
+  if (!checkable.length) {
+    reading.notes.push({ key: 'read.colour', spans: named.map(span) });
+    return;
+  }
+  const keys = new Set(checkable.map((n) => n.key));
+  let key = checkable[0].key;
+  if (keys.size === 2 && keys.has('white') && keys.has('off-white')) key = 'off-white';
+  else if (keys.size === 2 && keys.has('light-grey') && keys.has('cream')) key = 'cream';
+
+  const at = checkable.find((n) => n.key === key) ?? checkable[0];
+  reading.values.background = key;
+  reading.found.push({ field: 'background', value: key, from: at.from, to: at.to });
+}
+
+/**
+ * Figures that restate one already placed - "25 mm - 35 mm (1 inch to 1 3/8
+ * inches)" - are the same rule said twice, not a rule left unread.
+ */
+function dropRestatements(measures, reading) {
+  const v = reading.values;
+  const defined = (list) => list.filter((x) => x !== undefined);
+  const lengths = defined([v.widthMm, v.heightMm, v.headMinMm, v.headMaxMm]);
+  const near = (list, value, within) => list.some((x) => Math.abs(x - value) <= within);
+
+  for (const m of measures) {
+    if (m.used || m.noted) continue;
+    const values = m.shape === 'single' ? [m.b] : [m.a, m.b];
+    if (MM_PER[m.unit]) {
+      if (values.every((x) => near(lengths, x * MM_PER[m.unit], 1))) m.used = true;
+    } else if (m.unit === 'px') {
+      if (values.every((x) => near(defined([v.pxWidth, v.pxHeight]), x, 0))) m.used = true;
+    } else if (m.unit === 'kb' || m.unit === 'mb') {
+      const scale = m.unit === 'mb' ? 1024 : 1;
+      if (values.every((x) => near(defined([v.minKb, v.maxKb]), x * scale, 1))) m.used = true;
+    } else if (m.unit === 'dpi') {
+      m.used = true;
+    }
+  }
+}

--- a/tools/id-photo/styles.css
+++ b/tools/id-photo/styles.css
@@ -91,6 +91,61 @@
   padding-inline-start: 0.7rem;
 }
 
+/* The reader. A quote from the pasted text on one line and the boxes it filled
+   under it, so the check it asks for - does this say what the rule says - is
+   made by reading down, not by matching across. */
+.read-rules {
+  display: grid;
+  gap: 0.5rem;
+  margin-top: 1rem;
+  font-size: 0.88rem;
+}
+
+.read-rules textarea {
+  width: 100%;
+  min-height: 5.5rem;
+  resize: vertical;
+  box-sizing: border-box;
+}
+
+.read-rules button { justify-self: start; }
+
+.read-list {
+  margin: 0.5rem 0 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.45rem;
+  max-width: 74ch;
+}
+
+.read-list li {
+  padding: 0.45rem 0.7rem;
+  border-inline-start: 3px solid var(--accent);
+  background: var(--surface-2);
+  border-radius: var(--radius);
+  border-start-start-radius: 0;
+  border-end-start-radius: 0;
+  line-height: 1.5;
+}
+
+.read-notes li { border-inline-start-color: var(--border); color: var(--text-dim); }
+/* Not italic: Chinese has no italic, and the browser's slanted stand-in for
+   one is harder to read than the quotation marks alone. */
+.read-list q { overflow-wrap: anywhere; }
+.read-list q + q { margin-inline-start: 0.5rem; }
+
+.read-fields {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.2rem 1rem;
+  margin-top: 0.15rem;
+  font-size: 0.84rem;
+  color: var(--text-dim);
+}
+
+.read-fields b { color: var(--text); font-variant-numeric: tabular-nums; }
+
 .custom-panel {
   margin-top: 1rem;
   padding: 0.7rem 0.9rem;


### PR DESCRIPTION
**Stacked on #424** (the translation freeze): its base is that branch, so this diff is only the reader. When #424 merges, GitHub retargets this to `dev`.

Somebody whose document isn't in the list already holds its rule, as a paragraph off an embassy page or an exam registration notice. Until now they had to copy ten figures out of it into ten boxes by hand. The **"Type the numbers yourself"** entry now takes the paragraph: paste it, press **Read the rules**, and the boxes fill in.

## How it reads

`tools/id-photo/src/requirements.js` needs no model and fetches nothing. Every rule of this kind is numbers with units (35 mm, 2 inches, 600 pixels, 300 dpi, 240 KB) plus a few words saying what each number is for. It finds every number with a unit, including pairs (`35 x 45 mm`, `35mm(宽)×45mm(高)`), ranges (`between 29mm and 34mm`, `28-33mm`, `20KB至200KB`) and fractions (`1 3/8 inches`). It then decides what each number is for from the English or Chinese words beside it, in both scripts:

- a word straight after the number (`45mm high`), unless it labels the next one (`Width: 35 mm Height: 45 mm`);
- otherwise the nearest word before it (`宽33mm，高48mm`).

Ceilings and floors come from the words around the number (`不大于`, `no less than`, `20KB以上`, `240 KB or less`); a bare file size is a ceiling. Sizes, dpi and file sizes name themselves by their units, so those are read in any language.

## What it never does

Every filled box is listed under the words it was read from, so the only check that matters, whether the page read the rule correctly, takes one read down the list. Beyond that:

- **Two different photo sizes** (a passport and a visa on one page) are not chosen between. The note lists both.
- **A size given by name** (`二寸`, `2吋`) is not converted to millimetres, because studios disagree on what those names measure.
- **A background the page can't check** (blue, red) is named and the box left alone, rather than being swapped for white. When a rule offers alternatives (`white or light blue`), a checkable one wins; `white or off-white` maps to the page's own off-white entry.
- **A figure it can't place** (a head width, an eye position, a margin, a print-paper size like `4x6 inch photo paper`) is shown as read and not used, not dropped.
- A text that restates a figure (`2 x 2 inches (51 x 51 mm)`) counts as one size, and the millimetres win.

## Verified

- 17 new unit tests in `tests/js/id-photo-requirements.test.js`: US-style, UK-style, simplified and traditional Chinese rules, the bound words, two sizes, named sizes, colours, pixel ranges, paper sizes, eye positions, empty text, and offsets surviving full-width text.
- Targeted Python checks pass: `test_phrases` (English and Chinese define the same 12 new keys) and `test_english_in_js` (the count for id-photo hasn't grown).
- In the browser, English and Chinese: pasted rule → boxes filled → the rule table above updates (print size, head band, background, upload size, file size). The two other states were checked too: nothing readable ("no box was changed") and notes only (a blue background plus `二寸`).

## Before and after

The rule card with **Type the numbers yourself** chosen, before and after pasting a rule and pressing the button. The English one is a US-style rule with inches and millimetres; the Chinese one is a mainland-style rule with a head width in it, which is listed as read and not used.

| | Before | After |
|---|---|---|
| English | <img width="500" alt="English, before" src="https://github.com/user-attachments/assets/8f483d8c-f2a1-42c9-99e2-4903c8f90ba3" /> | <img width="500" alt="English, after" src="https://github.com/user-attachments/assets/1b4f651e-e54d-4ed9-97f6-8d662ab1cc71" /> |
| 中文 | <img width="500" alt="Chinese, before" src="https://github.com/user-attachments/assets/793691b8-f80b-4e1e-a211-c7421917819c" /> | <img width="500" alt="Chinese, after" src="https://github.com/user-attachments/assets/b42fa9ad-c868-447b-a31a-c3c684de7317" /> |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
